### PR TITLE
Introducing Valkey Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/gh/valkey-io/valkey/graph/badge.svg?token=KYYSJAYC5F)](https://codecov.io/gh/valkey-io/valkey)
+[![codecov](https://codecov.io/gh/valkey-io/valkey/graph/badge.svg?token=KYYSJAYC5F)](https://codecov.io/gh/valkey-io/valkey) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Valkey%20Guru-006BFF)](https://gurubase.io/g/valkey)
 
 This project was forked from the open source Redis project right before the transition to their new source available licenses.
 


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [Valkey Guru](https://gurubase.io/g/valkey) has been manually added to Gurubase. Valkey Guru uses the data from this repo and data from the [docs](https://valkey.io/) to answer questions by leveraging the LLM.

This PR introduces the "Valkey Guru", showcasing that Valkey now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "Valkey Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the Valkey documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable Valkey Guru in Gurubase, just let us know that's totally fine.
