### PR TITLE
Add latency sample for transaction and pipeline

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3112,6 +3112,10 @@ int canParseCommand(client *c) {
 }
 
 int processInputBuffer(client *c) {
+    mstime_t latency;
+    latencyStartMonitor(latency);
+    int processed = 0;
+
     /* Parse the query buffer. */
     while (c->querybuf && c->qb_pos < sdslen(c->querybuf)) {
         if (!canParseCommand(c)) {
@@ -3146,8 +3150,12 @@ int processInputBuffer(client *c) {
              * ASAP in that case. */
             return C_ERR;
         }
+        processed++;
     }
-
+    latencyEndMonitor(latency);
+    if (processed > 1) {
+        latencyAddSampleIfNeeded("pipeline", latency);
+    }
     return C_OK;
 }
 


### PR DESCRIPTION
If users put too many commands in a transaction or pipeline, the execution time might exceed the `latency_monitor_threshold` value. 
So, Maybe it's necessary to record latency for pipeline and transaction, which can help them to find out potential misuse of transaction or pipeline.