### PR TITLE
Support empty set

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3206,6 +3206,7 @@ standardConfig static_configs[] = {
     createBoolConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG, server.cluster_slot_stats_enabled, 0, NULL, NULL),
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 1, NULL, NULL),
     createBoolConfig("import-mode", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.import_mode, 0, NULL, NULL),
+    createBoolConfig("allow-empty-set", NULL, MODIFIABLE_CONFIG, server.allow_empty_set, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/intset.c
+++ b/src/intset.c
@@ -320,9 +320,6 @@ int intsetValidateIntegrity(const unsigned char *p, size_t size, int deep) {
     uint32_t count = intrev32ifbe(is->length);
     if (sizeof(*is) + count * record_size != size) return 0;
 
-    /* check that the set is not empty. */
-    if (count == 0) return 0;
-
     if (!deep) return 1;
 
     /* check that there are no dup or out of order records. */

--- a/src/server.h
+++ b/src/server.h
@@ -1930,6 +1930,10 @@ struct valkeyServer {
                                                  invocation of the event loop. */
     unsigned int max_new_conns_per_cycle;     /* The maximum number of tcp connections that will be accepted during each
                                                  invocation of the event loop. */
+    int allow_empty_set;                      /* Flag to control whether empty set is allowed in the database
+                                                 1 empty sets are preserved in database even after all elements are removed
+                                                 0 by default, key for the set is deleted when it becomes empty */
+
     /* AOF persistence */
     int aof_enabled;                    /* AOF configuration */
     int aof_state;                      /* AOF_(ON|OFF|WAIT_REWRITE) */

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -769,7 +769,7 @@ proc start_multiple_servers {num options code} {
     uplevel 1 $code
 }
 
-proc restart_server {level wait_ready rotate_logs {reconnect 1} {shutdown sigterm}} {
+proc restart_server {level wait_ready rotate_logs {reconnect 1} {shutdown sigterm} {config_override {}}} {
     set srv [lindex $::servers end+$level]
     if {$shutdown ne {sigterm}} {
         catch {[dict get $srv "client"] shutdown $shutdown}
@@ -797,6 +797,15 @@ proc restart_server {level wait_ready rotate_logs {reconnect 1} {shutdown sigter
     }
 
     set config_file [dict get $srv "config_file"]
+
+    # Apply config updates if provided
+    if {[llength $config_override] > 0} {
+        set fd [open $config_file "a"]
+        foreach {key value} $config_override {
+            puts $fd "$key $value"
+        }
+        close $fd
+    }
 
     set pid [spawn_server $config_file $stdout $stderr {}]
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -496,6 +496,31 @@ locale-collate ""
 #
 # extended-redis-compatibility no
 
+# This configuration controls whether Valkey allows the representation of empty sets in the database.
+# By default, when the last element of a set is removed, the key associated with the set is deleted.
+# Enabling this option allows Valkey to retain the key and store an empty set instead.
+#
+# This can be useful for scenarios where an empty set has semantic meaning in the application,
+# such as indicating that a query was executed but returned no results.
+#
+# When this option is enabled:
+# - Empty sets are preserved in the database, and their key will not be automatically deleted.
+# - The `SCARD` command will return 0 for these keys.
+# - These keys will remain in the database until explicitly deleted using the `DEL` command.
+#
+# Note:
+# - This setting may result in additional memory usage due to the retention of keys for empty sets.
+# - Ensure client applications handle empty sets correctly, as their presence differs from the absence of a key.
+# - When loading RDB files, empty sets are skipped by default unless this option is enabled.
+#   This ensures backward compatibility with existing RDB files created in versions where empty
+#   sets were not explicitly supported.
+# - Ensure that this setting is consistently enabled if your application relies on the presence of
+#   empty sets during RDB restores.
+#
+# Default: no
+#
+# allow-empty-set no
+
 ################################ SNAPSHOTTING  ################################
 
 # Save the DB to disk.


### PR DESCRIPTION
### Issue: https://github.com/valkey-io/valkey/issues/68

### Summary
This pull request introduces support for empty sets in Valkey, controlled by a new configuration option, allow-empty-set which is a strong demand in the Redis community (https://github.com/redis/redis/issues/6048). With this change, Valkey can preserve keys for sets even after all their elements have been removed, rather than deleting the key immediately. This feature provides additional flexibility for use cases where an empty set has semantic meaning

### Why This Change is Needed
In Valkey, when a set becomes empty (all its elements are removed), the key representing that set is automatically deleted from the database. While this behavior works for most use cases, it introduces limitations for certain scenarios where the distinction between an empty set (existent key) and a non-existent key is important.
For example:
Key: `active_users`
```
SADD active_users sungming 
SREM active_users sungming
EXISTS active_users 
> (integer) 0
```
Now in this case, the absence of the key (active_users) could mean either:
* The query hasn't been executed yet.
* The query was executed but returned no users.

The application would need to query its persistent database (e.g., SQL) to determine whether the key represents an empty set or has not been created yet. Alternatively, they could add a dummy value, such as an empty string (""), to the set to ensure the key persists. However, this approach is not ideal and could lead to unintended behavior or safety issues.

### Key changes
1. New Configuration Option (allow-empty-set):
Added the allow-empty-set configuration to valkey.conf.
Default: ```no``` (empty sets are deleted by default, preserving backward compatibility).
When enabled, keys for empty sets are retained in the database until explicitly deleted.

3. Database Behavior:
Empty sets are represented as valid keys with zero cardinality (SCARD returns 0).
These keys are preserved in memory and are only removed with the DEL command.

4. Persistence:
Empty sets are serialized and saved in the RDB file when allow-empty-set is enabled.
During RDB/AOF loading, empty sets are restored only if allow-empty-set is enabled. Otherwise, they are skipped.

### Test
Added unit tests and integration tests (TCL) to verify:
1. Persistence and RDB reloading of empty sets.
2. Correct behavior of set commands when allow-empty-set is enabled/disabled.
3. Compatibility with default behavior when the option is disabled.

### Backward Compatibility
The default behavior (allow-empty-set = no) ensures backward compatibility with existing applications.