### PR TITLE
add diskless-fallback option for repl-diskless-load configuration

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -86,6 +86,7 @@ configEnum shutdown_on_sig_enum[] = {{"default", 0},        {"save", SHUTDOWN_SA
 configEnum repl_diskless_load_enum[] = {{"disabled", REPL_DISKLESS_LOAD_DISABLED},
                                         {"on-empty-db", REPL_DISKLESS_LOAD_WHEN_DB_EMPTY},
                                         {"swapdb", REPL_DISKLESS_LOAD_SWAPDB},
+                                        {"diskless-fallback", REPL_DISKLESS_LOAD_SYNC_FALLBACK},
                                         {NULL, 0}};
 
 configEnum tls_auth_clients_enum[] = {{"no", TLS_CLIENT_AUTH_NO},

--- a/src/replication.c
+++ b/src/replication.c
@@ -65,8 +65,8 @@ static ConnectionType *connTypeOfReplication(void) {
 }
 
 static int shouldFallbackToDisklessLoad(void) {
-  		return server.repl_diskless_load == REPL_DISKLESS_LOAD_SYNC_FALLBACK &&
-  		        (server.last_sync_aborted == 1);
+    return server.repl_diskless_load == REPL_DISKLESS_LOAD_SYNC_FALLBACK &&
+           server.last_sync_aborted == 1;
 }
 
 /* Return the pointer to a string representing the replica ip:listening_port

--- a/src/replication.c
+++ b/src/replication.c
@@ -2193,12 +2193,12 @@ void readSyncBulkPayload(connection *conn) {
      * In case the the connection has been closed on the primary side during the 
      * rdb load due to a COB overrun, the connection will be placed in ERROR state.*/
     if (connGetState(conn) != CONN_STATE_CONNECTED) {
-  	    serverLog(LL_WARNING,"Error condition on socket for SYNC: %s",
-  	              connGetLastError(conn));
-  	    goto error;
-  	}
+        serverLog(LL_WARNING,"Error condition on socket for SYNC: %s",
+                  connGetLastError(conn));
+        goto error;
+    }
   	
-  	server.last_sync_aborted = 0;
+    server.last_sync_aborted = 0;
 
     /* Final setup of the connected replica <- primary link */
     replicationCreateMasterClient(server.repl_transfer_s, rsi.repl_stream_db);

--- a/src/replication.c
+++ b/src/replication.c
@@ -2192,7 +2192,7 @@ void readSyncBulkPayload(connection *conn) {
      * sending keepalive indication bytes from the replica to the primary.
      * In case the the connection has been closed on the primary side during the 
      * rdb load due to a COB overrun, the connection will be placed in ERROR state.*/
-  	if (connGetState(conn) != CONN_STATE_CONNECTED) {
+    if (connGetState(conn) != CONN_STATE_CONNECTED) {
   	    serverLog(LL_WARNING,"Error condition on socket for SYNC: %s",
   	              connGetLastError(conn));
   	    goto error;

--- a/src/replication.c
+++ b/src/replication.c
@@ -65,8 +65,7 @@ static ConnectionType *connTypeOfReplication(void) {
 }
 
 static int shouldFallbackToDisklessLoad(void) {
-    return server.repl_diskless_load == REPL_DISKLESS_LOAD_SYNC_FALLBACK &&
-           server.last_sync_aborted == 1;
+    return server.repl_diskless_load == REPL_DISKLESS_LOAD_SYNC_FALLBACK && server.last_sync_aborted == 1;
 }
 
 /* Return the pointer to a string representing the replica ip:listening_port
@@ -2190,14 +2189,13 @@ void readSyncBulkPayload(connection *conn) {
     /* We are loading the rdb from disk, which can take a while.
      * During the load we periodically process event loop events like
      * sending keepalive indication bytes from the replica to the primary.
-     * In case the the connection has been closed on the primary side during the 
+     * In case the the connection has been closed on the primary side during the
      * rdb load due to a COB overrun, the connection will be placed in ERROR state.*/
     if (connGetState(conn) != CONN_STATE_CONNECTED) {
-        serverLog(LL_WARNING,"Error condition on socket for SYNC: %s",
-                  connGetLastError(conn));
+        serverLog(LL_WARNING, "Error condition on socket for SYNC: %s", connGetLastError(conn));
         goto error;
     }
-  	
+
     server.last_sync_aborted = 0;
 
     /* Final setup of the connected replica <- primary link */

--- a/src/server.c
+++ b/src/server.c
@@ -628,16 +628,11 @@ const char *strChildType(int type) {
 
 
 const char *strRDBLoadType(int type) {
-    assert(type == RDB_LOAD_TYPE_PARSER ||
-           type == RDB_LOAD_TYPE_DISK ||
-           type == RDB_LOAD_TYPE_NONE);
-    switch(type) {
-        case RDB_LOAD_TYPE_PARSER:
-            return "parser";
-        case RDB_LOAD_TYPE_DISK:
-            return "disk";
-        default:
-            return "none";
+    assert(type == RDB_LOAD_TYPE_PARSER || type == RDB_LOAD_TYPE_DISK || type == RDB_LOAD_TYPE_NONE);
+    switch (type) {
+    case RDB_LOAD_TYPE_PARSER: return "parser";
+    case RDB_LOAD_TYPE_DISK: return "disk";
+    default: return "none";
     }
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -60,6 +60,7 @@
 #include <sys/utsname.h>
 #include <locale.h>
 #include <sys/socket.h>
+#include <assert.h>
 
 #ifdef __linux__
 #include <sys/mman.h>
@@ -627,13 +628,17 @@ const char *strChildType(int type) {
 
 
 const char *strRDBLoadType(int type) {
-    /* clang-format off */
+    assert(type == RDB_LOAD_TYPE_PARSER ||
+           type == RDB_LOAD_TYPE_DISK ||
+           type == RDB_LOAD_TYPE_NONE);
     switch(type) {
-    case RDB_LOAD_TYPE_PARSER: return "parser";
-    case RDB_LOAD_TYPE_DISK: return "disk";
-    default: return "unknown";
+        case RDB_LOAD_TYPE_PARSER:
+            return "parser";
+        case RDB_LOAD_TYPE_DISK:
+            return "disk";
+        default:
+            return "none";
     }
-    /* clang-format on */
 }
 
 /* Return true if there are active children processes doing RDB saving,

--- a/src/server.h
+++ b/src/server.h
@@ -673,9 +673,9 @@ typedef enum {
 
 /* RDB load type on replica. */
 #define RDB_LOAD_TYPE_NONE -1
-#define RDB_LOAD_TYPE_DISK 0    /* RDB is loaded to disk. */
-#define RDB_LOAD_TYPE_PARSER 1   /* RDB is loaded to parser. */
-const char *strRDBLoadType(int); 
+#define RDB_LOAD_TYPE_DISK 0   /* RDB is loaded to disk. */
+#define RDB_LOAD_TYPE_PARSER 1 /* RDB is loaded to parser. */
+const char *strRDBLoadType(int);
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes. */

--- a/src/server.h
+++ b/src/server.h
@@ -562,6 +562,7 @@ typedef enum {
 #define REPL_DISKLESS_LOAD_DISABLED 0
 #define REPL_DISKLESS_LOAD_WHEN_DB_EMPTY 1
 #define REPL_DISKLESS_LOAD_SWAPDB 2
+#define REPL_DISKLESS_LOAD_SYNC_FALLBACK 3
 
 /* TLS Client Authentication */
 #define TLS_CLIENT_AUTH_NO 0
@@ -669,6 +670,12 @@ typedef enum {
 #define RDB_CHILD_TYPE_NONE 0
 #define RDB_CHILD_TYPE_DISK 1   /* RDB is written to disk. */
 #define RDB_CHILD_TYPE_SOCKET 2 /* RDB is written to replica socket. */
+
+/* RDB load type on replica. */
+#define RDB_LOAD_TYPE_NONE -1
+#define RDB_LOAD_TYPE_DISK 0    /* RDB is loaded to disk. */
+#define RDB_LOAD_TYPE_PARSER 1   /* RDB is loaded to parser. */
+const char *strRDBLoadType(int); 
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes. */
@@ -1969,6 +1976,9 @@ struct valkeyServer {
                                          * when it receives an error on the replication stream */
     int repl_ignore_disk_write_error;   /* Configures whether replicas panic when unable to
                                          * persist writes to AOF. */
+    int last_sync_aborted; /* 1 if last sync with primary was aborteded on replica side, resets to 0 on sync success. */
+    int sync_aborts_total; /* total aborts on replica side during sync with primary. */
+    int replica_last_sync_type; /* last sync type on replica side - parser / disk. */
     /* The following two fields is where we store primary PSYNC replid/offset
      * while the PSYNC is in progress. At the end we'll copy the fields into
      * the server->primary client structure. */

--- a/tests/unit/cluster/diskless-sync-fallback.tcl
+++ b/tests/unit/cluster/diskless-sync-fallback.tcl
@@ -24,15 +24,13 @@ start_server {} {
             wait_for_condition 1000 50 {
                 [string match {*replica_last_sync_type:disk*} [$replica info replication]] &&
                 [string match {*connected_clients:1*} [$master info clients]]
-            }
-            else {
+            } else {
                 fail "Replica didn't try disk based load to begin with"
             }
 
             wait_for_condition 1000 50 {
                 [string match {*loading:1*} [$replica info persistence]] 
-            } 
-            else {
+            } else {
                 fail "Replica isn't loading"
             }
 
@@ -43,8 +41,7 @@ start_server {} {
 
             wait_for_condition 1000 50 {
                 [string match {*last_sync_aborted:1*} [$replica info replication]]
-            }
-            else {
+            } else {
                 fail "Primary didn't disconnect replica as expected"
             }
             
@@ -52,8 +49,7 @@ start_server {} {
 
             wait_for_condition 1000 50 {
                 [string match {*master_link_status:up*} [$replica info replication]]
-            }
-            else {
+            } else {
                 fail "Second sync attempt didn't succeeded from socket"
             }
 

--- a/tests/unit/cluster/diskless-sync-fallback.tcl
+++ b/tests/unit/cluster/diskless-sync-fallback.tcl
@@ -1,0 +1,62 @@
+# Check that sync method chosen by replica falls back to diskless in case of disk-based sync failure
+	 
+start_server {} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+    start_server {} {
+        set replica [srv 0 client]
+        $replica config set repl-diskless-load diskless-fallback
+    
+        test "Sync method falls back to diskless sync after disk-based fails" {
+
+            $replica config set key-load-delay 50
+            $master config set client-output-buffer-limit "replica 1mb 1mb 60"
+
+            #write to master so replica will have key to load during rdb load
+            for {set i 0} {$i < 200000} {incr i} {
+                $master set key:$i val:[concat "this is key :" ", $i!"]
+            }
+
+            set loglines [count_log_lines 0]
+            $replica replicaof $master_host $master_port
+            # wait for the replica to start reading the rdb
+
+            wait_for_condition 1000 50 {
+                    [string match {*replica_last_sync_type:disk*} [$replica info replication]] &&
+                    [string match {*connected_clients:1*} [$master info clients]]
+                } else {
+                    fail "Replica didn't try disk based load to begin with"
+            }
+
+            wait_for_condition 1000 50 {
+                    [string match {*loading:1*} [$replica info persistence]] 
+                } else {
+                    fail "Replica isn't loading"
+            }
+
+            # Writing more keys to the primary during sync to cause a COB overrun
+            for {set i 0} {$i < 60000} {incr i} {
+                $master set key:$i val:[concat "this is another key :" ", $i!"]
+            }
+
+             wait_for_condition 1000 50 {
+                    [string match {*last_sync_aborted:1*} [$replica info replication]]
+                } else {
+                    fail "Primary didn't disconnect replica as expected"
+            }
+            
+            # Validate the second sync attempt is from socket (parser)
+
+            wait_for_condition 1000 50 {
+                    [string match {*master_link_status:up*} [$replica info replication]]
+                } else {
+                    fail "Second sync attempt didn't succeeded from socket"
+            }
+
+            assert_match {*replica_last_sync_type:parser*} [$replica info replication]
+            assert_match {*last_sync_aborted:0*} [$replica info replication]
+
+        }
+    }
+}

--- a/valkey.conf
+++ b/valkey.conf
@@ -655,17 +655,19 @@ repl-diskless-sync-max-replicas 0
 # fully loaded in memory, resulting in higher memory usage.
 # For this reason we have the following options:
 #
-# "disabled"    - Don't use diskless load (store the rdb file to the disk first)
-# "swapdb"      - Keep current db contents in RAM while parsing the data directly
-#                 from the socket. Replicas in this mode can keep serving current
-#                 dataset while replication is in progress, except for cases where
-#                 they can't recognize primary as having a data set from same
-#                 replication history.
-#                 Note that this requires sufficient memory, if you don't have it,
-#                 you risk an OOM kill.
-# "on-empty-db" - Use diskless load only when current dataset is empty. This is 
-#                 safer and avoid having old and new dataset loaded side by side
-#                 during replication.
+# "disabled"          - Don't use diskless load (store the rdb file to the disk first)
+# "swapdb"            - Keep current db contents in RAM while parsing the data directly
+#                       from the socket. Replicas in this mode can keep serving current
+#                       dataset while replication is in progress, except for cases where
+#                       they can't recognize primary as having a data set from same
+#                       replication history.
+#                       Note that this requires sufficient memory, if you don't have it,
+#                       you risk an OOM kill.
+# "on-empty-db"       - Use diskless load only when current dataset is empty. This is 
+#                       safer and avoid having old and new dataset loaded side by side
+#                       during replication.
+# "diskless-fallback" - Use diskless load only as a fallback, in case disk-based syncs fails.
+#                       for example when writing to disk fails due to insufficient diskspace. 
 repl-diskless-load disabled
 
 # Master send PINGs to its replicas in a predefined interval. It's possible to


### PR DESCRIPTION
 
### Description
When a Replica with the default value of repl-diskless-load ("disabled") performs a full sync with the master, it first syncs the RDB data to disk. Only after completing this step does the Replica load the data into memory.

Disconnections during disk-based sync result sometimes in infinite sync loops and outdated data on the replica.  
The longer the primary and replica are disconnected and out of sync, the more stale the data that is on the replica becomes, and the less beneficial it becomes to do disk-based sync as time progresses.  

A common example is short writes (insufficient disk space) on the replica - if a replica doesn't have enough disk space for the RDB it will fail repeatedly. 

This solution will also address another issue - Replica Client Output Buffer overrun on the master side.
In many cases, high traffic persists during subsequent sync attempts, leading to repeating COB overruns.
Under the assumption that diskless syncs are faster, this will reduce the risk of exceeding the buffer size limit.

### Code Changes


#### `server.h`  and `server.c`
added the new fields - 

1. `sync_aborts_total ` - This field is incremented when we recognize that a disconnection happened during a sync attempt, for information purpose only.

2. `last_sync_aborted ` same as previous, but it's reset after a successful sync. we use it when choosing a new sync strategy. 

3. `replica_last_sync_type` indicates which strategy used in the last sync.
___
#### `replication.c` 
1. In the existing code, when a sync fails, `cancelReplicationHandshake` is called , which then calls `replicationAbortSyncTransfer `. `last_sync_aborted` is set to true, and `sync_aborts_total` is increased. 
2. function `shouldFallbackToDisklessLoad ` added in order to implement the fallback during  `useDisklessLoad` - the logic for replica choice of sync type. 
3. The Replica sends newline to primary node once when flushing it's data, and every time the RDB load progress. If the primary loses connection to the replica, the state will change is changed to CONN_STATE_ERROR. 

  added a check of connection state after the RDB load finish successfully, and before the load marked as finish by ```server.repl_state = REPL_STATE_CONNECTED``` and connection state changes. after that, sync is marked as successful and `last_sync_aborted` is reset. 


### Testing
Added a new test in tests/unit/cluster/diskless-sync-fallback.tcl which checks just the fallback logic;
If a disk-based sync has failed, then the next sync attempt should be diskless (RDB received straight to parser).