### PR TITLE
Cluster: Avoid usage of light weight messages to nodes with not ready bidirectional links

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4940,6 +4940,7 @@ void clusterPropagatePublish(robj *channel, robj *message, int sharded) {
         if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_HANDSHAKE)) continue;
         if (!node->link || node->pong_received < node->link->ctime) continue;
         if (nodeSupportsLightMsgHdrForPubSub(node)) {
+            if (!node->link || node->pong_received < node->link->ctime) continue;
             clusterSendMessage(node->link, msgblock_light);
         } else {
             if (msgblock == NULL) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4826,6 +4826,18 @@ void clusterSendUpdate(clusterLink *link, clusterNode *node) {
     clusterMsgSendBlockDecrRefCount(msgblock);
 }
 
+/* Inline functions that check support of light weight messages by node
+ * and avoid using light weight messages until the bidirectional
+ * link(s) have been established. */
+static inline bool nodeSupportsLightMsgHdrForPubSub(clusterNode *n) {
+    return n->link && n->pong_received >= n->link->ctime &&
+           (n->flags & CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED);
+}
+static inline bool nodeSupportsLightMsgHdrForModule(clusterNode *n) {
+    return n->link && n->pong_received >= n->link->ctime &&
+           (n->flags & CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED);
+}
+
 /* Create a MODULE message block.
  *
  * If is_light is 1, then build a message block with `clusterMsgLight` struct else `clusterMsg`. */
@@ -4939,8 +4951,6 @@ void clusterPropagatePublish(robj *channel, robj *message, int sharded) {
     while ((node = clusterNodeIterNext(&iter)) != NULL) {
         if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_HANDSHAKE)) continue;
         if (nodeSupportsLightMsgHdrForPubSub(node)) {
-            /* Avoid sending pub/sub light weight message until the bidirectional link(s) have been established. */
-            if (!node->link || node->pong_received < node->link->ctime) continue;
             clusterSendMessage(node->link, msgblock_light);
         } else {
             if (msgblock == NULL) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4939,6 +4939,7 @@ void clusterPropagatePublish(robj *channel, robj *message, int sharded) {
     while ((node = clusterNodeIterNext(&iter)) != NULL) {
         if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_HANDSHAKE)) continue;
         if (nodeSupportsLightMsgHdrForPubSub(node)) {
+            /* Avoid sending pub/sub light weight message until the bidirectional link(s) have been established. */
             if (!node->link || node->pong_received < node->link->ctime) continue;
             clusterSendMessage(node->link, msgblock_light);
         } else {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4938,6 +4938,7 @@ void clusterPropagatePublish(robj *channel, robj *message, int sharded) {
     clusterNode *node;
     while ((node = clusterNodeIterNext(&iter)) != NULL) {
         if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_HANDSHAKE)) continue;
+        if (!node->link || node->pong_received < node->link->ctime) continue;
         if (nodeSupportsLightMsgHdrForPubSub(node)) {
             clusterSendMessage(node->link, msgblock_light);
         } else {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4938,7 +4938,6 @@ void clusterPropagatePublish(robj *channel, robj *message, int sharded) {
     clusterNode *node;
     while ((node = clusterNodeIterNext(&iter)) != NULL) {
         if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_HANDSHAKE)) continue;
-        if (!node->link || node->pong_received < node->link->ctime) continue;
         if (nodeSupportsLightMsgHdrForPubSub(node)) {
             if (!node->link || node->pong_received < node->link->ctime) continue;
             clusterSendMessage(node->link, msgblock_light);

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -75,8 +75,6 @@ typedef struct clusterLink {
 #define nodeFailed(n) ((n)->flags & CLUSTER_NODE_FAIL)
 #define nodeCantFailover(n) ((n)->flags & CLUSTER_NODE_NOFAILOVER)
 #define nodeSupportsExtensions(n) ((n)->flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED)
-#define nodeSupportsLightMsgHdrForPubSub(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED)
-#define nodeSupportsLightMsgHdrForModule(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED)
 #define nodeInNormalState(n) (!((n)->flags & (CLUSTER_NODE_HANDSHAKE | CLUSTER_NODE_MEET | CLUSTER_NODE_PFAIL | CLUSTER_NODE_FAIL)))
 
 /* Cluster messages header */


### PR DESCRIPTION
After network failure nodes that come back to cluster do not always send and/or receive messages from other nodes in shard, this fix avoids usage of light weight messages to nodes with not ready bidirectional links.
If a light message arrives before any normal message, cluster link is freed because on the just established connection link->node has not been assigned yet and is required to be set for light weight message usage.

On a cluster with heavy pubsub load a long loop of disconnects is possible.

1. node A establishes cluster link to node B
2. node A propagates PUBLISH to node B
3. node B frees cluster link because of link->node == null as it has not received non-light messages yet
4. go to 1.

During this loop subscribers of node B does not receive any messages published to node A.

So here we want to make sure that PING was sent (and link->node was initialized) on this connection before using lightweight messages. In the meanwhile regular clusterMsg header is used to send pub/sub or module data.