### PR TITLE
Preparations to make serverObject (robj) opaque

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1985,7 +1985,7 @@ int rewriteSetObject(rio *r, robj *key, robj *o) {
 int rewriteSortedSetObject(rio *r, robj *key, robj *o) {
     long long count = 0, items = zsetLength(o);
 
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(o);
         unsigned char *eptr, *sptr;
         unsigned char *vstr;
@@ -2020,7 +2020,7 @@ int rewriteSortedSetObject(rio *r, robj *key, robj *o) {
             if (++count == AOF_REWRITE_ITEMS_PER_CMD) count = 0;
             items--;
         }
-    } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(o);
         hashtableIterator iter;
         hashtableInitIterator(&iter, zs->ht, 0);
@@ -2365,24 +2365,24 @@ int rewriteObjectRio(rio *aof, robj *o, int db_num) {
     expiretime = objectGetExpire(o);
 
     /* Save the key and associated value */
-    if (o->type == OBJ_STRING) {
+    if (objectGetType(o) == OBJ_STRING) {
         /* Emit a SET command */
         char cmd[] = "*3\r\n$3\r\nSET\r\n";
         if (rioWrite(aof, cmd, sizeof(cmd) - 1) == 0) return C_ERR;
         /* Key and value */
         if (rioWriteBulkObject(aof, &key) == 0) return C_ERR;
         if (rioWriteBulkObject(aof, o) == 0) return C_ERR;
-    } else if (o->type == OBJ_LIST) {
+    } else if (objectGetType(o) == OBJ_LIST) {
         if (rewriteListObject(aof, &key, o) == 0) return C_ERR;
-    } else if (o->type == OBJ_SET) {
+    } else if (objectGetType(o) == OBJ_SET) {
         if (rewriteSetObject(aof, &key, o) == 0) return C_ERR;
-    } else if (o->type == OBJ_ZSET) {
+    } else if (objectGetType(o) == OBJ_ZSET) {
         if (rewriteSortedSetObject(aof, &key, o) == 0) return C_ERR;
-    } else if (o->type == OBJ_HASH) {
+    } else if (objectGetType(o) == OBJ_HASH) {
         if (rewriteHashObject(aof, &key, o) == 0) return C_ERR;
-    } else if (o->type == OBJ_STREAM) {
+    } else if (objectGetType(o) == OBJ_STREAM) {
         if (rewriteStreamObject(aof, &key, o) == 0) return C_ERR;
-    } else if (o->type == OBJ_MODULE) {
+    } else if (objectGetType(o) == OBJ_MODULE) {
         if (rewriteModuleObject(aof, &key, o, db_num) == 0) return C_ERR;
     } else {
         serverPanic("Unknown object type");

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -673,7 +673,7 @@ unsigned char *getObjectReadOnlyString(robj *o, long *len, char *llbuf) {
 
     /* Set the 'p' pointer to the string, that can be just a stack allocated
      * array if our string was integer encoded. */
-    if (o && o->encoding == OBJ_ENCODING_INT) {
+    if (o && objectGetEncoding(o) == OBJ_ENCODING_INT) {
         p = (unsigned char *)llbuf;
         if (len) *len = ll2string(llbuf, LONG_STR_SIZE, (long)objectGetVal(o));
     } else if (o) {

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -645,7 +645,7 @@ static void handleClientsBlockedOnKey(readyList *rl) {
              *    module is trying to accomplish right now.
              * 3. In case of XREADGROUP call we will want to unblock on any change in object type
              *    or in case the key was deleted, since the group is no longer valid. */
-            if ((o != NULL && (receiver->bstate->btype == getBlockedTypeByType(o->type))) ||
+            if ((o != NULL && (receiver->bstate->btype == getBlockedTypeByType(objectGetType(o)))) ||
                 (o != NULL && (receiver->bstate->btype == BLOCKED_MODULE)) || (receiver->bstate->unblock_on_nokey)) {
                 if (receiver->bstate->btype != BLOCKED_MODULE)
                     unblockClientOnKey(receiver, rl->key);

--- a/src/db.c
+++ b/src/db.c
@@ -174,7 +174,7 @@ robj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply) {
 /* For hash keys, checks if they contain volatile items and updates tracking accordingly.
  * Always accesses the tracking kvstore, even if the tracking state doesn't change. */
 void dbUpdateObjectWithVolatileItemsTracking(serverDb *db, robj *o) {
-    if (o->type == OBJ_HASH) {
+    if (objectGetType(o) == OBJ_HASH) {
         if (hashTypeHasVolatileFields(o)) {
             dbTrackKeyWithVolatileItems(db, o);
         } else {
@@ -359,7 +359,7 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
         old = val;
     } else {
         /* Replace the old value at its location in the key space. */
-        val->lru = old->lru;
+        objectSetLRU(val, objectGetLRU(old));
         long long expire = objectGetExpire(old);
         new = objectSetKeyAndExpire(val, objectGetVal(key), expire);
         *oldref = new;
@@ -500,7 +500,7 @@ int dbGenericDeleteWithDictIndex(serverDb *db, robj *key, int async, int flags, 
         }
 
         /* If deleting a hash object, un-track it from the volatile items tracking if it contains volatile items.*/
-        if (val->type == OBJ_HASH && hashTypeHasVolatileFields(val)) {
+        if (objectGetType(val) == OBJ_HASH && hashTypeHasVolatileFields(val)) {
             dbUntrackKeyWithVolatileItems(db, val);
         }
 
@@ -525,7 +525,7 @@ int dbGenericDelete(serverDb *db, robj *key, int async, int flags) {
 /* Add a key with volatile items to the tracking kvstore. */
 void dbTrackKeyWithVolatileItems(serverDb *db, robj *o) {
     serverAssert(objectGetKey(o));
-    if (o->type == OBJ_HASH && hashTypeHasVolatileFields(o)) {
+    if (objectGetType(o) == OBJ_HASH && hashTypeHasVolatileFields(o)) {
         int dict_index = getKVStoreIndexForKey(objectGetKey(o));
         kvstoreHashtableAdd(db->keys_with_volatile_items, dict_index, o);
     }
@@ -583,7 +583,7 @@ int dbDelete(serverDb *db, robj *key) {
  * using an sdscat() call to append some data, or anything else.
  */
 robj *dbUnshareStringValue(serverDb *db, robj *key, robj *o) {
-    serverAssert(o->type == OBJ_STRING);
+    serverAssert(objectGetType(o) == OBJ_STRING);
     if (o->refcount != 1 || o->encoding != OBJ_ENCODING_RAW) {
         robj *decoded = getDecodedObject(o);
         o = createRawStringObject(objectGetVal(decoded), sdslen(objectGetVal(decoded)));
@@ -1067,7 +1067,7 @@ void hashtableScanCallback(void *privdata, void *entry) {
         zskiplistNode *node = (zskiplistNode *)entry;
         key = zslGetNodeElement(node);
         /* zset data is copied after filtering by key */
-    } else if (o->type == OBJ_HASH) {
+    } else if (objectGetType(o) == OBJ_HASH) {
         key = entryGetField(entry);
         if (!data->only_keys) {
             val.buf = entryGetValue(entry, &val.len);
@@ -1230,7 +1230,7 @@ void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor
 
     /* Object must be NULL (to iterate keys names), or the type of the object
      * must be Set, Sorted Set, or Hash. */
-    serverAssert(o == NULL || o->type == OBJ_SET || o->type == OBJ_HASH || o->type == OBJ_ZSET);
+    serverAssert(o == NULL || o->type == OBJ_SET || objectGetType(o) == OBJ_HASH || o->type == OBJ_ZSET);
 
     /* Iterate the collection.
      *
@@ -1251,7 +1251,7 @@ void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor
     } else if (o->type == OBJ_SET && o->encoding == OBJ_ENCODING_HASHTABLE) {
         ht = objectGetVal(o);
         free_callback = NULL;
-    } else if (o->type == OBJ_HASH && o->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetType(o) == OBJ_HASH && o->encoding == OBJ_ENCODING_HASHTABLE) {
         ht = objectGetVal(o);
         free_callback = NULL;
     } else if (o->type == OBJ_ZSET && o->encoding == OBJ_ENCODING_SKIPLIST) {
@@ -1331,7 +1331,7 @@ void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor
         }
         setTypeReleaseIterator(si);
         cursor = 0;
-    } else if ((o->type == OBJ_HASH || o->type == OBJ_ZSET) && o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if ((objectGetType(o) == OBJ_HASH || o->type == OBJ_ZSET) && o->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *p = lpFirst(objectGetVal(o));
         unsigned char *str;
         int64_t len;
@@ -1923,7 +1923,7 @@ robj *setExpire(client *c, serverDb *db, robj *key, long long when) {
     long long old_when = objectGetExpire(val);
 
     robj *newval = objectSetExpire(val, when);
-    if (newval->type == OBJ_HASH && hashTypeHasVolatileFields(newval)) {
+    if (objectGetType(newval) == OBJ_HASH && hashTypeHasVolatileFields(newval)) {
         /* Replace the pointer in the keys_with_volatile_items table without accessing the old pointer. */
         int dict_index = getKVStoreIndexForKey(objectGetKey(newval));
         hashtable *volatile_items_ht = kvstoreGetHashtable(db->keys_with_volatile_items, dict_index);

--- a/src/debug.c
+++ b/src/debug.c
@@ -151,15 +151,15 @@ void mixStringObjectDigest(unsigned char *digest, robj *o) {
  * will continue mixing this object digest to anything that was already
  * present. */
 void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o) {
-    uint32_t aux = htonl(o->type);
+    uint32_t aux = htonl(objectGetType(o));
     mixDigest(digest, &aux, sizeof(aux));
     long long expiretime = objectGetExpire(o);
     char buf[128];
 
     /* Save the key and associated value */
-    if (o->type == OBJ_STRING) {
+    if (objectGetType(o) == OBJ_STRING) {
         mixStringObjectDigest(digest, o);
-    } else if (o->type == OBJ_LIST) {
+    } else if (objectGetType(o) == OBJ_LIST) {
         listTypeIterator *li = listTypeInitIterator(o, 0, LIST_TAIL);
         listTypeEntry entry;
         while (listTypeNext(li, &entry)) {
@@ -168,7 +168,7 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
             decrRefCount(eleobj);
         }
         listTypeReleaseIterator(li);
-    } else if (o->type == OBJ_SET) {
+    } else if (objectGetType(o) == OBJ_SET) {
         setTypeIterator *si = setTypeInitIterator(o);
         sds sdsele;
         while ((sdsele = setTypeNextObject(si)) != NULL) {
@@ -176,10 +176,10 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
             sdsfree(sdsele);
         }
         setTypeReleaseIterator(si);
-    } else if (o->type == OBJ_ZSET) {
+    } else if (objectGetType(o) == OBJ_ZSET) {
         unsigned char eledigest[20];
 
-        if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
             unsigned char *zl = objectGetVal(o);
             unsigned char *eptr, *sptr;
             unsigned char *vstr;
@@ -209,7 +209,7 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
                 xorDigest(digest, eledigest, 20);
                 zzlNext(zl, &eptr, &sptr);
             }
-        } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST) {
             zset *zs = objectGetVal(o);
             hashtableIterator iter;
             hashtableInitIterator(&iter, zs->ht, 0);
@@ -229,7 +229,7 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
         } else {
             serverPanic("Unknown sorted set encoding");
         }
-    } else if (o->type == OBJ_HASH) {
+    } else if (objectGetType(o) == OBJ_HASH) {
         hashTypeIterator hi;
         hashTypeInitIterator(o, &hi);
         while (hashTypeNext(&hi) != C_ERR) {
@@ -246,7 +246,7 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
             xorDigest(digest, eledigest, 20);
         }
         hashTypeResetIterator(&hi);
-    } else if (o->type == OBJ_STREAM) {
+    } else if (objectGetType(o) == OBJ_STREAM) {
         streamIterator si;
         streamIteratorStart(&si, objectGetVal(o), NULL, NULL, 0);
         streamID id;
@@ -266,7 +266,7 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
             }
         }
         streamIteratorStop(&si);
-    } else if (o->type == OBJ_MODULE) {
+    } else if (objectGetType(o) == OBJ_MODULE) {
         ValkeyModuleDigest md = {{0}, {0}, keyobj, db->id};
         moduleValue *mv = objectGetVal(o);
         moduleType *mt = mv->type;
@@ -737,7 +737,7 @@ void debugCommand(client *c) {
 
         if ((o = objectCommandLookupOrReply(c, c->argv[2], shared.nokeyerr)) == NULL) return;
 
-        if (o->encoding != OBJ_ENCODING_LISTPACK) {
+        if (objectGetEncoding(o) != OBJ_ENCODING_LISTPACK) {
             addReplyError(c, "Not a listpack encoded object.");
         } else {
             lpRepr(objectGetVal(o));
@@ -750,7 +750,7 @@ void debugCommand(client *c) {
 
         int full = 0;
         if (c->argc == 4) full = atoi(objectGetVal(c->argv[3]));
-        if (o->encoding != OBJ_ENCODING_QUICKLIST) {
+        if (objectGetEncoding(o) != OBJ_ENCODING_QUICKLIST) {
             addReplyError(c, "Not a quicklist encoded object.");
         } else {
             quicklistRepr(objectGetVal(o), full);
@@ -972,7 +972,7 @@ void debugCommand(client *c) {
 
         /* Get the hashtable reference from the object, if possible. */
         hashtable *ht = NULL;
-        switch (o->encoding) {
+        switch (objectGetEncoding(o)) {
         case OBJ_ENCODING_SKIPLIST: {
             zset *zs = objectGetVal(o);
             ht = zs->ht;
@@ -1157,9 +1157,9 @@ void _serverAssertPrintClientInfo(const client *c) {
 }
 
 void serverLogObjectDebugInfo(const robj *o) {
-    serverLog(LL_WARNING, "Object type: %u", o->type);
-    serverLog(LL_WARNING, "Object encoding: %u", o->encoding);
-    serverLog(LL_WARNING, "Object refcount: %d", o->refcount);
+    serverLog(LL_WARNING, "Object type: %u", objectGetType(o));
+    serverLog(LL_WARNING, "Object encoding: %u", objectGetEncoding(o));
+    serverLog(LL_WARNING, "Object refcount: %d", objectGetRefcount(o));
 #if defined(UNSAFE_CRASH_REPORT) && UNSAFE_CRASH_REPORT
     /* This code is now disabled. o->ptr may be unreliable to print. in some
      * cases a ziplist could have already been freed by realloc, but not yet
@@ -1168,24 +1168,24 @@ void serverLogObjectDebugInfo(const robj *o) {
      * For some cases it may be ok to crash here again, but these could cause
      * invalid memory access which will bother valgrind and also possibly cause
      * random memory portion to be "leaked" into the logfile. */
-    if (o->type == OBJ_STRING && sdsEncodedObject(o)) {
+    if (objectGetType(o) == OBJ_STRING && sdsEncodedObject(o)) {
         serverLog(LL_WARNING, "Object raw string len: %zu", sdslen(o->ptr));
         if (sdslen(o->ptr) < 4096) {
             sds repr = sdscatrepr(sdsempty(), o->ptr, sdslen(o->ptr));
             serverLog(LL_WARNING, "Object raw string content: %s", repr);
             sdsfree(repr);
         }
-    } else if (o->type == OBJ_LIST) {
+    } else if (objectGetType(o) == OBJ_LIST) {
         serverLog(LL_WARNING, "List length: %d", (int)listTypeLength(o));
-    } else if (o->type == OBJ_SET) {
+    } else if (objectGetType(o) == OBJ_SET) {
         serverLog(LL_WARNING, "Set size: %d", (int)setTypeSize(o));
-    } else if (o->type == OBJ_HASH) {
+    } else if (objectGetType(o) == OBJ_HASH) {
         serverLog(LL_WARNING, "Hash size: %d", (int)hashTypeLength(o));
-    } else if (o->type == OBJ_ZSET) {
+    } else if (objectGetType(o) == OBJ_ZSET) {
         serverLog(LL_WARNING, "Sorted set size: %d", (int)zsetLength(o));
-        if (o->encoding == OBJ_ENCODING_SKIPLIST)
+        if (objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST)
             serverLog(LL_WARNING, "Skiplist level: %d", (int)((const zset *)o->ptr)->zsl->level);
-    } else if (o->type == OBJ_STREAM) {
+    } else if (objectGetType(o) == OBJ_STREAM) {
         serverLog(LL_WARNING, "Stream size: %d", (int)streamLength(o));
     }
 #endif

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -610,7 +610,7 @@ void ioThreadFreeArgv(robj **argv) {
         }
 
         /* The main-thread set the refcount to 0 to indicate that this is the last argument to free */
-        if (o->refcount == 0) {
+        if (objectGetRefcount(o) == 0) {
             last_arg = 1;
             o->refcount = 1;
         }

--- a/src/module.c
+++ b/src/module.c
@@ -793,7 +793,7 @@ int moduleCreateEmptyKey(ValkeyModuleKey *key, int type) {
 /* Frees key->iter and sets it to NULL. */
 static void moduleFreeKeyIterator(ValkeyModuleKey *key) {
     serverAssert(key->iter != NULL);
-    switch (key->value->type) {
+    switch (objectGetType(key->value)) {
     case OBJ_LIST: listTypeReleaseIterator(key->iter); break;
     case OBJ_STREAM:
         streamIteratorStop(key->iter);
@@ -808,7 +808,7 @@ static void moduleFreeKeyIterator(ValkeyModuleKey *key) {
  * Frees list iterator and sets it to NULL. */
 static void moduleFreeListIterator(void *data) {
     ValkeyModuleKey *key = (ValkeyModuleKey *)data;
-    serverAssert(key->value->type == OBJ_LIST);
+    serverAssert(objectGetType(key->value) == OBJ_LIST);
     if (key->iter) moduleFreeKeyIterator(key);
 }
 
@@ -827,7 +827,7 @@ int moduleDelKeyIfEmpty(ValkeyModuleKey *key) {
     int isempty;
     robj *o = key->value;
 
-    switch (o->type) {
+    switch (objectGetType(o)) {
     case OBJ_LIST: isempty = listTypeLength(o) == 0; break;
     case OBJ_SET: isempty = setTypeSize(o) == 0; break;
     case OBJ_ZSET: isempty = zsetLength(o) == 0; break;
@@ -4264,7 +4264,7 @@ static void moduleInitKey(ValkeyModuleKey *kp, ValkeyModuleCtx *ctx, robj *keyna
 
 /* Initialize the type-specific part of the key. Only when key has a value. */
 static void moduleInitKeyTypeSpecific(ValkeyModuleKey *key) {
-    switch (key->value->type) {
+    switch (objectGetType(key->value)) {
     case OBJ_ZSET: zsetKeyReset(key); break;
     case OBJ_STREAM: key->u.stream.signalready = 0; break;
     }
@@ -4340,7 +4340,7 @@ static void moduleCloseKey(ValkeyModuleKey *key) {
     if ((key->mode & VALKEYMODULE_WRITE) && signal) signalModifiedKey(key->ctx->client, key->db, key->key);
     if (key->value) {
         if (key->iter) moduleFreeKeyIterator(key);
-        switch (key->value->type) {
+        switch (objectGetType(key->value)) {
         case OBJ_ZSET: VM_ZsetRangeStop(key); break;
         case OBJ_STREAM:
             if (key->u.stream.signalready) /* One or more VM_StreamAdd() have been done. */
@@ -4366,7 +4366,7 @@ int VM_KeyType(ValkeyModuleKey *key) {
     if (key == NULL || key->value == NULL) return VALKEYMODULE_KEYTYPE_EMPTY;
     /* We map between defines so that we are free to change the internal
      * defines as desired. */
-    switch (key->value->type) {
+    switch (objectGetType(key->value)) {
     case OBJ_STRING: return VALKEYMODULE_KEYTYPE_STRING;
     case OBJ_LIST: return VALKEYMODULE_KEYTYPE_LIST;
     case OBJ_SET: return VALKEYMODULE_KEYTYPE_SET;
@@ -4385,7 +4385,7 @@ int VM_KeyType(ValkeyModuleKey *key) {
  * If the key pointer is NULL or the key is empty, zero is returned. */
 size_t VM_ValueLength(ValkeyModuleKey *key) {
     if (key == NULL || key->value == NULL) return 0;
-    switch (key->value->type) {
+    switch (objectGetType(key->value)) {
     case OBJ_STRING: return stringObjectLen(key->value);
     case OBJ_LIST: return listTypeLength(key->value);
     case OBJ_SET: return setTypeSize(key->value);
@@ -4584,11 +4584,11 @@ char *VM_StringDMA(ValkeyModuleKey *key, size_t *len, int mode) {
         return emptystring;
     }
 
-    if (key->value->type != OBJ_STRING) return NULL;
+    if (objectGetType(key->value) != OBJ_STRING) return NULL;
 
     /* For write access, and even for read access if the object is encoded,
      * we unshare the string (that has the side effect of decoding it). */
-    if ((mode & VALKEYMODULE_WRITE) || key->value->encoding != OBJ_ENCODING_RAW)
+    if ((mode & VALKEYMODULE_WRITE) || objectGetEncoding(key->value) != OBJ_ENCODING_RAW)
         key->value = dbUnshareStringValue(key->db, key->key, key->value);
 
     *len = sdslen(objectGetVal(key->value));
@@ -4609,7 +4609,7 @@ char *VM_StringDMA(ValkeyModuleKey *key, size_t *len, int mode) {
  * unless the new length value requested is zero. */
 int VM_StringTruncate(ValkeyModuleKey *key, size_t newlen) {
     if (!(key->mode & VALKEYMODULE_WRITE)) return VALKEYMODULE_ERR;
-    if (key->value && key->value->type != OBJ_STRING) return VALKEYMODULE_ERR;
+    if (key->value && objectGetType(key->value) != OBJ_STRING) return VALKEYMODULE_ERR;
     if (newlen > 512 * 1024 * 1024) return VALKEYMODULE_ERR;
 
     /* Empty key and new len set to 0. Just return VALKEYMODULE_OK without
@@ -4673,7 +4673,7 @@ int moduleListIteratorSeek(ValkeyModuleKey *key, long index, int mode) {
     if (!key) {
         errno = EINVAL;
         return 0;
-    } else if (!key->value || key->value->type != OBJ_LIST) {
+    } else if (!key->value || objectGetType(key->value) != OBJ_LIST) {
         errno = ENOTSUP;
         return 0;
     }
@@ -4731,7 +4731,7 @@ int VM_ListPush(ValkeyModuleKey *key, int where, ValkeyModuleString *ele) {
     if (!key || !ele) {
         errno = EINVAL;
         return VALKEYMODULE_ERR;
-    } else if (key->value != NULL && key->value->type != OBJ_LIST) {
+    } else if (key->value != NULL && objectGetType(key->value) != OBJ_LIST) {
         errno = ENOTSUP;
         return VALKEYMODULE_ERR;
     }
@@ -4741,7 +4741,7 @@ int VM_ListPush(ValkeyModuleKey *key, int where, ValkeyModuleString *ele) {
     }
 
     if (!(key->mode & VALKEYMODULE_WRITE)) return VALKEYMODULE_ERR;
-    if (key->value && key->value->type != OBJ_LIST) return VALKEYMODULE_ERR;
+    if (key->value && objectGetType(key->value) != OBJ_LIST) return VALKEYMODULE_ERR;
     if (key->iter) moduleFreeKeyIterator(key);
     if (key->value == NULL) moduleCreateEmptyKey(key, VALKEYMODULE_KEYTYPE_LIST);
     listTypeTryConversionAppend(key->value, &ele, 0, 0, moduleFreeListIterator, key);
@@ -4765,7 +4765,7 @@ ValkeyModuleString *VM_ListPop(ValkeyModuleKey *key, int where) {
     if (!key) {
         errno = EINVAL;
         return NULL;
-    } else if (key->value == NULL || key->value->type != OBJ_LIST) {
+    } else if (key->value == NULL || objectGetType(key->value) != OBJ_LIST) {
         errno = ENOTSUP;
         return NULL;
     } else if (!(key->mode & VALKEYMODULE_WRITE)) {
@@ -4830,7 +4830,7 @@ int VM_ListSet(ValkeyModuleKey *key, long index, ValkeyModuleString *value) {
         errno = EINVAL;
         return VALKEYMODULE_ERR;
     }
-    if (!key->value || key->value->type != OBJ_LIST) {
+    if (!key->value || objectGetType(key->value) != OBJ_LIST) {
         errno = ENOTSUP;
         return VALKEYMODULE_ERR;
     }
@@ -4868,11 +4868,11 @@ int VM_ListInsert(ValkeyModuleKey *key, long index, ValkeyModuleString *value) {
     } else if (key != NULL && key->value == NULL && (index == 0 || index == -1)) {
         /* Insert in empty key => push. */
         return VM_ListPush(key, VALKEYMODULE_LIST_TAIL, value);
-    } else if (key != NULL && key->value != NULL && key->value->type == OBJ_LIST &&
+    } else if (key != NULL && key->value != NULL && objectGetType(key->value) == OBJ_LIST &&
                (index == (long)listTypeLength(key->value) || index == -1)) {
         /* Insert after the last element => push tail. */
         return VM_ListPush(key, VALKEYMODULE_LIST_TAIL, value);
-    } else if (key != NULL && key->value != NULL && key->value->type == OBJ_LIST &&
+    } else if (key != NULL && key->value != NULL && objectGetType(key->value) == OBJ_LIST &&
                (index == 0 || index == -(long)listTypeLength(key->value) - 1)) {
         /* Insert before the first element => push head. */
         return VM_ListPush(key, VALKEYMODULE_LIST_HEAD, value);
@@ -4990,7 +4990,7 @@ int moduleZsetAddFlagsFromCoreFlags(int flags) {
 int VM_ZsetAdd(ValkeyModuleKey *key, double score, ValkeyModuleString *ele, int *flagsptr) {
     int in_flags = 0, out_flags = 0;
     if (!(key->mode & VALKEYMODULE_WRITE)) return VALKEYMODULE_ERR;
-    if (key->value && key->value->type != OBJ_ZSET) return VALKEYMODULE_ERR;
+    if (key->value && objectGetType(key->value) != OBJ_ZSET) return VALKEYMODULE_ERR;
     if (key->value == NULL) moduleCreateEmptyKey(key, VALKEYMODULE_KEYTYPE_ZSET);
     if (flagsptr) in_flags = moduleZsetAddFlagsToCoreFlags(*flagsptr);
     if (zsetAdd(key->value, score, objectGetVal(ele), in_flags, &out_flags, NULL) == 0) {
@@ -5018,7 +5018,7 @@ int VM_ZsetAdd(ValkeyModuleKey *key, double score, ValkeyModuleString *ele, int 
 int VM_ZsetIncrby(ValkeyModuleKey *key, double score, ValkeyModuleString *ele, int *flagsptr, double *newscore) {
     int in_flags = 0, out_flags = 0;
     if (!(key->mode & VALKEYMODULE_WRITE)) return VALKEYMODULE_ERR;
-    if (key->value && key->value->type != OBJ_ZSET) return VALKEYMODULE_ERR;
+    if (key->value && objectGetType(key->value) != OBJ_ZSET) return VALKEYMODULE_ERR;
     if (key->value == NULL) moduleCreateEmptyKey(key, VALKEYMODULE_KEYTYPE_ZSET);
     if (flagsptr) in_flags = moduleZsetAddFlagsToCoreFlags(*flagsptr);
     in_flags |= ZADD_IN_INCR;
@@ -5051,7 +5051,7 @@ int VM_ZsetIncrby(ValkeyModuleKey *key, double score, ValkeyModuleString *ele, i
  * Empty keys will be handled correctly by doing nothing. */
 int VM_ZsetRem(ValkeyModuleKey *key, ValkeyModuleString *ele, int *deleted) {
     if (!(key->mode & VALKEYMODULE_WRITE)) return VALKEYMODULE_ERR;
-    if (key->value && key->value->type != OBJ_ZSET) return VALKEYMODULE_ERR;
+    if (key->value && objectGetType(key->value) != OBJ_ZSET) return VALKEYMODULE_ERR;
     if (key->value != NULL && zsetDel(key->value, objectGetVal(ele))) {
         if (deleted) *deleted = 1;
         moduleDelKeyIfEmpty(key);
@@ -5071,7 +5071,7 @@ int VM_ZsetRem(ValkeyModuleKey *key, ValkeyModuleString *ele, int *deleted) {
  */
 int VM_ZsetScore(ValkeyModuleKey *key, ValkeyModuleString *ele, double *score) {
     if (key->value == NULL) return VALKEYMODULE_ERR;
-    if (key->value->type != OBJ_ZSET) return VALKEYMODULE_ERR;
+    if (objectGetType(key->value) != OBJ_ZSET) return VALKEYMODULE_ERR;
     if (zsetScore(key->value, objectGetVal(ele), score) == C_ERR) return VALKEYMODULE_ERR;
     return VALKEYMODULE_OK;
 }
@@ -5088,7 +5088,7 @@ void zsetKeyReset(ValkeyModuleKey *key) {
 
 /* Stop a sorted set iteration. */
 void VM_ZsetRangeStop(ValkeyModuleKey *key) {
-    if (!key->value || key->value->type != OBJ_ZSET) return;
+    if (!key->value || objectGetType(key->value) != OBJ_ZSET) return;
     /* Free resources if needed. */
     if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_LEX) zsetFreeLexRange(&key->u.zset.lrs);
     /* Setup sensible values so that misused iteration API calls when an
@@ -5099,7 +5099,7 @@ void VM_ZsetRangeStop(ValkeyModuleKey *key) {
 
 /* Return the "End of range" flag value to signal the end of the iteration. */
 int VM_ZsetRangeEndReached(ValkeyModuleKey *key) {
-    if (!key->value || key->value->type != OBJ_ZSET) return 1;
+    if (!key->value || objectGetType(key->value) != OBJ_ZSET) return 1;
     return key->u.zset.er;
 }
 
@@ -5110,7 +5110,7 @@ int VM_ZsetRangeEndReached(ValkeyModuleKey *key) {
  * otherwise the last. Return VALKEYMODULE_OK on success otherwise
  * VALKEYMODULE_ERR. */
 int zsetInitScoreRange(ValkeyModuleKey *key, double min, double max, int minex, int maxex, int first) {
-    if (!key->value || key->value->type != OBJ_ZSET) return VALKEYMODULE_ERR;
+    if (!key->value || objectGetType(key->value) != OBJ_ZSET) return VALKEYMODULE_ERR;
 
     VM_ZsetRangeStop(key);
     key->u.zset.type = VALKEYMODULE_ZSET_RANGE_SCORE;
@@ -5124,9 +5124,9 @@ int zsetInitScoreRange(ValkeyModuleKey *key, double min, double max, int minex, 
     zrs->minex = minex;
     zrs->maxex = maxex;
 
-    if (key->value->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(key->value) == OBJ_ENCODING_LISTPACK) {
         key->u.zset.current = first ? zzlFirstInRange(objectGetVal(key->value), zrs) : zzlLastInRange(objectGetVal(key->value), zrs);
-    } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(key->value) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(key->value);
         zskiplist *zsl = zs->zsl;
         key->u.zset.current = first ? zslNthInRange(zsl, zrs, 0, NULL) : zslNthInRange(zsl, zrs, -1, NULL);
@@ -5172,7 +5172,7 @@ int VM_ZsetLastInScoreRange(ValkeyModuleKey *key, double min, double max, int mi
  * Note that this function takes 'min' and 'max' in the same form of the
  * ZRANGEBYLEX command. */
 int zsetInitLexRange(ValkeyModuleKey *key, ValkeyModuleString *min, ValkeyModuleString *max, int first) {
-    if (!key->value || key->value->type != OBJ_ZSET) return VALKEYMODULE_ERR;
+    if (!key->value || objectGetType(key->value) != OBJ_ZSET) return VALKEYMODULE_ERR;
 
     VM_ZsetRangeStop(key);
     key->u.zset.er = 0;
@@ -5186,10 +5186,10 @@ int zsetInitLexRange(ValkeyModuleKey *key, ValkeyModuleString *min, ValkeyModule
      * otherwise we don't want the zlexrangespec to be freed. */
     key->u.zset.type = VALKEYMODULE_ZSET_RANGE_LEX;
 
-    if (key->value->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(key->value) == OBJ_ENCODING_LISTPACK) {
         key->u.zset.current =
             first ? zzlFirstInLexRange(objectGetVal(key->value), zlrs) : zzlLastInLexRange(objectGetVal(key->value), zlrs);
-    } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(key->value) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(key->value);
         zskiplist *zsl = zs->zsl;
         key->u.zset.current = first ? zslNthInLexRange(zsl, zlrs, 0) : zslNthInLexRange(zsl, zlrs, -1);
@@ -5229,9 +5229,9 @@ int VM_ZsetLastInLexRange(ValkeyModuleKey *key, ValkeyModuleString *min, ValkeyM
 ValkeyModuleString *VM_ZsetRangeCurrentElement(ValkeyModuleKey *key, double *score) {
     ValkeyModuleString *str;
 
-    if (!key->value || key->value->type != OBJ_ZSET) return NULL;
+    if (!key->value || objectGetType(key->value) != OBJ_ZSET) return NULL;
     if (key->u.zset.current == NULL) return NULL;
-    if (key->value->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(key->value) == OBJ_ENCODING_LISTPACK) {
         unsigned char *eptr, *sptr;
         eptr = key->u.zset.current;
         sds ele = lpGetObject(eptr);
@@ -5240,7 +5240,7 @@ ValkeyModuleString *VM_ZsetRangeCurrentElement(ValkeyModuleKey *key, double *sco
             *score = zzlGetScore(sptr);
         }
         str = createObject(OBJ_STRING, ele);
-    } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(key->value) == OBJ_ENCODING_SKIPLIST) {
         zskiplistNode *ln = key->u.zset.current;
         if (score) *score = ln->score;
         sds ele = zslGetNodeElement(ln);
@@ -5256,10 +5256,10 @@ ValkeyModuleString *VM_ZsetRangeCurrentElement(ValkeyModuleKey *key, double *sco
  * a next element, 0 if we are already at the latest element or the range
  * does not include any item at all. */
 int VM_ZsetRangeNext(ValkeyModuleKey *key) {
-    if (!key->value || key->value->type != OBJ_ZSET) return 0;
+    if (!key->value || objectGetType(key->value) != OBJ_ZSET) return 0;
     if (!key->u.zset.type || !key->u.zset.current) return 0; /* No active iterator. */
 
-    if (key->value->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(key->value) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(key->value);
         unsigned char *eptr = key->u.zset.current;
         unsigned char *next;
@@ -5290,7 +5290,7 @@ int VM_ZsetRangeNext(ValkeyModuleKey *key) {
             key->u.zset.current = next;
             return 1;
         }
-    } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(key->value) == OBJ_ENCODING_SKIPLIST) {
         zskiplistNode *ln = key->u.zset.current, *next = ln->level[0].forward;
         if (next == NULL) {
             key->u.zset.er = 1;
@@ -5318,10 +5318,10 @@ int VM_ZsetRangeNext(ValkeyModuleKey *key) {
  * a previous element, 0 if we are already at the first element or the range
  * does not include any item at all. */
 int VM_ZsetRangePrev(ValkeyModuleKey *key) {
-    if (!key->value || key->value->type != OBJ_ZSET) return 0;
+    if (!key->value || objectGetType(key->value) != OBJ_ZSET) return 0;
     if (!key->u.zset.type || !key->u.zset.current) return 0; /* No active iterator. */
 
-    if (key->value->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(key->value) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(key->value);
         unsigned char *eptr = key->u.zset.current;
         unsigned char *prev;
@@ -5352,7 +5352,7 @@ int VM_ZsetRangePrev(ValkeyModuleKey *key) {
             key->u.zset.current = prev;
             return 1;
         }
-    } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(key->value) == OBJ_ENCODING_SKIPLIST) {
         zskiplistNode *ln = key->u.zset.current, *prev = ln->backward;
         if (prev == NULL) {
             key->u.zset.er = 1;
@@ -5392,14 +5392,14 @@ int VM_ZsetRangePrev(ValkeyModuleKey *key) {
  *
  * The function receives the hash key, field name, buffer to share along with its size. */
 int VM_HashSetStringRef(ValkeyModuleKey *key, ValkeyModuleString *field, const char *buf, size_t len) {
-    if (!key || !key->value || key->value->type != OBJ_HASH || !field || !buf) return VALKEYMODULE_ERR;
+    if (!key || !key->value || objectGetType(key->value) != OBJ_HASH || !field || !buf) return VALKEYMODULE_ERR;
     return hashTypeUpdateAsStringRef(key->value, objectGetVal(field), buf, len);
 }
 
 /* Checks if the value of a hash entry is a shared string reference (stringRef).
  * The function receives the hash key and field name to perform the check against. */
 int VM_HashHasStringRef(ValkeyModuleKey *key, ValkeyModuleString *field) {
-    if (!key || !key->value || key->value->type != OBJ_HASH) return VALKEYMODULE_ERR;
+    if (!key || !key->value || objectGetType(key->value) != OBJ_HASH) return VALKEYMODULE_ERR;
     return hashTypeHasStringRef(key->value, objectGetVal(field));
 }
 /* Set the field of the specified hash field to the specified value.
@@ -5475,7 +5475,7 @@ int VM_HashSet(ValkeyModuleKey *key, int flags, ...) {
                            VALKEYMODULE_HASH_COUNT_ALL))) {
         errno = EINVAL;
         return 0;
-    } else if (key->value && key->value->type != OBJ_HASH) {
+    } else if (key->value && objectGetType(key->value) != OBJ_HASH) {
         errno = ENOTSUP;
         return 0;
     } else if (!(key->mode & VALKEYMODULE_WRITE)) {
@@ -5583,7 +5583,7 @@ int VM_HashSet(ValkeyModuleKey *key, int flags, ...) {
  */
 int VM_HashGet(ValkeyModuleKey *key, int flags, ...) {
     va_list ap;
-    if (key->value && key->value->type != OBJ_HASH) return VALKEYMODULE_ERR;
+    if (key->value && objectGetType(key->value) != OBJ_HASH) return VALKEYMODULE_ERR;
 
     va_start(ap, flags);
     while (1) {
@@ -5676,7 +5676,7 @@ int VM_StreamAdd(ValkeyModuleKey *key, int flags, ValkeyModuleStreamID *id, Valk
         (!(flags & VALKEYMODULE_STREAM_ADD_AUTOID) && !id)) { /* id required */
         errno = EINVAL;
         return VALKEYMODULE_ERR;
-    } else if (key->value && key->value->type != OBJ_STREAM) {
+    } else if (key->value && objectGetType(key->value) != OBJ_STREAM) {
         errno = ENOTSUP; /* wrong type */
         return VALKEYMODULE_ERR;
     } else if (!(key->mode & VALKEYMODULE_WRITE)) {
@@ -5751,7 +5751,7 @@ int VM_StreamDelete(ValkeyModuleKey *key, ValkeyModuleStreamID *id) {
     if (!key || !id) {
         errno = EINVAL;
         return VALKEYMODULE_ERR;
-    } else if (!key->value || key->value->type != OBJ_STREAM) {
+    } else if (!key->value || objectGetType(key->value) != OBJ_STREAM) {
         errno = ENOTSUP; /* wrong type */
         return VALKEYMODULE_ERR;
     } else if (!(key->mode & VALKEYMODULE_WRITE) || key->iter != NULL) {
@@ -5822,7 +5822,7 @@ int VM_StreamIteratorStart(ValkeyModuleKey *key, int flags, ValkeyModuleStreamID
     if (!key || (flags & ~(VALKEYMODULE_STREAM_ITERATOR_EXCLUSIVE | VALKEYMODULE_STREAM_ITERATOR_REVERSE))) {
         errno = EINVAL; /* key missing or invalid flags */
         return VALKEYMODULE_ERR;
-    } else if (!key->value || key->value->type != OBJ_STREAM) {
+    } else if (!key->value || objectGetType(key->value) != OBJ_STREAM) {
         errno = ENOTSUP;
         return VALKEYMODULE_ERR; /* not a stream */
     } else if (key->iter) {
@@ -5869,7 +5869,7 @@ int VM_StreamIteratorStop(ValkeyModuleKey *key) {
     if (!key) {
         errno = EINVAL;
         return VALKEYMODULE_ERR;
-    } else if (!key->value || key->value->type != OBJ_STREAM) {
+    } else if (!key->value || objectGetType(key->value) != OBJ_STREAM) {
         errno = ENOTSUP;
         return VALKEYMODULE_ERR;
     } else if (!key->iter) {
@@ -5911,7 +5911,7 @@ int VM_StreamIteratorNextID(ValkeyModuleKey *key, ValkeyModuleStreamID *id, long
     if (!key) {
         errno = EINVAL;
         return VALKEYMODULE_ERR;
-    } else if (!key->value || key->value->type != OBJ_STREAM) {
+    } else if (!key->value || objectGetType(key->value) != OBJ_STREAM) {
         errno = ENOTSUP;
         return VALKEYMODULE_ERR;
     } else if (!key->iter) {
@@ -5967,7 +5967,7 @@ int VM_StreamIteratorNextField(ValkeyModuleKey *key, ValkeyModuleString **field_
     if (!key) {
         errno = EINVAL;
         return VALKEYMODULE_ERR;
-    } else if (!key->value || key->value->type != OBJ_STREAM) {
+    } else if (!key->value || objectGetType(key->value) != OBJ_STREAM) {
         errno = ENOTSUP;
         return VALKEYMODULE_ERR;
     } else if (!key->iter) {
@@ -6010,7 +6010,7 @@ int VM_StreamIteratorDelete(ValkeyModuleKey *key) {
     if (!key) {
         errno = EINVAL;
         return VALKEYMODULE_ERR;
-    } else if (!key->value || key->value->type != OBJ_STREAM) {
+    } else if (!key->value || objectGetType(key->value) != OBJ_STREAM) {
         errno = ENOTSUP;
         return VALKEYMODULE_ERR;
     } else if (!(key->mode & VALKEYMODULE_WRITE) || !key->iter) {
@@ -6047,7 +6047,7 @@ long long VM_StreamTrimByLength(ValkeyModuleKey *key, int flags, long long lengt
     if (!key || (flags & ~(VALKEYMODULE_STREAM_TRIM_APPROX)) || length < 0) {
         errno = EINVAL;
         return -1;
-    } else if (!key->value || key->value->type != OBJ_STREAM) {
+    } else if (!key->value || objectGetType(key->value) != OBJ_STREAM) {
         errno = ENOTSUP;
         return -1;
     } else if (!(key->mode & VALKEYMODULE_WRITE)) {
@@ -6077,7 +6077,7 @@ long long VM_StreamTrimByID(ValkeyModuleKey *key, int flags, ValkeyModuleStreamI
     if (!key || (flags & ~(VALKEYMODULE_STREAM_TRIM_APPROX)) || !id) {
         errno = EINVAL;
         return -1;
-    } else if (!key->value || key->value->type != OBJ_STREAM) {
+    } else if (!key->value || objectGetType(key->value) != OBJ_STREAM) {
         errno = ENOTSUP;
         return -1;
     } else if (!(key->mode & VALKEYMODULE_WRITE)) {
@@ -12025,14 +12025,14 @@ static void moduleScanKeyHashtableCallback(void *privdata, void *entry) {
     robj *value = NULL;
     sds key = NULL;
 
-    if (o->type == OBJ_SET) {
+    if (objectGetType(o) == OBJ_SET) {
         key = entry;
         /* no value */
-    } else if (o->type == OBJ_ZSET) {
+    } else if (objectGetType(o) == OBJ_ZSET) {
         zskiplistNode *node = (zskiplistNode *)entry;
         key = zslGetNodeElement(node);
         value = createStringObjectFromLongDouble(node->score, 0);
-    } else if (o->type == OBJ_HASH) {
+    } else if (objectGetType(o) == OBJ_HASH) {
         key = entryGetField(entry);
         size_t val_len;
         char *val = entryGetValue(entry, &val_len);
@@ -12102,12 +12102,12 @@ int VM_ScanKey(ValkeyModuleKey *key, ValkeyModuleScanCursor *cursor, ValkeyModul
     }
     hashtable *ht = NULL;
     robj *o = key->value;
-    if (o->type == OBJ_SET) {
-        if (o->encoding == OBJ_ENCODING_HASHTABLE) ht = objectGetVal(o);
-    } else if (o->type == OBJ_HASH) {
-        if (o->encoding == OBJ_ENCODING_HASHTABLE) ht = objectGetVal(o);
-    } else if (o->type == OBJ_ZSET) {
-        if (o->encoding == OBJ_ENCODING_SKIPLIST) ht = ((zset *)objectGetVal(o))->ht;
+    if (objectGetType(o) == OBJ_SET) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) ht = objectGetVal(o);
+    } else if (objectGetType(o) == OBJ_HASH) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) ht = objectGetVal(o);
+    } else if (objectGetType(o) == OBJ_ZSET) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST) ht = ((zset *)objectGetVal(o))->ht;
     } else {
         errno = EINVAL;
         return 0;
@@ -12124,7 +12124,7 @@ int VM_ScanKey(ValkeyModuleKey *key, ValkeyModuleScanCursor *cursor, ValkeyModul
             cursor->done = 1;
             ret = 0;
         }
-    } else if (o->type == OBJ_SET) {
+    } else if (objectGetType(o) == OBJ_SET) {
         setTypeIterator *si = setTypeInitIterator(o);
         sds sdsele;
         while ((sdsele = setTypeNextObject(si)) != NULL) {
@@ -12136,7 +12136,7 @@ int VM_ScanKey(ValkeyModuleKey *key, ValkeyModuleScanCursor *cursor, ValkeyModul
         cursor->cursor = 1;
         cursor->done = 1;
         ret = 0;
-    } else if (o->type == OBJ_ZSET || o->type == OBJ_HASH) {
+    } else if (objectGetType(o) == OBJ_ZSET || objectGetType(o) == OBJ_HASH) {
         unsigned char *p = lpSeek(objectGetVal(o), 0);
         unsigned char *vstr;
         unsigned int vlen;
@@ -14784,7 +14784,7 @@ int VM_GetTypeMethodVersion(void) {
  */
 int VM_ModuleTypeReplaceValue(ValkeyModuleKey *key, moduleType *mt, void *new_value, void **old_value) {
     if (!(key->mode & VALKEYMODULE_WRITE) || key->iter) return VALKEYMODULE_ERR;
-    if (!key->value || key->value->type != OBJ_MODULE) return VALKEYMODULE_ERR;
+    if (!key->value || objectGetType(key->value) != OBJ_MODULE) return VALKEYMODULE_ERR;
 
     moduleValue *mv = objectGetVal(key->value);
     if (mv->type != mt) return VALKEYMODULE_ERR;

--- a/src/networking.c
+++ b/src/networking.c
@@ -171,7 +171,7 @@ typedef enum {
  * for a string object. This includes internal fragmentation. */
 size_t getStringObjectSdsUsedMemory(robj *o) {
     serverAssertWithInfo(NULL, o, o->type == OBJ_STRING);
-    if (o->encoding != OBJ_ENCODING_INT) {
+    if (objectGetEncoding(o) != OBJ_ENCODING_INT) {
         return sdsAllocSize(objectGetVal(o));
     }
     return 0;
@@ -181,7 +181,7 @@ size_t getStringObjectSdsUsedMemory(robj *o) {
  * This does NOT include internal fragmentation or sds unused space. */
 size_t getStringObjectLen(robj *o) {
     serverAssertWithInfo(NULL, o, o->type == OBJ_STRING);
-    switch (o->encoding) {
+    switch (objectGetEncoding(o)) {
     case OBJ_ENCODING_RAW: return sdslen(objectGetVal(o));
     case OBJ_ENCODING_EMBSTR: return sdslen(objectGetVal(o));
     default: return 0; /* Just integer encoding for now. */

--- a/src/object.c
+++ b/src/object.c
@@ -103,10 +103,10 @@ static robj *createUnembeddedObjectWithKeyAndExpire(int type, void *val, const_s
     /* Allocate and set the declared fields. */
     size_t bufsize = 0;
     robj *o = zmalloc_usable(min_size, &bufsize);
-    o->type = type;
-    o->encoding = OBJ_ENCODING_RAW;
+    objectSetType(o, type);
+    objectSetEncoding(o, OBJ_ENCODING_RAW);
     o->refcount = 1;
-    o->lru = 0;
+    objectSetLRU(o, 0);
     o->hasembkey = has_embkey;
     o->hasembval = 0;
     o->val_ptr = val;
@@ -143,8 +143,8 @@ robj *createObject(int type, void *val) {
 }
 
 void initObjectLRUOrLFU(robj *o) {
-    if (o->refcount == OBJ_SHARED_REFCOUNT) return;
-    o->lru = lrulfu_init();
+    if (objectGetRefcount(o) == OBJ_SHARED_REFCOUNT) return;
+    objectSetLRU(o, lrulfu_init());
 }
 
 /* Set a special refcount in the object to make it "shared":
@@ -159,7 +159,7 @@ void initObjectLRUOrLFU(robj *o) {
  *
  */
 robj *makeObjectShared(robj *o) {
-    serverAssert(o->refcount == 1);
+    serverAssert(objectGetRefcount(o) == 1);
     o->refcount = OBJ_SHARED_REFCOUNT;
     return o;
 }
@@ -207,10 +207,10 @@ static robj *createEmbeddedStringObjectWithKeyAndExpire(const char *val_ptr,
     /* Allocate and set the declared fields. */
     size_t bufsize = 0;
     robj *o = zmalloc_usable(min_size, &bufsize);
-    o->type = OBJ_STRING;
-    o->encoding = OBJ_ENCODING_EMBSTR;
+    objectSetType(o, OBJ_STRING);
+    objectSetEncoding(o, OBJ_ENCODING_EMBSTR);
     o->refcount = 1;
-    o->lru = 0;
+    objectSetLRU(o, 0);
     o->hasexpire = (expire != EXPIRY_NONE);
     o->hasembkey = has_embkey;
     o->hasembval = 1;
@@ -304,6 +304,7 @@ void *objectGetVal(const robj *o) {
             data += 1 + hdr_size;                /* +1 for header size byte */
             data += sdslen((const_sds)data) + 1; /* +1 for null terminator */
         }
+        assert(objectGetEncoding(o) == OBJ_ENCODING_EMBSTR);
         return data + sdsHdrSize(SDS_TYPE_8);
     } else {
         return o->val_ptr;
@@ -362,7 +363,7 @@ void objectSetVal(robj *o, void *val) {
  * object. Consider using dbUnshareStringValue() or similar if at all possible */
 void objectUnembedVal(robj *o) {
     assert(o->hasembval);
-    assert(o->encoding == OBJ_ENCODING_EMBSTR);
+    assert(objectGetEncoding(o) == OBJ_ENCODING_EMBSTR);
 
     const_sds embedded_sds = objectGetVal(o);
     assert(sdsAllocSize(embedded_sds) >= sizeof(void *));
@@ -375,7 +376,7 @@ void objectUnembedVal(robj *o) {
     memmove(objectEmbeddedData(o) + sizeof(void *), objectEmbeddedData(o), embedded_data_size);
 
     o->hasembval = 0;
-    o->encoding = OBJ_ENCODING_RAW;
+    objectSetEncoding(o, OBJ_ENCODING_RAW);
     o->val_ptr = new_val;
 }
 
@@ -383,34 +384,34 @@ void objectUnembedVal(robj *o) {
  * the old object's reference counter is decremented and possibly freed. Use the
  * returned object instead of 'o' after calling this function. */
 robj *objectSetKeyAndExpire(robj *o, const_sds key, long long expire) {
-    if (o->type == OBJ_STRING && o->encoding == OBJ_ENCODING_EMBSTR) {
+    if (objectGetType(o) == OBJ_STRING && objectGetEncoding(o) == OBJ_ENCODING_EMBSTR) {
         robj *new = createStringObjectWithKeyAndExpire(objectGetVal(o), sdslen(objectGetVal(o)), key, expire);
-        new->lru = o->lru;
+        objectSetLRU(new, objectGetLRU(o));
         decrRefCount(o);
         return new;
     }
 
     /* Create a new object with embedded key. Reuse ptr if possible. */
     void *ptr;
-    if (o->refcount == 1) {
+    if (objectGetRefcount(o) == 1) {
         /* Reuse the ptr. There are no other references to o. */
         ptr = o->val_ptr;
         o->val_ptr = NULL;
-    } else if (o->type == OBJ_STRING && o->encoding == OBJ_ENCODING_INT) {
+    } else if (objectGetType(o) == OBJ_STRING && objectGetEncoding(o) == OBJ_ENCODING_INT) {
         /* The pointer is not allocated memory. We can just copy the pointer. */
         ptr = o->val_ptr;
-    } else if (o->type == OBJ_STRING && o->encoding == OBJ_ENCODING_RAW) {
+    } else if (objectGetType(o) == OBJ_STRING && objectGetEncoding(o) == OBJ_ENCODING_RAW) {
         /* Dup the string. */
         ptr = sdsdup(o->val_ptr);
     } else {
-        serverAssert(o->type != OBJ_STRING);
+        serverAssert(objectGetType(o) != OBJ_STRING);
         /* There are multiple references to this non-string object. Most types
          * can be duplicated, but for a module type is not always possible. */
         serverPanic("Not implemented");
     }
-    robj *new = createUnembeddedObjectWithKeyAndExpire(o->type, ptr, key, expire);
-    new->encoding = o->encoding;
-    new->lru = o->lru;
+    robj *new = createUnembeddedObjectWithKeyAndExpire(objectGetType(o), ptr, key, expire);
+    objectSetEncoding(new, objectGetEncoding(o));
+    objectSetLRU(new, objectGetLRU(o));
     decrRefCount(o);
     return new;
 }
@@ -442,7 +443,7 @@ robj *createStringObjectFromLongLongWithOptions(long long value, int flag) {
     } else {
         if ((value >= LONG_MIN && value <= LONG_MAX) && flag != LL2STROBJ_NO_INT_ENC) {
             o = createObject(OBJ_STRING, NULL);
-            o->encoding = OBJ_ENCODING_INT;
+            objectSetEncoding(o, OBJ_ENCODING_INT);
             o->val_ptr = (void *)((long)value);
         } else {
             char buf[LONG_STR_SIZE];
@@ -494,9 +495,9 @@ robj *createStringObjectFromLongDouble(long double value, int humanfriendly) {
 robj *dupStringObject(const robj *o) {
     robj *d;
 
-    serverAssert(o->type == OBJ_STRING);
+    serverAssert(objectGetType(o) == OBJ_STRING);
 
-    switch (o->encoding) {
+    switch (objectGetEncoding(o)) {
     case OBJ_ENCODING_RAW: return createRawStringObject(objectGetVal(o), sdslen(objectGetVal(o)));
     case OBJ_ENCODING_EMBSTR: return createEmbeddedStringObject(objectGetVal(o), sdslen(objectGetVal(o)));
     case OBJ_ENCODING_INT:
@@ -511,42 +512,42 @@ robj *dupStringObject(const robj *o) {
 robj *createQuicklistObject(int fill, int compress) {
     quicklist *l = quicklistNew(fill, compress);
     robj *o = createObject(OBJ_LIST, l);
-    o->encoding = OBJ_ENCODING_QUICKLIST;
+    objectSetEncoding(o, OBJ_ENCODING_QUICKLIST);
     return o;
 }
 
 robj *createListListpackObject(void) {
     unsigned char *lp = lpNew(0);
     robj *o = createObject(OBJ_LIST, lp);
-    o->encoding = OBJ_ENCODING_LISTPACK;
+    objectSetEncoding(o, OBJ_ENCODING_LISTPACK);
     return o;
 }
 
 robj *createSetObject(void) {
     hashtable *ht = hashtableCreate(&setHashtableType);
     robj *o = createObject(OBJ_SET, ht);
-    o->encoding = OBJ_ENCODING_HASHTABLE;
+    objectSetEncoding(o, OBJ_ENCODING_HASHTABLE);
     return o;
 }
 
 robj *createIntsetObject(void) {
     intset *is = intsetNew();
     robj *o = createObject(OBJ_SET, is);
-    o->encoding = OBJ_ENCODING_INTSET;
+    objectSetEncoding(o, OBJ_ENCODING_INTSET);
     return o;
 }
 
 robj *createSetListpackObject(void) {
     unsigned char *lp = lpNew(0);
     robj *o = createObject(OBJ_SET, lp);
-    o->encoding = OBJ_ENCODING_LISTPACK;
+    objectSetEncoding(o, OBJ_ENCODING_LISTPACK);
     return o;
 }
 
 robj *createHashObject(void) {
     unsigned char *zl = lpNew(0);
     robj *o = createObject(OBJ_HASH, zl);
-    o->encoding = OBJ_ENCODING_LISTPACK;
+    objectSetEncoding(o, OBJ_ENCODING_LISTPACK);
     return o;
 }
 
@@ -557,21 +558,21 @@ robj *createZsetObject(void) {
     zs->ht = hashtableCreate(&zsetHashtableType);
     zs->zsl = zslCreate();
     o = createObject(OBJ_ZSET, zs);
-    o->encoding = OBJ_ENCODING_SKIPLIST;
+    objectSetEncoding(o, OBJ_ENCODING_SKIPLIST);
     return o;
 }
 
 robj *createZsetListpackObject(void) {
     unsigned char *lp = lpNew(0);
     robj *o = createObject(OBJ_ZSET, lp);
-    o->encoding = OBJ_ENCODING_LISTPACK;
+    objectSetEncoding(o, OBJ_ENCODING_LISTPACK);
     return o;
 }
 
 robj *createStreamObject(void) {
     stream *s = streamNew();
     robj *o = createObject(OBJ_STREAM, s);
-    o->encoding = OBJ_ENCODING_STREAM;
+    objectSetEncoding(o, OBJ_ENCODING_STREAM);
     return o;
 }
 
@@ -583,15 +584,15 @@ robj *createModuleObject(moduleType *mt, void *value) {
 }
 
 void freeStringObject(robj *o) {
-    if (o->encoding == OBJ_ENCODING_RAW) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_RAW) {
         sdsfree(objectGetVal(o));
     }
 }
 
 void freeListObject(robj *o) {
-    if (o->encoding == OBJ_ENCODING_QUICKLIST) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_QUICKLIST) {
         quicklistRelease(objectGetVal(o));
-    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         lpFree(objectGetVal(o));
     } else {
         serverPanic("Unknown list encoding type");
@@ -599,7 +600,7 @@ void freeListObject(robj *o) {
 }
 
 void freeSetObject(robj *o) {
-    switch (o->encoding) {
+    switch (objectGetEncoding(o)) {
     case OBJ_ENCODING_HASHTABLE: hashtableRelease((hashtable *)objectGetVal(o)); break;
     case OBJ_ENCODING_INTSET:
     case OBJ_ENCODING_LISTPACK: zfree(objectGetVal(o)); break;
@@ -609,7 +610,7 @@ void freeSetObject(robj *o) {
 
 void freeZsetObject(robj *o) {
     zset *zs;
-    switch (o->encoding) {
+    switch (objectGetEncoding(o)) {
     case OBJ_ENCODING_SKIPLIST:
         zs = objectGetVal(o);
         hashtableRelease(zs->ht);
@@ -622,7 +623,7 @@ void freeZsetObject(robj *o) {
 }
 
 void freeHashObject(robj *o) {
-    switch (o->encoding) {
+    switch (objectGetEncoding(o)) {
     case OBJ_ENCODING_HASHTABLE:
         hashTypeFreeVolatileSet(o);
         hashtableRelease((hashtable *)objectGetVal(o));
@@ -643,21 +644,21 @@ void freeStreamObject(robj *o) {
 }
 
 void incrRefCount(robj *o) {
-    if (o->refcount < OBJ_FIRST_SPECIAL_REFCOUNT) {
+    if (objectGetRefcount(o) < OBJ_FIRST_SPECIAL_REFCOUNT) {
         o->refcount++;
     } else {
-        if (o->refcount == OBJ_SHARED_REFCOUNT) {
+        if (objectGetRefcount(o) == OBJ_SHARED_REFCOUNT) {
             /* Nothing to do: this refcount is immutable. */
-        } else if (o->refcount == OBJ_STATIC_REFCOUNT) {
+        } else if (objectGetRefcount(o) == OBJ_STATIC_REFCOUNT) {
             serverPanic("You tried to retain an object allocated in the stack");
         }
     }
 }
 
 void decrRefCount(robj *o) {
-    if (o->refcount == 1) {
+    if (objectGetRefcount(o) == 1) {
         if (objectGetVal(o) != NULL) {
-            switch (o->type) {
+            switch (objectGetType(o)) {
             case OBJ_STRING: freeStringObject(o); break;
             case OBJ_LIST: freeListObject(o); break;
             case OBJ_SET: freeSetObject(o); break;
@@ -670,8 +671,8 @@ void decrRefCount(robj *o) {
         }
         zfree(o);
     } else {
-        if (o->refcount <= 0) serverPanic("decrRefCount against refcount <= 0");
-        if (o->refcount != OBJ_SHARED_REFCOUNT) o->refcount--;
+        if (objectGetRefcount(o) <= 0) serverPanic("decrRefCount against refcount <= 0");
+        if (objectGetRefcount(o) != OBJ_SHARED_REFCOUNT) o->refcount--;
     }
 }
 
@@ -687,14 +688,14 @@ void dismissSds(sds s) {
 
 /* See dismissObject() */
 void dismissStringObject(robj *o) {
-    if (o->encoding == OBJ_ENCODING_RAW) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_RAW) {
         dismissSds(objectGetVal(o));
     }
 }
 
 /* See dismissObject() */
 void dismissListObject(robj *o, size_t size_hint) {
-    if (o->encoding == OBJ_ENCODING_QUICKLIST) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_QUICKLIST) {
         quicklist *ql = objectGetVal(o);
         serverAssert(ql->len != 0);
         /* We iterate all nodes only when average node size is bigger than a
@@ -710,7 +711,7 @@ void dismissListObject(robj *o, size_t size_hint) {
                 node = node->next;
             }
         }
-    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         dismissMemory(objectGetVal(o), lpBytes((unsigned char *)objectGetVal(o)));
     } else {
         serverPanic("Unknown list encoding type");
@@ -719,7 +720,7 @@ void dismissListObject(robj *o, size_t size_hint) {
 
 /* See dismissObject() */
 void dismissSetObject(robj *o, size_t size_hint) {
-    if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         hashtable *ht = objectGetVal(o);
         serverAssert(hashtableSize(ht) != 0);
         /* We iterate all nodes only when average member size is bigger than a
@@ -736,9 +737,9 @@ void dismissSetObject(robj *o, size_t size_hint) {
         }
 
         dismissHashtable(ht);
-    } else if (o->encoding == OBJ_ENCODING_INTSET) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_INTSET) {
         dismissMemory(objectGetVal(o), intsetBlobLen((intset *)objectGetVal(o)));
-    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         dismissMemory(objectGetVal(o), lpBytes((unsigned char *)objectGetVal(o)));
     } else {
         serverPanic("Unknown set encoding type");
@@ -747,7 +748,7 @@ void dismissSetObject(robj *o, size_t size_hint) {
 
 /* See dismissObject() */
 void dismissZsetObject(robj *o, size_t size_hint) {
-    if (o->encoding == OBJ_ENCODING_SKIPLIST) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(o);
         zskiplist *zsl = zs->zsl;
         serverAssert(zslGetLength(zsl) != 0);
@@ -763,7 +764,7 @@ void dismissZsetObject(robj *o, size_t size_hint) {
         }
 
         dismissHashtable(zs->ht);
-    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         dismissMemory(objectGetVal(o), lpBytes((unsigned char *)objectGetVal(o)));
     } else {
         serverPanic("Unknown zset encoding type");
@@ -772,7 +773,7 @@ void dismissZsetObject(robj *o, size_t size_hint) {
 
 /* See dismissObject() */
 void dismissHashObject(robj *o, size_t size_hint) {
-    if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         hashtable *ht = objectGetVal(o);
         serverAssert(hashtableSize(ht) != 0);
         /* We iterate all fields only when average field/value size is bigger than
@@ -788,7 +789,7 @@ void dismissHashObject(robj *o, size_t size_hint) {
         }
 
         dismissHashtable(ht);
-    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         dismissMemory(objectGetVal(o), lpBytes((unsigned char *)objectGetVal(o)));
     } else {
         serverPanic("Unknown hash encoding type");
@@ -835,8 +836,8 @@ void dismissObject(robj *o, size_t size_hint) {
         /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
          * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
-    if (o->refcount != 1) return;
-    switch (o->type) {
+    if (objectGetRefcount(o) != 1) return;
+    switch (objectGetType(o)) {
     case OBJ_STRING: dismissStringObject(o); break;
     case OBJ_LIST: dismissListObject(o, size_hint); break;
     case OBJ_SET: dismissSetObject(o, size_hint); break;
@@ -853,7 +854,7 @@ void dismissObject(robj *o, size_t size_hint) {
 
 int checkType(client *c, robj *o, int type) {
     /* A NULL is considered an empty key */
-    if (o && o->type != type) {
+    if (o && objectGetType(o) != type) {
         addReplyErrorObject(c, shared.wrongtypeerr);
         return 1;
     }
@@ -865,8 +866,8 @@ int isSdsRepresentableAsLongLong(sds s, long long *llval) {
 }
 
 int isObjectRepresentableAsLongLong(robj *o, long long *llval) {
-    serverAssertWithInfo(NULL, o, o->type == OBJ_STRING);
-    if (o->encoding == OBJ_ENCODING_INT) {
+    serverAssertWithInfo(NULL, o, objectGetType(o) == OBJ_STRING);
+    if (objectGetEncoding(o) == OBJ_ENCODING_INT) {
         if (llval) *llval = (long)objectGetVal(o);
         return C_OK;
     } else {
@@ -877,7 +878,7 @@ int isObjectRepresentableAsLongLong(robj *o, long long *llval) {
 /* Optimize the SDS string inside the string object to require little space,
  * in case there is more than 10% of free space at the end of the SDS. */
 void trimStringObjectIfNeeded(robj *o, int trim_small_values) {
-    if (o->encoding != OBJ_ENCODING_RAW) return;
+    if (objectGetEncoding(o) != OBJ_ENCODING_RAW) return;
     /* A string may have free space in the following cases:
      * 1. When an arg len is greater than PROTO_MBULK_BIG_ARG the query buffer may be used directly as the SDS string.
      * 2. When utilizing the argument caching mechanism in Lua.
@@ -901,7 +902,7 @@ robj *tryObjectEncodingEx(robj *o, int try_trim) {
      * in this function. Other types use encoded memory efficient
      * representations but are handled by the commands implementing
      * the type. */
-    serverAssertWithInfo(NULL, o, o->type == OBJ_STRING);
+    serverAssertWithInfo(NULL, o, objectGetType(o) == OBJ_STRING);
 
     /* We try some specialized encoding only for objects that are
      * RAW or EMBSTR encoded, in other words objects that are still
@@ -911,7 +912,7 @@ robj *tryObjectEncodingEx(robj *o, int try_trim) {
     /* It's not safe to encode shared objects: shared objects can be shared
      * everywhere in the "object space" of the server and may end in places where
      * they are not handled. We handle them only as values in the keyspace. */
-    if (o->refcount > 1) return o;
+    if (objectGetRefcount(o) > 1) return o;
 
     /* Check if we can represent this string as a long integer.
      * Note that we are sure that a string larger than 20 chars is not
@@ -919,12 +920,12 @@ robj *tryObjectEncodingEx(robj *o, int try_trim) {
     len = sdslen(s);
     if (len <= 20 && string2l(s, len, &value)) {
         /* This object is encodable as a long. */
-        if (o->encoding == OBJ_ENCODING_RAW) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_RAW) {
             sdsfree(objectGetVal(o));
-            o->encoding = OBJ_ENCODING_INT;
+            objectSetEncoding(o, OBJ_ENCODING_INT);
             o->val_ptr = (void *)value;
             return o;
-        } else if (o->encoding == OBJ_ENCODING_EMBSTR) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_EMBSTR) {
             decrRefCount(o);
             return createStringObjectFromLongLongForValue(value);
         }
@@ -935,7 +936,7 @@ robj *tryObjectEncodingEx(robj *o, int try_trim) {
      * In this representation the object and the SDS string are allocated
      * in the same chunk of memory to save space and cache misses. */
     if (shouldEmbedStringObject(len, NULL, EXPIRY_NONE)) {
-        if (o->encoding == OBJ_ENCODING_EMBSTR) return o;
+        if (objectGetEncoding(o) == OBJ_ENCODING_EMBSTR) return o;
         robj *emb = createEmbeddedStringObject(s, sdslen(s));
         decrRefCount(o);
         return emb;
@@ -962,7 +963,7 @@ robj *getDecodedObject(robj *o) {
         incrRefCount(o);
         return o;
     }
-    if (o->type == OBJ_STRING && o->encoding == OBJ_ENCODING_INT) {
+    if (objectGetType(o) == OBJ_STRING && objectGetEncoding(o) == OBJ_ENCODING_INT) {
         char buf[32];
 
         ll2string(buf, 32, (long)objectGetVal(o));
@@ -1045,7 +1046,7 @@ int equalStringObjects(robj *a, robj *b) {
 }
 
 size_t stringObjectLen(robj *o) {
-    serverAssertWithInfo(NULL, o, o->type == OBJ_STRING);
+    serverAssertWithInfo(NULL, o, objectGetType(o) == OBJ_STRING);
     if (sdsEncodedObject(o)) {
         return sdslen(objectGetVal(o));
     } else {
@@ -1059,10 +1060,10 @@ int getDoubleFromObject(const robj *o, double *target) {
     if (o == NULL) {
         value = 0;
     } else {
-        serverAssertWithInfo(NULL, o, o->type == OBJ_STRING);
+        serverAssertWithInfo(NULL, o, objectGetType(o) == OBJ_STRING);
         if (sdsEncodedObject(o)) {
             if (!string2d(objectGetVal(o), sdslen(objectGetVal(o)), &value)) return C_ERR;
-        } else if (o->encoding == OBJ_ENCODING_INT) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_INT) {
             value = (long)objectGetVal(o);
         } else {
             serverPanic("Unknown string encoding");
@@ -1092,10 +1093,10 @@ int getLongDoubleFromObject(robj *o, long double *target) {
     if (o == NULL) {
         value = 0;
     } else {
-        serverAssertWithInfo(NULL, o, o->type == OBJ_STRING);
+        serverAssertWithInfo(NULL, o, objectGetType(o) == OBJ_STRING);
         if (sdsEncodedObject(o)) {
             if (!string2ld(objectGetVal(o), sdslen(objectGetVal(o)), &value)) return C_ERR;
-        } else if (o->encoding == OBJ_ENCODING_INT) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_INT) {
             value = (long)objectGetVal(o);
         } else {
             serverPanic("Unknown string encoding");
@@ -1125,10 +1126,10 @@ int getLongLongFromObject(robj *o, long long *target) {
     if (o == NULL) {
         value = 0;
     } else {
-        serverAssertWithInfo(NULL, o, o->type == OBJ_STRING);
+        serverAssertWithInfo(NULL, o, objectGetType(o) == OBJ_STRING);
         if (sdsEncodedObject(o)) {
             if (string2ll(objectGetVal(o), sdslen(objectGetVal(o)), &value) == 0) return C_ERR;
-        } else if (o->encoding == OBJ_ENCODING_INT) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_INT) {
             value = (long)objectGetVal(o);
         } else {
             serverPanic("Unknown string encoding");
@@ -1225,14 +1226,14 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
     size_t elesize = 0, samples = 0;
     size_t asize = zmalloc_size((void *)o);
 
-    if (o->type == OBJ_STRING) {
-        if (o->encoding == OBJ_ENCODING_RAW) {
+    if (objectGetType(o) == OBJ_STRING) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_RAW) {
             asize += sdsAllocSize(objectGetVal(o));
-        } else if (o->encoding != OBJ_ENCODING_INT && o->encoding != OBJ_ENCODING_EMBSTR) {
+        } else if (objectGetEncoding(o) != OBJ_ENCODING_INT && objectGetEncoding(o) != OBJ_ENCODING_EMBSTR) {
             serverPanic("Unknown string encoding");
         }
-    } else if (o->type == OBJ_LIST) {
-        if (o->encoding == OBJ_ENCODING_QUICKLIST) {
+    } else if (objectGetType(o) == OBJ_LIST) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_QUICKLIST) {
             quicklist *ql = objectGetVal(o);
             quicklistNode *node = ql->head;
             asize += sizeof(quicklist);
@@ -1241,13 +1242,13 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
                 samples++;
             } while ((node = node->next) && samples < sample_size);
             asize += (double)elesize / samples * ql->len;
-        } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
             asize += zmalloc_size(objectGetVal(o));
         } else {
             serverPanic("Unknown list encoding");
         }
-    } else if (o->type == OBJ_SET) {
-        if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetType(o) == OBJ_SET) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
             hashtable *ht = objectGetVal(o);
             asize += hashtableMemUsage(ht);
 
@@ -1261,17 +1262,17 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
             }
             hashtableCleanupIterator(&iter);
             if (samples) asize += (double)elesize / samples * hashtableSize(ht);
-        } else if (o->encoding == OBJ_ENCODING_INTSET) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_INTSET) {
             asize += zmalloc_size(objectGetVal(o));
-        } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
             asize += zmalloc_size(objectGetVal(o));
         } else {
             serverPanic("Unknown set encoding");
         }
-    } else if (o->type == OBJ_ZSET) {
-        if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetType(o) == OBJ_ZSET) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
             asize += zmalloc_size(objectGetVal(o));
-        } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST) {
             hashtable *ht = ((zset *)objectGetVal(o))->ht;
             zskiplist *zsl = ((zset *)objectGetVal(o))->zsl;
             zskiplistNode *zheader = zslGetHeader(zsl);
@@ -1286,10 +1287,10 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
         } else {
             serverPanic("Unknown sorted set encoding");
         }
-    } else if (o->type == OBJ_HASH) {
-        if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetType(o) == OBJ_HASH) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
             asize += zmalloc_size(objectGetVal(o));
-        } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
             hashtable *ht = objectGetVal(o);
             hashtableIterator iter;
             vset *volatile_fields = hashtableMetadata(ht);
@@ -1307,7 +1308,7 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
         } else {
             serverPanic("Unknown hash encoding");
         }
-    } else if (o->type == OBJ_STREAM) {
+    } else if (objectGetType(o) == OBJ_STREAM) {
         stream *s = objectGetVal(o);
         asize += sizeof(*s);
         asize += raxAllocSize(s->rax);
@@ -1378,7 +1379,7 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
             raxStop(&ri);
             if (samples) asize += (double)elesize / samples * raxSize(s->cgroups);
         }
-    } else if (o->type == OBJ_MODULE) {
+    } else if (objectGetType(o) == OBJ_MODULE) {
         asize += moduleGetMemUsage(key, o, sample_size, dbid);
     } else {
         serverPanic("Unknown object type");
@@ -1676,19 +1677,19 @@ sds getMemoryDoctorReport(void) {
 /* Return the LFU frequency for an object. */
 uint8_t objectGetLFUFrequency(robj *o) {
     uint8_t freq;
-    o->lru = lfu_getFrequency(o->lru, &freq);
+    objectSetLRU(o, lfu_getFrequency(objectGetLRU(o), &freq));
     return freq;
 }
 
 /* Return the LRU idle time for an object. */
 uint32_t objectGetLRUIdleSecs(robj *o) {
-    return lru_getIdleSecs(o->lru);
+    return lru_getIdleSecs(objectGetLRU(o));
 }
 
 /* Return an indication of idleness.  Larger numbers are more idle. */
 uint32_t objectGetIdleness(robj *o) {
     uint32_t idleness;
-    o->lru = lrulfu_getIdleness(o->lru, &idleness);
+    objectSetLRU(o, lrulfu_getIdleness(objectGetLRU(o), &idleness));
     return idleness;
 }
 
@@ -1747,10 +1748,10 @@ void objectCommand(client *c) {
         addReplyHelp(c, help);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "refcount") && c->argc == 3) {
         if ((o = objectCommandLookupOrReply(c, c->argv[2], shared.null[c->resp])) == NULL) return;
-        addReplyLongLong(c, o->refcount);
+        addReplyLongLong(c, objectGetRefcount(o));
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "encoding") && c->argc == 3) {
         if ((o = objectCommandLookupOrReply(c, c->argv[2], shared.null[c->resp])) == NULL) return;
-        addReplyBulkCString(c, strEncoding(o->encoding));
+        addReplyBulkCString(c, strEncoding(objectGetEncoding(o)));
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "idletime") && c->argc == 3) {
         if ((o = objectCommandLookupOrReply(c, c->argv[2], shared.null[c->resp])) == NULL) return;
         if (server.maxmemory_policy & MAXMEMORY_FLAG_LFU) {
@@ -1758,7 +1759,7 @@ void objectCommand(client *c) {
                              "switching between policies at runtime LRU and LFU data will take some time to adjust.");
             return;
         }
-        addReplyLongLong(c, lru_getIdleSecs(o->lru));
+        addReplyLongLong(c, lru_getIdleSecs(objectGetLRU(o)));
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "freq") && c->argc == 3) {
         if ((o = objectCommandLookupOrReply(c, c->argv[2], shared.null[c->resp])) == NULL) return;
         if (!(server.maxmemory_policy & MAXMEMORY_FLAG_LFU)) {

--- a/src/object.c
+++ b/src/object.c
@@ -49,6 +49,36 @@
  * so if expire is set later, we don't need to reallocate the object. */
 #define KEY_SIZE_TO_INCLUDE_EXPIRE_THRESHOLD 128
 
+/* ===================== Accessor functions for serverObject fields ==================== */
+
+int objectGetType(const robj *o) {
+    return o->type;
+}
+
+void objectSetType(robj *o, int type) {
+    o->type = type;
+}
+
+int objectGetEncoding(const robj *o) {
+    return o->encoding;
+}
+
+void objectSetEncoding(robj *o, int encoding) {
+    o->encoding = encoding;
+}
+
+unsigned int objectGetRefcount(const robj *o) {
+    return o->refcount;
+}
+
+unsigned int objectGetLRU(const robj *o) {
+    return o->lru;
+}
+
+void objectSetLRU(robj *o, unsigned int lru) {
+    o->lru = lru;
+}
+
 /* ===================== Creation and parsing of objects ==================== */
 
 /* Creates an object, optionally with embedded key and expire fields. The key

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -716,33 +716,33 @@ int rdbLoadBinaryFloatValue(rio *rdb, float *val) {
 /* Return the RDB object type to use for saving object "o", or -1 if the object
  * can't be represented in the given RDB version (only for older RDB). */
 int rdbGetObjectType(robj *o, int rdbver) {
-    switch (o->type) {
+    switch (objectGetType(o)) {
     case OBJ_STRING: return RDB_TYPE_STRING;
     case OBJ_LIST:
-        if (o->encoding == OBJ_ENCODING_QUICKLIST || o->encoding == OBJ_ENCODING_LISTPACK)
+        if (objectGetEncoding(o) == OBJ_ENCODING_QUICKLIST || objectGetEncoding(o) == OBJ_ENCODING_LISTPACK)
             return RDB_TYPE_LIST_QUICKLIST_2;
         else
             serverPanic("Unknown list encoding");
     case OBJ_SET:
-        if (o->encoding == OBJ_ENCODING_INTSET)
+        if (objectGetEncoding(o) == OBJ_ENCODING_INTSET)
             return RDB_TYPE_SET_INTSET;
-        else if (o->encoding == OBJ_ENCODING_HASHTABLE)
+        else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE)
             return RDB_TYPE_SET;
-        else if (o->encoding == OBJ_ENCODING_LISTPACK)
+        else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK)
             return RDB_TYPE_SET_LISTPACK;
         else
             serverPanic("Unknown set encoding");
     case OBJ_ZSET:
-        if (o->encoding == OBJ_ENCODING_LISTPACK)
+        if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK)
             return RDB_TYPE_ZSET_LISTPACK;
-        else if (o->encoding == OBJ_ENCODING_SKIPLIST)
+        else if (objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST)
             return RDB_TYPE_ZSET_2;
         else
             serverPanic("Unknown sorted set encoding");
     case OBJ_HASH:
-        if (o->encoding == OBJ_ENCODING_LISTPACK)
+        if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK)
             return RDB_TYPE_HASH_LISTPACK;
-        else if (o->encoding == OBJ_ENCODING_HASHTABLE)
+        else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE)
             if (hashTypeHasVolatileFields(o))
                 if (rdbver >= 80)
                     return RDB_TYPE_HASH_2;
@@ -872,13 +872,13 @@ ssize_t rdbSaveStreamConsumers(rio *rdb, streamCG *cg) {
  * Returns -1 on error, number of bytes written on success. */
 ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid, unsigned char rdbtype) {
     ssize_t n = 0, nwritten = 0;
-    if (o->type == OBJ_STRING) {
+    if (objectGetType(o) == OBJ_STRING) {
         /* Save a string value */
         if ((n = rdbSaveStringObject(rdb, o)) == -1) return -1;
         nwritten += n;
-    } else if (o->type == OBJ_LIST) {
+    } else if (objectGetType(o) == OBJ_LIST) {
         /* Save a list value */
-        if (o->encoding == OBJ_ENCODING_QUICKLIST) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_QUICKLIST) {
             quicklist *ql = objectGetVal(o);
             quicklistNode *node = ql->head;
 
@@ -900,7 +900,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid, unsigned char rdbt
                 }
                 node = node->next;
             }
-        } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
             unsigned char *lp = objectGetVal(o);
 
             /* Save list listpack as a fake quicklist that only has a single node. */
@@ -913,9 +913,9 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid, unsigned char rdbt
         } else {
             serverPanic("Unknown list encoding");
         }
-    } else if (o->type == OBJ_SET) {
+    } else if (objectGetType(o) == OBJ_SET) {
         /* Save a set value */
-        if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
             hashtable *set = objectGetVal(o);
 
             if ((n = rdbSaveLen(rdb, hashtableSize(set))) == -1) {
@@ -935,26 +935,26 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid, unsigned char rdbt
                 nwritten += n;
             }
             hashtableCleanupIterator(&iterator);
-        } else if (o->encoding == OBJ_ENCODING_INTSET) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_INTSET) {
             size_t l = intsetBlobLen((intset *)objectGetVal(o));
 
             if ((n = rdbSaveRawString(rdb, objectGetVal(o), l)) == -1) return -1;
             nwritten += n;
-        } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
             size_t l = lpBytes((unsigned char *)objectGetVal(o));
             if ((n = rdbSaveRawString(rdb, objectGetVal(o), l)) == -1) return -1;
             nwritten += n;
         } else {
             serverPanic("Unknown set encoding");
         }
-    } else if (o->type == OBJ_ZSET) {
+    } else if (objectGetType(o) == OBJ_ZSET) {
         /* Save a sorted set value */
-        if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
             size_t l = lpBytes((unsigned char *)objectGetVal(o));
 
             if ((n = rdbSaveRawString(rdb, objectGetVal(o), l)) == -1) return -1;
             nwritten += n;
-        } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST) {
             zset *zs = objectGetVal(o);
             zskiplist *zsl = zs->zsl;
 
@@ -981,14 +981,14 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid, unsigned char rdbt
         } else {
             serverPanic("Unknown sorted set encoding");
         }
-    } else if (o->type == OBJ_HASH) {
+    } else if (objectGetType(o) == OBJ_HASH) {
         /* Save a hash value */
-        if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
             size_t l = lpBytes((unsigned char *)objectGetVal(o));
 
             if ((n = rdbSaveRawString(rdb, objectGetVal(o), l)) == -1) return -1;
             nwritten += n;
-        } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
             serverAssert(rdbtype == RDB_TYPE_HASH || rdbtype == RDB_TYPE_HASH_2);
             hashtable *ht = objectGetVal(o);
 
@@ -1030,7 +1030,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid, unsigned char rdbt
         } else {
             serverPanic("Unknown hash encoding");
         }
-    } else if (o->type == OBJ_STREAM) {
+    } else if (objectGetType(o) == OBJ_STREAM) {
         /* Store how many listpacks we have inside the radix tree. */
         stream *s = objectGetVal(o);
         rax *rax = s->rax;
@@ -1140,7 +1140,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid, unsigned char rdbt
             }
             raxStop(&ri);
         }
-    } else if (o->type == OBJ_MODULE) {
+    } else if (objectGetType(o) == OBJ_MODULE) {
         /* Save a module-specific value. */
         ValkeyModuleIO io;
         moduleValue *mv = objectGetVal(o);
@@ -1992,7 +1992,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
             sumelelen += elelen;
             if (elelen > maxelelen) maxelelen = elelen;
 
-            if (o->encoding == OBJ_ENCODING_INTSET) {
+            if (objectGetEncoding(o) == OBJ_ENCODING_INTSET) {
                 /* Fetch integer value from element. */
                 if (isSdsRepresentableAsLongLong(sdsele, &llval) == C_OK) {
                     uint8_t success;
@@ -2019,7 +2019,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
 
             /* This will also be called when the set was just converted
              * to a listpack encoded set. */
-            if (o->encoding == OBJ_ENCODING_LISTPACK) {
+            if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
                 if (setTypeSize(o) < server.set_max_listpack_entries && elelen <= server.set_max_listpack_value &&
                     lpSafeToAdd(objectGetVal(o), elelen)) {
                     unsigned char *p = lpFirst(objectGetVal(o));
@@ -2040,7 +2040,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
 
             /* This will also be called when the set was just converted
              * to a regular hash table encoded set. */
-            if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+            if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
                 if (!hashtableAdd((hashtable *)objectGetVal(o), sdsele)) {
                     rdbReportCorruptRDB("Duplicate set members detected");
                     decrRefCount(o);
@@ -2144,7 +2144,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
 
 
         /* Load every field and value into the ziplist */
-        while (o->encoding == OBJ_ENCODING_LISTPACK && len > 0) {
+        while (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK && len > 0) {
             len--;
             /* Load raw strings */
             if ((field = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL)) == NULL) {
@@ -2173,7 +2173,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
             }
 
             /* Convert to hash table if size threshold is exceeded */
-            if (o->encoding != OBJ_ENCODING_HASHTABLE &&
+            if (objectGetEncoding(o) != OBJ_ENCODING_HASHTABLE &&
                 (sdslen(field) > server.hash_max_listpack_value || sdslen(value) > server.hash_max_listpack_value ||
                  !lpSafeToAdd(objectGetVal(o), sdslen(field) + sdslen(value)))) {
                 hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
@@ -2205,7 +2205,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
             dupSearchHashtable = NULL;
         }
 
-        if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
             if (!hashtableTryExpand(objectGetVal(o), len)) {
                 rdbReportCorruptRDB("OOM in hashtableTryExpand %llu", (unsigned long long)len);
                 decrRefCount(o);
@@ -2214,7 +2214,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
         }
 
         /* Load remaining fields and values into the hash table */
-        while (o->encoding == OBJ_ENCODING_HASHTABLE && len > 0) {
+        while (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE && len > 0) {
             len--;
             /* Load encoded strings */
             if ((field = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL)) == NULL) {
@@ -2417,8 +2417,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 hashtableRelease(dupSearchHashtable);
                 zfree(objectGetVal(o));
                 objectSetVal(o, lp);
-                o->type = OBJ_HASH;
-                o->encoding = OBJ_ENCODING_LISTPACK;
+                objectSetType(o, OBJ_HASH);
+                objectSetEncoding(o, OBJ_ENCODING_LISTPACK);
 
                 if (hashTypeLength(o) > server.hash_max_listpack_entries || maxlen > server.hash_max_listpack_value) {
                     hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
@@ -2446,9 +2446,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
             }
 
             zfree(encoded);
-            o->type = OBJ_LIST;
+            objectSetType(o, OBJ_LIST);
             objectSetVal(o, ql);
-            o->encoding = OBJ_ENCODING_QUICKLIST;
+            objectSetEncoding(o, OBJ_ENCODING_QUICKLIST);
             break;
         }
         case RDB_TYPE_SET_INTSET:
@@ -2460,8 +2460,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 decrRefCount(o);
                 return NULL;
             }
-            o->type = OBJ_SET;
-            o->encoding = OBJ_ENCODING_INTSET;
+            objectSetType(o, OBJ_SET);
+            objectSetEncoding(o, OBJ_ENCODING_INTSET);
             if (intsetLen(objectGetVal(o)) > server.set_max_intset_entries) setTypeConvert(o, OBJ_ENCODING_HASHTABLE);
             break;
         case RDB_TYPE_SET_LISTPACK:
@@ -2473,8 +2473,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 decrRefCount(o);
                 return NULL;
             }
-            o->type = OBJ_SET;
-            o->encoding = OBJ_ENCODING_LISTPACK;
+            objectSetType(o, OBJ_SET);
+            objectSetEncoding(o, OBJ_ENCODING_LISTPACK);
 
             if (setTypeSize(o) == 0) {
                 zfree(encoded);
@@ -2508,9 +2508,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
             }
 
             zfree(objectGetVal(o));
-            o->type = OBJ_ZSET;
+            objectSetType(o, OBJ_ZSET);
             objectSetVal(o, lp);
-            o->encoding = OBJ_ENCODING_LISTPACK;
+            objectSetEncoding(o, OBJ_ENCODING_LISTPACK);
             if (zsetLength(o) == 0) {
                 decrRefCount(o);
                 goto emptykey;
@@ -2542,8 +2542,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 decrRefCount(o);
                 return NULL;
             }
-            o->type = OBJ_ZSET;
-            o->encoding = OBJ_ENCODING_LISTPACK;
+            objectSetType(o, OBJ_ZSET);
+            objectSetEncoding(o, OBJ_ENCODING_LISTPACK);
             if (zsetLength(o) == 0) {
                 decrRefCount(o);
                 goto emptykey;
@@ -2564,8 +2564,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
 
             zfree(objectGetVal(o));
             objectSetVal(o, lp);
-            o->type = OBJ_HASH;
-            o->encoding = OBJ_ENCODING_LISTPACK;
+            objectSetType(o, OBJ_HASH);
+            objectSetEncoding(o, OBJ_ENCODING_LISTPACK);
             if (hashTypeLength(o) == 0) {
                 decrRefCount(o);
                 goto emptykey;
@@ -2586,8 +2586,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 decrRefCount(o);
                 return NULL;
             }
-            o->type = OBJ_HASH;
-            o->encoding = OBJ_ENCODING_LISTPACK;
+            objectSetType(o, OBJ_HASH);
+            objectSetEncoding(o, OBJ_ENCODING_LISTPACK);
             if (hashTypeLength(o) == 0) {
                 decrRefCount(o);
                 goto emptykey;

--- a/src/replication.c
+++ b/src/replication.c
@@ -356,7 +356,7 @@ void feedReplicationBufferWithObject(robj *o) {
     void *p;
     size_t len;
 
-    if (o->encoding == OBJ_ENCODING_INT) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_INT) {
         len = ll2string(llstr, sizeof(llstr), (long)objectGetVal(o));
         p = llstr;
     } else {

--- a/src/server.c
+++ b/src/server.c
@@ -494,7 +494,7 @@ uint64_t dictEncObjHash(const void *key) {
 
     if (sdsEncodedObject(o)) {
         return dictGenHashFunction(objectGetVal(o), sdslen((sds)objectGetVal(o)));
-    } else if (o->encoding == OBJ_ENCODING_INT) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_INT) {
         char buf[32];
         int len;
 

--- a/src/server.h
+++ b/src/server.h
@@ -3178,7 +3178,7 @@ int compareStringObjects(const robj *a, const robj *b);
 int collateStringObjects(const robj *a, const robj *b);
 int equalStringObjects(robj *a, robj *b);
 void trimStringObjectIfNeeded(robj *o, int trim_small_values);
-#define sdsEncodedObject(objptr) (objptr->encoding == OBJ_ENCODING_RAW || objptr->encoding == OBJ_ENCODING_EMBSTR)
+#define sdsEncodedObject(objptr) (objectGetEncoding(objptr) == OBJ_ENCODING_RAW || objectGetEncoding(objptr) == OBJ_ENCODING_EMBSTR)
 
 /* Objects with val and/or key embedded */
 robj *objectSetKeyAndExpire(robj *o, const_sds key, long long expire);
@@ -3191,6 +3191,16 @@ mstime_t objectGetExpire(const robj *o);
 uint8_t objectGetLFUFrequency(robj *o);
 uint32_t objectGetLRUIdleSecs(robj *o);
 uint32_t objectGetIdleness(robj *o);
+
+/* Accessor functions for serverObject fields.
+ * Use these instead of direct field access for encapsulation. */
+int objectGetType(const robj *o);
+void objectSetType(robj *o, int type);
+int objectGetEncoding(const robj *o);
+void objectSetEncoding(robj *o, int encoding);
+unsigned int objectGetRefcount(const robj *o);
+unsigned int objectGetLRU(const robj *o);
+void objectSetLRU(robj *o, unsigned int lru);
 
 /* Synchronous I/O with timeout */
 ssize_t syncWrite(int fd, char *ptr, ssize_t size, long long timeout);

--- a/src/sort.c
+++ b/src/sort.c
@@ -118,13 +118,13 @@ robj *lookupKeyByPattern(serverDb *db, robj *pattern, robj *subst) {
     if (o == NULL) goto noobj;
 
     if (fieldobj) {
-        if (o->type != OBJ_HASH) goto noobj;
+        if (objectGetType(o) != OBJ_HASH) goto noobj;
 
         /* Retrieve value from hash by the field name. The returned object
          * is a new object with refcount already incremented. */
         o = hashTypeGetValueObject(o, objectGetVal(fieldobj));
     } else {
-        if (o->type != OBJ_STRING) goto noobj;
+        if (objectGetType(o) != OBJ_STRING) goto noobj;
 
         /* Every object that this function returns needs to have its refcount
          * increased. sortCommand decreases it again. */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -62,15 +62,15 @@ static mstime_t entryGetExpiryVsetFunc(const void *e) {
  *----------------------------------------------------------------------------*/
 
 static vset *hashTypeGetVolatileSet(robj *o) {
-    serverAssert(o->encoding == OBJ_ENCODING_HASHTABLE);
+    serverAssert(objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE);
     vset *set = (vset *)hashtableMetadata(objectGetVal(o));
     return vsetIsValid(set) ? set : NULL;
 }
 
 bool hashTypeHasVolatileFields(robj *o) {
     if (o == NULL) return false;
-    serverAssert(o->type == OBJ_HASH);
-    if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    serverAssert(objectGetType(o) == OBJ_HASH);
+    if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         vset *set = hashTypeGetVolatileSet(o);
         if (set && !vsetIsEmpty(set))
             return true;
@@ -81,7 +81,7 @@ bool hashTypeHasVolatileFields(robj *o) {
 /* make any access to the hash object elements ignore the specific elements expiration.
  * This is mainly in order to be able to access hash elements which are already expired. */
 static inline void hashTypeIgnoreTTL(robj *o, bool ignore) {
-    if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         /* prevent placing access function if not needed */
         if (!ignore && hashTypeGetVolatileSet(o) == NULL) {
             ignore = true;
@@ -91,7 +91,7 @@ static inline void hashTypeIgnoreTTL(robj *o, bool ignore) {
 }
 
 static vset *hashTypeGetOrcreateVolatileSet(robj *o) {
-    serverAssert(o->encoding == OBJ_ENCODING_HASHTABLE);
+    serverAssert(objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE);
     vset *set = (vset *)hashtableMetadata(objectGetVal(o));
     if (!vsetIsValid(set)) {
         vsetInit(set);
@@ -198,7 +198,7 @@ void hashTypeTryConversion(robj *o, robj **argv, int start, int end) {
 int hashTypeGetFromListpack(robj *o, sds field, unsigned char **vstr, unsigned int *vlen, long long *vll) {
     unsigned char *zl, *fptr = NULL, *vptr = NULL;
 
-    serverAssert(o->encoding == OBJ_ENCODING_LISTPACK);
+    serverAssert(objectGetEncoding(o) == OBJ_ENCODING_LISTPACK);
 
     zl = objectGetVal(o);
     fptr = lpFirst(zl);
@@ -232,13 +232,13 @@ int hashTypeGetFromListpack(robj *o, sds field, unsigned char **vstr, unsigned i
  * If *expiry is populated than the function will also provide the current field expiration time
  * or EXPIRY_NONE in case the field has no expiration time defined. */
 int hashTypeGetValue(robj *o, sds field, unsigned char **vstr, unsigned int *vlen, long long *vll, mstime_t *expiry) {
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         *vstr = NULL;
         if (hashTypeGetFromListpack(o, field, vstr, vlen, vll) == 0) {
             if (expiry) *expiry = EXPIRY_NONE;
             return C_OK;
         }
-    } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         void *entry = NULL;
         hashtableFind(objectGetVal(o), field, &entry);
         if (entry) {
@@ -261,12 +261,12 @@ int hashTypeGetValue(robj *o, sds field, unsigned char **vstr, unsigned int *vle
  * The matching item expiration time is assigned to `expiry` memory location, if specified.
  * In case the item has no assigned expiration time, -1 is returned. */
 int hashTypeGetExpiry(robj *o, sds field, mstime_t *expiry) {
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         if (hashTypeExists(o, field)) {
             if (expiry) *expiry = EXPIRY_NONE;
             return C_OK;
         }
-    } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         void *found_element = NULL;
         if (hashtableFind(objectGetVal(o), field, &found_element)) {
             if (expiry) *expiry = entryGetExpiry(found_element);
@@ -319,7 +319,7 @@ int hashTypeExists(robj *o, sds field) {
 }
 
 bool hashTypeHasStringRef(robj *o, sds field) {
-    if (o->encoding == OBJ_ENCODING_LISTPACK) return false;
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) return false;
     hashtable *ht = objectGetVal(o);
     void **entry_ref = hashtableFindRef(ht, field);
     return (entryHasStringRef(*entry_ref));
@@ -334,7 +334,7 @@ int hashTypeUpdateAsStringRef(robj *o, sds field, const char *buf, size_t len) {
 
     if (hashTypeGetValue(o, field, &vstr, &vlen, &vll, NULL) != C_OK) return C_ERR;
     // require HASHTABLE encoding due to aux bits and pointer storage.
-    if (o->encoding == OBJ_ENCODING_LISTPACK) hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
 
     hashtable *ht = objectGetVal(o);
     void **entry_ref = hashtableFindRef(ht, field);
@@ -371,12 +371,12 @@ int hashTypeSet(robj *o, sds field, sds value, mstime_t expiry, int flags, bool 
     /* Check if the field is too long for listpack, and convert before adding the item.
      * This is needed for HINCRBY* case since in other commands this is handled early by
      * hashTypeTryConversion, so this check will be a NOP. */
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         if (expiry != EXPIRY_NONE || sdslen(field) > server.hash_max_listpack_value || sdslen(value) > server.hash_max_listpack_value)
             hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
     }
 
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl, *fptr, *vptr;
 
         zl = objectGetVal(o);
@@ -403,7 +403,7 @@ int hashTypeSet(robj *o, sds field, sds value, mstime_t expiry, int flags, bool 
 
         /* Check if the listpack needs to be converted to a hash table */
         if (hashTypeLength(o) > server.hash_max_listpack_entries) hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
-    } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         hashtable *ht = objectGetVal(o);
 
         sds v;
@@ -473,7 +473,7 @@ static expiryModificationResult hashTypeSetExpire(robj *o, sds field, mstime_t e
     if (o == NULL) return EXPIRATION_MODIFICATION_NOT_EXIST;
 
     bool time_is_expired = checkAlreadyExpired(expiry);
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         unsigned char *vstr;
         unsigned int vlen;
         long long vll;
@@ -497,7 +497,7 @@ static expiryModificationResult hashTypeSetExpire(robj *o, sds field, mstime_t e
     }
 
     /* we must be hashtable encoded */
-    serverAssert(o->encoding == OBJ_ENCODING_HASHTABLE);
+    serverAssert(objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE);
 
     hashtable *ht = objectGetVal(o);
     void **entry_ref = NULL;
@@ -553,9 +553,9 @@ static expiryModificationResult hashTypeSetExpire(robj *o, sds field, mstime_t e
 
 static expiryModificationResult hashTypePersist(robj *o, sds field) {
     /* NULL object returns -2 */
-    if (o == NULL || o->type != OBJ_HASH) return EXPIRATION_MODIFICATION_NOT_EXIST;
+    if (o == NULL || objectGetType(o) != OBJ_HASH) return EXPIRATION_MODIFICATION_NOT_EXIST;
 
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         if (hashTypeExists(o, field))
             /* When listpack representation is used, All items are without expiry */
             return EXPIRATION_MODIFICATION_FAILED;
@@ -582,8 +582,8 @@ static expiryModificationResult hashTypePersist(robj *o, sds field) {
  * Return true on deleted and false on not found. */
 bool hashTypeDelete(robj *o, sds field) {
     bool deleted = false;
-    serverAssert(o && o->type == OBJ_HASH);
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    serverAssert(o && objectGetType(o) == OBJ_HASH);
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl, *fptr;
 
         zl = objectGetVal(o);
@@ -597,7 +597,7 @@ bool hashTypeDelete(robj *o, sds field) {
                 deleted = true;
             }
         }
-    } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         hashtable *ht = objectGetVal(o);
         void *entry = NULL;
         deleted = hashtablePop(ht, field, &entry);
@@ -613,7 +613,7 @@ bool hashTypeDelete(robj *o, sds field) {
 
 /* Return the number of elements in a hash. */
 unsigned long hashTypeLength(const robj *o) {
-    switch (o->encoding) {
+    switch (objectGetEncoding(o)) {
     case OBJ_ENCODING_LISTPACK:
         return lpLength(objectGetVal(o)) / 2;
     case OBJ_ENCODING_HASHTABLE:
@@ -768,7 +768,7 @@ robj *hashTypeLookupWriteOrCreate(client *c, robj *key) {
 
 
 void hashTypeConvertListpack(robj *o, int enc) {
-    serverAssert(o->encoding == OBJ_ENCODING_LISTPACK);
+    serverAssert(objectGetEncoding(o) == OBJ_ENCODING_LISTPACK);
 
     if (enc == OBJ_ENCODING_LISTPACK) {
         /* Nothing to do... */
@@ -799,7 +799,7 @@ void hashTypeConvertListpack(robj *o, int enc) {
         }
         hashTypeResetIterator(&hi);
         zfree(objectGetVal(o));
-        o->encoding = OBJ_ENCODING_HASHTABLE;
+        objectSetEncoding(o, OBJ_ENCODING_HASHTABLE);
         objectSetVal(o, ht);
     } else {
         serverPanic("Unknown hash encoding");
@@ -807,9 +807,9 @@ void hashTypeConvertListpack(robj *o, int enc) {
 }
 
 void hashTypeConvert(robj *o, int enc) {
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         hashTypeConvertListpack(o, enc);
-    } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         serverPanic("Not implemented");
     } else {
         serverPanic("Unknown hash encoding");
@@ -825,16 +825,16 @@ robj *hashTypeDup(robj *o) {
     robj *hobj;
     hashTypeIterator hi;
 
-    serverAssert(o->type == OBJ_HASH);
+    serverAssert(objectGetType(o) == OBJ_HASH);
 
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(o);
         size_t sz = lpBytes(zl);
         unsigned char *new_zl = zmalloc(sz);
         memcpy(new_zl, zl, sz);
         hobj = createObject(OBJ_HASH, new_zl);
         hobj->encoding = OBJ_ENCODING_LISTPACK;
-    } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         hashtable *ht = hashtableCreate(&hashHashtableType);
         hashtableExpand(ht, hashtableSize((const hashtable *)objectGetVal(o)));
         hobj = createObject(OBJ_HASH, ht);
@@ -2399,7 +2399,7 @@ typedef struct {
 static int hashTypeExpireEntry(void *entry, void *c) {
     expiryContext *ctx = c;
     robj *o = ctx->key;
-    serverAssert(o->encoding == OBJ_ENCODING_HASHTABLE && hashtableSize(objectGetVal(o)) > 0);
+    serverAssert(objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE && hashtableSize(objectGetVal(o)) > 0);
     hashtable *ht = objectGetVal(o);
     void *entry_ptr = NULL;
     bool deleted = hashtablePop(ht, entry, &entry_ptr);
@@ -2416,7 +2416,7 @@ static int hashTypeExpireEntry(void *entry, void *c) {
 /* Extract expired entries from a hash object's volatile set.
  * Returns number of expired entries, populates `out_entries`. */
 size_t hashTypeDeleteExpiredFields(robj *o, mstime_t now, unsigned long max_fields, robj **out_entries) {
-    serverAssert(o->encoding == OBJ_ENCODING_HASHTABLE);
+    serverAssert(objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE);
 
     vset *vset = hashTypeGetVolatileSet(o);
     if (!vset) {

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -40,7 +40,7 @@
  * If callback is given the function is called in order for caller to do some work
  * before the list conversion. */
 static void listTypeTryConvertListpack(robj *o, robj **argv, int start, int end, beforeConvertCB fn, void *data) {
-    serverAssert(o->encoding == OBJ_ENCODING_LISTPACK);
+    serverAssert(objectGetEncoding(o) == OBJ_ENCODING_LISTPACK);
 
     size_t add_bytes = 0;
     size_t add_length = 0;
@@ -66,7 +66,7 @@ static void listTypeTryConvertListpack(robj *o, robj **argv, int start, int end,
         else
             lpFree(objectGetVal(o));
         objectSetVal(o, ql);
-        o->encoding = OBJ_ENCODING_QUICKLIST;
+        objectSetEncoding(o, OBJ_ENCODING_QUICKLIST);
     }
 }
 
@@ -80,7 +80,7 @@ static void listTypeTryConvertListpack(robj *o, robj **argv, int start, int end,
  * If callback is given the function is called in order for caller to do some work
  * before the list conversion. */
 static void listTypeTryConvertQuicklist(robj *o, int shrinking, beforeConvertCB fn, void *data) {
-    serverAssert(o->encoding == OBJ_ENCODING_QUICKLIST);
+    serverAssert(objectGetEncoding(o) == OBJ_ENCODING_QUICKLIST);
 
     size_t sz_limit;
     unsigned int count_limit;
@@ -125,10 +125,10 @@ static void listTypeTryConvertQuicklist(robj *o, int shrinking, beforeConvertCB 
  *                       order to avoid repeated conversions on every list change. */
 static void
 listTypeTryConversionRaw(robj *o, list_conv_type lct, robj **argv, int start, int end, beforeConvertCB fn, void *data) {
-    if (o->encoding == OBJ_ENCODING_QUICKLIST) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_QUICKLIST) {
         if (lct == LIST_CONV_GROWING) return; /* Growing has nothing to do with quicklist */
         listTypeTryConvertQuicklist(o, lct == LIST_CONV_SHRINKING, fn, data);
-    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         if (lct == LIST_CONV_SHRINKING) return; /* Shrinking has nothing to do with listpack */
         listTypeTryConvertListpack(o, argv, start, end, fn, data);
     } else {
@@ -371,10 +371,10 @@ int listTypeReplaceAtIndex(robj *o, int index, robj *value) {
     size_t vlen = sdslen(vstr);
     int replaced = 0;
 
-    if (o->encoding == OBJ_ENCODING_QUICKLIST) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_QUICKLIST) {
         quicklist *ql = objectGetVal(o);
         replaced = quicklistReplaceAtIndex(ql, index, vstr, vlen);
-    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         unsigned char *p = lpSeek(objectGetVal(o), index);
         if (p) {
             objectSetVal(o, lpReplace(objectGetVal(o), &p, (unsigned char *)vstr, vlen));
@@ -721,9 +721,9 @@ void addListRangeReply(client *c, robj *o, long start, long end, int reverse) {
     rangelen = (end - start) + 1;
 
     int from = reverse ? end : start;
-    if (o->encoding == OBJ_ENCODING_QUICKLIST)
+    if (objectGetEncoding(o) == OBJ_ENCODING_QUICKLIST)
         addListQuicklistRangeReply(c, o, from, rangelen, reverse);
-    else if (o->encoding == OBJ_ENCODING_LISTPACK)
+    else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK)
         addListListpackRangeReply(c, o, from, rangelen, reverse);
     else
         serverPanic("Unknown list encoding");
@@ -894,10 +894,10 @@ void ltrimCommand(client *c) {
     }
 
     /* Remove list elements to perform the trim */
-    if (o->encoding == OBJ_ENCODING_QUICKLIST) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_QUICKLIST) {
         quicklistDelRange(objectGetVal(o), 0, ltrim);
         quicklistDelRange(objectGetVal(o), -rtrim, rtrim);
-    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         objectSetVal(o, lpDeleteRange(objectGetVal(o), 0, ltrim));
         objectSetVal(o, lpDeleteRange(objectGetVal(o), -rtrim, rtrim));
     } else {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -559,24 +559,24 @@ robj *setTypeDup(robj *o) {
     robj *set;
     setTypeIterator *si;
 
-    serverAssert(o->type == OBJ_SET);
+    serverAssert(objectGetType(o) == OBJ_SET);
 
     /* Create a new set object that have the same encoding as the original object's encoding */
-    if (o->encoding == OBJ_ENCODING_INTSET) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_INTSET) {
         intset *is = objectGetVal(o);
         size_t size = intsetBlobLen(is);
         intset *newis = zmalloc(size);
         memcpy(newis, is, size);
         set = createObject(OBJ_SET, newis);
         set->encoding = OBJ_ENCODING_INTSET;
-    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         unsigned char *lp = objectGetVal(o);
         size_t sz = lpBytes(lp);
         unsigned char *new_lp = zmalloc(sz);
         memcpy(new_lp, lp, sz);
         set = createObject(OBJ_SET, new_lp);
         set->encoding = OBJ_ENCODING_LISTPACK;
-    } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         set = createSetObject();
         hashtable *ht = objectGetVal(o);
         hashtableExpand(objectGetVal(set), hashtableSize(ht));

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -161,7 +161,7 @@ void streamNextID(streamID *last_id, streamID *new_id) {
 robj *streamDup(robj *o) {
     robj *sobj;
 
-    serverAssert(o->type == OBJ_STREAM);
+    serverAssert(objectGetType(o) == OBJ_STREAM);
 
     switch (o->encoding) {
     case OBJ_ENCODING_STREAM: sobj = createStreamObject(); break;

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -499,7 +499,7 @@ void getrangeCommand(client *c) {
     if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.emptybulk)) == NULL ||
         checkType(c, o, OBJ_STRING)) return;
 
-    if (o->encoding == OBJ_ENCODING_INT) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_INT) {
         str = llbuf;
         strlen = ll2string(llbuf, sizeof(llbuf), (long)objectGetVal(o));
     } else {
@@ -710,7 +710,7 @@ void incrDecrCommand(client *c, long long incr) {
     }
     value += incr;
 
-    if (o && o->refcount == 1 && o->encoding == OBJ_ENCODING_INT &&
+    if (o && o->refcount == 1 && objectGetEncoding(o) == OBJ_ENCODING_INT &&
         value >= LONG_MIN && value <= LONG_MAX) {
         new = o;
         objectSetVal(o, (void *)((long)value));

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1716,17 +1716,17 @@ robj *zsetDup(robj *o) {
     zset *zs;
     zset *new_zs;
 
-    serverAssert(o->type == OBJ_ZSET);
+    serverAssert(objectGetType(o) == OBJ_ZSET);
 
     /* Create a new sorted set object that have the same encoding as the original object's encoding */
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(o);
         size_t sz = lpBytes(zl);
         unsigned char *new_zl = zmalloc(sz);
         memcpy(new_zl, zl, sz);
         zobj = createObject(OBJ_ZSET, new_zl);
         zobj->encoding = OBJ_ENCODING_LISTPACK;
-    } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST) {
         zobj = createZsetObject();
         zs = objectGetVal(o);
         new_zs = objectGetVal(zobj);


### PR DESCRIPTION
Part of #3017 

This PR makes replaces direct field accesses to `serverObject` with accessor functions for `type`, `encoding`, `refcount`, and `lru` fields.

### Changes

- Added accessor functions: `objectGetType()`/`objectSetType()`, `objectGetEncoding()`/`objectSetEncoding()`, `objectGetRefcount()`, `objectGetLRU()`/`objectSetLRU()`
- Updated `sdsEncodedObject` macro to use `objectGetEncoding()`
- Replaced direct field accesses (`o->type`, `o->encoding`, `o->refcount`, `o->lru`) across ~20 files with accessor functions

### Implementation Notes

- Struct definition remains in `server.h` to support stack allocation via `initStaticStringObject`
- Not all direct field accesses are handled and there is no way to catch direct field accesses as long as the struct isn't truly opaque - which is future work
