### PR TITLE
Fix error "SSL routines::bad length" when connTLSWrite is called second time with smaller buffer

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -452,6 +452,9 @@ typedef struct tls_connection {
     SSL *ssl;
     char *ssl_error;
     listNode *pending_list_node;
+    /* Per https://docs.openssl.org/master/man3/SSL_write, after a write call with partially written data,
+     * we must make subsequent write calls with the same length. We use this field to keep track of 
+     * the previous write length. */
     size_t last_failed_write_data_len;
 } tls_connection;
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -453,7 +453,7 @@ typedef struct tls_connection {
     char *ssl_error;
     listNode *pending_list_node;
     /* Per https://docs.openssl.org/master/man3/SSL_write, after a write call with partially written data,
-     * we must make subsequent write calls with the same length. We use this field to keep track of 
+     * we must make subsequent write calls with the same length. We use this field to keep track of
      * the previous write length. */
     size_t last_failed_write_data_len;
 } tls_connection;

--- a/src/tls.c
+++ b/src/tls.c
@@ -452,6 +452,7 @@ typedef struct tls_connection {
     SSL *ssl;
     char *ssl_error;
     listNode *pending_list_node;
+    size_t last_failed_write_data_len;
 } tls_connection;
 
 static connection *createTLSConnection(int client_side) {
@@ -911,10 +912,12 @@ static int connTLSWrite(connection *conn_, const void *data, size_t data_len) {
     if (conn->c.state != CONN_STATE_CONNECTED) return -1;
     ERR_clear_error();
     ret = SSL_write(conn->ssl, data, data_len);
+    conn->last_failed_write_data_len = ret < 0 ? data_len : 0;
     return updateStateAfterSSLIO(conn, ret, 1);
 }
 
 static int connTLSWritev(connection *conn_, const struct iovec *iov, int iovcnt) {
+    tls_connection *conn = (tls_connection *)conn_;
     if (iovcnt == 1) return connTLSWrite(conn_, iov[0].iov_base, iov[0].iov_len);
 
     /* Accumulate the amount of bytes of each buffer and check if it exceeds NET_MAX_WRITES_PER_EVENT. */
@@ -927,7 +930,7 @@ static int connTLSWritev(connection *conn_, const struct iovec *iov, int iovcnt)
     /* The amount of all buffers is greater than NET_MAX_WRITES_PER_EVENT,
      * which is not worth doing so much memory copying to reduce system calls,
      * therefore, invoke connTLSWrite() multiple times to avoid memory copies. */
-    if (iov_bytes_len > NET_MAX_WRITES_PER_EVENT) {
+    if (iov_bytes_len > NET_MAX_WRITES_PER_EVENT && iovcnt > 0 && iov[0].iov_len >= conn->last_failed_write_data_len) {
         ssize_t tot_sent = 0;
         for (int i = 0; i < iovcnt; i++) {
             ssize_t sent = connTLSWrite(conn_, iov[i].iov_base, iov[i].iov_len);

--- a/src/tls.c
+++ b/src/tls.c
@@ -917,10 +917,11 @@ static int connTLSWrite(connection *conn_, const void *data, size_t data_len) {
     /* In case when last write failed due to some internal reason, retry has to provide
      * at least the same amount of bytes (https://docs.openssl.org/master/man3/SSL_write).
      * If that condition is not met, OpenSSL will return "SSL routines::bad length".
-     * When this assertion gets hit, caller has to be fixed to provide required bytes. */
+     * Currently we only suspect this can happen during primary cron sending '\n' 
+     * indication to the replica, so we silently return from this function without 
+     * impacting the connection state. */
     if (data_len < conn->last_failed_write_data_len) {
-        /* Keep assertion when debug is enabled, otherwise just return -1 */
-        debugServerAssert(0);
+        // TODO: place debugAssert for this case once the known issue described is resolved
         return -1;
     }
     ret = SSL_write(conn->ssl, data, data_len);

--- a/src/tls.c
+++ b/src/tls.c
@@ -918,7 +918,11 @@ static int connTLSWrite(connection *conn_, const void *data, size_t data_len) {
      * at least the same amount of bytes (https://docs.openssl.org/master/man3/SSL_write).
      * If that condition is not met, OpenSSL will return "SSL routines::bad length".
      * When this assertion gets hit, caller has to be fixed to provide required bytes. */
-    debugServerAssert(data_len >= conn->last_failed_write_data_len);
+    if (data_len < conn->last_failed_write_data_len) {
+        /* Keep assertion when debug is enabled, otherwise just return -1 */
+        debugServerAssert(0);
+        return -1;
+    }
     ret = SSL_write(conn->ssl, data, data_len);
     conn->last_failed_write_data_len = ret <= 0 ? data_len : 0;
     return updateStateAfterSSLIO(conn, ret, 1);

--- a/src/tls.c
+++ b/src/tls.c
@@ -917,8 +917,8 @@ static int connTLSWrite(connection *conn_, const void *data, size_t data_len) {
     /* In case when last write failed due to some internal reason, retry has to provide
      * at least the same amount of bytes (https://docs.openssl.org/master/man3/SSL_write).
      * If that condition is not met, OpenSSL will return "SSL routines::bad length".
-     * Currently we only suspect this can happen during primary cron sending '\n' 
-     * indication to the replica, so we silently return from this function without 
+     * Currently we only suspect this can happen during primary cron sending '\n'
+     * indication to the replica, so we silently return from this function without
      * impacting the connection state. */
     if (data_len < conn->last_failed_write_data_len) {
         // TODO: place debugAssert for this case once the known issue described is resolved

--- a/src/tls.c
+++ b/src/tls.c
@@ -914,10 +914,11 @@ static int connTLSWrite(connection *conn_, const void *data, size_t data_len) {
 
     if (conn->c.state != CONN_STATE_CONNECTED) return -1;
     ERR_clear_error();
-    if (data_len < conn->last_failed_write_data_len) {
-        conn->c.last_errno = EBUSY;
-        return -1;
-    }
+    /* In case when last write failed due to some internal reason, retry has to provide
+     * at least the same amount of bytes (https://docs.openssl.org/master/man3/SSL_write).
+     * If that condition is not met, OpenSSL will return "SSL routines::bad length".
+     * When this assertion gets hit, caller has to be fixed to provide required bytes. */
+    debugServerAssert(data_len >= conn->last_failed_write_data_len);
     ret = SSL_write(conn->ssl, data, data_len);
     conn->last_failed_write_data_len = ret <= 0 ? data_len : 0;
     return updateStateAfterSSLIO(conn, ret, 1);

--- a/src/tls.c
+++ b/src/tls.c
@@ -914,7 +914,10 @@ static int connTLSWrite(connection *conn_, const void *data, size_t data_len) {
 
     if (conn->c.state != CONN_STATE_CONNECTED) return -1;
     ERR_clear_error();
-    serverAssert(data_len >= conn->last_failed_write_data_len);
+    if (data_len < conn->last_failed_write_data_len) {
+        conn->c.last_errno = EBUSY;
+        return -1;
+    }
     ret = SSL_write(conn->ssl, data, data_len);
     conn->last_failed_write_data_len = ret <= 0 ? data_len : 0;
     return updateStateAfterSSLIO(conn, ret, 1);
@@ -931,9 +934,14 @@ static int connTLSWritev(connection *conn_, const struct iovec *iov, int iovcnt)
         if (iov_bytes_len > NET_MAX_WRITES_PER_EVENT) break;
     }
 
-    /* The amount of all buffers is greater than NET_MAX_WRITES_PER_EVENT,
-     * which is not worth doing so much memory copying to reduce system calls,
-     * therefore, invoke connTLSWrite() multiple times to avoid memory copies. */
+    /* In case the amount of all buffers is greater than NET_MAX_WRITES_PER_EVENT,
+     * it might not worth doing so much memory copying to reduce system calls,
+     * therefore, invoke connTLSWrite() multiple times to avoid memory copies.
+     * However, in case when last write failed we still have to repeat sending last_failed_write_data_len
+     * bytes. Because of openssl implementation we cannot repeat sending writes with length smaller than
+     * the last failed write (https://docs.openssl.org/master/man3/SSL_write) so in case the first io buffer
+     * does not provide at least the same amount of bytes as previous failed write, we will have to fallback to
+     * memory copy to a static buffer before calling SSL_write. */
     if (iov_bytes_len > NET_MAX_WRITES_PER_EVENT && iovcnt > 0 && iov[0].iov_len >= conn->last_failed_write_data_len) {
         ssize_t tot_sent = 0;
         for (int i = 0; i < iovcnt; i++) {
@@ -948,7 +956,11 @@ static int connTLSWritev(connection *conn_, const struct iovec *iov, int iovcnt)
     /* The amount of all buffers is less than NET_MAX_WRITES_PER_EVENT,
      * which is worth doing more memory copies in exchange for fewer system calls,
      * so concatenate these scattered buffers into a contiguous piece of memory
-     * and send it away by one call to connTLSWrite(). */
+     * and send it away by one call to connTLSWrite().
+     * However, code can fallback here in case when last write failed and first
+     * element of io is buffer not big enough to provide required amount of bytes
+     * to retry, so iov_bytes_len may exceed NET_MAX_WRITES_PER_EVENT by the amount
+     * of remaining bytes from last taken io. */
     char buf[iov_bytes_len];
     size_t offset = 0;
     for (int i = 0; i < iovcnt && offset < iov_bytes_len; i++) {


### PR DESCRIPTION
Issue described in #1135 

When call to `connTLSWrite` fails on next attempt `connTLSWritev` should provide buffer with at least same amount of bytes,
but if first call was with buffer smaller than `NET_MAX_WRITES_PER_EVENT` then buffer gets larger and exceed `NET_MAX_WRITES_PER_EVENT`, `connTLSWritev` will not combine `iov` into one buffer resulting into chance that first element of `iov` is smaller than last failed call to `connTLSWrite` and causing `SSL routines::bad length`.

This change force combining `iov`s into one buffer if first element of `iov` is smaller than last failed write by `connTLSWrite`