### PR TITLE
Log failed cluster node(s) state periodically to capture transient state for debuggability

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5533,6 +5533,24 @@ void clusterCron(void) {
     }
 
     if (update_state || server.cluster->state == CLUSTER_FAIL) clusterUpdateState();
+
+    /* Log cluster info and nodes information for better debugability of the transient cluster state */
+    if (server.verbosity <= LL_VERBOSE) {
+        run_with_period(5000) {
+            sds cluster_info = genClusterInfoString();
+            sds cluster_nodes = clusterGenNodesDescription(NULL, 0, 0);
+
+            sds infostring = sdscatprintf(sdsempty(), "\r\n# Cluster info\r\n");
+            infostring = sdscatsds(infostring, cluster_info);
+            infostring = sdscatprintf(infostring, "\n------ CLUSTER NODES OUTPUT ------\n");
+            infostring = sdscatsds(infostring, cluster_nodes);
+            serverLog(LL_VERBOSE, "%s", infostring);
+
+            sdsfree(cluster_info);
+            sdsfree(cluster_nodes);
+            sdsfree(infostring);
+        }
+    }
 }
 
 /* This function is called before the event handler returns to sleep for


### PR DESCRIPTION
This PR logs CLUSTER INFO / CLUSTER NODES output every 5 seconds to the log file for verbose/debug loglevel mode.

Certain times few nodes are not in convergence with the entire cluster and there are no logs captured about the divergence. This logging could help us better analyze in test setup where we can aggressively log more cluster information. 

