### PR TITLE
Enhance ACL WHOAMI command to display active ACL rules for the current connection 

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2910,9 +2910,18 @@ void aclCommand(client *c) {
             }
         }
         raxStop(&ri);
-    } else if (!strcasecmp(sub, "whoami") && c->argc == 2) {
+    } else if (!strcasecmp(sub, "whoami") && (c->argc == 2 || c->argc == 3)) {
         if (c->user != NULL) {
-            addReplyBulkCBuffer(c, c->user->name, sdslen(c->user->name));
+            if (c->argc == 3) {
+                sds config = sdsnew(c->user->name);
+                config = sdscatlen(config, " ", 1);
+                robj *descr = ACLDescribeUser(c->user);
+                config = sdscatsds(config, descr->ptr);
+                decrRefCount(descr);
+                addReplyBulkSds(c, config);
+            } else {
+                addReplyBulkCBuffer(c, c->user->name, sdslen(c->user->name));
+            }
         } else {
             addReplyNull(c);
         }

--- a/src/commands.def
+++ b/src/commands.def
@@ -6380,7 +6380,9 @@ struct COMMAND_ARG ACL_SETUSER_Args[] = {
 
 #ifndef SKIP_CMD_HISTORY_TABLE
 /* ACL WHOAMI history */
-#define ACL_WHOAMI_History NULL
+commandHistory ACL_WHOAMI_History[] = {
+{"9.0.0","Added the `FULL` option."},
+};
 #endif
 
 #ifndef SKIP_CMD_TIPS_TABLE
@@ -6392,6 +6394,11 @@ struct COMMAND_ARG ACL_SETUSER_Args[] = {
 /* ACL WHOAMI key specs */
 #define ACL_WHOAMI_Keyspecs NULL
 #endif
+
+/* ACL WHOAMI argument table */
+struct COMMAND_ARG ACL_WHOAMI_Args[] = {
+{MAKE_ARG("full",ARG_TYPE_PURE_TOKEN,-1,"FULL",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+};
 
 /* ACL command table */
 struct COMMAND_STRUCT ACL_Subcommands[] = {
@@ -6407,7 +6414,7 @@ struct COMMAND_STRUCT ACL_Subcommands[] = {
 {MAKE_CMD("save","Saves the effective ACL rules in the configured ACL file.","O(N). Where N is the number of configured users.","6.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,ACL_SAVE_History,0,ACL_SAVE_Tips,2,aclCommand,2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,0,ACL_SAVE_Keyspecs,0,NULL,0)},
 {MAKE_CMD("setuser","Creates and modifies an ACL user and its rules.","O(N). Where N is the number of rules provided.","6.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,ACL_SETUSER_History,2,ACL_SETUSER_Tips,2,aclCommand,-3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,0,ACL_SETUSER_Keyspecs,0,NULL,2),.args=ACL_SETUSER_Args},
 {MAKE_CMD("users","Lists all ACL users.","O(N). Where N is the number of configured users.","6.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,ACL_USERS_History,0,ACL_USERS_Tips,0,aclCommand,2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,0,ACL_USERS_Keyspecs,0,NULL,0)},
-{MAKE_CMD("whoami","Returns the authenticated username of the current connection.","O(1)","6.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,ACL_WHOAMI_History,0,ACL_WHOAMI_Tips,0,aclCommand,2,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,0,ACL_WHOAMI_Keyspecs,0,NULL,0)},
+{MAKE_CMD("whoami","Returns the authenticated username of the current connection or its effective rules in ACL file format.","O(1)","6.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,ACL_WHOAMI_History,1,ACL_WHOAMI_Tips,0,aclCommand,-2,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,0,ACL_WHOAMI_Keyspecs,0,NULL,1),.args=ACL_WHOAMI_Args},
 {0}
 };
 

--- a/src/commands/acl-whoami.json
+++ b/src/commands/acl-whoami.json
@@ -1,12 +1,18 @@
 {
     "WHOAMI": {
-        "summary": "Returns the authenticated username of the current connection.",
+        "summary": "Returns the authenticated username of the current connection or its effective rules in ACL file format.",
         "complexity": "O(1)",
         "group": "server",
         "since": "6.0.0",
-        "arity": 2,
+        "arity": -2,
         "container": "ACL",
         "function": "aclCommand",
+        "history": [
+            [
+                "9.0.0",
+                "Added the `FULL` option."
+            ]
+        ],
         "command_flags": [
             "NOSCRIPT",
             "LOADING",
@@ -16,6 +22,16 @@
         "reply_schema": {
             "type": "string",
             "description": "The username of the current connection."
-        }
+        },
+        "arguments": [
+            {
+                "name": "full",
+                "type": "pure-token",
+                "token": "FULL",
+                "optional": true,
+                "since": "9.0.0"
+            }
+        ]
+
     }
 }

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -3,6 +3,10 @@ start_server {tags {"acl external:skip"}} {
         r ACL WHOAMI
     } {default}
 
+    test {Connections with the effective ACL rules of the default user} {
+        r ACL WHOAMI FULL
+    } {*default on nopass*}
+
     test {It is possible to create new users} {
         r ACL setuser newuser
     }


### PR DESCRIPTION
Current ACL WHOAMI can only display the username for the current connection.
It need to call ACL LIST to get the active ACL rules, thus there are 2 disadvantages: 

1. CALL 2 commands to get ACL rules for the current connection
2. ACL LIST will display all users and their ACL rules, it is not necessary,

This PR allows the current connection to call once "ACL WHOAMI FULL" to get all information.