### PR TITLE
Reset prefetch and ACL stats via CONFIG RESETSTAT

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2866,6 +2866,14 @@ void resetServerStats(void) {
     server.el_cmd_cnt_max = 0;
     server.stat_active_time = 0;
     server.el_iteration_active = false;
+    server.stat_total_prefetch_batches = 0;
+    server.stat_total_prefetch_entries = 0;
+    server.acl_info.invalid_cmd_accesses = 0;
+    server.acl_info.invalid_key_accesses = 0;
+    server.acl_info.user_auth_failures = 0;
+    server.acl_info.invalid_channel_accesses = 0;
+    server.acl_info.acl_access_denied_tls_cert = 0;
+    server.acl_info.invalid_db_accesses = 0;
     lazyfreeResetStats();
 }
 
@@ -3073,14 +3081,6 @@ void initServer(void) {
     server.aof_last_write_errno = 0;
     server.repl_good_replicas_count = 0;
     server.last_sig_received = 0;
-
-    /* Initiate acl info struct */
-    server.acl_info.invalid_cmd_accesses = 0;
-    server.acl_info.invalid_key_accesses = 0;
-    server.acl_info.user_auth_failures = 0;
-    server.acl_info.invalid_channel_accesses = 0;
-    server.acl_info.acl_access_denied_tls_cert = 0;
-    server.acl_info.invalid_db_accesses = 0;
 
     /* Create the timer callback, this is our way to process many background
      * operations incrementally, like eviction of unaccessed expired keys, etc. */


### PR DESCRIPTION
Add the missing counter resets in resetServerStats() so that
CONFIG RESETSTAT clears the io_threaded_total_prefetch_* and
the acl_access_denied_* stats.

Note that although the acl_access_denied_* stats are security
relevant, CONFIG RESETSTAT is an admin-only command, so resetting
them is acceptable — just as ACL LOG RESET already lets an admin
clear ACL security logs and related state.
