### PR TITLE
config option to stop master on AOF write error

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1201,6 +1201,7 @@ void flushAppendOnlyFile(int force) {
                           "Can't recover from AOF write error when replicas-to-fail-on-aof-short-write is '%d' "
                           "and there are enough actual replicas. Exiting...",
                           server.replicas_to_fail_on_aof_short_write);
+                if (server.cluster_enabled) clusterAutoFailoverOnShutdown();
                 exit(1);
             }
 

--- a/src/aof.c
+++ b/src/aof.c
@@ -1196,12 +1196,16 @@ void flushAppendOnlyFile(int force) {
                       "Can't recover from AOF write error when the AOF fsync policy is 'always'. Exiting...");
             exit(1);
         } else {
-            if (getGoodReplicasCount(0) >= server.replicas_to_fail_on_aof_short_write) {
+            if (server.replicas_to_fail_on_aof_write_error >= 0 &&
+                getGoodReplicasCount(0) >= server.replicas_to_fail_on_aof_write_error) {
                 serverLog(LL_WARNING,
-                          "Can't recover from AOF write error when replicas-to-fail-on-aof-short-write is '%d' "
+                          "Can't recover from AOF write error when replicas-to-fail-on-aof-write-error is '%d' "
                           "and there are enough actual replicas. Exiting...",
-                          server.replicas_to_fail_on_aof_short_write);
-                if (server.cluster_enabled) clusterAutoFailoverOnShutdown();
+                          server.replicas_to_fail_on_aof_write_error);
+                if (server.cluster_enabled) {
+                    usleep(server.cluster_node_timeout * 1000);
+                    clusterAutoFailoverOnShutdown();
+                }
                 exit(1);
             }
 

--- a/src/aof.c
+++ b/src/aof.c
@@ -1196,6 +1196,14 @@ void flushAppendOnlyFile(int force) {
                       "Can't recover from AOF write error when the AOF fsync policy is 'always'. Exiting...");
             exit(1);
         } else {
+            if (getGoodReplicasCount(0) >= server.replicas_to_fail_on_aof_short_write) {
+                serverLog(LL_WARNING,
+                          "Can't recover from AOF write error when replicas-to-fail-on-aof-short-write is '%d' "
+                          "and there are enough actual replicas. Exiting...",
+                          server.replicas_to_fail_on_aof_short_write);
+                exit(1);
+            }
+
             /* Recover from failed write leaving data into the buffer. However
              * set an error to stop accepting writes as long as the error
              * condition is not cleared. */

--- a/src/aof.c
+++ b/src/aof.c
@@ -1196,17 +1196,14 @@ void flushAppendOnlyFile(int force) {
                       "Can't recover from AOF write error when the AOF fsync policy is 'always'. Exiting...");
             exit(1);
         } else {
-            if (server.replicas_to_fail_on_aof_write_error >= 0 &&
-                getGoodReplicasCount(0) >= server.replicas_to_fail_on_aof_write_error) {
-                serverLog(LL_WARNING,
-                          "Can't recover from AOF write error when replicas-to-fail-on-aof-write-error is '%d' "
-                          "and there are enough actual replicas. Exiting...",
-                          server.replicas_to_fail_on_aof_write_error);
-                if (server.cluster_enabled) {
-                    usleep(server.cluster_node_timeout * 1000);
-                    clusterAutoFailoverOnShutdown();
+            if (server.shutdown_on_aof_error) {
+                int flags = SHUTDOWN_RO | SHUTDOWN_FORCE | SHUTDOWN_FAILOVER;
+                if (prepareReplicasForShutdown(flags) == C_OK) {
+                    serverLog(LL_WARNING, "Can't recover from AOF write error with shutdown-on-aof-error=yes. Exiting...");
+                    exit(1);
+                } else {
+                    return; /* Shutdown gonna be processed in serverCron. */
                 }
-                exit(1);
             }
 
             /* Recover from failed write leaving data into the buffer. However

--- a/src/config.c
+++ b/src/config.c
@@ -3361,6 +3361,7 @@ standardConfig static_configs[] = {
     createIntConfig("rdma-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.rdma_ctx_config.port, 0, INTEGER_CONFIG, NULL, updateRdmaPort),
     createIntConfig("rdma-rx-size", NULL, IMMUTABLE_CONFIG, 64 * 1024, 16 * 1024 * 1024, server.rdma_ctx_config.rx_size, 1024 * 1024, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("rdma-completion-vector", NULL, IMMUTABLE_CONFIG, -1, 1024, server.rdma_ctx_config.completion_vector, -1, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("replicas-to-fail-on-aof-short-write", NULL, MODIFIABLE_CONFIG, -1, 1024, server.replicas_to_fail_on_aof_short_write, -1, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),

--- a/src/config.c
+++ b/src/config.c
@@ -3361,7 +3361,7 @@ standardConfig static_configs[] = {
     createIntConfig("rdma-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.rdma_ctx_config.port, 0, INTEGER_CONFIG, NULL, updateRdmaPort),
     createIntConfig("rdma-rx-size", NULL, IMMUTABLE_CONFIG, 64 * 1024, 16 * 1024 * 1024, server.rdma_ctx_config.rx_size, 1024 * 1024, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("rdma-completion-vector", NULL, IMMUTABLE_CONFIG, -1, 1024, server.rdma_ctx_config.completion_vector, -1, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("replicas-to-fail-on-aof-short-write", NULL, MODIFIABLE_CONFIG, -1, 1024, server.replicas_to_fail_on_aof_short_write, -1, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("replicas-to-fail-on-aof-write-error", NULL, MODIFIABLE_CONFIG, -1, 1024, server.replicas_to_fail_on_aof_write_error, -1, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),

--- a/src/config.c
+++ b/src/config.c
@@ -3251,6 +3251,7 @@ standardConfig static_configs[] = {
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 1, NULL, NULL),
     createBoolConfig("lua-enable-insecure-api", "lua-enable-deprecated-api", MODIFIABLE_CONFIG | HIDDEN_CONFIG | PROTECTED_CONFIG, server.lua_enable_insecure_api, 0, NULL, updateLuaEnableInsecureApi),
     createBoolConfig("import-mode", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.import_mode, 0, NULL, NULL),
+    createBoolConfig("shutdown-on-aof-error", NULL, MODIFIABLE_CONFIG, server.shutdown_on_aof_error, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),
@@ -3361,7 +3362,6 @@ standardConfig static_configs[] = {
     createIntConfig("rdma-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.rdma_ctx_config.port, 0, INTEGER_CONFIG, NULL, updateRdmaPort),
     createIntConfig("rdma-rx-size", NULL, IMMUTABLE_CONFIG, 64 * 1024, 16 * 1024 * 1024, server.rdma_ctx_config.rx_size, 1024 * 1024, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("rdma-completion-vector", NULL, IMMUTABLE_CONFIG, -1, 1024, server.rdma_ctx_config.completion_vector, -1, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("replicas-to-fail-on-aof-write-error", NULL, MODIFIABLE_CONFIG, -1, 1024, server.replicas_to_fail_on_aof_write_error, -1, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),

--- a/src/eval.c
+++ b/src/eval.c
@@ -238,7 +238,13 @@ int evalExtractShebangFlags(sds body,
         }
 
         if (out_engine) {
-            size_t engine_name_len = sdslen(parts[0]) - 2;
+            size_t part0_len = sdslen(parts[0]);
+            if (part0_len < 2) {
+                if (err) *err = sdsnew("Invalid engine in script shebang: too short");
+                sdsfreesplitres(parts, numparts);
+                return C_ERR;
+            }
+            size_t engine_name_len = part0_len - 2;
             *out_engine = zcalloc(engine_name_len + 1);
             valkey_strlcpy(*out_engine, parts[0] + 2, engine_name_len + 1);
         }

--- a/src/replication.c
+++ b/src/replication.c
@@ -4842,24 +4842,28 @@ void replicationResurrectProvisionalPrimary(void) {
 
 /* ------------------------- MIN-REPLICAS-TO-WRITE  --------------------------- */
 
-/* This function counts the number of replicas with lag <= min-replicas-max-lag.
- * If the option is active, the server will prevent writes if there are not
- * enough connected replicas with the specified lag (or less). */
-void refreshGoodReplicasCount(void) {
+int getGoodReplicasCount(int max_lag) {
     listIter li;
     listNode *ln;
     int good = 0;
-
-    if (!server.repl_min_replicas_to_write || !server.repl_min_replicas_max_lag) return;
 
     listRewind(server.replicas, &li);
     while ((ln = listNext(&li))) {
         client *replica = ln->value;
         time_t lag = server.unixtime - replica->repl_data->repl_ack_time;
 
-        if (replica->repl_data->repl_state == REPLICA_STATE_ONLINE && lag <= server.repl_min_replicas_max_lag) good++;
+        if (replica->repl_data->repl_state == REPLICA_STATE_ONLINE && lag <= max_lag) good++;
     }
-    server.repl_good_replicas_count = good;
+    return good;
+}
+
+/* This function counts the number of replicas with lag <= min-replicas-max-lag.
+ * If the option is active, the server will prevent writes if there are not
+ * enough connected replicas with the specified lag (or less). */
+void refreshGoodReplicasCount(void) {
+    if (!server.repl_min_replicas_to_write || !server.repl_min_replicas_max_lag) return;
+
+    server.repl_good_replicas_count = getGoodReplicasCount(server.repl_min_replicas_max_lag);
 }
 
 /* return true if status of good replicas is OK. otherwise false */

--- a/src/server.c
+++ b/src/server.c
@@ -7208,12 +7208,6 @@ int iAmPrimary(void) {
             (server.cluster_enabled && clusterNodeIsPrimary(getMyClusterNode())));
 }
 
-int isPrimaryWithEnoughActualReplicas(void) {
-    if (!iAmPrimary()) {
-        return 0;
-    }
-}
-
 /* Main is marked as weak so that unit tests can use their own main function. */
 __attribute__((weak)) int main(int argc, char **argv) {
     struct timeval tv;

--- a/src/server.c
+++ b/src/server.c
@@ -4567,6 +4567,20 @@ void closeListeningSockets(int unlink_unix_socket) {
     }
 }
 
+int prepareReplicasForShutdown(int flags) {
+    server.shutdown_flags = flags;
+    /* If we have any replicas, let them catch up the replication offset before
+     * we shut down, to avoid data loss. */
+    if (!(server.shutdown_flags & SHUTDOWN_NOW) && server.shutdown_timeout != 0 && !isReadyToShutdown()) {
+        server.shutdown_mstime = server.mstime + server.shutdown_timeout * 1000;
+        if (!isPausedActions(PAUSE_ACTION_REPLICA)) sendGetackToReplicas();
+        pauseActions(PAUSE_DURING_SHUTDOWN, LLONG_MAX, PAUSE_ACTIONS_CLIENT_WRITE_SET);
+        serverLog(LL_NOTICE, "Waiting for replicas before shutting down.");
+        return C_ERR;
+    }
+    return C_OK;
+}
+
 /* Prepare for shutting down the server.
  *
  * The client *c can be NULL, it may come from a signal. If client is passed in,
@@ -4612,8 +4626,6 @@ int prepareForShutdown(client *c, int flags) {
      * Also when in Sentinel mode clear the SAVE flag and force NOSAVE. */
     if (server.loading || server.sentinel_mode) flags = (flags & ~SHUTDOWN_SAVE) | SHUTDOWN_NOSAVE;
 
-    server.shutdown_flags = flags;
-
     if (c != NULL) {
         sds client = catClientInfoShortString(sdsempty(), c, server.hide_user_data_from_log);
         serverLog(LL_NOTICE, "User requested shutdown... (user request from '%s')", client);
@@ -4623,13 +4635,7 @@ int prepareForShutdown(client *c, int flags) {
     }
     if (server.supervised_mode == SUPERVISED_SYSTEMD) serverCommunicateSystemd("STOPPING=1\n");
 
-    /* If we have any replicas, let them catch up the replication offset before
-     * we shut down, to avoid data loss. */
-    if (!(flags & SHUTDOWN_NOW) && server.shutdown_timeout != 0 && !isReadyToShutdown()) {
-        server.shutdown_mstime = server.mstime + server.shutdown_timeout * 1000;
-        if (!isPausedActions(PAUSE_ACTION_REPLICA)) sendGetackToReplicas();
-        pauseActions(PAUSE_DURING_SHUTDOWN, LLONG_MAX, PAUSE_ACTIONS_CLIENT_WRITE_SET);
-        serverLog(LL_NOTICE, "Waiting for replicas before shutting down.");
+    if (prepareReplicasForShutdown(flags) == C_ERR) {
         return C_ERR;
     }
 
@@ -4686,7 +4692,8 @@ int abortShutdown(void) {
  * it's not safe to call exit(). */
 int finishShutdown(void) {
     bool save = (server.shutdown_flags & SHUTDOWN_SAVE) != 0;
-    bool nosave = (server.shutdown_flags & SHUTDOWN_NOSAVE) != 0;
+    bool ro = (server.shutdown_flags & SHUTDOWN_RO) != 0;
+    bool nosave = (server.shutdown_flags & SHUTDOWN_NOSAVE) != 0 || ro;
     bool force = (server.shutdown_flags & SHUTDOWN_FORCE) != 0;
     bool safe = (server.shutdown_flags & SHUTDOWN_SAFE) != 0;
     bool failover = (server.shutdown_flags & SHUTDOWN_FAILOVER) != 0;
@@ -4765,7 +4772,7 @@ int finishShutdown(void) {
         serverLog(LL_WARNING, "There is a child rewriting the AOF. Killing it!");
         killAppendOnlyChild();
     }
-    if (server.aof_state != AOF_OFF) {
+    if (server.aof_state != AOF_OFF && !ro) {
         /* Append only file: flush buffers and fsync() the AOF at exit */
         serverLog(LL_NOTICE, "Calling fsync() on the AOF file.");
         flushAppendOnlyFile(1);

--- a/src/server.c
+++ b/src/server.c
@@ -7208,6 +7208,12 @@ int iAmPrimary(void) {
             (server.cluster_enabled && clusterNodeIsPrimary(getMyClusterNode())));
 }
 
+int isPrimaryWithEnoughActualReplicas(void) {
+    if (!iAmPrimary()) {
+        return 0;
+    }
+}
+
 /* Main is marked as weak so that unit tests can use their own main function. */
 __attribute__((weak)) int main(int argc, char **argv) {
     struct timeval tv;

--- a/src/server.h
+++ b/src/server.h
@@ -603,6 +603,7 @@ typedef enum {
 #define SHUTDOWN_FORCE (1 << 3)    /* Don't let errors prevent shutdown. */
 #define SHUTDOWN_SAFE (1 << 4)     /* Shutdown only when safe. */
 #define SHUTDOWN_FAILOVER (1 << 5) /* Trigger failover when shutting down a primary. */
+#define SHUTDOWN_RO (1 << 6)       /* Don't write to disk on shutdown. */
 
 /* Command call flags, see call() function */
 #define CMD_CALL_NONE 0
@@ -1765,16 +1766,16 @@ struct valkeyServer {
     int thp_enabled;                     /* If true, THP is enabled. */
     size_t page_size;                    /* The page size of OS. */
     /* Modules */
-    dict *moduleapi;                                               /* Exported core APIs dictionary for modules. */
-    dict *sharedapi;                                               /* Like moduleapi but containing the APIs that
-                                                                      modules share with each other. */
-    dict *module_configs_queue;                                    /* Dict that stores module configurations from .conf file until after modules are loaded
-                                                                      during startup or arguments to loadex. */
-    list *loadmodule_queue;                                        /* List of modules to load at startup. */
-    int module_pipe[2];                                            /* Pipe used to awake the event loop by module threads. */
-    pid_t child_pid;                                               /* PID of current child */
-    int child_type;                                                /* Type of current child */
-    _Atomic int module_gil_acquiring __attribute__((aligned(32))); /* Indicates whether the GIL is being acquiring by the main thread. */
+    dict *moduleapi;                                                             /* Exported core APIs dictionary for modules. */
+    dict *sharedapi;                                                             /* Like moduleapi but containing the APIs that
+                                                                                    modules share with each other. */
+    dict *module_configs_queue;                                                  /* Dict that stores module configurations from .conf file until after modules are loaded
+                                                                                    during startup or arguments to loadex. */
+    list *loadmodule_queue;                                                      /* List of modules to load at startup. */
+    int module_pipe[2];                                                          /* Pipe used to awake the event loop by module threads. */
+    pid_t child_pid;                                                             /* PID of current child */
+    int child_type;                                                              /* Type of current child */
+    _Atomic int module_gil_acquiring __attribute__((aligned(__alignof__(int)))); /* Indicates whether the GIL is being acquiring by the main thread. */
     /* Networking */
     int port;                              /* TCP listening port */
     int tls_port;                          /* TLS listening port */
@@ -1818,20 +1819,20 @@ struct valkeyServer {
     uint32_t paused_actions;    /* Bitmask of actions that are currently paused */
     list *postponed_clients;    /* List of postponed clients */
     pause_event client_pause_per_purpose[NUM_PAUSE_PURPOSES];
-    char neterr[ANET_ERR_LEN];                                    /* Error buffer for anet.c */
-    dict *migrate_cached_sockets;                                 /* MIGRATE cached sockets */
-    _Atomic uint64_t next_client_id __attribute__((aligned(64))); /* Next client unique ID. Incremental. */
-    int protected_mode;                                           /* Don't accept external connections. */
-    int io_threads_num;                                           /* Number of IO threads to use. */
-    int active_io_threads_num;                                    /* Current number of active IO threads, includes main thread. */
-    int events_per_io_thread;                                     /* Number of events on the event loop to trigger IO threads activation. */
-    int prefetch_batch_max_size;                                  /* Maximum number of keys to prefetch in a single batch */
-    long long events_processed_while_blocked;                     /* processEventsWhileBlocked() */
-    int enable_protected_configs;                                 /* Enable the modification of protected configs, see PROTECTED_ACTION_ALLOWED_* */
-    int enable_debug_cmd;                                         /* Enable DEBUG commands, see PROTECTED_ACTION_ALLOWED_* */
-    int enable_module_cmd;                                        /* Enable MODULE commands, see PROTECTED_ACTION_ALLOWED_* */
-    int enable_debug_assert;                                      /* Enable debug asserts */
-    int debug_client_enforce_reply_list;                          /* Force client to always use the reply list */
+    char neterr[ANET_ERR_LEN];                                                       /* Error buffer for anet.c */
+    dict *migrate_cached_sockets;                                                    /* MIGRATE cached sockets */
+    _Atomic uint64_t next_client_id __attribute__((aligned(__alignof__(uint64_t)))); /* Next client unique ID. Incremental. */
+    int protected_mode;                                                              /* Don't accept external connections. */
+    int io_threads_num;                                                              /* Number of IO threads to use. */
+    int active_io_threads_num;                                                       /* Current number of active IO threads, includes main thread. */
+    int events_per_io_thread;                                                        /* Number of events on the event loop to trigger IO threads activation. */
+    int prefetch_batch_max_size;                                                     /* Maximum number of keys to prefetch in a single batch */
+    long long events_processed_while_blocked;                                        /* processEventsWhileBlocked() */
+    int enable_protected_configs;                                                    /* Enable the modification of protected configs, see PROTECTED_ACTION_ALLOWED_* */
+    int enable_debug_cmd;                                                            /* Enable DEBUG commands, see PROTECTED_ACTION_ALLOWED_* */
+    int enable_module_cmd;                                                           /* Enable MODULE commands, see PROTECTED_ACTION_ALLOWED_* */
+    int enable_debug_assert;                                                         /* Enable debug asserts */
+    int debug_client_enforce_reply_list;                                             /* Force client to always use the reply list */
     /* Reply construction copy avoidance */
     int min_io_threads_copy_avoid;           /* Minimum number of IO threads for copy avoidance in reply construction */
     int min_string_size_copy_avoid_threaded; /* Minimum bulk string size for copy avoidance in reply construction when IO threads enabled */
@@ -1982,45 +1983,45 @@ struct valkeyServer {
     unsigned int max_new_conns_per_cycle;     /* The maximum number of tcp connections that will be accepted during each
                                                  invocation of the event loop. */
     /* AOF persistence */
-    int aof_enabled;                                               /* AOF configuration */
-    int aof_state;                                                 /* AOF_(ON|OFF|WAIT_REWRITE) */
-    int aof_fsync;                                                 /* Kind of fsync() policy */
-    char *aof_filename;                                            /* Basename of the AOF file and manifest file */
-    char *aof_dirname;                                             /* Name of the AOF directory */
-    int aof_no_fsync_on_rewrite;                                   /* Don't fsync if a rewrite is in prog. */
-    int aof_rewrite_perc;                                          /* Rewrite AOF if % growth is > M and... */
-    off_t aof_rewrite_min_size;                                    /* the AOF file is at least N bytes. */
-    off_t aof_rewrite_base_size;                                   /* AOF size on latest startup or rewrite. */
-    off_t aof_current_size;                                        /* AOF current size (Including BASE + INCRs). */
-    off_t aof_last_incr_size;                                      /* The size of the latest incr AOF. */
-    off_t aof_last_incr_fsync_offset;                              /* AOF offset which is already requested to be synced to disk.
-                                                                    * Compare with the aof_last_incr_size. */
-    int aof_flush_sleep;                                           /* Micros to sleep before flush. (used by tests) */
-    int aof_rewrite_scheduled;                                     /* Rewrite once BGSAVE terminates. */
-    sds aof_buf;                                                   /* AOF buffer, written before entering the event loop */
-    int aof_fd;                                                    /* File descriptor of currently selected AOF file */
-    int aof_selected_db;                                           /* Currently selected DB in AOF */
-    mstime_t aof_flush_postponed_start;                            /* mstime of postponed AOF flush */
-    mstime_t aof_last_fsync;                                       /* mstime of last fsync() */
-    time_t aof_rewrite_time_last;                                  /* Time used by last AOF rewrite run. */
-    time_t aof_rewrite_time_start;                                 /* Current AOF rewrite start time. */
-    time_t aof_cur_timestamp;                                      /* Current record timestamp in AOF */
-    int aof_timestamp_enabled;                                     /* Enable record timestamp in AOF */
-    int aof_lastbgrewrite_status;                                  /* C_OK or C_ERR */
-    unsigned long aof_delayed_fsync;                               /* delayed AOF fsync() counter */
-    int aof_rewrite_incremental_fsync;                             /* fsync incrementally while aof rewriting? */
-    int rdb_save_incremental_fsync;                                /* fsync incrementally while rdb saving? */
-    int aof_last_write_status;                                     /* C_OK or C_ERR */
-    int aof_last_write_errno;                                      /* Valid if aof write/fsync status is ERR */
-    int aof_load_truncated;                                        /* Don't stop on unexpected AOF EOF. */
-    int aof_use_rdb_preamble;                                      /* Specify base AOF to use RDB encoding on AOF rewrites. */
-    int aof_rewrite_use_rdb_preamble;                              /* Base AOF to use RDB encoding on AOF rewrites start. */
-    _Atomic int aof_bio_fsync_status __attribute__((aligned(32))); /* Status of AOF fsync in bio job. */
-    _Atomic int aof_bio_fsync_errno __attribute__((aligned(32)));  /* Errno of AOF fsync in bio job. */
-    aofManifest *aof_manifest;                                     /* Used to track AOFs. */
-    int aof_disable_auto_gc;                                       /* If disable automatically deleting HISTORY type AOFs?
-                                                                    * default no. (for testings). */
-    int replicas_to_fail_on_aof_write_error;                       /* Fail primary on AOF write error if there are enough actual replicas. */
+    int aof_enabled;                                                             /* AOF configuration */
+    int aof_state;                                                               /* AOF_(ON|OFF|WAIT_REWRITE) */
+    int aof_fsync;                                                               /* Kind of fsync() policy */
+    char *aof_filename;                                                          /* Basename of the AOF file and manifest file */
+    char *aof_dirname;                                                           /* Name of the AOF directory */
+    int aof_no_fsync_on_rewrite;                                                 /* Don't fsync if a rewrite is in prog. */
+    int aof_rewrite_perc;                                                        /* Rewrite AOF if % growth is > M and... */
+    off_t aof_rewrite_min_size;                                                  /* the AOF file is at least N bytes. */
+    off_t aof_rewrite_base_size;                                                 /* AOF size on latest startup or rewrite. */
+    off_t aof_current_size;                                                      /* AOF current size (Including BASE + INCRs). */
+    off_t aof_last_incr_size;                                                    /* The size of the latest incr AOF. */
+    off_t aof_last_incr_fsync_offset;                                            /* AOF offset which is already requested to be synced to disk.
+                                                                                  * Compare with the aof_last_incr_size. */
+    int aof_flush_sleep;                                                         /* Micros to sleep before flush. (used by tests) */
+    int aof_rewrite_scheduled;                                                   /* Rewrite once BGSAVE terminates. */
+    sds aof_buf;                                                                 /* AOF buffer, written before entering the event loop */
+    int aof_fd;                                                                  /* File descriptor of currently selected AOF file */
+    int aof_selected_db;                                                         /* Currently selected DB in AOF */
+    mstime_t aof_flush_postponed_start;                                          /* mstime of postponed AOF flush */
+    mstime_t aof_last_fsync;                                                     /* mstime of last fsync() */
+    time_t aof_rewrite_time_last;                                                /* Time used by last AOF rewrite run. */
+    time_t aof_rewrite_time_start;                                               /* Current AOF rewrite start time. */
+    time_t aof_cur_timestamp;                                                    /* Current record timestamp in AOF */
+    int aof_timestamp_enabled;                                                   /* Enable record timestamp in AOF */
+    int aof_lastbgrewrite_status;                                                /* C_OK or C_ERR */
+    unsigned long aof_delayed_fsync;                                             /* delayed AOF fsync() counter */
+    int aof_rewrite_incremental_fsync;                                           /* fsync incrementally while aof rewriting? */
+    int rdb_save_incremental_fsync;                                              /* fsync incrementally while rdb saving? */
+    int aof_last_write_status;                                                   /* C_OK or C_ERR */
+    int aof_last_write_errno;                                                    /* Valid if aof write/fsync status is ERR */
+    int aof_load_truncated;                                                      /* Don't stop on unexpected AOF EOF. */
+    int aof_use_rdb_preamble;                                                    /* Specify base AOF to use RDB encoding on AOF rewrites. */
+    int aof_rewrite_use_rdb_preamble;                                            /* Base AOF to use RDB encoding on AOF rewrites start. */
+    _Atomic int aof_bio_fsync_status __attribute__((aligned(__alignof__(int)))); /* Status of AOF fsync in bio job. */
+    _Atomic int aof_bio_fsync_errno __attribute__((aligned(__alignof__(int))));  /* Errno of AOF fsync in bio job. */
+    aofManifest *aof_manifest;                                                   /* Used to track AOFs. */
+    int aof_disable_auto_gc;                                                     /* If disable automatically deleting HISTORY type AOFs?
+                                                                                  * default no. (for testings). */
+    int shutdown_on_aof_error;                                                   /* Fail primary on AOF write error. */
 
     /* RDB persistence */
     long long dirty;                      /* Changes to DB from the last save */
@@ -2082,52 +2083,52 @@ struct valkeyServer {
     int shutdown_on_sigterm; /* Shutdown flags configured for SIGTERM. */
 
     /* Replication (primary) */
-    char replid[CONFIG_RUN_ID_SIZE + 1];                                    /* My current replication ID. */
-    char replid2[CONFIG_RUN_ID_SIZE + 1];                                   /* replid inherited from primary*/
-    long long primary_repl_offset;                                          /* My current replication offset */
-    long long second_replid_offset;                                         /* Accept offsets up to this for replid2. */
-    _Atomic long long fsynced_reploff_pending __attribute__((aligned(64))); /* Largest replication offset to
+    char replid[CONFIG_RUN_ID_SIZE + 1];                                                        /* My current replication ID. */
+    char replid2[CONFIG_RUN_ID_SIZE + 1];                                                       /* replid inherited from primary*/
+    long long primary_repl_offset;                                                              /* My current replication offset */
+    long long second_replid_offset;                                                             /* Accept offsets up to this for replid2. */
+    _Atomic long long fsynced_reploff_pending __attribute__((aligned(__alignof__(long long)))); /* Largest replication offset to
                                       * potentially have been fsynced, applied to
                                         fsynced_reploff only when AOF state is AOF_ON
                                         (not during the initial rewrite) */
-    long long fsynced_reploff;                 /* Largest replication offset that has been confirmed to be fsynced */
-    int replicas_eldb;                         /* Last SELECTed DB in replication output */
-    int repl_ping_replica_period;              /* Primary pings the replica every N seconds */
-    replBacklog *repl_backlog;                 /* Replication backlog for partial syncs */
-    long long repl_backlog_size;               /* Backlog circular buffer size */
-    replDataBuf pending_repl_data;             /* Replication data buffer for dual-channel-replication */
-    time_t repl_backlog_time_limit;            /* Time without replicas after the backlog
-                                                  gets released. */
-    time_t repl_no_replicas_since;             /* We have no replicas since that time.
-                                                Only valid if server.replicas len is 0. */
-    int repl_min_replicas_to_write;            /* Min number of replicas to write. */
-    int repl_min_replicas_max_lag;             /* Max lag of <count> replicas to write. */
-    int repl_good_replicas_count;              /* Number of replicas with lag <= max_lag. */
-    int repl_diskless_sync;                    /* Primary send RDB to replicas sockets directly. */
-    int repl_diskless_load;                    /* Replica parse RDB directly from the socket.
-                                                * see REPL_DISKLESS_LOAD_* enum */
-    int repl_diskless_sync_delay;              /* Delay to start a diskless repl BGSAVE. */
-    int repl_diskless_sync_max_replicas;       /* Max replicas for diskless repl BGSAVE
-                                                * delay (start sooner if they all connect). */
-    int dual_channel_replication;              /* Config used to determine if the replica should
-                                                * use dual channel replication for full syncs. */
-    _Atomic int replica_bio_disk_save_state __attribute__((aligned(32)));   /* Flag set by the bio thread to indicate that the
-                                                * RDB save to disk has completed, or failed */
-    _Atomic bool replica_bio_abort_save __attribute__((aligned(8)));       /* Flag set by main thread, used to signal to replica's
-                                                * disk-saving bio thread to abort the save */
-    long long bio_stat_net_repl_input_bytes;   /* Used to calculate stat_net_repl_input_bytes on the
-                                                * replica's bio thread without touching main thread vars */
-    off_t bio_repl_transfer_size;              /* Used to calculate bio_repl_transfer_size on the
-                                                * replica's bio thread without touching main thread vars */
-    off_t bio_repl_transfer_read;              /* Used to calculate bio_repl_transfer_read on the
-                                                * replica's bio thread without touching main thread vars */
-    int wait_before_rdb_client_free;           /* Grace period in seconds for replica main channel
-                                                * to establish psync. */
-    int debug_pause_after_fork;                /* Debug param that pauses the main process
-                                                * after a replication fork() (for bgsave). */
-    size_t repl_buffer_mem;                    /* The memory of replication buffer. */
-    list *repl_buffer_blocks;                  /* Replication buffers blocks list
-                                                * (serving replica clients and repl backlog) */
+    long long fsynced_reploff;                                                                  /* Largest replication offset that has been confirmed to be fsynced */
+    int replicas_eldb;                                                                          /* Last SELECTed DB in replication output */
+    int repl_ping_replica_period;                                                               /* Primary pings the replica every N seconds */
+    replBacklog *repl_backlog;                                                                  /* Replication backlog for partial syncs */
+    long long repl_backlog_size;                                                                /* Backlog circular buffer size */
+    replDataBuf pending_repl_data;                                                              /* Replication data buffer for dual-channel-replication */
+    time_t repl_backlog_time_limit;                                                             /* Time without replicas after the backlog
+                                                                                                   gets released. */
+    time_t repl_no_replicas_since;                                                              /* We have no replicas since that time.
+                                                                                                 Only valid if server.replicas len is 0. */
+    int repl_min_replicas_to_write;                                                             /* Min number of replicas to write. */
+    int repl_min_replicas_max_lag;                                                              /* Max lag of <count> replicas to write. */
+    int repl_good_replicas_count;                                                               /* Number of replicas with lag <= max_lag. */
+    int repl_diskless_sync;                                                                     /* Primary send RDB to replicas sockets directly. */
+    int repl_diskless_load;                                                                     /* Replica parse RDB directly from the socket.
+                                                                                                 * see REPL_DISKLESS_LOAD_* enum */
+    int repl_diskless_sync_delay;                                                               /* Delay to start a diskless repl BGSAVE. */
+    int repl_diskless_sync_max_replicas;                                                        /* Max replicas for diskless repl BGSAVE
+                                                                                                 * delay (start sooner if they all connect). */
+    int dual_channel_replication;                                                               /* Config used to determine if the replica should
+                                                                                                 * use dual channel replication for full syncs. */
+    _Atomic int replica_bio_disk_save_state __attribute__((aligned(__alignof__(int))));         /* Flag set by the bio thread to indicate that the
+                                                                                                 * RDB save to disk has completed, or failed */
+    _Atomic bool replica_bio_abort_save __attribute__((aligned(__alignof__(bool))));            /* Flag set by main thread, used to signal to replica's
+                                                                                                 * disk-saving bio thread to abort the save */
+    long long bio_stat_net_repl_input_bytes;                                                    /* Used to calculate stat_net_repl_input_bytes on the
+                                                                                                 * replica's bio thread without touching main thread vars */
+    off_t bio_repl_transfer_size;                                                               /* Used to calculate bio_repl_transfer_size on the
+                                                                                                 * replica's bio thread without touching main thread vars */
+    off_t bio_repl_transfer_read;                                                               /* Used to calculate bio_repl_transfer_read on the
+                                                                                                 * replica's bio thread without touching main thread vars */
+    int wait_before_rdb_client_free;                                                            /* Grace period in seconds for replica main channel
+                                                                                                 * to establish psync. */
+    int debug_pause_after_fork;                                                                 /* Debug param that pauses the main process
+                                                                                                 * after a replication fork() (for bgsave). */
+    size_t repl_buffer_mem;                                                                     /* The memory of replication buffer. */
+    list *repl_buffer_blocks;                                                                   /* Replication buffers blocks list
+                                                                                                 * (serving replica clients and repl backlog) */
     /* Replication (replica) */
     char *primary_user;     /* AUTH with this user and primary_auth with primary */
     sds primary_auth;       /* AUTH with this password with primary */
@@ -3161,7 +3162,6 @@ void replicationCachePrimary(client *c);
 void resizeReplicationBacklog(void);
 void replicationSetPrimary(char *ip, int port, int full_sync_required, bool disconnect_blocked);
 void replicationUnsetPrimary(void);
-int getGoodReplicasCount(int max_lag);
 void refreshGoodReplicasCount(void);
 int checkGoodReplicasStatus(void);
 void processClientsWaitingReplicas(void);
@@ -3425,10 +3425,10 @@ void preventCommandAOF(client *c);
 void preventCommandReplication(client *c);
 void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd);
 void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int64_t duration_hist);
+int prepareReplicasForShutdown(int flags);
 int prepareForShutdown(client *c, int flags);
 void replyToClientsBlockedOnShutdown(void);
 int abortShutdown(void);
-void clusterAutoFailoverOnShutdown(void);
 void afterCommand(client *c);
 int isReplicatedClient(client *c);
 int mustObeyClient(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -3426,6 +3426,7 @@ void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int
 int prepareForShutdown(client *c, int flags);
 void replyToClientsBlockedOnShutdown(void);
 int abortShutdown(void);
+void clusterAutoFailoverOnShutdown(void);
 void afterCommand(client *c);
 int isReplicatedClient(client *c);
 int mustObeyClient(client *c);
@@ -4209,7 +4210,6 @@ void debugPauseProcess(void);
 #define serverDebugMark() printf("-- MARK %s:%d --\n", __FILE__, __LINE__)
 
 int iAmPrimary(void);
-int isPrimaryWithEnoughActualReplicas(void);
 
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)

--- a/src/server.h
+++ b/src/server.h
@@ -151,7 +151,8 @@ struct hdr_histogram;
 #define CONFIG_BGSAVE_RETRY_DELAY 5              /* Wait a few secs before trying again. */
 #define CONFIG_DEFAULT_PID_FILE "/var/run/valkey.pid"
 #define CONFIG_DEFAULT_BINDADDR_COUNT 2
-#define CONFIG_DEFAULT_BINDADDR {"*", "-::*"}
+#define CONFIG_DEFAULT_BINDADDR \
+    {"*", "-::*"}
 #define CONFIG_BINDADDR_MAX 16
 #define CONFIG_MIN_RESERVED_FDS 32
 #define CONFIG_DEFAULT_PROC_TITLE_TEMPLATE "{title} {listen-addr} {server-mode}"
@@ -1604,7 +1605,8 @@ typedef struct rdbSaveInfo {
     long long repl_offset;                /* Replication offset. */
 } rdbSaveInfo;
 
-#define RDB_SAVE_INFO_INIT {-1, 0, "0000000000000000000000000000000000000000", -1}
+#define RDB_SAVE_INFO_INIT \
+    {-1, 0, "0000000000000000000000000000000000000000", -1}
 
 struct malloc_stats {
     size_t zmalloc_used;
@@ -1763,16 +1765,16 @@ struct valkeyServer {
     int thp_enabled;                     /* If true, THP is enabled. */
     size_t page_size;                    /* The page size of OS. */
     /* Modules */
-    dict *moduleapi;                  /* Exported core APIs dictionary for modules. */
-    dict *sharedapi;                  /* Like moduleapi but containing the APIs that
-                                         modules share with each other. */
-    dict *module_configs_queue;       /* Dict that stores module configurations from .conf file until after modules are loaded
-                                         during startup or arguments to loadex. */
-    list *loadmodule_queue;           /* List of modules to load at startup. */
-    int module_pipe[2];               /* Pipe used to awake the event loop by module threads. */
-    pid_t child_pid;                  /* PID of current child */
-    int child_type;                   /* Type of current child */
-    _Atomic int module_gil_acquiring; /* Indicates whether the GIL is being acquiring by the main thread. */
+    dict *moduleapi;                                               /* Exported core APIs dictionary for modules. */
+    dict *sharedapi;                                               /* Like moduleapi but containing the APIs that
+                                                                      modules share with each other. */
+    dict *module_configs_queue;                                    /* Dict that stores module configurations from .conf file until after modules are loaded
+                                                                      during startup or arguments to loadex. */
+    list *loadmodule_queue;                                        /* List of modules to load at startup. */
+    int module_pipe[2];                                            /* Pipe used to awake the event loop by module threads. */
+    pid_t child_pid;                                               /* PID of current child */
+    int child_type;                                                /* Type of current child */
+    _Atomic int module_gil_acquiring __attribute__((aligned(32))); /* Indicates whether the GIL is being acquiring by the main thread. */
     /* Networking */
     int port;                              /* TCP listening port */
     int tls_port;                          /* TLS listening port */
@@ -1816,20 +1818,20 @@ struct valkeyServer {
     uint32_t paused_actions;    /* Bitmask of actions that are currently paused */
     list *postponed_clients;    /* List of postponed clients */
     pause_event client_pause_per_purpose[NUM_PAUSE_PURPOSES];
-    char neterr[ANET_ERR_LEN];                /* Error buffer for anet.c */
-    dict *migrate_cached_sockets;             /* MIGRATE cached sockets */
-    _Atomic uint64_t next_client_id;          /* Next client unique ID. Incremental. */
-    int protected_mode;                       /* Don't accept external connections. */
-    int io_threads_num;                       /* Number of IO threads to use. */
-    int active_io_threads_num;                /* Current number of active IO threads, includes main thread. */
-    int events_per_io_thread;                 /* Number of events on the event loop to trigger IO threads activation. */
-    int prefetch_batch_max_size;              /* Maximum number of keys to prefetch in a single batch */
-    long long events_processed_while_blocked; /* processEventsWhileBlocked() */
-    int enable_protected_configs;             /* Enable the modification of protected configs, see PROTECTED_ACTION_ALLOWED_* */
-    int enable_debug_cmd;                     /* Enable DEBUG commands, see PROTECTED_ACTION_ALLOWED_* */
-    int enable_module_cmd;                    /* Enable MODULE commands, see PROTECTED_ACTION_ALLOWED_* */
-    int enable_debug_assert;                  /* Enable debug asserts */
-    int debug_client_enforce_reply_list;      /* Force client to always use the reply list */
+    char neterr[ANET_ERR_LEN];                                    /* Error buffer for anet.c */
+    dict *migrate_cached_sockets;                                 /* MIGRATE cached sockets */
+    _Atomic uint64_t next_client_id __attribute__((aligned(64))); /* Next client unique ID. Incremental. */
+    int protected_mode;                                           /* Don't accept external connections. */
+    int io_threads_num;                                           /* Number of IO threads to use. */
+    int active_io_threads_num;                                    /* Current number of active IO threads, includes main thread. */
+    int events_per_io_thread;                                     /* Number of events on the event loop to trigger IO threads activation. */
+    int prefetch_batch_max_size;                                  /* Maximum number of keys to prefetch in a single batch */
+    long long events_processed_while_blocked;                     /* processEventsWhileBlocked() */
+    int enable_protected_configs;                                 /* Enable the modification of protected configs, see PROTECTED_ACTION_ALLOWED_* */
+    int enable_debug_cmd;                                         /* Enable DEBUG commands, see PROTECTED_ACTION_ALLOWED_* */
+    int enable_module_cmd;                                        /* Enable MODULE commands, see PROTECTED_ACTION_ALLOWED_* */
+    int enable_debug_assert;                                      /* Enable debug asserts */
+    int debug_client_enforce_reply_list;                          /* Force client to always use the reply list */
     /* Reply construction copy avoidance */
     int min_io_threads_copy_avoid;           /* Minimum number of IO threads for copy avoidance in reply construction */
     int min_string_size_copy_avoid_threaded; /* Minimum bulk string size for copy avoidance in reply construction when IO threads enabled */
@@ -1980,45 +1982,45 @@ struct valkeyServer {
     unsigned int max_new_conns_per_cycle;     /* The maximum number of tcp connections that will be accepted during each
                                                  invocation of the event loop. */
     /* AOF persistence */
-    int aof_enabled;                         /* AOF configuration */
-    int aof_state;                           /* AOF_(ON|OFF|WAIT_REWRITE) */
-    int aof_fsync;                           /* Kind of fsync() policy */
-    char *aof_filename;                      /* Basename of the AOF file and manifest file */
-    char *aof_dirname;                       /* Name of the AOF directory */
-    int aof_no_fsync_on_rewrite;             /* Don't fsync if a rewrite is in prog. */
-    int aof_rewrite_perc;                    /* Rewrite AOF if % growth is > M and... */
-    off_t aof_rewrite_min_size;              /* the AOF file is at least N bytes. */
-    off_t aof_rewrite_base_size;             /* AOF size on latest startup or rewrite. */
-    off_t aof_current_size;                  /* AOF current size (Including BASE + INCRs). */
-    off_t aof_last_incr_size;                /* The size of the latest incr AOF. */
-    off_t aof_last_incr_fsync_offset;        /* AOF offset which is already requested to be synced to disk.
-                                              * Compare with the aof_last_incr_size. */
-    int aof_flush_sleep;                     /* Micros to sleep before flush. (used by tests) */
-    int aof_rewrite_scheduled;               /* Rewrite once BGSAVE terminates. */
-    sds aof_buf;                             /* AOF buffer, written before entering the event loop */
-    int aof_fd;                              /* File descriptor of currently selected AOF file */
-    int aof_selected_db;                     /* Currently selected DB in AOF */
-    mstime_t aof_flush_postponed_start;      /* mstime of postponed AOF flush */
-    mstime_t aof_last_fsync;                 /* mstime of last fsync() */
-    time_t aof_rewrite_time_last;            /* Time used by last AOF rewrite run. */
-    time_t aof_rewrite_time_start;           /* Current AOF rewrite start time. */
-    time_t aof_cur_timestamp;                /* Current record timestamp in AOF */
-    int aof_timestamp_enabled;               /* Enable record timestamp in AOF */
-    int aof_lastbgrewrite_status;            /* C_OK or C_ERR */
-    unsigned long aof_delayed_fsync;         /* delayed AOF fsync() counter */
-    int aof_rewrite_incremental_fsync;       /* fsync incrementally while aof rewriting? */
-    int rdb_save_incremental_fsync;          /* fsync incrementally while rdb saving? */
-    int aof_last_write_status;               /* C_OK or C_ERR */
-    int aof_last_write_errno;                /* Valid if aof write/fsync status is ERR */
-    int aof_load_truncated;                  /* Don't stop on unexpected AOF EOF. */
-    int aof_use_rdb_preamble;                /* Specify base AOF to use RDB encoding on AOF rewrites. */
-    int aof_rewrite_use_rdb_preamble;        /* Base AOF to use RDB encoding on AOF rewrites start. */
-    _Atomic int aof_bio_fsync_status;        /* Status of AOF fsync in bio job. */
-    _Atomic int aof_bio_fsync_errno;         /* Errno of AOF fsync in bio job. */
-    aofManifest *aof_manifest;               /* Used to track AOFs. */
-    int aof_disable_auto_gc;                 /* If disable automatically deleting HISTORY type AOFs?
-                                              * default no. (for testings). */
-    int replicas_to_fail_on_aof_short_write; /* Fail primary on AOF short write error if there are enough actual replicas. */
+    int aof_enabled;                                               /* AOF configuration */
+    int aof_state;                                                 /* AOF_(ON|OFF|WAIT_REWRITE) */
+    int aof_fsync;                                                 /* Kind of fsync() policy */
+    char *aof_filename;                                            /* Basename of the AOF file and manifest file */
+    char *aof_dirname;                                             /* Name of the AOF directory */
+    int aof_no_fsync_on_rewrite;                                   /* Don't fsync if a rewrite is in prog. */
+    int aof_rewrite_perc;                                          /* Rewrite AOF if % growth is > M and... */
+    off_t aof_rewrite_min_size;                                    /* the AOF file is at least N bytes. */
+    off_t aof_rewrite_base_size;                                   /* AOF size on latest startup or rewrite. */
+    off_t aof_current_size;                                        /* AOF current size (Including BASE + INCRs). */
+    off_t aof_last_incr_size;                                      /* The size of the latest incr AOF. */
+    off_t aof_last_incr_fsync_offset;                              /* AOF offset which is already requested to be synced to disk.
+                                                                    * Compare with the aof_last_incr_size. */
+    int aof_flush_sleep;                                           /* Micros to sleep before flush. (used by tests) */
+    int aof_rewrite_scheduled;                                     /* Rewrite once BGSAVE terminates. */
+    sds aof_buf;                                                   /* AOF buffer, written before entering the event loop */
+    int aof_fd;                                                    /* File descriptor of currently selected AOF file */
+    int aof_selected_db;                                           /* Currently selected DB in AOF */
+    mstime_t aof_flush_postponed_start;                            /* mstime of postponed AOF flush */
+    mstime_t aof_last_fsync;                                       /* mstime of last fsync() */
+    time_t aof_rewrite_time_last;                                  /* Time used by last AOF rewrite run. */
+    time_t aof_rewrite_time_start;                                 /* Current AOF rewrite start time. */
+    time_t aof_cur_timestamp;                                      /* Current record timestamp in AOF */
+    int aof_timestamp_enabled;                                     /* Enable record timestamp in AOF */
+    int aof_lastbgrewrite_status;                                  /* C_OK or C_ERR */
+    unsigned long aof_delayed_fsync;                               /* delayed AOF fsync() counter */
+    int aof_rewrite_incremental_fsync;                             /* fsync incrementally while aof rewriting? */
+    int rdb_save_incremental_fsync;                                /* fsync incrementally while rdb saving? */
+    int aof_last_write_status;                                     /* C_OK or C_ERR */
+    int aof_last_write_errno;                                      /* Valid if aof write/fsync status is ERR */
+    int aof_load_truncated;                                        /* Don't stop on unexpected AOF EOF. */
+    int aof_use_rdb_preamble;                                      /* Specify base AOF to use RDB encoding on AOF rewrites. */
+    int aof_rewrite_use_rdb_preamble;                              /* Base AOF to use RDB encoding on AOF rewrites start. */
+    _Atomic int aof_bio_fsync_status __attribute__((aligned(32))); /* Status of AOF fsync in bio job. */
+    _Atomic int aof_bio_fsync_errno __attribute__((aligned(32)));  /* Errno of AOF fsync in bio job. */
+    aofManifest *aof_manifest;                                     /* Used to track AOFs. */
+    int aof_disable_auto_gc;                                       /* If disable automatically deleting HISTORY type AOFs?
+                                                                    * default no. (for testings). */
+    int replicas_to_fail_on_aof_short_write;                       /* Fail primary on AOF short write error if there are enough actual replicas. */
 
     /* RDB persistence */
     long long dirty;                      /* Changes to DB from the last save */
@@ -2080,11 +2082,11 @@ struct valkeyServer {
     int shutdown_on_sigterm; /* Shutdown flags configured for SIGTERM. */
 
     /* Replication (primary) */
-    char replid[CONFIG_RUN_ID_SIZE + 1];       /* My current replication ID. */
-    char replid2[CONFIG_RUN_ID_SIZE + 1];      /* replid inherited from primary*/
-    long long primary_repl_offset;             /* My current replication offset */
-    long long second_replid_offset;            /* Accept offsets up to this for replid2. */
-    _Atomic long long fsynced_reploff_pending; /* Largest replication offset to
+    char replid[CONFIG_RUN_ID_SIZE + 1];                                    /* My current replication ID. */
+    char replid2[CONFIG_RUN_ID_SIZE + 1];                                   /* replid inherited from primary*/
+    long long primary_repl_offset;                                          /* My current replication offset */
+    long long second_replid_offset;                                         /* Accept offsets up to this for replid2. */
+    _Atomic long long fsynced_reploff_pending __attribute__((aligned(64))); /* Largest replication offset to
                                       * potentially have been fsynced, applied to
                                         fsynced_reploff only when AOF state is AOF_ON
                                         (not during the initial rewrite) */
@@ -2109,9 +2111,9 @@ struct valkeyServer {
                                                 * delay (start sooner if they all connect). */
     int dual_channel_replication;              /* Config used to determine if the replica should
                                                 * use dual channel replication for full syncs. */
-    _Atomic int replica_bio_disk_save_state;   /* Flag set by the bio thread to indicate that the
+    _Atomic int replica_bio_disk_save_state __attribute__((aligned(32)));   /* Flag set by the bio thread to indicate that the
                                                 * RDB save to disk has completed, or failed */
-    _Atomic bool replica_bio_abort_save;       /* Flag set by main thread, used to signal to replica's
+    _Atomic bool replica_bio_abort_save __attribute__((aligned(8)));       /* Flag set by main thread, used to signal to replica's
                                                 * disk-saving bio thread to abort the save */
     long long bio_stat_net_repl_input_bytes;   /* Used to calculate stat_net_repl_input_bytes on the
                                                 * replica's bio thread without touching main thread vars */

--- a/src/server.h
+++ b/src/server.h
@@ -2020,7 +2020,7 @@ struct valkeyServer {
     aofManifest *aof_manifest;                                     /* Used to track AOFs. */
     int aof_disable_auto_gc;                                       /* If disable automatically deleting HISTORY type AOFs?
                                                                     * default no. (for testings). */
-    int replicas_to_fail_on_aof_short_write;                       /* Fail primary on AOF short write error if there are enough actual replicas. */
+    int replicas_to_fail_on_aof_write_error;                       /* Fail primary on AOF write error if there are enough actual replicas. */
 
     /* RDB persistence */
     long long dirty;                      /* Changes to DB from the last save */

--- a/src/server.h
+++ b/src/server.h
@@ -1980,44 +1980,45 @@ struct valkeyServer {
     unsigned int max_new_conns_per_cycle;     /* The maximum number of tcp connections that will be accepted during each
                                                  invocation of the event loop. */
     /* AOF persistence */
-    int aof_enabled;                    /* AOF configuration */
-    int aof_state;                      /* AOF_(ON|OFF|WAIT_REWRITE) */
-    int aof_fsync;                      /* Kind of fsync() policy */
-    char *aof_filename;                 /* Basename of the AOF file and manifest file */
-    char *aof_dirname;                  /* Name of the AOF directory */
-    int aof_no_fsync_on_rewrite;        /* Don't fsync if a rewrite is in prog. */
-    int aof_rewrite_perc;               /* Rewrite AOF if % growth is > M and... */
-    off_t aof_rewrite_min_size;         /* the AOF file is at least N bytes. */
-    off_t aof_rewrite_base_size;        /* AOF size on latest startup or rewrite. */
-    off_t aof_current_size;             /* AOF current size (Including BASE + INCRs). */
-    off_t aof_last_incr_size;           /* The size of the latest incr AOF. */
-    off_t aof_last_incr_fsync_offset;   /* AOF offset which is already requested to be synced to disk.
-                                         * Compare with the aof_last_incr_size. */
-    int aof_flush_sleep;                /* Micros to sleep before flush. (used by tests) */
-    int aof_rewrite_scheduled;          /* Rewrite once BGSAVE terminates. */
-    sds aof_buf;                        /* AOF buffer, written before entering the event loop */
-    int aof_fd;                         /* File descriptor of currently selected AOF file */
-    int aof_selected_db;                /* Currently selected DB in AOF */
-    mstime_t aof_flush_postponed_start; /* mstime of postponed AOF flush */
-    mstime_t aof_last_fsync;            /* mstime of last fsync() */
-    time_t aof_rewrite_time_last;       /* Time used by last AOF rewrite run. */
-    time_t aof_rewrite_time_start;      /* Current AOF rewrite start time. */
-    time_t aof_cur_timestamp;           /* Current record timestamp in AOF */
-    int aof_timestamp_enabled;          /* Enable record timestamp in AOF */
-    int aof_lastbgrewrite_status;       /* C_OK or C_ERR */
-    unsigned long aof_delayed_fsync;    /* delayed AOF fsync() counter */
-    int aof_rewrite_incremental_fsync;  /* fsync incrementally while aof rewriting? */
-    int rdb_save_incremental_fsync;     /* fsync incrementally while rdb saving? */
-    int aof_last_write_status;          /* C_OK or C_ERR */
-    int aof_last_write_errno;           /* Valid if aof write/fsync status is ERR */
-    int aof_load_truncated;             /* Don't stop on unexpected AOF EOF. */
-    int aof_use_rdb_preamble;           /* Specify base AOF to use RDB encoding on AOF rewrites. */
-    int aof_rewrite_use_rdb_preamble;   /* Base AOF to use RDB encoding on AOF rewrites start. */
-    _Atomic int aof_bio_fsync_status;   /* Status of AOF fsync in bio job. */
-    _Atomic int aof_bio_fsync_errno;    /* Errno of AOF fsync in bio job. */
-    aofManifest *aof_manifest;          /* Used to track AOFs. */
-    int aof_disable_auto_gc;            /* If disable automatically deleting HISTORY type AOFs?
-                                           default no. (for testings). */
+    int aof_enabled;                         /* AOF configuration */
+    int aof_state;                           /* AOF_(ON|OFF|WAIT_REWRITE) */
+    int aof_fsync;                           /* Kind of fsync() policy */
+    char *aof_filename;                      /* Basename of the AOF file and manifest file */
+    char *aof_dirname;                       /* Name of the AOF directory */
+    int aof_no_fsync_on_rewrite;             /* Don't fsync if a rewrite is in prog. */
+    int aof_rewrite_perc;                    /* Rewrite AOF if % growth is > M and... */
+    off_t aof_rewrite_min_size;              /* the AOF file is at least N bytes. */
+    off_t aof_rewrite_base_size;             /* AOF size on latest startup or rewrite. */
+    off_t aof_current_size;                  /* AOF current size (Including BASE + INCRs). */
+    off_t aof_last_incr_size;                /* The size of the latest incr AOF. */
+    off_t aof_last_incr_fsync_offset;        /* AOF offset which is already requested to be synced to disk.
+                                              * Compare with the aof_last_incr_size. */
+    int aof_flush_sleep;                     /* Micros to sleep before flush. (used by tests) */
+    int aof_rewrite_scheduled;               /* Rewrite once BGSAVE terminates. */
+    sds aof_buf;                             /* AOF buffer, written before entering the event loop */
+    int aof_fd;                              /* File descriptor of currently selected AOF file */
+    int aof_selected_db;                     /* Currently selected DB in AOF */
+    mstime_t aof_flush_postponed_start;      /* mstime of postponed AOF flush */
+    mstime_t aof_last_fsync;                 /* mstime of last fsync() */
+    time_t aof_rewrite_time_last;            /* Time used by last AOF rewrite run. */
+    time_t aof_rewrite_time_start;           /* Current AOF rewrite start time. */
+    time_t aof_cur_timestamp;                /* Current record timestamp in AOF */
+    int aof_timestamp_enabled;               /* Enable record timestamp in AOF */
+    int aof_lastbgrewrite_status;            /* C_OK or C_ERR */
+    unsigned long aof_delayed_fsync;         /* delayed AOF fsync() counter */
+    int aof_rewrite_incremental_fsync;       /* fsync incrementally while aof rewriting? */
+    int rdb_save_incremental_fsync;          /* fsync incrementally while rdb saving? */
+    int aof_last_write_status;               /* C_OK or C_ERR */
+    int aof_last_write_errno;                /* Valid if aof write/fsync status is ERR */
+    int aof_load_truncated;                  /* Don't stop on unexpected AOF EOF. */
+    int aof_use_rdb_preamble;                /* Specify base AOF to use RDB encoding on AOF rewrites. */
+    int aof_rewrite_use_rdb_preamble;        /* Base AOF to use RDB encoding on AOF rewrites start. */
+    _Atomic int aof_bio_fsync_status;        /* Status of AOF fsync in bio job. */
+    _Atomic int aof_bio_fsync_errno;         /* Errno of AOF fsync in bio job. */
+    aofManifest *aof_manifest;               /* Used to track AOFs. */
+    int aof_disable_auto_gc;                 /* If disable automatically deleting HISTORY type AOFs?
+                                              * default no. (for testings). */
+    int replicas_to_fail_on_aof_short_write; /* Fail primary on AOF short write error if there are enough actual replicas. */
 
     /* RDB persistence */
     long long dirty;                      /* Changes to DB from the last save */
@@ -3158,6 +3159,7 @@ void replicationCachePrimary(client *c);
 void resizeReplicationBacklog(void);
 void replicationSetPrimary(char *ip, int port, int full_sync_required, bool disconnect_blocked);
 void replicationUnsetPrimary(void);
+int getGoodReplicasCount(int max_lag);
 void refreshGoodReplicasCount(void);
 int checkGoodReplicasStatus(void);
 void processClientsWaitingReplicas(void);
@@ -4207,6 +4209,7 @@ void debugPauseProcess(void);
 #define serverDebugMark() printf("-- MARK %s:%d --\n", __FILE__, __LINE__)
 
 int iAmPrimary(void);
+int isPrimaryWithEnoughActualReplicas(void);
 
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -45,6 +45,7 @@
 
 #include "sds.h"
 #include "ae.h"
+#include <valkey/valkey.h>
 #ifdef USE_OPENSSL
 #include <openssl/ssl.h>
 #include <openssl/err.h>

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -45,7 +45,6 @@
 
 #include "sds.h"
 #include "ae.h"
-#include <valkey/valkey.h>
 #ifdef USE_OPENSSL
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -104,14 +103,14 @@ static struct config {
     int mptcp;
     struct cliSSLconfig sslconfig;
     int numclients;
-    _Atomic int liveclients;
+    _Atomic int liveclients __attribute__((aligned(__alignof__(int))));
     int requests;
     int duration;
     int warmup_duration;
     _Atomic int current_warmup_duration;
-    _Atomic int requests_issued;
-    _Atomic int requests_finished;
-    _Atomic int previous_requests_finished;
+    _Atomic int requests_issued __attribute__((aligned(__alignof__(int))));
+    _Atomic int requests_finished __attribute__((aligned(__alignof__(int))));
+    _Atomic int previous_requests_finished __attribute__((aligned(__alignof__(int))));
     int last_printed_bytes;
     long long previous_tick;
     int keysize;
@@ -147,9 +146,9 @@ static struct config {
     struct hdr_histogram *latency_histogram;
     struct hdr_histogram *current_sec_latency_histogram;
     struct hdr_histogram *rps_histogram;
-    _Atomic int is_fetching_slots;
-    _Atomic int is_updating_slots;
-    _Atomic int slots_last_update;
+    _Atomic int is_fetching_slots __attribute__((aligned(__alignof__(int))));
+    _Atomic int is_updating_slots __attribute__((aligned(__alignof__(int))));
+    _Atomic int slots_last_update __attribute__((aligned(__alignof__(int))));
     int enable_tracking;
     int num_functions;
     int num_keys_in_fcall;
@@ -157,7 +156,7 @@ static struct config {
     pthread_mutex_t is_updating_slots_mutex;
     int resp3; /* use RESP3 */
     int rps;
-    atomic_uint_fast64_t last_time_ns;
+    atomic_uint_fast64_t last_time_ns __attribute__((aligned(__alignof__(uint_fast64_t))));
     uint64_t time_per_token;
     uint64_t time_per_burst;
 } config;

--- a/valkey.conf
+++ b/valkey.conf
@@ -1720,9 +1720,9 @@ aof-use-rdb-preamble yes
 # the AOF format in a way that may not be compatible with existing AOF parsers.
 aof-timestamp-enabled no
 
-# Fail primary on AOF short write error if there are this replicas count with 0 lag.
+# Fail primary on AOF write error if there are this replicas count with 0 lag.
 # -1 (default) prevents failing.
-replicas-to-fail-on-aof-short-write -1
+replicas-to-fail-on-aof-write-error -1
 
 ################################ SHUTDOWN #####################################
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -1720,6 +1720,10 @@ aof-use-rdb-preamble yes
 # the AOF format in a way that may not be compatible with existing AOF parsers.
 aof-timestamp-enabled no
 
+# Fail primary on AOF short write error if there are this replicas count with 0 lag.
+# -1 (default) prevents failing.
+replicas-to-fail-on-aof-short-write -1
+
 ################################ SHUTDOWN #####################################
 
 # Maximum time to wait for replicas when shutting down, in seconds.

--- a/valkey.conf
+++ b/valkey.conf
@@ -1720,9 +1720,9 @@ aof-use-rdb-preamble yes
 # the AOF format in a way that may not be compatible with existing AOF parsers.
 aof-timestamp-enabled no
 
-# Fail primary on AOF write error if there are this replicas count with 0 lag.
-# -1 (default) prevents failing.
-replicas-to-fail-on-aof-write-error -1
+# Fail primary on AOF write error.
+# In cluster node failover attempt is made during shutdown-timeout.
+shutdown-on-aof-error no
 
 ################################ SHUTDOWN #####################################
 


### PR DESCRIPTION
when we have a primary disk filled with AOF we might finally have it stalled forever in that state - in this PR the config option is added to kill master having enough good replicas on such occasion (with recently added failover attempt for cluster-version reused)