### PR TITLE
add parameter for initiating bgrewriteaof on exceeding threshold AOF size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ build-debug/
 build-release/
 cmake-build-debug/
 cmake-build-release/
+.codeassistant

--- a/src/aof.c
+++ b/src/aof.c
@@ -1012,7 +1012,7 @@ int startAppendOnly(void) {
  * is likely to fail. However apparently in modern systems this is no longer
  * true, and in general it looks just more resilient to retry the write. If
  * there is an actual error condition we'll get it at the next try.
- * We also run bgrewriteaof on aof-max-size exceeding here. */
+ * We also run bgrewriteaof on auto-aof-rewrite-max-size exceeding here. */
 ssize_t aofWrite(int fd, const char *buf, size_t len) {
     ssize_t nwritten = 0, totwritten = 0;
 

--- a/src/aof.c
+++ b/src/aof.c
@@ -917,7 +917,7 @@ void aof_background_fsync_and_close(int fd) {
 void killAppendOnlyChild(void) {
     int statloc;
     /* No AOFRW child? return. */
-    if (server.child_type != CHILD_TYPE_AOF) return;
+    if (!isAofRewriteInProgress()) return;
     /* Kill AOFRW child, wait for child exit. */
     serverLog(LL_NOTICE, "Killing running AOF rewrite child: %ld", (long)server.child_pid);
     if (kill(server.child_pid, SIGUSR1) != -1) {
@@ -964,7 +964,7 @@ int startAppendOnly(void) {
     serverAssert(server.aof_state == AOF_OFF);
 
     server.aof_state = AOF_WAIT_REWRITE;
-    if (hasActiveChildProcess() && server.child_type != CHILD_TYPE_AOF) {
+    if (hasActiveChildProcess() && !isAofRewriteInProgress()) {
         server.aof_rewrite_scheduled = 1;
         serverLog(LL_NOTICE, "AOF was enabled but there is already another background operation. An AOF background was "
                              "scheduled to start when possible.");
@@ -976,7 +976,7 @@ int startAppendOnly(void) {
         /* If there is a pending AOF rewrite, we need to switch it off and
          * start a new one: the old one cannot be reused because it is not
          * accumulating the AOF buffer. */
-        if (server.child_type == CHILD_TYPE_AOF) {
+        if (isAofRewriteInProgress()) {
             serverLog(LL_NOTICE, "AOF was enabled but there is already an AOF rewriting in background. Stopping "
                                  "background AOF and starting a rewrite now.");
             killAppendOnlyChild();
@@ -1011,9 +1011,22 @@ int startAppendOnly(void) {
  * the first call is short, there is a end-of-space condition, so the next
  * is likely to fail. However apparently in modern systems this is no longer
  * true, and in general it looks just more resilient to retry the write. If
- * there is an actual error condition we'll get it at the next try. */
+ * there is an actual error condition we'll get it at the next try.
+ * We also run bgrewriteaof on aof-max-size exceeding here. */
 ssize_t aofWrite(int fd, const char *buf, size_t len) {
     ssize_t nwritten = 0, totwritten = 0;
+
+    if (!isAofRewriteInProgress() &&
+        server.aof_max_size &&
+        server.aof_current_size >= server.aof_max_size &&
+        server.aof_rewrite_base_size < server.aof_max_size) {
+        /* 1. no need to start already initiated rewrite
+           2. aof-max-size == 0 turns off this
+           3. size should be large enough
+           4. last rewrite success should be less than aof-max-size - or we might end up with eternal rewrites
+        */
+        rewriteAppendOnlyFileBackground();
+    }
 
     while (len) {
         nwritten = write(fd, buf, len);
@@ -1349,7 +1362,7 @@ void feedAppendOnlyFile(int dictid, robj **argv, int argc) {
     /* Append to the AOF buffer. This will be flushed on disk just before
      * of re-entering the event loop, so before the client will get a
      * positive reply about the operation performed. */
-    if (server.aof_state == AOF_ON || (server.aof_state == AOF_WAIT_REWRITE && server.child_type == CHILD_TYPE_AOF)) {
+    if (server.aof_state == AOF_ON || (server.aof_state == AOF_WAIT_REWRITE && isAofRewriteInProgress())) {
         server.aof_buf = sdscatlen(server.aof_buf, buf, sdslen(buf));
     }
 
@@ -2532,7 +2545,7 @@ int rewriteAppendOnlyFileBackground(void) {
 }
 
 void bgrewriteaofCommand(client *c) {
-    if (server.child_type == CHILD_TYPE_AOF) {
+    if (isAofRewriteInProgress()) {
         addReplyError(c, "Background append only file rewriting already in progress");
     } else if (hasActiveChildProcess() || server.in_exec) {
         server.aof_rewrite_scheduled = 1;

--- a/src/aof.c
+++ b/src/aof.c
@@ -1016,18 +1016,6 @@ int startAppendOnly(void) {
 ssize_t aofWrite(int fd, const char *buf, size_t len) {
     ssize_t nwritten = 0, totwritten = 0;
 
-    if (!isAofRewriteInProgress() &&
-        server.aof_max_size &&
-        server.aof_current_size >= server.aof_max_size &&
-        server.aof_rewrite_base_size < server.aof_max_size) {
-        /* 1. no need to start already initiated rewrite
-           2. aof-max-size == 0 turns off this
-           3. size should be large enough
-           4. last rewrite success should be less than aof-max-size - or we might end up with eternal rewrites
-        */
-        rewriteAppendOnlyFileBackground();
-    }
-
     while (len) {
         nwritten = write(fd, buf, len);
 

--- a/src/config.c
+++ b/src/config.c
@@ -3417,7 +3417,7 @@ standardConfig static_configs[] = {
     /* Other configs */
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60 * 60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */
     createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64 * 1024 * 1024, MEMORY_CONFIG, NULL, NULL),
-    createOffTConfig("aof-max-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_max_size, 0, MEMORY_CONFIG, NULL, NULL),
+    createOffTConfig("auto-aof-rewrite-max-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_max_size, 0, MEMORY_CONFIG, NULL, NULL),
     createOffTConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1024, INT_MAX, server.loading_process_events_interval_bytes, 1024 * 1024 * 2, INTEGER_CONFIG, NULL, NULL),
 
     /* Tls configs */

--- a/src/config.c
+++ b/src/config.c
@@ -3417,6 +3417,7 @@ standardConfig static_configs[] = {
     /* Other configs */
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60 * 60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */
     createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64 * 1024 * 1024, MEMORY_CONFIG, NULL, NULL),
+    createOffTConfig("aof-max-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_max_size, 0, MEMORY_CONFIG, NULL, NULL),
     createOffTConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1024, INT_MAX, server.loading_process_events_interval_bytes, 1024 * 1024 * 2, INTEGER_CONFIG, NULL, NULL),
 
     /* Tls configs */

--- a/src/server.c
+++ b/src/server.c
@@ -1576,15 +1576,15 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
     databasesCron();
 
     /* Start a scheduled AOF rewrite if this was requested by the user while
-     * a BGSAVE was in progress. Also handle rewrites triggered by aof-max-size. */
+     * a BGSAVE was in progress. Also handle rewrites triggered by auto-aof-rewrite-max-size. */
     if (!hasActiveChildProcess() && !aofRewriteLimited()) {
         if (server.aof_rewrite_scheduled ||
-            server.aof_current_size >= server.aof_rewrite_min_size &&
-            server.aof_current_size >= server.aof_max_size &&
-            server.aof_rewrite_base_size < server.aof_max_size) {
+            (server.aof_current_size >= server.aof_rewrite_min_size &&
+             server.aof_current_size >= server.aof_rewrite_max_size &&
+             server.aof_rewrite_base_size < server.aof_rewrite_max_size)) {
             /* user-initiated OR
                (AOF is large enough AND
-               last rewrite success should be less than aof-max-size - or we might end up with eternal rewrites)
+               last rewrite success should be less than auto-aof-rewrite-max-size - or we might end up with eternal rewrites)
             */
             rewriteAppendOnlyFileBackground();
         }
@@ -6164,17 +6164,10 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "slot_migration_fork_in_progress:%d\r\n", server.child_type == CHILD_TYPE_SLOT_MIGRATION));
 
         if (server.aof_enabled) {
-            char aof_current_size_hdsk[64];
-            char aof_max_size_hdsk[64];
-            bytesToHuman(aof_current_size_hdsk, sizeof(aof_current_size_hdsk), (unsigned long long)server.aof_current_size);
-            bytesToHuman(aof_max_size_hdsk, sizeof(aof_max_size_hdsk), (unsigned long long)server.aof_max_size);
             info = sdscatprintf(
                 info,
                 FMTARGS(
                     "aof_current_size:%lld\r\n", (long long)server.aof_current_size,
-                    "aof_current_size_human:%s\r\n", aof_current_size_hdsk,
-                    "aof_max_size:%lld\r\n", (long long)server.aof_max_size,
-                    "aof_max_size_human:%s\r\n", aof_max_size_hdsk,
                     "aof_base_size:%lld\r\n", (long long)server.aof_rewrite_base_size,
                     "aof_pending_rewrite:%d\r\n", server.aof_rewrite_scheduled,
                     "aof_buffer_length:%zu\r\n", sdslen(server.aof_buf),
@@ -7548,12 +7541,12 @@ __attribute__((weak)) int main(int argc, char **argv) {
                   server.maxmemory);
     }
 
-    /* Warning the user about suspicious aof-max-size setting. */
-    if (server.aof_max_size > 0 && server.aof_max_size < 1024 * 1024) {
+    /* Warning the user about suspicious auto-aof-rewrite-max-size setting. */
+    if (server.aof_rewrite_max_size > 0 && server.aof_rewrite_max_size < 1024 * 1024) {
         serverLog(LL_WARNING,
-                  "WARNING: You specified a aof-max-size value that is less than 1MB (current value is %lld bytes). Are "
+                  "WARNING: You specified a auto-aof-rewrite-max-size value that is less than 1MB (current value is %lld bytes). Are "
                   "you sure this is what you really want?",
-                  (long long)server.aof_max_size);
+                  (long long)server.aof_rewrite_max_size);
     }
 
     serverSetCpuAffinity(server.server_cpulist);

--- a/src/server.c
+++ b/src/server.c
@@ -1576,9 +1576,18 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
     databasesCron();
 
     /* Start a scheduled AOF rewrite if this was requested by the user while
-     * a BGSAVE was in progress. */
-    if (!hasActiveChildProcess() && server.aof_rewrite_scheduled && !aofRewriteLimited()) {
-        rewriteAppendOnlyFileBackground();
+     * a BGSAVE was in progress. Also handle rewrites triggered by aof-max-size. */
+    if (!hasActiveChildProcess() && !aofRewriteLimited()) {
+        if (server.aof_rewrite_scheduled ||
+            server.aof_current_size >= server.aof_rewrite_min_size &&
+            server.aof_current_size >= server.aof_max_size &&
+            server.aof_rewrite_base_size < server.aof_max_size) {
+            /* user-initiated OR
+               (AOF is large enough AND
+               last rewrite success should be less than aof-max-size - or we might end up with eternal rewrites)
+            */
+            rewriteAppendOnlyFileBackground();
+        }
     }
 
     /* Check if a background saving or AOF rewrite in progress terminated. */

--- a/src/server.c
+++ b/src/server.c
@@ -1405,7 +1405,7 @@ void checkChildrenDone(void) {
             if (!bysignal && exitcode == 0) receiveChildInfo();
             if (server.child_type == CHILD_TYPE_RDB) {
                 backgroundSaveDoneHandler(exitcode, bysignal);
-            } else if (server.child_type == CHILD_TYPE_AOF) {
+            } else if (isAofRewriteInProgress()) {
                 backgroundRewriteDoneHandler(exitcode, bysignal);
             } else if (server.child_type == CHILD_TYPE_MODULE) {
                 ModuleForkDoneHandler(exitcode, bysignal);
@@ -2666,6 +2666,10 @@ int createSocketAcceptHandler(connListener *sfd, aeFileProc *accept_handler) {
         }
     }
     return C_OK;
+}
+
+int isAofRewriteInProgress(void) {
+    return server.child_type == CHILD_TYPE_AOF;
 }
 
 /* Initialize a set of file descriptors to listen to the specified 'port'
@@ -4749,7 +4753,7 @@ int finishShutdown(void) {
 
     /* Kill the AOF saving child as the AOF we already have may be longer
      * but contains the full dataset anyway. */
-    if (server.child_type == CHILD_TYPE_AOF) {
+    if (isAofRewriteInProgress()) {
         /* If we have AOF enabled but haven't written the AOF yet, don't
          * shutdown or else the dataset will be lost. */
         if (server.aof_state == AOF_WAIT_REWRITE) {
@@ -6137,10 +6141,10 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "rdb_last_load_keys_expired:%lld\r\n", server.rdb_last_load_keys_expired,
                 "rdb_last_load_keys_loaded:%lld\r\n", server.rdb_last_load_keys_loaded,
                 "aof_enabled:%d\r\n", server.aof_state != AOF_OFF,
-                "aof_rewrite_in_progress:%d\r\n", server.child_type == CHILD_TYPE_AOF,
+                "aof_rewrite_in_progress:%d\r\n", isAofRewriteInProgress(),
                 "aof_rewrite_scheduled:%d\r\n", server.aof_rewrite_scheduled,
                 "aof_last_rewrite_time_sec:%jd\r\n", (intmax_t)server.aof_rewrite_time_last,
-                "aof_current_rewrite_time_sec:%jd\r\n", (intmax_t)((server.child_type != CHILD_TYPE_AOF) ? -1 : time(NULL) - server.aof_rewrite_time_start),
+                "aof_current_rewrite_time_sec:%jd\r\n", (intmax_t)((!isAofRewriteInProgress()) ? -1 : time(NULL) - server.aof_rewrite_time_start),
                 "aof_last_bgrewrite_status:%s\r\n", (server.aof_lastbgrewrite_status == C_OK ? "ok" : "err"),
                 "aof_rewrites:%lld\r\n", server.stat_aof_rewrites,
                 "aof_rewrites_consecutive_failures:%lld\r\n", server.stat_aofrw_consecutive_failures,
@@ -6151,10 +6155,17 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "slot_migration_fork_in_progress:%d\r\n", server.child_type == CHILD_TYPE_SLOT_MIGRATION));
 
         if (server.aof_enabled) {
+            char aof_current_size_hdsk[64];
+            char aof_max_size_hdsk[64];
+            bytesToHuman(aof_current_size_hdsk, sizeof(aof_current_size_hdsk), (unsigned long long)server.aof_current_size);
+            bytesToHuman(aof_max_size_hdsk, sizeof(aof_max_size_hdsk), (unsigned long long)server.aof_max_size);
             info = sdscatprintf(
                 info,
                 FMTARGS(
                     "aof_current_size:%lld\r\n", (long long)server.aof_current_size,
+                    "aof_current_size_human:%s\r\n", aof_current_size_hdsk,
+                    "aof_max_size:%lld\r\n", (long long)server.aof_max_size,
+                    "aof_max_size_human:%s\r\n", aof_max_size_hdsk,
                     "aof_base_size:%lld\r\n", (long long)server.aof_rewrite_base_size,
                     "aof_pending_rewrite:%d\r\n", server.aof_rewrite_scheduled,
                     "aof_buffer_length:%zu\r\n", sdslen(server.aof_buf),
@@ -7526,6 +7537,14 @@ __attribute__((weak)) int main(int argc, char **argv) {
                   "WARNING: You specified a maxmemory value that is less than 1MB (current value is %llu bytes). Are "
                   "you sure this is what you really want?",
                   server.maxmemory);
+    }
+
+    /* Warning the user about suspicious aof-max-size setting. */
+    if (server.aof_max_size > 0 && server.aof_max_size < 1024 * 1024) {
+        serverLog(LL_WARNING,
+                  "WARNING: You specified a aof-max-size value that is less than 1MB (current value is %lld bytes). Are "
+                  "you sure this is what you really want?",
+                  (long long)server.aof_max_size);
     }
 
     serverSetCpuAffinity(server.server_cpulist);

--- a/src/server.h
+++ b/src/server.h
@@ -1990,6 +1990,7 @@ struct valkeyServer {
     off_t aof_rewrite_min_size;         /* the AOF file is at least N bytes. */
     off_t aof_rewrite_base_size;        /* AOF size on latest startup or rewrite. */
     off_t aof_current_size;             /* AOF current size (Including BASE + INCRs). */
+    off_t aof_max_size;                 /* Max number of disk bytes to use for AOF */
     off_t aof_last_incr_size;           /* The size of the latest incr AOF. */
     off_t aof_last_incr_fsync_offset;   /* AOF offset which is already requested to be synced to disk.
                                          * Compare with the aof_last_incr_size. */
@@ -3226,6 +3227,7 @@ void flushAppendOnlyFile(int force);
 void feedAppendOnlyFile(int dictid, robj **argv, int argc);
 void aofRemoveTempFile(pid_t childpid, int from_signal);
 int rewriteAppendOnlyFileBackground(void);
+int isAofRewriteInProgress(void);
 int loadAppendOnlyFiles(aofManifest *am);
 void stopAppendOnly(void);
 int startAppendOnly(void);

--- a/src/server.h
+++ b/src/server.h
@@ -1738,41 +1738,41 @@ struct valkeyServer {
     hashtable *commands;      /* Command table */
     hashtable *orig_commands; /* Command table before command renaming. */
     aeEventLoop *el;
-    _Atomic AeIoState io_poll_state;     /* Indicates the state of the IO polling. */
-    int io_ae_fired_events;              /* Number of poll events received by the IO thread. */
-    rax *errors;                         /* Errors table */
-    volatile sig_atomic_t shutdown_asap; /* Shutdown ordered by signal handler. */
-    mstime_t shutdown_mstime;            /* Timestamp to limit graceful shutdown. */
-    int last_sig_received;               /* Indicates the last SIGNAL received, if any (e.g., SIGINT or SIGTERM). */
-    int shutdown_flags;                  /* Flags passed to prepareForShutdown(). */
-    int activerehashing;                 /* Incremental rehash in serverCron() */
-    int active_defrag_cpu_percent;       /* Current desired CPU percentage for active defrag */
-    char *pidfile;                       /* PID file path */
-    int arch_bits;                       /* 32 or 64 depending on sizeof(long) */
-    int cronloops;                       /* Number of times the cron function run */
-    char runid[CONFIG_RUN_ID_SIZE + 1];  /* ID always different at every exec. */
-    int sentinel_mode;                   /* True if this instance is a Sentinel. */
-    size_t initial_memory_usage;         /* Bytes used after initialization. */
-    int always_show_logo;                /* Show logo even for non-stdout logging. */
-    int in_exec;                         /* Are we inside EXEC? */
-    int busy_module_yield_flags;         /* Are we inside a busy module? (triggered by RM_Yield). see BUSY_MODULE_YIELD_ flags. */
-    const char *busy_module_yield_reply; /* When non-null, we are inside RM_Yield. */
-    char *ignore_warnings;               /* Config: warnings that should be ignored. */
-    int client_pause_in_transaction;     /* Was a client pause executed during this Exec? */
-    int server_del_keys_in_slot;         /* The server is deleting the keys in the dirty slot. */
-    int thp_enabled;                     /* If true, THP is enabled. */
-    size_t page_size;                    /* The page size of OS. */
+    _Atomic AeIoState io_poll_state __attribute__((aligned(__alignof__(AeIoState)))); /* Indicates the state of the IO polling. */
+    int io_ae_fired_events;                                                           /* Number of poll events received by the IO thread. */
+    rax *errors;                                                                      /* Errors table */
+    volatile sig_atomic_t shutdown_asap;                                              /* Shutdown ordered by signal handler. */
+    mstime_t shutdown_mstime;                                                         /* Timestamp to limit graceful shutdown. */
+    int last_sig_received;                                                            /* Indicates the last SIGNAL received, if any (e.g., SIGINT or SIGTERM). */
+    int shutdown_flags;                                                               /* Flags passed to prepareForShutdown(). */
+    int activerehashing;                                                              /* Incremental rehash in serverCron() */
+    int active_defrag_cpu_percent;                                                    /* Current desired CPU percentage for active defrag */
+    char *pidfile;                                                                    /* PID file path */
+    int arch_bits;                                                                    /* 32 or 64 depending on sizeof(long) */
+    int cronloops;                                                                    /* Number of times the cron function run */
+    char runid[CONFIG_RUN_ID_SIZE + 1];                                               /* ID always different at every exec. */
+    int sentinel_mode;                                                                /* True if this instance is a Sentinel. */
+    size_t initial_memory_usage;                                                      /* Bytes used after initialization. */
+    int always_show_logo;                                                             /* Show logo even for non-stdout logging. */
+    int in_exec;                                                                      /* Are we inside EXEC? */
+    int busy_module_yield_flags;                                                      /* Are we inside a busy module? (triggered by RM_Yield). see BUSY_MODULE_YIELD_ flags. */
+    const char *busy_module_yield_reply;                                              /* When non-null, we are inside RM_Yield. */
+    char *ignore_warnings;                                                            /* Config: warnings that should be ignored. */
+    int client_pause_in_transaction;                                                  /* Was a client pause executed during this Exec? */
+    int server_del_keys_in_slot;                                                      /* The server is deleting the keys in the dirty slot. */
+    int thp_enabled;                                                                  /* If true, THP is enabled. */
+    size_t page_size;                                                                 /* The page size of OS. */
     /* Modules */
-    dict *moduleapi;                  /* Exported core APIs dictionary for modules. */
-    dict *sharedapi;                  /* Like moduleapi but containing the APIs that
-                                         modules share with each other. */
-    dict *module_configs_queue;       /* Dict that stores module configurations from .conf file until after modules are loaded
-                                         during startup or arguments to loadex. */
-    list *loadmodule_queue;           /* List of modules to load at startup. */
-    int module_pipe[2];               /* Pipe used to awake the event loop by module threads. */
-    pid_t child_pid;                  /* PID of current child */
-    int child_type;                   /* Type of current child */
-    _Atomic int module_gil_acquiring; /* Indicates whether the GIL is being acquiring by the main thread. */
+    dict *moduleapi;                                                             /* Exported core APIs dictionary for modules. */
+    dict *sharedapi;                                                             /* Like moduleapi but containing the APIs that
+                                                                                    modules share with each other. */
+    dict *module_configs_queue;                                                  /* Dict that stores module configurations from .conf file until after modules are loaded
+                                                                                    during startup or arguments to loadex. */
+    list *loadmodule_queue;                                                      /* List of modules to load at startup. */
+    int module_pipe[2];                                                          /* Pipe used to awake the event loop by module threads. */
+    pid_t child_pid;                                                             /* PID of current child */
+    int child_type;                                                              /* Type of current child */
+    _Atomic int module_gil_acquiring __attribute__((aligned(__alignof__(int)))); /* Indicates whether the GIL is being acquiring by the main thread. */
     /* Networking */
     int port;                              /* TCP listening port */
     int tls_port;                          /* TLS listening port */
@@ -1816,20 +1816,20 @@ struct valkeyServer {
     uint32_t paused_actions;    /* Bitmask of actions that are currently paused */
     list *postponed_clients;    /* List of postponed clients */
     pause_event client_pause_per_purpose[NUM_PAUSE_PURPOSES];
-    char neterr[ANET_ERR_LEN];                /* Error buffer for anet.c */
-    dict *migrate_cached_sockets;             /* MIGRATE cached sockets */
-    _Atomic uint64_t next_client_id;          /* Next client unique ID. Incremental. */
-    int protected_mode;                       /* Don't accept external connections. */
-    int io_threads_num;                       /* Number of IO threads to use. */
-    int active_io_threads_num;                /* Current number of active IO threads, includes main thread. */
-    int events_per_io_thread;                 /* Number of events on the event loop to trigger IO threads activation. */
-    int prefetch_batch_max_size;              /* Maximum number of keys to prefetch in a single batch */
-    long long events_processed_while_blocked; /* processEventsWhileBlocked() */
-    int enable_protected_configs;             /* Enable the modification of protected configs, see PROTECTED_ACTION_ALLOWED_* */
-    int enable_debug_cmd;                     /* Enable DEBUG commands, see PROTECTED_ACTION_ALLOWED_* */
-    int enable_module_cmd;                    /* Enable MODULE commands, see PROTECTED_ACTION_ALLOWED_* */
-    int enable_debug_assert;                  /* Enable debug asserts */
-    int debug_client_enforce_reply_list;      /* Force client to always use the reply list */
+    char neterr[ANET_ERR_LEN];                                                       /* Error buffer for anet.c */
+    dict *migrate_cached_sockets;                                                    /* MIGRATE cached sockets */
+    _Atomic uint64_t next_client_id __attribute__((aligned(__alignof__(uint64_t)))); /* Next client unique ID. Incremental. */
+    int protected_mode;                                                              /* Don't accept external connections. */
+    int io_threads_num;                                                              /* Number of IO threads to use. */
+    int active_io_threads_num;                                                       /* Current number of active IO threads, includes main thread. */
+    int events_per_io_thread;                                                        /* Number of events on the event loop to trigger IO threads activation. */
+    int prefetch_batch_max_size;                                                     /* Maximum number of keys to prefetch in a single batch */
+    long long events_processed_while_blocked;                                        /* processEventsWhileBlocked() */
+    int enable_protected_configs;                                                    /* Enable the modification of protected configs, see PROTECTED_ACTION_ALLOWED_* */
+    int enable_debug_cmd;                                                            /* Enable DEBUG commands, see PROTECTED_ACTION_ALLOWED_* */
+    int enable_module_cmd;                                                           /* Enable MODULE commands, see PROTECTED_ACTION_ALLOWED_* */
+    int enable_debug_assert;                                                         /* Enable debug asserts */
+    int debug_client_enforce_reply_list;                                             /* Force client to always use the reply list */
     /* Reply construction copy avoidance */
     int min_io_threads_copy_avoid;           /* Minimum number of IO threads for copy avoidance in reply construction */
     int min_string_size_copy_avoid_threaded; /* Minimum bulk string size for copy avoidance in reply construction when IO threads enabled */
@@ -1980,45 +1980,45 @@ struct valkeyServer {
     unsigned int max_new_conns_per_cycle;     /* The maximum number of tcp connections that will be accepted during each
                                                  invocation of the event loop. */
     /* AOF persistence */
-    int aof_enabled;                    /* AOF configuration */
-    int aof_state;                      /* AOF_(ON|OFF|WAIT_REWRITE) */
-    int aof_fsync;                      /* Kind of fsync() policy */
-    char *aof_filename;                 /* Basename of the AOF file and manifest file */
-    char *aof_dirname;                  /* Name of the AOF directory */
-    int aof_no_fsync_on_rewrite;        /* Don't fsync if a rewrite is in prog. */
-    int aof_rewrite_perc;               /* Rewrite AOF if % growth is > M and... */
-    off_t aof_rewrite_min_size;         /* the AOF file is at least N bytes. */
-    off_t aof_rewrite_base_size;        /* AOF size on latest startup or rewrite. */
-    off_t aof_current_size;             /* AOF current size (Including BASE + INCRs). */
-    off_t aof_max_size;                 /* Max number of disk bytes to use for AOF */
-    off_t aof_last_incr_size;           /* The size of the latest incr AOF. */
-    off_t aof_last_incr_fsync_offset;   /* AOF offset which is already requested to be synced to disk.
-                                         * Compare with the aof_last_incr_size. */
-    int aof_flush_sleep;                /* Micros to sleep before flush. (used by tests) */
-    int aof_rewrite_scheduled;          /* Rewrite once BGSAVE terminates. */
-    sds aof_buf;                        /* AOF buffer, written before entering the event loop */
-    int aof_fd;                         /* File descriptor of currently selected AOF file */
-    int aof_selected_db;                /* Currently selected DB in AOF */
-    mstime_t aof_flush_postponed_start; /* mstime of postponed AOF flush */
-    mstime_t aof_last_fsync;            /* mstime of last fsync() */
-    time_t aof_rewrite_time_last;       /* Time used by last AOF rewrite run. */
-    time_t aof_rewrite_time_start;      /* Current AOF rewrite start time. */
-    time_t aof_cur_timestamp;           /* Current record timestamp in AOF */
-    int aof_timestamp_enabled;          /* Enable record timestamp in AOF */
-    int aof_lastbgrewrite_status;       /* C_OK or C_ERR */
-    unsigned long aof_delayed_fsync;    /* delayed AOF fsync() counter */
-    int aof_rewrite_incremental_fsync;  /* fsync incrementally while aof rewriting? */
-    int rdb_save_incremental_fsync;     /* fsync incrementally while rdb saving? */
-    int aof_last_write_status;          /* C_OK or C_ERR */
-    int aof_last_write_errno;           /* Valid if aof write/fsync status is ERR */
-    int aof_load_truncated;             /* Don't stop on unexpected AOF EOF. */
-    int aof_use_rdb_preamble;           /* Specify base AOF to use RDB encoding on AOF rewrites. */
-    int aof_rewrite_use_rdb_preamble;   /* Base AOF to use RDB encoding on AOF rewrites start. */
-    _Atomic int aof_bio_fsync_status;   /* Status of AOF fsync in bio job. */
-    _Atomic int aof_bio_fsync_errno;    /* Errno of AOF fsync in bio job. */
-    aofManifest *aof_manifest;          /* Used to track AOFs. */
-    int aof_disable_auto_gc;            /* If disable automatically deleting HISTORY type AOFs?
-                                           default no. (for testings). */
+    int aof_enabled;                                                             /* AOF configuration */
+    int aof_state;                                                               /* AOF_(ON|OFF|WAIT_REWRITE) */
+    int aof_fsync;                                                               /* Kind of fsync() policy */
+    char *aof_filename;                                                          /* Basename of the AOF file and manifest file */
+    char *aof_dirname;                                                           /* Name of the AOF directory */
+    int aof_no_fsync_on_rewrite;                                                 /* Don't fsync if a rewrite is in prog. */
+    int aof_rewrite_perc;                                                        /* Rewrite AOF if % growth is > M and... */
+    off_t aof_rewrite_max_size;                                                  /* OR AOF base is > N and... */
+    off_t aof_rewrite_min_size;                                                  /* the AOF file is at least N bytes. */
+    off_t aof_rewrite_base_size;                                                 /* AOF size on latest startup or rewrite. */
+    off_t aof_current_size;                                                      /* AOF current size (Including BASE + INCRs). */
+    off_t aof_last_incr_size;                                                    /* The size of the latest incr AOF. */
+    off_t aof_last_incr_fsync_offset;                                            /* AOF offset which is already requested to be synced to disk.
+                                                                                  * Compare with the aof_last_incr_size. */
+    int aof_flush_sleep;                                                         /* Micros to sleep before flush. (used by tests) */
+    int aof_rewrite_scheduled;                                                   /* Rewrite once BGSAVE terminates. */
+    sds aof_buf;                                                                 /* AOF buffer, written before entering the event loop */
+    int aof_fd;                                                                  /* File descriptor of currently selected AOF file */
+    int aof_selected_db;                                                         /* Currently selected DB in AOF */
+    mstime_t aof_flush_postponed_start;                                          /* mstime of postponed AOF flush */
+    mstime_t aof_last_fsync;                                                     /* mstime of last fsync() */
+    time_t aof_rewrite_time_last;                                                /* Time used by last AOF rewrite run. */
+    time_t aof_rewrite_time_start;                                               /* Current AOF rewrite start time. */
+    time_t aof_cur_timestamp;                                                    /* Current record timestamp in AOF */
+    int aof_timestamp_enabled;                                                   /* Enable record timestamp in AOF */
+    int aof_lastbgrewrite_status;                                                /* C_OK or C_ERR */
+    unsigned long aof_delayed_fsync;                                             /* delayed AOF fsync() counter */
+    int aof_rewrite_incremental_fsync;                                           /* fsync incrementally while aof rewriting? */
+    int rdb_save_incremental_fsync;                                              /* fsync incrementally while rdb saving? */
+    int aof_last_write_status;                                                   /* C_OK or C_ERR */
+    int aof_last_write_errno;                                                    /* Valid if aof write/fsync status is ERR */
+    int aof_load_truncated;                                                      /* Don't stop on unexpected AOF EOF. */
+    int aof_use_rdb_preamble;                                                    /* Specify base AOF to use RDB encoding on AOF rewrites. */
+    int aof_rewrite_use_rdb_preamble;                                            /* Base AOF to use RDB encoding on AOF rewrites start. */
+    _Atomic int aof_bio_fsync_status __attribute__((aligned(__alignof__(int)))); /* Status of AOF fsync in bio job. */
+    _Atomic int aof_bio_fsync_errno __attribute__((aligned(__alignof__(int))));  /* Errno of AOF fsync in bio job. */
+    aofManifest *aof_manifest;                                                   /* Used to track AOFs. */
+    int aof_disable_auto_gc;                                                     /* If disable automatically deleting HISTORY type AOFs?
+                                                                                    default no. (for testings). */
 
     /* RDB persistence */
     long long dirty;                      /* Changes to DB from the last save */
@@ -2080,52 +2080,52 @@ struct valkeyServer {
     int shutdown_on_sigterm; /* Shutdown flags configured for SIGTERM. */
 
     /* Replication (primary) */
-    char replid[CONFIG_RUN_ID_SIZE + 1];       /* My current replication ID. */
-    char replid2[CONFIG_RUN_ID_SIZE + 1];      /* replid inherited from primary*/
-    long long primary_repl_offset;             /* My current replication offset */
-    long long second_replid_offset;            /* Accept offsets up to this for replid2. */
-    _Atomic long long fsynced_reploff_pending; /* Largest replication offset to
+    char replid[CONFIG_RUN_ID_SIZE + 1];                                                        /* My current replication ID. */
+    char replid2[CONFIG_RUN_ID_SIZE + 1];                                                       /* replid inherited from primary*/
+    long long primary_repl_offset;                                                              /* My current replication offset */
+    long long second_replid_offset;                                                             /* Accept offsets up to this for replid2. */
+    _Atomic long long fsynced_reploff_pending __attribute__((aligned(__alignof__(long long)))); /* Largest replication offset to
                                       * potentially have been fsynced, applied to
                                         fsynced_reploff only when AOF state is AOF_ON
                                         (not during the initial rewrite) */
-    long long fsynced_reploff;                 /* Largest replication offset that has been confirmed to be fsynced */
-    int replicas_eldb;                         /* Last SELECTed DB in replication output */
-    int repl_ping_replica_period;              /* Primary pings the replica every N seconds */
-    replBacklog *repl_backlog;                 /* Replication backlog for partial syncs */
-    long long repl_backlog_size;               /* Backlog circular buffer size */
-    replDataBuf pending_repl_data;             /* Replication data buffer for dual-channel-replication */
-    time_t repl_backlog_time_limit;            /* Time without replicas after the backlog
-                                                  gets released. */
-    time_t repl_no_replicas_since;             /* We have no replicas since that time.
-                                                Only valid if server.replicas len is 0. */
-    int repl_min_replicas_to_write;            /* Min number of replicas to write. */
-    int repl_min_replicas_max_lag;             /* Max lag of <count> replicas to write. */
-    int repl_good_replicas_count;              /* Number of replicas with lag <= max_lag. */
-    int repl_diskless_sync;                    /* Primary send RDB to replicas sockets directly. */
-    int repl_diskless_load;                    /* Replica parse RDB directly from the socket.
-                                                * see REPL_DISKLESS_LOAD_* enum */
-    int repl_diskless_sync_delay;              /* Delay to start a diskless repl BGSAVE. */
-    int repl_diskless_sync_max_replicas;       /* Max replicas for diskless repl BGSAVE
-                                                * delay (start sooner if they all connect). */
-    int dual_channel_replication;              /* Config used to determine if the replica should
-                                                * use dual channel replication for full syncs. */
-    _Atomic int replica_bio_disk_save_state;   /* Flag set by the bio thread to indicate that the
-                                                * RDB save to disk has completed, or failed */
-    _Atomic bool replica_bio_abort_save;       /* Flag set by main thread, used to signal to replica's
-                                                * disk-saving bio thread to abort the save */
-    long long bio_stat_net_repl_input_bytes;   /* Used to calculate stat_net_repl_input_bytes on the
-                                                * replica's bio thread without touching main thread vars */
-    off_t bio_repl_transfer_size;              /* Used to calculate bio_repl_transfer_size on the
-                                                * replica's bio thread without touching main thread vars */
-    off_t bio_repl_transfer_read;              /* Used to calculate bio_repl_transfer_read on the
-                                                * replica's bio thread without touching main thread vars */
-    int wait_before_rdb_client_free;           /* Grace period in seconds for replica main channel
-                                                * to establish psync. */
-    int debug_pause_after_fork;                /* Debug param that pauses the main process
-                                                * after a replication fork() (for bgsave). */
-    size_t repl_buffer_mem;                    /* The memory of replication buffer. */
-    list *repl_buffer_blocks;                  /* Replication buffers blocks list
-                                                * (serving replica clients and repl backlog) */
+    long long fsynced_reploff;                                                                  /* Largest replication offset that has been confirmed to be fsynced */
+    int replicas_eldb;                                                                          /* Last SELECTed DB in replication output */
+    int repl_ping_replica_period;                                                               /* Primary pings the replica every N seconds */
+    replBacklog *repl_backlog;                                                                  /* Replication backlog for partial syncs */
+    long long repl_backlog_size;                                                                /* Backlog circular buffer size */
+    replDataBuf pending_repl_data;                                                              /* Replication data buffer for dual-channel-replication */
+    time_t repl_backlog_time_limit;                                                             /* Time without replicas after the backlog
+                                                                                                   gets released. */
+    time_t repl_no_replicas_since;                                                              /* We have no replicas since that time.
+                                                                                                 Only valid if server.replicas len is 0. */
+    int repl_min_replicas_to_write;                                                             /* Min number of replicas to write. */
+    int repl_min_replicas_max_lag;                                                              /* Max lag of <count> replicas to write. */
+    int repl_good_replicas_count;                                                               /* Number of replicas with lag <= max_lag. */
+    int repl_diskless_sync;                                                                     /* Primary send RDB to replicas sockets directly. */
+    int repl_diskless_load;                                                                     /* Replica parse RDB directly from the socket.
+                                                                                                 * see REPL_DISKLESS_LOAD_* enum */
+    int repl_diskless_sync_delay;                                                               /* Delay to start a diskless repl BGSAVE. */
+    int repl_diskless_sync_max_replicas;                                                        /* Max replicas for diskless repl BGSAVE
+                                                                                                 * delay (start sooner if they all connect). */
+    int dual_channel_replication;                                                               /* Config used to determine if the replica should
+                                                                                                 * use dual channel replication for full syncs. */
+    _Atomic int replica_bio_disk_save_state __attribute__((aligned(__alignof__(int))));         /* Flag set by the bio thread to indicate that the
+                                                                                                 * RDB save to disk has completed, or failed */
+    _Atomic bool replica_bio_abort_save __attribute__((aligned(__alignof__(bool))));            /* Flag set by main thread, used to signal to replica's
+                                                                                                 * disk-saving bio thread to abort the save */
+    long long bio_stat_net_repl_input_bytes;                                                    /* Used to calculate stat_net_repl_input_bytes on the
+                                                                                                 * replica's bio thread without touching main thread vars */
+    off_t bio_repl_transfer_size;                                                               /* Used to calculate bio_repl_transfer_size on the
+                                                                                                 * replica's bio thread without touching main thread vars */
+    off_t bio_repl_transfer_read;                                                               /* Used to calculate bio_repl_transfer_read on the
+                                                                                                 * replica's bio thread without touching main thread vars */
+    int wait_before_rdb_client_free;                                                            /* Grace period in seconds for replica main channel
+                                                                                                 * to establish psync. */
+    int debug_pause_after_fork;                                                                 /* Debug param that pauses the main process
+                                                                                                 * after a replication fork() (for bgsave). */
+    size_t repl_buffer_mem;                                                                     /* The memory of replication buffer. */
+    list *repl_buffer_blocks;                                                                   /* Replication buffers blocks list
+                                                                                                 * (serving replica clients and repl backlog) */
     /* Replication (replica) */
     char *primary_user;     /* AUTH with this user and primary_auth with primary */
     sds primary_auth;       /* AUTH with this password with primary */
@@ -2141,33 +2141,33 @@ struct valkeyServer {
         long long read_reploff;
         int dbid;
     } repl_provisional_primary;
-    client *cached_primary;              /* Cached primary to be reused for PSYNC. */
-    rio *loading_rio;                    /* Pointer to the rio object currently used for loading data. */
-    int repl_syncio_timeout;             /* Timeout for synchronous I/O calls */
-    int repl_state;                      /* Replication status if the instance is a replica */
-    int repl_rdb_channel_state;          /* State of the replica's rdb channel during dual-channel-replication */
-    off_t repl_transfer_size;            /* Size of RDB to read from primary during sync. */
-    off_t repl_transfer_read;            /* Amount of RDB read from primary during sync. */
-    off_t repl_transfer_last_fsync_off;  /* Offset when we fsync-ed last time. */
-    connection *repl_transfer_s;         /* Replica -> Primary SYNC connection */
-    connection *repl_rdb_transfer_s;     /* Primary FULL SYNC connection (RDB download) */
-    int repl_transfer_fd;                /* Replica -> Primary SYNC temp file descriptor */
-    char *repl_transfer_tmpfile;         /* Replica-> Primary SYNC temp file name */
-    _Atomic time_t repl_transfer_lastio; /* Unix time of the latest read, for timeout */
-    int repl_serve_stale_data;           /* Serve stale data when link is down? */
-    int repl_replica_ro;                 /* Replica is read only? */
-    int repl_replica_ignore_maxmemory;   /* If true replicas do not evict. */
-    time_t repl_down_since;              /* Unix time at which link with primary went down */
-    int repl_disable_tcp_nodelay;        /* Disable TCP_NODELAY after SYNC? */
-    int repl_mptcp;                      /* Use Multipath TCP for replica on client side */
-    int replica_priority;                /* Reported in INFO and used by Sentinel. */
-    int replica_announced;               /* If true, replica is announced by Sentinel */
-    int replica_announce_port;           /* Give the primary this listening port. */
-    char *replica_announce_ip;           /* Give the primary this ip address. */
-    int propagation_error_behavior;      /* Configures the behavior of the replica
-                                          * when it receives an error on the replication stream */
-    int repl_ignore_disk_write_error;    /* Configures whether replicas panic when unable to
-                                          * persist writes to AOF. */
+    client *cached_primary;                                                            /* Cached primary to be reused for PSYNC. */
+    rio *loading_rio;                                                                  /* Pointer to the rio object currently used for loading data. */
+    int repl_syncio_timeout;                                                           /* Timeout for synchronous I/O calls */
+    int repl_state;                                                                    /* Replication status if the instance is a replica */
+    int repl_rdb_channel_state;                                                        /* State of the replica's rdb channel during dual-channel-replication */
+    off_t repl_transfer_size;                                                          /* Size of RDB to read from primary during sync. */
+    off_t repl_transfer_read;                                                          /* Amount of RDB read from primary during sync. */
+    off_t repl_transfer_last_fsync_off;                                                /* Offset when we fsync-ed last time. */
+    connection *repl_transfer_s;                                                       /* Replica -> Primary SYNC connection */
+    connection *repl_rdb_transfer_s;                                                   /* Primary FULL SYNC connection (RDB download) */
+    int repl_transfer_fd;                                                              /* Replica -> Primary SYNC temp file descriptor */
+    char *repl_transfer_tmpfile;                                                       /* Replica-> Primary SYNC temp file name */
+    _Atomic time_t repl_transfer_lastio __attribute__((aligned(__alignof__(time_t)))); /* Unix time of the latest read, for timeout */
+    int repl_serve_stale_data;                                                         /* Serve stale data when link is down? */
+    int repl_replica_ro;                                                               /* Replica is read only? */
+    int repl_replica_ignore_maxmemory;                                                 /* If true replicas do not evict. */
+    time_t repl_down_since;                                                            /* Unix time at which link with primary went down */
+    int repl_disable_tcp_nodelay;                                                      /* Disable TCP_NODELAY after SYNC? */
+    int repl_mptcp;                                                                    /* Use Multipath TCP for replica on client side */
+    int replica_priority;                                                              /* Reported in INFO and used by Sentinel. */
+    int replica_announced;                                                             /* If true, replica is announced by Sentinel */
+    int replica_announce_port;                                                         /* Give the primary this listening port. */
+    char *replica_announce_ip;                                                         /* Give the primary this ip address. */
+    int propagation_error_behavior;                                                    /* Configures the behavior of the replica
+                                                                                        * when it receives an error on the replication stream */
+    int repl_ignore_disk_write_error;                                                  /* Configures whether replicas panic when unable to
+                                                                                        * persist writes to AOF. */
 
     /* The following two fields is where we store primary PSYNC replid/offset
      * while the PSYNC is in progress. At the end we'll copy the fields into
@@ -2224,14 +2224,14 @@ struct valkeyServer {
     int list_max_listpack_size;
     int list_compress_depth;
     /* time cache */
-    _Atomic time_t unixtime;     /* Unix time sampled every cron cycle. */
-    time_t timezone;             /* Cached timezone. As set by tzset(). */
-    _Atomic int daylight_active; /* Currently in daylight saving time. */
-    mstime_t mstime;             /* 'unixtime' in milliseconds. */
-    ustime_t ustime;             /* 'unixtime' in microseconds. */
-    mstime_t cmd_time_snapshot;  /* Time snapshot of the root execution nesting. */
-    size_t blocking_op_nesting;  /* Nesting level of blocking operation, used to reset blocked_last_cron. */
-    long long blocked_last_cron; /* Indicate the mstime of the last time we did cron jobs from a blocking operation */
+    _Atomic time_t unixtime __attribute__((aligned(__alignof__(time_t))));  /* Unix time sampled every cron cycle. */
+    time_t timezone;                                                        /* Cached timezone. As set by tzset(). */
+    _Atomic int daylight_active __attribute__((aligned(__alignof__(int)))); /* Currently in daylight saving time. */
+    mstime_t mstime;                                                        /* 'unixtime' in milliseconds. */
+    ustime_t ustime;                                                        /* 'unixtime' in microseconds. */
+    mstime_t cmd_time_snapshot;                                             /* Time snapshot of the root execution nesting. */
+    size_t blocking_op_nesting;                                             /* Nesting level of blocking operation, used to reset blocked_last_cron. */
+    long long blocked_last_cron;                                            /* Indicate the mstime of the last time we did cron jobs from a blocking operation */
     /* Pubsub */
     kvstore *pubsub_channels;      /* Map channels to list of subscribed clients */
     dict *pubsub_patterns;         /* A dict of pubsub_patterns */

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -30,6 +30,7 @@
 
 #include "fmacros.h"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -104,14 +105,14 @@ static struct config {
     int mptcp;
     struct cliSSLconfig sslconfig;
     int numclients;
-    _Atomic int liveclients;
+    _Atomic int liveclients __attribute__((aligned(__alignof__(int))));
     int requests;
     int duration;
     int warmup_duration;
-    _Atomic int current_warmup_duration;
-    _Atomic int requests_issued;
-    _Atomic int requests_finished;
-    _Atomic int previous_requests_finished;
+    _Atomic int current_warmup_duration __attribute__((aligned(__alignof__(int))));
+    _Atomic int requests_issued __attribute__((aligned(__alignof__(int))));
+    _Atomic int requests_finished __attribute__((aligned(__alignof__(int))));
+    _Atomic int previous_requests_finished __attribute__((aligned(__alignof__(int))));
     int last_printed_bytes;
     long long previous_tick;
     int keysize;
@@ -147,9 +148,9 @@ static struct config {
     struct hdr_histogram *latency_histogram;
     struct hdr_histogram *current_sec_latency_histogram;
     struct hdr_histogram *rps_histogram;
-    _Atomic int is_fetching_slots;
-    _Atomic int is_updating_slots;
-    _Atomic int slots_last_update;
+    _Atomic int is_fetching_slots __attribute__((aligned(__alignof__(int))));
+    _Atomic int is_updating_slots __attribute__((aligned(__alignof__(int))));
+    _Atomic int slots_last_update __attribute__((aligned(__alignof__(int))));
     int enable_tracking;
     int num_functions;
     int num_keys_in_fcall;
@@ -157,7 +158,7 @@ static struct config {
     pthread_mutex_t is_updating_slots_mutex;
     int resp3; /* use RESP3 */
     int rps;
-    atomic_uint_fast64_t last_time_ns;
+    atomic_uint_fast64_t last_time_ns __attribute__((aligned(__alignof__(uint_fast64_t))));
     uint64_t time_per_token;
     uint64_t time_per_burst;
 } config;

--- a/tests/unit/aof-max-size.tcl
+++ b/tests/unit/aof-max-size.tcl
@@ -1,0 +1,26 @@
+proc setup {{size 1}} {
+    r set k v
+    r config set aof-max-size $size
+    r set k2 v2
+}
+
+proc cleanup {} {
+    r config set aof-max-size 0
+    r flushall
+}
+
+start_server {tags {"external:skip"}} {
+    r config set auto-aof-rewrite-percentage 0 ; # disable auto-rewrite
+    r config set appendonly yes ; # enable AOF
+
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    test "Low aof-max-size starts AOF rewrite" {
+        setup
+        wait_for_log_messages 0 {"*Background append only file rewriting started*"} 0 100 10
+        r set k3 v3
+        cleanup
+    }
+}
+

--- a/tests/unit/aof-max-size.tcl
+++ b/tests/unit/aof-max-size.tcl
@@ -25,7 +25,7 @@ proc check_rewrites_new {count} {
 proc setup {aof_max_size {min_size 64mb}} {
     r config set hz 10  ; # serverCron runs every ~100ms
     r config set auto-aof-rewrite-percentage 0 ; # disable auto-rewrite
-    r config set aof-max-size $aof_max_size
+    r config set auto-aof-rewrite-max-size $aof_max_size
     r config set auto-aof-rewrite-min-size $min_size
     r config set appendonly yes ; # enable AOF
 
@@ -44,14 +44,14 @@ proc check_rewrites_old {log_count_before aof_rewrites} {
 }
 
 proc cleanup {} {
-    r config set aof-max-size 0
+    r config set auto-aof-rewrite-max-size 0
     r flushall
 }
 
 proc fill_aof_to_size {target_size_mb {repeated_keys_size 0}} {
-    # Save current aof-max-size and disable it during fill
-    set saved_max_size [lindex [r config get aof-max-size] 1]
-    r config set aof-max-size 0
+    # Save current auto-aof-rewrite-max-size and disable it during fill
+    set saved_max_size [lindex [r config get auto-aof-rewrite-max-size] 1]
+    r config set auto-aof-rewrite-max-size 0
 
     set target_bytes [expr {$target_size_mb * 1024 * 1024}]
     set current_size [status r aof_current_size]
@@ -71,14 +71,14 @@ proc fill_aof_to_size {target_size_mb {repeated_keys_size 0}} {
         }
     }
 
-    # Restore original aof-max-size
-    r config set aof-max-size $saved_max_size
+    # Restore original auto-aof-rewrite-max-size
+    r config set auto-aof-rewrite-max-size $saved_max_size
 
     return $current_size
 }
 
 start_server {tags {"external:skip" "slow"}} {
-    test "aof-max-size triggers successful rewrite and reduces size" {
+    test "auto-aof-rewrite-max-size triggers successful rewrite and reduces size" {
         setup 102400 64kb
 
         # Fill AOF with redundant commands that will compress during rewrite
@@ -99,7 +99,7 @@ start_server {tags {"external:skip" "slow"}} {
 }
 
 start_server {tags {"external:skip" "slow"}} {
-    test "aof-max-size prevents eternal rewrite loop when base >= max" {
+    test "auto-aof-rewrite-max-size prevents eternal rewrite loop when base >= max" {
         setup 51200 32kb
 
         # Create dataset that won't compress below 50KB using fill helper
@@ -124,7 +124,7 @@ start_server {tags {"external:skip" "slow"}} {
 }
 
 start_server {tags {"external:skip" "slow"}} {
-    test "aof-max-size=0 disables size-based rewriting" {
+    test "auto-aof-rewrite-max-size=0 disables size-based rewriting" {
         setup 0 0
 
         set log_count_before [count_log_message 0 "*Background append only file rewriting started*"]
@@ -140,16 +140,16 @@ start_server {tags {"external:skip" "slow"}} {
 }
 
 start_server {tags {"external:skip" "slow"}} {
-    test "user-initiated BGREWRITEAOF works independently of aof-max-size" {
+    test "user-initiated BGREWRITEAOF works independently of auto-aof-rewrite-max-size" {
         setup 10485760
 
-        # Add some data but not enough to trigger aof-max-size
+        # Add some data but not enough to trigger auto-aof-rewrite-max-size
         fill_aof_to_size 1
 
         # Manually trigger rewrite
         assert {[r bgrewriteaof] eq "Background append only file rewriting started"}
 
-        # Should start rewrite even though aof-max-size not exceeded
+        # Should start rewrite even though auto-aof-rewrite-max-size not exceeded
         check_rewrites_new 2
 
         cleanup
@@ -157,7 +157,7 @@ start_server {tags {"external:skip" "slow"}} {
 }
 
 start_server {tags {"external:skip" "slow"}} {
-    test "aof-max-size checks all conditions in serverCron" {
+    test "auto-aof-rewrite-max-size checks all conditions in serverCron" {
         setup 524288 262144
 
         set log_count_before [count_log_message 0 "*Background append only file rewriting started*"]

--- a/tests/unit/aof-max-size.tcl
+++ b/tests/unit/aof-max-size.tcl
@@ -1,7 +1,46 @@
-proc setup {{size 1}} {
-    r set k v
-    r config set aof-max-size $size
-    r set k2 v2
+proc ensure_cron {} {
+    set before [s expired_keys]
+    r setex expired_key 1 v
+    wait_for_condition 50 100 {
+        [s expired_keys] > $before
+    } else {
+        fail "serverCron never runs"
+    }
+
+    assert_equal [expr {$before + 1}] [s expired_keys]
+}
+
+proc check_rewrites_new {count} {
+    ensure_cron
+
+    # Wait for new rewrite to finish
+    wait_for_condition 50 100 {
+        [s aof_rewrite_in_progress] eq 0 &&
+        [s aof_rewrites] eq $count
+    } else {
+        fail "Rewrite behaviour is unexpected: progress=[s aof_rewrite_in_progress], rewrites=[s aof_rewrites], expected=$count"
+    }
+}
+
+proc setup {aof_max_size {min_size 64mb}} {
+    r config set hz 10  ; # serverCron runs every ~100ms
+    r config set auto-aof-rewrite-percentage 0 ; # disable auto-rewrite
+    r config set aof-max-size $aof_max_size
+    r config set auto-aof-rewrite-min-size $min_size
+    r config set appendonly yes ; # enable AOF
+
+    # Wait for initial serverCron to schedule and execute rewrite
+    check_rewrites_new 1
+}
+
+proc check_rewrites_old {log_count_before aof_rewrites} {
+    ensure_cron
+
+    set log_count_after [count_log_message 0 "*Background append only file rewriting started*"]
+    # Should still be the same (no new rewrite triggered)
+    assert {$log_count_after == $log_count_before}
+    assert {[s aof_rewrite_in_progress] == 0}
+    assert {[s aof_rewrites] == $aof_rewrites}
 }
 
 proc cleanup {} {
@@ -9,18 +48,135 @@ proc cleanup {} {
     r flushall
 }
 
-start_server {tags {"external:skip"}} {
-    r config set auto-aof-rewrite-percentage 0 ; # disable auto-rewrite
-    r config set appendonly yes ; # enable AOF
+proc fill_aof_to_size {target_size_mb {repeated_keys_size 0}} {
+    # Save current aof-max-size and disable it during fill
+    set saved_max_size [lindex [r config get aof-max-size] 1]
+    r config set aof-max-size 0
 
-    set master_host [srv 0 host]
-    set master_port [srv 0 port]
+    set target_bytes [expr {$target_size_mb * 1024 * 1024}]
+    set current_size [status r aof_current_size]
+    set iterations 0
 
-    test "Low aof-max-size starts AOF rewrite" {
-        setup
-        wait_for_log_messages 0 {"*Background append only file rewriting started*"} 0 100 10
-        r set k3 v3
+    while {$current_size < $target_bytes && $iterations < 100000} {
+        if {$repeated_keys_size > 0} {
+            # Overwrite only N keys repeatedly to create redundancy
+            r set key[expr {$iterations % $repeated_keys_size}] [string repeat "x" 1000]
+        } else {
+            # Use unique keys
+            r set fillkey$iterations [string repeat "x" 1000]
+        }
+        incr iterations
+        if {$iterations % 100 == 0} {
+            set current_size [status r aof_current_size]
+        }
+    }
+
+    # Restore original aof-max-size
+    r config set aof-max-size $saved_max_size
+
+    return $current_size
+}
+
+start_server {tags {"external:skip" "slow"}} {
+    test "aof-max-size triggers successful rewrite and reduces size" {
+        setup 102400 64kb
+
+        # Fill AOF with redundant commands that will compress during rewrite
+        # Overwrite only 1000 keys repeatedly to create AOF bloat
+        fill_aof_to_size 2 1000
+
+        set size_before [status r aof_current_size]
+        assert {$size_before > 102400}
+
+        # Wait for serverCron to schedule and execute rewrite
+        check_rewrites_new 2
+
+        set size_after [status r aof_current_size]
+        assert {$size_after < $size_before}
+
         cleanup
     }
 }
 
+start_server {tags {"external:skip" "slow"}} {
+    test "aof-max-size prevents eternal rewrite loop when base >= max" {
+        setup 51200 32kb
+
+        # Create dataset that won't compress below 50KB using fill helper
+        fill_aof_to_size 2
+
+        # Wait for serverCron to schedule and execute rewrite
+        check_rewrites_new 2
+
+        set base_size [s aof_base_size]
+        assert {$base_size >= 51200}
+
+        set log_count_before [count_log_message 0 "*Background append only file rewriting started*"]
+
+        # Add more data
+        fill_aof_to_size 0.1
+
+        # Wait a bit for serverCron cycles
+        check_rewrites_old $log_count_before 2
+
+        cleanup
+    }
+}
+
+start_server {tags {"external:skip" "slow"}} {
+    test "aof-max-size=0 disables size-based rewriting" {
+        setup 0 0
+
+        set log_count_before [count_log_message 0 "*Background append only file rewriting started*"]
+
+        # Fill AOF with data
+        fill_aof_to_size 2
+
+        # Wait a bit for serverCron cycles
+        check_rewrites_old $log_count_before 1
+
+        cleanup
+    }
+}
+
+start_server {tags {"external:skip" "slow"}} {
+    test "user-initiated BGREWRITEAOF works independently of aof-max-size" {
+        setup 10485760
+
+        # Add some data but not enough to trigger aof-max-size
+        fill_aof_to_size 1
+
+        # Manually trigger rewrite
+        assert {[r bgrewriteaof] eq "Background append only file rewriting started"}
+
+        # Should start rewrite even though aof-max-size not exceeded
+        check_rewrites_new 2
+
+        cleanup
+    }
+}
+
+start_server {tags {"external:skip" "slow"}} {
+    test "aof-max-size checks all conditions in serverCron" {
+        setup 524288 262144
+
+        set log_count_before [count_log_message 0 "*Background append only file rewriting started*"]
+
+        # Fill to just above min-size but below max-size (0.3MB)
+        fill_aof_to_size 0.3
+
+        set current_size [status r aof_current_size]
+        assert {$current_size > 262144 && $current_size < 524288}
+
+        # Should NOT trigger rewrite (not at max-size yet)
+        check_rewrites_old $log_count_before 1
+
+        # Now exceed max-size (0.6MB)
+        fill_aof_to_size 0.6
+
+        # Should trigger rewrite now
+        check_rewrites_new 2
+
+        cleanup
+    }
+}

--- a/valkey.conf
+++ b/valkey.conf
@@ -1720,6 +1720,9 @@ aof-use-rdb-preamble yes
 # the AOF format in a way that may not be compatible with existing AOF parsers.
 aof-timestamp-enabled no
 
+# Maximum size for AOF files on disk in bytes. Ignored, if set to 0.
+aof-max-size 0 
+
 ################################ SHUTDOWN #####################################
 
 # Maximum time to wait for replicas when shutting down, in seconds.

--- a/valkey.conf
+++ b/valkey.conf
@@ -1720,7 +1720,23 @@ aof-use-rdb-preamble yes
 # the AOF format in a way that may not be compatible with existing AOF parsers.
 aof-timestamp-enabled no
 
-# Maximum size for AOF files on disk in bytes. Ignored, if set to 0.
+# Maximum target size for AOF files on disk in bytes. This is a soft limit
+# that triggers automatic background rewrites when exceeded, not a hard limit
+# that prevents writes.
+#
+# When the AOF file size reaches this threshold, a background rewrite is
+# automatically triggered (similar to auto-aof-rewrite-percentage but based
+# on absolute size rather than percentage growth).
+#
+# Important notes:
+# - Set to 0 to disable size-based triggering (default)
+# - The actual AOF size may exceed this limit if:
+#   * Your working dataset is larger than the limit
+#   * A rewrite is already in progress
+#   * The rewritten AOF cannot compress below this size
+# - This works alongside auto-aof-rewrite-percentage. Whichever condition
+#   is met first will trigger the rewrite.
+# - Recommended: Set this to at least 2x your typical working dataset size
 aof-max-size 0 
 
 ################################ SHUTDOWN #####################################

--- a/valkey.conf
+++ b/valkey.conf
@@ -1667,6 +1667,8 @@ appendfsync everysec
 no-appendfsync-on-rewrite no
 
 # Automatic rewrite of the append only file.
+#
+# Option 1 (auto-aof-rewrite-percentage).
 # The server is able to automatically rewrite the log file implicitly calling
 # BGREWRITEAOF when the AOF log size grows by the specified percentage.
 #
@@ -1682,9 +1684,29 @@ no-appendfsync-on-rewrite no
 #
 # Specify a percentage of zero in order to disable the automatic AOF
 # rewrite feature.
+#
+# Option 2 (auto-aof-rewrite-max-size).
+# AOF base target maximum in bytes. This is a soft limit
+# that triggers automatic background rewrites when exceeded, not a hard limit
+# that prevents writes.
+#
+# When the AOF file size reaches this threshold, a background rewrite is
+# automatically triggered (similar to auto-aof-rewrite-percentage but based
+# on absolute size rather than percentage growth).
+#
+# Important notes:
+# - Set to 0 to disable size-based triggering (default)
+# - The actual AOF size may exceed this limit if:
+#   * Your working dataset is larger than the limit
+#   * A rewrite is already in progress
+#   * The rewritten AOF cannot compress below this size
+# - This works alongside auto-aof-rewrite-percentage. Whichever condition
+#   is met first will trigger the rewrite.
+# - Recommended: Set this to at least 2x your typical working dataset size
 
 auto-aof-rewrite-percentage 100
 auto-aof-rewrite-min-size 64mb
+auto-aof-rewrite-max-size 0
 
 # An AOF file may be found to be truncated at the end during the server
 # startup process, when the AOF data gets loaded back into memory.
@@ -1718,26 +1740,7 @@ aof-use-rdb-preamble yes
 # The server supports recording timestamp annotations in the AOF to support restoring
 # the data from a specific point-in-time. However, using this capability changes
 # the AOF format in a way that may not be compatible with existing AOF parsers.
-aof-timestamp-enabled no
-
-# Maximum target size for AOF files on disk in bytes. This is a soft limit
-# that triggers automatic background rewrites when exceeded, not a hard limit
-# that prevents writes.
-#
-# When the AOF file size reaches this threshold, a background rewrite is
-# automatically triggered (similar to auto-aof-rewrite-percentage but based
-# on absolute size rather than percentage growth).
-#
-# Important notes:
-# - Set to 0 to disable size-based triggering (default)
-# - The actual AOF size may exceed this limit if:
-#   * Your working dataset is larger than the limit
-#   * A rewrite is already in progress
-#   * The rewritten AOF cannot compress below this size
-# - This works alongside auto-aof-rewrite-percentage. Whichever condition
-#   is met first will trigger the rewrite.
-# - Recommended: Set this to at least 2x your typical working dataset size
-aof-max-size 0 
+aof-timestamp-enabled no 
 
 ################################ SHUTDOWN #####################################
 


### PR DESCRIPTION
there are some scenarios of filling up the whole disk besides any chosen AOF rewrite strategy - the simplest is this:
- we have auto-aof-rewrite-percentage 100,
- and last automatic rewrite compacted AOF to 51% of disk,
-> we'll never try again.

we can lower auto-percentage, but in some cases it's not what we want to. I suggest that we add soft upper limit in this PR:
- if no AOF rewrite is running currently,
- and limit is set in config,
- and AOF exceed the limit,
- and last rewrite compacted AOF to somewhat smaller than limit (otherwise we might end up with useless attempts of uninterrupted rewrites)
-> bgrewriteaof is initiated.

this doesn't completely solves the problem, but gives some additional possibilities for some users to improve the situation initially described in #540 (noticed that solution from the issue seems to be inappropriate for some cases)