### PR TITLE
Implemented a merge queue for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
       - '**/*.md'
       - '**/00-RELEASENOTES'
       - '**/COPYING'
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
This pull requests adds GitHub merge queue functionality to automate testing and merging of pull requests. After a pull request meets the requirements that we set in GitHub settings, it will be added to the merge queue. We can also select the setting that allows us to manually add the PR to the queue. We can choose the number of PRs that we want in the queue at a time (batch size). All these PRs that are currently in the queue will then be added to the unstable branch and tested against all the daily tests. If they pass, all the PRs in the queue will be merged into unstable. This is a useful feature to see which commits can impact the daily tests. If the tests fail against the batch then the merge queue will split up each individual commit and test it against the daily tests to find out which commit is causing the failure. 

Check here for more information on merge queues: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue


**Settings that need to be enabled**

1. Enable Merge Queue in Settings (Settings -> Branches -> Branch Protection Rules -> Click on `Add Rule`)
2. Scroll down and check `require merge queue` and input the desired settings under this section.
3. You can also edit the `require status checks to pass before merging` section in settings.

I set it to run all the daily tests except the valgrind and macOS tests.

Example Runs in my own test org: https://github.com/Merge-Queue-Test-For-Valkey/merge-queue-test/actions/runs/19626527240/job/56196367079

Note: #2702 also modifies the daily.yml file. Assuming that PR is merged first I will go back and rebase this PR since we both add workflow calls.

Resolves #2086 