### PR TITLE
Allow multi-slot MGET in Cluster Mode

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1081,12 +1081,16 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
             } else {
                 /* If it is not the first key/channel, make sure it is exactly
                  * the same key/channel as the first we saw or an allowed crossslot situation. */
-                int prevent_crossslot = (cmd_flags & CMD_WRITE) // eliminate issues with client->current_slot
-                    || pubsubshard_included // pubsub does not benefit and too many edge cases
-                    || c->cmd->proc == execCommand // We do not permit crossslot transactions to prevent client code which will break when cluster topology changes
-                    // finally, if any key is migrating we cannot permit the crossslot since we don't check if the specific keys are affected
+                int prevent_crossslot =
+                    (cmd_flags & CMD_WRITE)        // eliminate issues with client->current_slot
+                    || pubsubshard_included        // pubsub does not benefit and too many edge cases
+                    || c->cmd->proc == execCommand // We do not permit crossslot transactions to prevent client code
+                                                   // which will break when cluster topology changes
+                    // finally, if any key is migrating we cannot permit the crossslot since we don't check if the
+                    // specific keys are affected
                     //  this could potentially be relaxed in the future.
-                    || migrating_slot || importing_slot || getMigratingSlotDest(slot) != NULL || getImportingSlotSource(slot) != NULL;
+                    || migrating_slot || importing_slot || getMigratingSlotDest(slot) != NULL ||
+                    getImportingSlotSource(slot) != NULL;
                 if (slot != thisslot && prevent_crossslot) {
                     /* Error: multiple keys from different slots. */
                     getKeysFreeResult(&result);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -989,7 +989,7 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
     clusterNode *n = NULL;
     robj *firstkey = NULL;
     int multiple_keys = 0;
-    int multi_slot = false;
+    int multi_slot = 0;
     multiState *ms, _ms;
     multiCmd mc;
     int i, slot = 0, migrating_slot = 0, importing_slot = 0, missing_keys = 0, existing_keys = 0;
@@ -1099,7 +1099,7 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
                         if (error_code) *error_code = CLUSTER_REDIR_CROSS_SLOT;
                         return NULL;
                     } else {
-                        multi_slot = true;
+                        multi_slot = 1;
                     }
                 }
                 if (importing_slot && !multiple_keys && !equalStringObjects(firstkey, thiskey)) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -989,6 +989,7 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
     clusterNode *n = NULL;
     robj *firstkey = NULL;
     int multiple_keys = 0;
+    int multi_slot = false;
     multiState *ms, _ms;
     multiCmd mc;
     int i, slot = 0, migrating_slot = 0, importing_slot = 0, missing_keys = 0, existing_keys = 0;
@@ -1089,13 +1090,17 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
                     // finally, if any key is migrating we cannot permit the crossslot since we don't check if the
                     // specific keys are affected
                     //  this could potentially be relaxed in the future.
-                    || migrating_slot || importing_slot || getMigratingSlotDest(slot) != NULL ||
-                    getImportingSlotSource(slot) != NULL;
-                if (slot != thisslot && prevent_crossslot) {
-                    /* Error: multiple keys from different slots. */
-                    getKeysFreeResult(&result);
-                    if (error_code) *error_code = CLUSTER_REDIR_CROSS_SLOT;
-                    return NULL;
+                    || migrating_slot || importing_slot || getMigratingSlotDest(thisslot) != NULL ||
+                    getImportingSlotSource(thisslot) != NULL || n != getNodeBySlot(thisslot);
+                if (slot != thisslot) {
+                    if (prevent_crossslot) {
+                        /* Error: multiple keys from different slots. */
+                        getKeysFreeResult(&result);
+                        if (error_code) *error_code = CLUSTER_REDIR_CROSS_SLOT;
+                        return NULL;
+                    } else {
+                        multi_slot = true;
+                    }
                 }
                 if (importing_slot && !multiple_keys && !equalStringObjects(firstkey, thiskey)) {
                     /* Flag this request as one with multiple different
@@ -1150,7 +1155,11 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
     }
 
     /* Return the hashslot by reference. */
-    if (hashslot) *hashslot = slot;
+    if (hashslot) {
+        // If we have multiple slots we disable slot caching on the client
+        //  In the future perhaps this optimization could be extended to work with multiple keys
+        *hashslot = multi_slot ? -1 : slot;
+    }
 
     /* MIGRATE always works in the context of the local node if the slot
      * is open (migrating or importing state). We need to be able to freely

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1080,8 +1080,14 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
                 }
             } else {
                 /* If it is not the first key/channel, make sure it is exactly
-                 * the same key/channel as the first we saw. */
-                if (slot != thisslot) {
+                 * the same key/channel as the first we saw or an allowed crossslot situation. */
+                int prevent_crossslot = (cmd_flags & CMD_WRITE) // eliminate issues with client->current_slot
+                    || pubsubshard_included // pubsub does not benefit and too many edge cases
+                    || c->cmd->proc == execCommand // We do not permit crossslot transactions to prevent client code which will break when cluster topology changes
+                    // finally, if any key is migrating we cannot permit the crossslot since we don't check if the specific keys are affected
+                    //  this could potentially be relaxed in the future.
+                    || migrating_slot || importing_slot || getMigratingSlotDest(slot) != NULL || getImportingSlotSource(slot) != NULL;
+                if (slot != thisslot && prevent_crossslot) {
                     /* Error: multiple keys from different slots. */
                     getKeysFreeResult(&result);
                     if (error_code) *error_code = CLUSTER_REDIR_CROSS_SLOT;

--- a/src/server.c
+++ b/src/server.c
@@ -5646,7 +5646,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "executable:%s\r\n", server.executable ? server.executable : "",
                 "config_file:%s\r\n", server.configfile ? server.configfile : "",
                 "io_threads_active:%i\r\n", server.active_io_threads_num > 1,
-                "availability_zone:%s\r\n", server.availability_zone));
+                "availability_zone:%s\r\n", server.availability_zone,
+                "features:%s\r\n", "cluster_mget"));
 
         /* Conditional properties */
         if (isShutdownInitiated()) {


### PR DESCRIPTION
The current restrictions for MGET in cluster mode is that all keys must reside in the same slot.  This results in very high inefficiency for high batch use cases as the batch has to be cracked into individual GETs.  Because there are 16k slots its very unlikely we will find a pair we can send with MGET making it nearly useless in cluster mode.

Instead we can relax the condition a bit and permit MGET if all slots reside on this node and none are migrating.  This allows us to serve the request in the common case.  In the case where a slot was migrated or changed we still send CROSSSLOT and the client will know to break the batch down to individual GETs.

Because we expect there to be cases where we still send CROSSSLOT simply doing an MGET test on the client is not sufficient to communicate this new support.  To help this along we introduce a new INFO field called "features".  This is intended to work similar to the features flag in lscpu where new features get added over time.  Now the client can check this and determine if it still needs to breakup batches or if they can be sent in one go.

Note: tests will come in a little bit but we can start the conversation of the feature now.

Old Behaviour:
```
127.0.0.1:30001> get a
(error) MOVED 15495 127.0.0.1:30003
127.0.0.1:30001> get b
(nil)
127.0.0.1:30001> get c
(error) MOVED 7365 127.0.0.1:30002
127.0.0.1:30001> get d
(error) MOVED 11298 127.0.0.1:30003
127.0.0.1:30001> get e
(error) MOVED 15363 127.0.0.1:30003
127.0.0.1:30001> get f
(nil)
127.0.0.1:30001> mget b f
(error) CROSSSLOT Keys in request don't hash to the same slot
```

New Behavior:
```
127.0.0.1:30001> get a
(error) MOVED 15495 127.0.0.1:30003
127.0.0.1:30001> get b
(nil)
127.0.0.1:30001> get c
(error) MOVED 7365 127.0.0.1:30002
127.0.0.1:30001> get d
(error) MOVED 11298 127.0.0.1:30003
127.0.0.1:30001> get e
(error) MOVED 15363 127.0.0.1:30003
127.0.0.1:30001> get f
(nil)
127.0.0.1:30001> mget b f
1) (nil)
2) (nil)
```