### PR TITLE
Change the usec_per_call operation from float to long long division

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5490,10 +5490,10 @@ sds genValkeyInfoStringCommandStats(sds info, hashtable *commands) {
         char *tmpsafe;
         if (c->calls || c->failed_calls || c->rejected_calls) {
             info = sdscatprintf(info,
-                                "cmdstat_%s:calls=%lld,usec=%lld,usec_per_call=%.2f"
+                                "cmdstat_%s:calls=%lld,usec=%lld,usec_per_call=%lld"
                                 ",rejected_calls=%lld,failed_calls=%lld\r\n",
                                 getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->calls,
-                                c->microseconds, (c->calls == 0) ? 0 : ((float)c->microseconds / c->calls),
+                                c->microseconds, (c->calls == 0) ? 0 : (c->microseconds / c->calls),
                                 c->rejected_calls, c->failed_calls);
             if (tmpsafe != NULL) zfree(tmpsafe);
         }


### PR DESCRIPTION
## Affected command by this change
INFO commandstats (- only `usec_per_call` metric)

### Changed results example
`cmdstat_set:calls=2,usec=36,usec_per_call=18,rejected_calls=1,failed_calls=0
cmdstat_get:calls=3,usec=13,usec_per_call=4,rejected_calls=1,failed_calls=0
cmdstat_info:calls=6,usec=444,usec_per_call=74,rejected_calls=0,failed_calls=0
cmdstat_command|docs:calls=2,usec=3951,usec_per_call=1975,rejected_calls=0,failed_calls=0`

## Context

The `usec_per_call` is a simple AVG metric that divides the execution time by the number of calls. However, it was performing the calculation by converting long long to float. For two reasons, usec_per_call does not require the high accuracy of a float level:

1. There are not many reasons to know the average value in units smaller than microseconds.
2. It currently displays the value of only two digits after the decimal point for accuracy
3. The client(or monitoring tool) can also calculate because there are `calls` and `usec` metrics. 

Therefore, I propose changing the implementation to a simple long long division operation without the floating-point conversion and computation.

This change will benefit users who are using various commands in valkey and using high-resolution metrics in commandstats.

## Alternatives
The engine already has calls and usec metrics, so clients or users can calculate `usec_per_call` accurately enough. Also, engine needs to perform a type conversion and then divide to get this metric for every commands and subcommands. 

So I finally want to propose removing this metric, but that would be a breaking change and impact many clients. Therefore, I would first propose removing the unnecessary float conversions.

## Simple performance testing (Updated at Apr 15)

**Env**
- EC2 r6i.2xlarge
- random long long number division. 10000 iterations & 10 runs
- With type casting(float), Without type casting(long long - Below, it's written "int division" )
- Using rdtsc for getting cpu cycles

![Screenshot 2025-04-14 at 1 04 37 PM](https://github.com/user-attachments/assets/d65b41d6-776c-451b-9fa5-8095b4d28adf)
