### PR TITLE
Batch applying events to kqueue

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -899,6 +899,16 @@ jobs:
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --verbose --clients 1 --no-latency --dump-logs ${{github.event.inputs.test_args}}
+      - name: make distclean
+        run: make distclean
+      - name: make with kqueue batch
+        run: make SERVER_CFLAGS='-Werror -DUSE_KQUEUE_BATCH'
+      - name: test with kqueue batch
+        if: true && !contains(github.event.inputs.skiptests, 'valkey')
+        run: ./runtest --accurate --verbose --clients 1 --no-latency --dump-logs ${{github.event.inputs.test_args}}
+      - name: module api test with kqueue batch
+        if: true && !contains(github.event.inputs.skiptests, 'modules')
+        run: CFLAGS='-Werror' ./runtest-moduleapi --verbose --clients 1 --no-latency --dump-logs ${{github.event.inputs.test_args}}
 
   test-macos-latest-sentinel:
     runs-on: macos-latest
@@ -925,6 +935,13 @@ jobs:
       - name: sentinel tests
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
         run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
+      - name: make distclean
+        run: make distclean
+      - name: make with kqueue batch
+        run: make SERVER_CFLAGS='-Werror -DUSE_KQUEUE_BATCH'
+      - name: sentinel tests with kqueue batch
+        if: true && !contains(github.event.inputs.skiptests, 'sentinel')
+        run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
 
   test-macos-latest-cluster:
     runs-on: macos-latest
@@ -949,6 +966,13 @@ jobs:
       - name: make
         run: make SERVER_CFLAGS='-Werror'
       - name: cluster tests
+        if: true && !contains(github.event.inputs.skiptests, 'cluster')
+        run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
+      - name: make distclean
+        run: make distclean
+      - name: make with kqueue batch
+        run: make SERVER_CFLAGS='-Werror -DUSE_KQUEUE_BATCH'
+      - name: cluster tests with kqueue batch
         if: true && !contains(github.event.inputs.skiptests, 'cluster')
         run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
@@ -980,6 +1004,10 @@ jobs:
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
         run: make SERVER_CFLAGS='-Werror -DSERVER_TEST'
+      - name: make distclean
+        run: make distclean
+      - name: make with kqueue batch
+        run: make SERVER_CFLAGS='-Werror -DSERVER_TEST -DUSE_KQUEUE_BATCH'
 
   test-freebsd:
     runs-on: macos-12

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ libssl-dev on Debian/Ubuntu) and run:
 
     % make BUILD_TLS=yes
 
-To build with systemd support, you'll need systemd development libraries (such 
+To build with systemd support, you'll need systemd development libraries (such
 as libsystemd-dev on Debian/Ubuntu or systemd-devel on CentOS) and run:
 
     % make USE_SYSTEMD=yes
@@ -111,7 +111,7 @@ Monotonic clock
 
 By default, Valkey will build using the POSIX clock_gettime function as the
 monotonic clock source.  On most modern systems, the internal processor clock
-can be used to improve performance.  Cautions can be found here: 
+can be used to improve performance.  Cautions can be found here:
     http://oliveryang.net/2015/09/pitfalls-of-TSC-usage/
 
 To build with support for the processor's internal instruction clock, use:
@@ -125,6 +125,24 @@ Valkey will build with a user-friendly colorized output by default.
 If you want to see a more verbose output, use the following:
 
     % make V=1
+
+Kqueue optimization
+-------------
+
+To build Valkey with the kqueue optimization where we buffer events and
+register them at once along with retrieving pending events via `kevent()`
+instead of registering events to kqueue one by one. This should conserve
+plenty of system calls to `kevent` in some scenarios.
+
+Note that this optimization will change the current semantics of registering and
+deregistering events via `kevent` by buffering events and deferring the operations.
+When some unexpected errors occur, it could panic the process. So, enable this
+optimization with caution.
+Visit [#449](https://github.com/valkey-io/valkey/pull/449) for more contexts.
+
+To enable this optimization, use:
+
+    % make SERVER_CFLAGS='-DUSE_KQUEUE_BATCH'
 
 Running Valkey
 -------------

--- a/src/ae_kqueue.c
+++ b/src/ae_kqueue.c
@@ -33,10 +33,17 @@
 #include <sys/event.h>
 #include <sys/time.h>
 
+#define MAX_QUEUED_EVENTS 1024
+
 typedef struct aeApiState {
     int kqfd;
     struct kevent *events;
-
+#ifdef USE_KQUEUE_BATCH
+    /* changes is used to buffer incoming events that will be
+     * registered in bulk via kevent(2). */
+    struct kevent changes[MAX_QUEUED_EVENTS];
+    unsigned int num_changes;
+#endif
     /* Events mask for merge read and write event.
      * To reduce memory consumption, we use 2 bits to store the mask
      * of an event, so that 1 byte will store the mask of 4 events. */
@@ -75,6 +82,9 @@ static int aeApiCreate(aeEventLoop *eventLoop) {
         return -1;
     }
     anetCloexec(state->kqfd);
+#ifdef USE_KQUEUE_BATCH
+    state->num_changes = 0;
+#endif
     state->eventsMask = zmalloc(EVENT_MASK_MALLOC_SIZE(eventLoop->setsize));
     memset(state->eventsMask, 0, EVENT_MASK_MALLOC_SIZE(eventLoop->setsize));
     eventLoop->apidata = state;
@@ -101,6 +111,31 @@ static void aeApiFree(aeEventLoop *eventLoop) {
 
 static int aeApiAddEvent(aeEventLoop *eventLoop, int fd, int mask) {
     aeApiState *state = eventLoop->apidata;
+#ifdef USE_KQUEUE_BATCH
+    /* Instead of registering events to kqueue one by one, we buffer events and
+     * register them at once along with retrieving pending events in aeApiPoll. */
+    while (mask & AE_READABLE || mask & AE_WRITABLE) {
+        if (mask & AE_READABLE) {
+            mask &= ~AE_READABLE;
+            EV_SET(state->changes + state->num_changes, fd, EVFILT_READ, EV_ADD, 0, 0, NULL);
+        } else if (mask & AE_WRITABLE) {
+            mask &= ~AE_WRITABLE;
+            EV_SET(state->changes + state->num_changes, fd, EVFILT_WRITE, EV_ADD, 0, 0, NULL);
+        }
+        /* The current changelist is full, register it to kqueue now and
+         * then rewind it to make room for follow-up events. */
+        if (++state->num_changes == MAX_QUEUED_EVENTS) {
+            if (kevent(state->kqfd, state->changes, state->num_changes, NULL, 0, NULL))
+                /* An error occurs while processing an element of the changelist,
+                 * this is unexpected and indicates somewhere went wrong.
+                 * We panic for this situation directly because we won't be unable to
+                 * learn about this failure later. */
+                panic("aeApiAddEvent: kevent, %s", strerror(errno));
+            state->num_changes = 0; /* rewind the changelist. */
+        }
+    }
+    return 0;
+#else
     struct kevent evs[2];
     int nch = 0;
 
@@ -108,31 +143,74 @@ static int aeApiAddEvent(aeEventLoop *eventLoop, int fd, int mask) {
     if (mask & AE_WRITABLE) EV_SET(evs + nch++, fd, EVFILT_WRITE, EV_ADD, 0, 0, NULL);
 
     return kevent(state->kqfd, evs, nch, NULL, 0, NULL);
+#endif
 }
 
 static void aeApiDelEvent(aeEventLoop *eventLoop, int fd, int mask) {
     aeApiState *state = eventLoop->apidata;
+    /* At this point, we somehow receive deletion requests for events that
+     * are not registered in kqueue yet, which could causes kevent(2) to
+     * fail and return ENOENT. Therefore, we need to use aeEventLoop->events
+     * to mask out the events that are not registered in kqueue and get the
+     * valid events which are requested to be deleted. */
+    int delmask = eventLoop->events[fd].mask & mask;
+
+#ifdef USE_KQUEUE_BATCH
+    /* Instead of applying events to kqueue one by one, we buffer events
+     * and apply them at once. */
+    while (delmask & AE_READABLE || delmask & AE_WRITABLE) {
+        if (delmask & AE_READABLE) {
+            delmask &= ~AE_READABLE;
+            EV_SET(state->changes + state->num_changes, fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+        } else if (delmask & AE_WRITABLE) {
+            delmask &= ~AE_WRITABLE;
+            EV_SET(state->changes + state->num_changes, fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
+        }
+        /* The current changelist is full, apply it to kqueue now and
+         * then rewind it to make room for follow-up events. */
+        if (++state->num_changes == MAX_QUEUED_EVENTS) {
+            if (kevent(state->kqfd, state->changes, state->num_changes, NULL, 0, NULL))
+                panic("aeApiDelEvent: kevent, %s", strerror(errno));
+            state->num_changes = 0; /* rewind the changelist. */
+        }
+    }
+
+    /* When it comes to EV_DELETE events, we don't defer but apply them immediately
+     * because the caller often closed the file descriptor right after they called
+     * aeDeleteFileEvent(), and kevent(2) would report ENOENT or EBADF if the changelist
+     * contained any closed file descriptors. */
+    if (state->num_changes > 0) {
+        if (kevent(state->kqfd, state->changes, state->num_changes, NULL, 0, NULL))
+            panic("aeApiDelEvent: kevent, %s", strerror(errno));
+        state->num_changes = 0; /* rewind the changelist. */
+    }
+#else
     struct kevent evs[2];
     int nch = 0;
 
-    if (mask & AE_READABLE) EV_SET(evs + nch++, fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
-    if (mask & AE_WRITABLE) EV_SET(evs + nch++, fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
+    if (delmask & AE_READABLE) EV_SET(evs + nch++, fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+    if (delmask & AE_WRITABLE) EV_SET(evs + nch++, fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
 
     kevent(state->kqfd, evs, nch, NULL, 0, NULL);
+#endif
 }
 
 static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
     aeApiState *state = eventLoop->apidata;
     int retval, numevents = 0;
 
+    struct timespec ts, *timeout = NULL;
     if (tvp != NULL) {
-        struct timespec timeout;
-        timeout.tv_sec = tvp->tv_sec;
-        timeout.tv_nsec = tvp->tv_usec * 1000;
-        retval = kevent(state->kqfd, NULL, 0, state->events, eventLoop->setsize, &timeout);
-    } else {
-        retval = kevent(state->kqfd, NULL, 0, state->events, eventLoop->setsize, NULL);
+        ts.tv_sec = tvp->tv_sec;
+        ts.tv_nsec = tvp->tv_usec * 1000;
+        timeout = &ts;
     }
+#ifdef USE_KQUEUE_BATCH
+    retval = kevent(state->kqfd, state->changes, state->num_changes, state->events, eventLoop->setsize, timeout);
+    state->num_changes = 0;
+#else
+    retval = kevent(state->kqfd, NULL, 0, state->events, eventLoop->setsize, timeout);
+#endif
 
     if (retval > 0) {
         int j;


### PR DESCRIPTION
`kqueue` has the capability of batch applying events:

> The kevent,() kevent64() and kevent_qos() system calls are used to
     register events with the queue, and return any pending events to the
     user.  The changelist argument is a pointer to an array of kevent,
     kevent64_s or kevent_qos_s structures, as defined in <sys/event.h>.  All
     changes contained in the changelist are applied before any pending events
     are read from the queue.  The nchanges argument gives the size of
     changelist.

This PR implements this functionality for `kqueue` with which we're able to reduce plenty of system calls of `kevent(2)`.