### PR TITLE
test: add valgrind:skip tag to automatically skip tests under valgrind

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -104,9 +104,13 @@ The following compatibility and capability tags are currently used:
 | `needs:save`              | Uses `SAVE` or `BGSAVE` to create an RDB file. |
 | `needs:other-server`      | Requires `--other-server-path`. |
 | `singledb`                | Test runs as if `--singledb` was given. |
+| `valgrind:skip`           | Not compatible with `--valgrind`. |
 
 When using an external server (`--host` and `--port`), filtering using the
 `external:skip` tags is done automatically.
+
+When using `--valgrind`, filtering using the `valgrind:skip` tag is done
+automatically.
 
 When using `--cluster-mode`, filtering using the `cluster:skip` tag is done
 automatically.

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -61,14 +61,14 @@ if {$backtrace_supported} {
     }
 }
 
-# Valgrind will complain that the process terminated by a signal, skip it.
-if {!$::valgrind} {
-    if {$backtrace_supported} {
-        set check_cb check_log_backtrace_for_debug
-    } else {
-        set check_cb check_crash_log
-    }
+if {$backtrace_supported} {
+    set check_cb check_log_backtrace_for_debug
+} else {
+    set check_cb check_crash_log
+}
 
+# Valgrind will complain that the process terminated by a signal, skip it.
+tags {"valgrind:skip"} {
     # test being killed by a SIGABRT from outside
     set server_path [tmpdir server1.log]
     start_server [list overrides [list dir $server_path crash-memcheck-enabled no]] {

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -278,6 +278,11 @@ proc tags_acceptable {tags err_return} {
         return 0
     }
 
+    if {$::valgrind && [lsearch -exact $tags "valgrind:skip"] >= 0} {
+        set err "Not supported when running under Valgrind"
+        return 0
+    }
+    
     return 1
 }
 

--- a/tests/unit/io-threads.tcl
+++ b/tests/unit/io-threads.tcl
@@ -35,13 +35,10 @@ proc activate_io_threads_and_wait {} {
     }
 }
 
-start_server {config "minimal.conf" tags {"external:skip"} overrides {enable-debug-command {yes} io-threads 5}} {
+start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overrides {enable-debug-command {yes} io-threads 5}} {
     # Skip if non io-threads mode - as it is relevant only for io-threads mode
     assert_equal {io-threads 5} [r config get io-threads]
     test {Force the use of IO threads and assert active IO thread usage} {
-        if {$::valgrind} {
-            skip "Too slow with Valgrind"
-        }
         activate_io_threads_and_wait
         set info [r info]
         set io_threads_count [dict get [r config get io-threads] io-threads]

--- a/tests/unit/moduleapi/crash.tcl
+++ b/tests/unit/moduleapi/crash.tcl
@@ -4,7 +4,7 @@ set testmodule [file normalize tests/modules/crash.so]
 set backtrace_supported [system_backtrace_supported]
 
 # Valgrind will complain that the process terminated by a signal, skip it.
-if {!$::valgrind} {
+tags {"valgrind:skip"} {
     start_server {tags {"modules"}} {
         r module load $testmodule assert
         test {Test module crash when info crashes with an assertion } {

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -874,13 +874,13 @@ start_server {tags {"hash"}} {
     # 1.23 cannot be represented correctly with 64 bit doubles, so we skip
     # the test, since we are only testing pretty printing here and is not
     # a bug if the program outputs things like 1.299999...
-    if {!$::valgrind && [string match *x86_64* [exec uname -a]]} {
+    if {[string match *x86_64* [exec uname -a]]} {
         test {Test HINCRBYFLOAT for correct float representation (issue #2846)} {
             r del myhash
             assert {[r hincrbyfloat myhash float 1.23] eq {1.23}}
             assert {[r hincrbyfloat myhash float 0.77] eq {2}}
             assert {[r hincrbyfloat myhash float -0.1] eq {1.9}}
-        }
+        } {} {valgrind:skip}
     }
 
     test {Hash ziplist of various encodings} {
@@ -934,10 +934,8 @@ start_server {tags {"hash"}} {
     } {ZIP_INT_8B 127 ZIP_INT_16B 32767 ZIP_INT_32B 2147483647 ZIP_INT_64B 9223372036854775808 ZIP_INT_IMM_MIN 0 ZIP_INT_IMM_MAX 12}
 
     # On some platforms strtold("+inf") with valgrind returns a non-inf result
-    if {!$::valgrind} {
-        test {HINCRBYFLOAT does not allow NaN or Infinity} {
-            assert_error "*value is NaN or Infinity*" {r hincrbyfloat hfoo field +inf}
-            assert_equal 0 [r exists hfoo]
-        }
-    }
+    test {HINCRBYFLOAT does not allow NaN or Infinity} {
+        assert_error "*value is NaN or Infinity*" {r hincrbyfloat hfoo field +inf}
+        assert_equal 0 [r exists hfoo]
+    } {} {valgrind:skip}
 }

--- a/tests/unit/type/incr.tcl
+++ b/tests/unit/type/incr.tcl
@@ -141,8 +141,7 @@ start_server {tags {"incr"}} {
     } {WRONGTYPE*}
 
     # On some platforms strtold("+inf") with valgrind returns a non-inf result
-    if {!$::valgrind} {
-        test {INCRBYFLOAT does not allow NaN or Infinity} {
+    test {INCRBYFLOAT does not allow NaN or Infinity} {
             r set foo 0
             set err {}
             catch {r incrbyfloat foo +inf} err
@@ -150,8 +149,7 @@ start_server {tags {"incr"}} {
             # p.s. no way I can force NaN to test it from the API because
             # there is no way to increment / decrement by infinity nor to
             # perform divisions.
-        } {ERR *would produce*}
-    }
+    } {ERR *would produce*} {valgrind:skip}
 
     test {INCRBYFLOAT decrement} {
         r set foo 1


### PR DESCRIPTION
**Fixes #3127**

Please review when someone gets the time. Thanks!

## Description
Adds a `valgrind:skip` tag to automatically skip tests when running with `--valgrind`. This allows skipping before the server starts, rather than checking `$::valgrind` inside tests.

## Changes
- Added tag check in `server.tcl`
- Replaced `!$::valgrind` checks with the new tag in affected tests
- Updated README documentation
- Refactored tests in `hash.tcl` by adding `valgrind:skip` tag inline
- Added `valgrind:skip` tag to a test in `incr.tcl`

## Testing
Verified tests are correctly skipped with `--valgrind` and run normally without it.

## AI Usage
Used AI to help understand TCL syntax (first time working with the language).