### PR TITLE
Adding support for DumpSerializedValue API

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -248,6 +248,7 @@ struct ValkeyModuleBlockedClient;
 typedef int (*ValkeyModuleCmdFunc)(ValkeyModuleCtx *ctx, void **argv, int argc);
 typedef int (*ValkeyModuleAuthCallback)(ValkeyModuleCtx *ctx, void *username, void *password, ValkeyModuleString **err);
 typedef void (*ValkeyModuleDisconnectFunc)(ValkeyModuleCtx *ctx, struct ValkeyModuleBlockedClient *bc);
+void createDumpPayload(rio *payload, robj *o, robj *key, int dbid);
 
 /* This struct holds the information about a command registered by a module.*/
 struct ValkeyModuleCommand {
@@ -7532,6 +7533,32 @@ ValkeyModuleString *VM_SaveDataTypeToString(ValkeyModuleCtx *ctx, void *data, co
     }
 }
 
+/**
+ * Serialize the value of a given key from the database of the module context's client.
+ * If the serialization fails for any reason (e.g. key doesn't exist, or rdbSaveObject() fails), return NULL
+ * Otherwise return ValkeyModuleString which contains the serialized value for the key.
+ */
+ValkeyModuleString *VM_DumpSerializedValue(ValkeyModuleCtx *ctx, ValkeyModuleString *key) {
+    if (!ctx || !key) {
+        return NULL;
+    }
+
+    int flags = LOOKUP_NOEFFECTS;
+    robj *value = lookupKeyReadWithFlags(ctx->client->db, key, flags);
+    if (!value) {
+        return NULL;
+    }
+    rio payload;
+    rioInitWithBuffer(&payload, sdsempty());
+    createDumpPayload(&payload, value, key, ctx->client->db->id);
+
+    // Create a ValkeyModuleString (robj*) with the result SDS and return it.
+    sds result = payload.io.buffer.ptr;
+    ValkeyModuleString *o = createObject(OBJ_STRING, result);
+    autoMemoryAdd(ctx, VALKEYMODULE_AM_STRING, o);
+    return o;
+}
+
 /* Returns the name of the key currently being processed. */
 const ValkeyModuleString *VM_GetKeyNameFromDigest(ValkeyModuleDigest *dig) {
     return dig->key;
@@ -14012,6 +14039,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(SaveLongDouble);
     REGISTER_API(LoadLongDouble);
     REGISTER_API(SaveDataTypeToString);
+    REGISTER_API(DumpSerializedValue);
     REGISTER_API(LoadDataTypeFromString);
     REGISTER_API(LoadDataTypeFromStringEncver);
     REGISTER_API(EmitAOF);

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1473,6 +1473,8 @@ VALKEYMODULE_API void *(*ValkeyModule_LoadDataTypeFromStringEncver)(const Valkey
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_SaveDataTypeToString)(ValkeyModuleCtx *ctx,
                                                                           void *data,
                                                                           const ValkeyModuleType *mt)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_DumpSerializedValue) (ValkeyModuleCtx *ctx, 
+                                             ValkeyModuleString *key) VALKEYMODULE_ATTR;
 VALKEYMODULE_API void (*ValkeyModule_Log)(ValkeyModuleCtx *ctx, const char *level, const char *fmt, ...)
     VALKEYMODULE_ATTR VALKEYMODULE_ATTR_PRINTF(3, 4);
 VALKEYMODULE_API void (*ValkeyModule_LogIOError)(ValkeyModuleIO *io, const char *levelstr, const char *fmt, ...)
@@ -2073,6 +2075,7 @@ static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, in
     VALKEYMODULE_GET_API(SaveDataTypeToString);
     VALKEYMODULE_GET_API(LoadDataTypeFromString);
     VALKEYMODULE_GET_API(LoadDataTypeFromStringEncver);
+    VALKEYMODULE_GET_API(DumpSerializedValue);
     VALKEYMODULE_GET_API(EmitAOF);
     VALKEYMODULE_GET_API(Log);
     VALKEYMODULE_GET_API(LogIOError);

--- a/tests/modules/datatype.c
+++ b/tests/modules/datatype.c
@@ -141,6 +141,31 @@ static int datatype_restore(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int
     return VALKEYMODULE_OK;
 }
 
+/*
+* takes a key and returns its serialized value
+*/
+static int save_object(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc){
+    if (argc != 2) {
+        ValkeyModule_WrongArity(ctx);
+        return VALKEYMODULE_OK;
+    }
+
+    /* dumpserializedvalue opens and reads the original key and then serializes it */
+    ValkeyModuleString *serialized_value = ValkeyModule_DumpSerializedValue(ctx, argv[1]);
+    if (!serialized_value) {
+        ValkeyModule_ReplyWithError(ctx, "Failed to serialize");
+        return VALKEYMODULE_OK;
+    }
+
+    size_t len = 0;
+    const char *str = ValkeyModule_StringPtrLen(serialized_value, &len);
+
+    /* Reply with the string buffer and ensure we free the serialized value */
+    ValkeyModule_ReplyWithStringBuffer(ctx, str, len);
+    ValkeyModule_FreeString(ctx, serialized_value);
+    return VALKEYMODULE_OK;
+}
+
 static int datatype_get(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     if (argc != 2) {
         ValkeyModule_WrongArity(ctx);
@@ -293,6 +318,9 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
 
     if (ValkeyModule_CreateCommand(ctx,"datatype.restore", datatype_restore,
                                   "write deny-oom", 1, 1, 1) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+    
+    if (ValkeyModule_CreateCommand(ctx, "datatype.save_object", save_object, "write", 1, 1, 1) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
     if (ValkeyModule_CreateCommand(ctx,"datatype.dump", datatype_dump,"",1,1,1) == VALKEYMODULE_ERR)

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -131,4 +131,24 @@ start_server {tags {"modules"}} {
 
         assert_equal 1 [llength $keys]
     }
+
+    test {DataType: Dump Serialized Value correctly serializes strings} {
+        r set key value
+        set serialized [r datatype.save_object key]
+        r restore newkey 0 $serialized
+        r get newkey
+    } {value}
+
+    test {DataType: Dump Serialized Value correctly serializes hashes} {
+        r hset myhash field1 myvalue
+        set serialized [r datatype.save_object myhash]
+        r restore newhash 0 $serialized
+        r hgetall newhash
+    } {field1 myvalue}
+
+    test {DataType: Dump Serialized Value handles nonexistent keys} {
+        r del nonexistent_key
+        catch {r datatype.save_object nonexistent_key} result
+        set result
+    } {Failed to serialize}
 }


### PR DESCRIPTION
The purpose of this API is for Modules to be able to access a key and retrieve its associated value in order to serialize that value. This allows modules to extract and store data in a format that can later be reconstructed. 

A use case is when building a CDC module, we need to generate the serialized version of any given key (of any data type). This allows for any specific key and its value(s) to be logged in the CDC message.