### PR TITLE
add warning log when certs are expired/not yet valid

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1707,6 +1707,11 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
             tlsApplyPendingReload();
         }
     }
+    if (server.tls_port || server.tls_replication || server.tls_cluster) {
+        run_with_period(3600000) {
+            tlsLogCertValidityIfNeeded();
+        }
+    }
 #endif
 
     if (moduleCount()) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -458,22 +458,75 @@ static int tlsPasswordCallback(char *buf, int size, int rwflag, void *u) {
     return (int)pass_len;
 }
 
+static const char *getCertSerialString(X509 *cert, char *buf, size_t buf_len);
+
+static void logCertIssue(const char *context, X509 *cert, const char *issue) {
+    if (!context || !issue) return;
+    if (cert) {
+        char serial_buf[128];
+        const char *serial_str = getCertSerialString(cert, serial_buf, sizeof(serial_buf));
+        serverLog(LL_WARNING, "%s TLS certificate %s (serial %s).", context, issue, serial_str);
+    } else {
+        serverLog(LL_WARNING, "%s TLS certificate %s.", context, issue);
+    }
+}
+
 static void logExpiredCert(const char *context, X509 *cert) {
-    if (!cert || !context) return;
-    serverLog(LL_WARNING, "%s TLS certificate has expired.", context);
+    if (!cert) return;
+    logCertIssue(context, cert, "has expired");
 }
 
 static void logNotYetValidCert(const char *context, X509 *cert) {
-    if (!context || !cert) return;
-    serverLog(LL_WARNING, "%s TLS certificate is not yet valid.", context);
+    if (!cert) return;
+    logCertIssue(context, cert, "is not yet valid");
+}
+
+static void logMissingCert(const char *context) {
+    logCertIssue(context, NULL, "is missing");
+}
+
+static void logInvalidValidityCert(const char *context, X509 *cert) {
+    logCertIssue(context, cert, "has invalid validity period");
+}
+
+static const char *getCertSerialString(X509 *cert, char *buf, size_t buf_len) {
+    if (!cert || !buf || buf_len == 0) return "unknown";
+    ASN1_INTEGER *serial = X509_get_serialNumber(cert);
+    if (!serial) return "unknown";
+    BIGNUM *bn = ASN1_INTEGER_to_BN(serial, NULL);
+    if (!bn) return "unknown";
+    char *hex = BN_bn2hex(bn);
+    if (!hex) {
+        BN_free(bn);
+        return "unknown";
+    }
+    snprintf(buf, buf_len, "%s", hex);
+    OPENSSL_free(hex);
+    BN_free(bn);
+    return buf;
+}
+
+static void logExpiredCertIfNeeded(const char *label, X509 *cert) {
+    if (!label || !cert) return;
+    const ASN1_TIME *not_after = X509_get0_notAfter(cert);
+    if (!not_after) return;
+    if (X509_cmp_current_time(not_after) < 0) {
+        logExpiredCert(label, cert);
+    }
 }
 
 /* Check a single X509 certificate validity */
 static bool isCertValid(X509 *cert, const char *context) {
-    if (!cert) return false;
+    if (!cert) {
+        logMissingCert(context);
+        return false;
+    }
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after = X509_get0_notAfter(cert);
-    if (!not_before || !not_after) return false;
+    if (!not_before || !not_after) {
+        logInvalidValidityCert(context, cert);
+        return false;
+    }
     int not_before_cmp = X509_cmp_current_time(not_before);
     int not_after_cmp = X509_cmp_current_time(not_after);
     if (not_before_cmp > 0) {
@@ -540,9 +593,15 @@ static bool loadCaCertDir(SSL_CTX *ctx, const char *ca_cert_dir) {
 /* Iterate over all CA certs in the SSL_CTX and fail-fast if any are invalid */
 static bool areAllCaCertsValid(SSL_CTX *ctx) {
     X509_STORE *store = SSL_CTX_get_cert_store(ctx);
-    if (!store) return false;
+    if (!store) {
+        serverLog(LL_WARNING, "CA TLS certificate store is unavailable.");
+        return false;
+    }
     STACK_OF(X509_OBJECT) *objs = X509_STORE_get0_objects(store);
-    if (!objs) return false;
+    if (!objs) {
+        serverLog(LL_WARNING, "CA TLS certificate store is empty.");
+        return false;
+    }
     for (int i = 0; i < sk_X509_OBJECT_num(objs); i++) {
         X509_OBJECT *obj = sk_X509_OBJECT_value(objs, i);
         int type = X509_OBJECT_get_type(obj);
@@ -602,8 +661,6 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
 
     X509 *server_cert = SSL_CTX_get0_certificate(ctx);
     if (!isCertValid(server_cert, client ? "Client" : "Server")) {
-        serverLog(LL_WARNING, "%s TLS certificate is invalid. Aborting TLS configuration.",
-                  client ? "Client" : "Server");
         goto error;
     }
 
@@ -626,7 +683,6 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
         }
 
         if (!areAllCaCertsValid(ctx)) {
-            serverLog(LL_WARNING, "One or more loaded CA certificates are invalid. Aborting TLS configuration.");
             goto error;
         }
     }
@@ -1028,6 +1084,53 @@ void tlsReconfigureIfNeeded(void) {
         return;
     }
     bioCreateTlsReloadJob();
+}
+
+void tlsLogCertValidityIfNeeded(void) {
+    if (!valkey_tls_ctx) return;
+
+    X509 *server_cert = SSL_CTX_get0_certificate(valkey_tls_ctx);
+    logExpiredCertIfNeeded("Server", server_cert);
+
+    if (valkey_tls_client_ctx && server.tls_ctx_config.client_cert_file) {
+        X509 *client_cert = SSL_CTX_get0_certificate(valkey_tls_client_ctx);
+        logExpiredCertIfNeeded("Client", client_cert);
+    }
+
+    if (server.tls_ctx_config.ca_cert_file || server.tls_ctx_config.ca_cert_dir) {
+        X509_STORE *store = SSL_CTX_get_cert_store(valkey_tls_ctx);
+        if (!store) return;
+        STACK_OF(X509_OBJECT) *objs = X509_STORE_get0_objects(store);
+        if (!objs) return;
+        int expired_ca_count = 0;
+        int logged = 0;
+        const int max_log = 3;
+        for (int i = 0; i < sk_X509_OBJECT_num(objs); i++) {
+            X509_OBJECT *obj = sk_X509_OBJECT_value(objs, i);
+            int type = X509_OBJECT_get_type(obj);
+            if (type == X509_LU_X509) {
+                X509 *ca_cert = X509_OBJECT_get0_X509(obj);
+                const ASN1_TIME *not_after = X509_get0_notAfter(ca_cert);
+                if (!not_after) continue;
+                int days = 0, secs = 0;
+                if (!ASN1_TIME_diff(&days, &secs, NULL, not_after)) continue;
+                long long remaining = (long long)days * 86400 + secs;
+                if (remaining <= 0) {
+                    expired_ca_count++;
+                    if (logged < max_log) {
+                        logExpiredCert("CA", ca_cert);
+                        logged++;
+                    }
+                }
+            }
+        }
+        if (expired_ca_count > max_log) {
+            serverLog(LL_WARNING, "CA TLS certificates expired: %d (logged %d).",
+                      expired_ca_count, max_log);
+        } else if (expired_ca_count > 0 && expired_ca_count <= max_log) {
+            serverLog(LL_WARNING, "CA TLS certificates expired: %d.", expired_ca_count);
+        }
+    }
 }
 
 static ConnectionType CT_TLS;

--- a/src/tls.c
+++ b/src/tls.c
@@ -466,7 +466,7 @@ static int isCertExpired(X509 *cert) {
 }
 
 static void logExpiredCert(const char *context, X509 *cert, const char *path) {
-    if (!isCertExpired(cert)) return;
+    if (!cert || !context) return;
     char subject[256];
     const char *subject_str = "unknown";
     X509_NAME *name = X509_get_subject_name(cert);
@@ -480,14 +480,35 @@ static void logExpiredCert(const char *context, X509 *cert, const char *path) {
     }
 }
 
+static void logNotYetValidCert(const char *context, X509 *cert, const char *path) {
+    if (!context || !cert) return;
+    char subject[256];
+    const char *subject_str = "unknown";
+    X509_NAME *name = X509_get_subject_name(cert);
+    if (name && X509_NAME_oneline(name, subject, sizeof(subject))) {
+        subject_str = subject;
+    }
+    if (path) {
+        serverLog(LL_WARNING, "%s TLS certificate is not yet valid (file: %s)", context, path);
+    } else {
+        serverLog(LL_WARNING, "%s TLS certificate is not yet valid: subject=%s", context, subject_str);
+    }
+}
+
 /* Check a single X509 certificate validity */
-static bool isCertValid(X509 *cert) {
+static bool isCertValid(X509 *cert, const char *context, const char *path) {
     if (!cert) return false;
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after = X509_get0_notAfter(cert);
     if (!not_before || !not_after) return false;
-    if (X509_cmp_current_time(not_before) > 0 ||
-        X509_cmp_current_time(not_after) < 0) {
+    int not_before_cmp = X509_cmp_current_time(not_before);
+    int not_after_cmp = X509_cmp_current_time(not_after);
+    if (not_before_cmp > 0) {
+        logNotYetValidCert(context, cert, path);
+        return false;
+    }
+    if (not_after_cmp < 0) {
+        logExpiredCert(context, cert, path);
         return false;
     }
     return true;
@@ -554,11 +575,8 @@ static bool areAllCaCertsValid(SSL_CTX *ctx) {
         int type = X509_OBJECT_get_type(obj);
         if (type == X509_LU_X509) {
             X509 *ca_cert = X509_OBJECT_get0_X509(obj);
-            if (ca_cert) {
-                logExpiredCert("CA", ca_cert, NULL);
-                if (!isCertValid(ca_cert)) {
-                    return false;
-                }
+            if (ca_cert && !isCertValid(ca_cert, "CA", NULL)) {
+                return false;
             }
         }
     }
@@ -611,10 +629,7 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
 
     X509 *server_cert = SSL_CTX_get0_certificate(ctx);
     int expired = isCertExpired(server_cert);
-    if (expired) {
-        logExpiredCert(client ? "Client" : "Server", server_cert, cert_file);
-    }
-    if (!isCertValid(server_cert)) {
+    if (!isCertValid(server_cert, client ? "Client" : "Server", cert_file)) {
         if (!expired) {
             serverLog(LL_WARNING, "%s TLS certificate is invalid. Aborting TLS configuration.",
                       client ? "Client" : "Server");

--- a/src/tls.c
+++ b/src/tls.c
@@ -458,45 +458,18 @@ static int tlsPasswordCallback(char *buf, int size, int rwflag, void *u) {
     return (int)pass_len;
 }
 
-static int isCertExpired(X509 *cert) {
-    if (!cert) return 0;
-    const ASN1_TIME *not_after = X509_get0_notAfter(cert);
-    if (!not_after) return 0;
-    return X509_cmp_current_time(not_after) < 0;
-}
-
-static void logExpiredCert(const char *context, X509 *cert, const char *path) {
+static void logExpiredCert(const char *context, X509 *cert) {
     if (!cert || !context) return;
-    char subject[256];
-    const char *subject_str = "unknown";
-    X509_NAME *name = X509_get_subject_name(cert);
-    if (name && X509_NAME_oneline(name, subject, sizeof(subject))) {
-        subject_str = subject;
-    }
-    if (path) {
-        serverLog(LL_WARNING, "%s TLS certificate has expired (file: %s)", context, path);
-    } else {
-        serverLog(LL_WARNING, "%s TLS certificate has expired: subject=%s", context, subject_str);
-    }
+    serverLog(LL_WARNING, "%s TLS certificate has expired.", context);
 }
 
-static void logNotYetValidCert(const char *context, X509 *cert, const char *path) {
+static void logNotYetValidCert(const char *context, X509 *cert) {
     if (!context || !cert) return;
-    char subject[256];
-    const char *subject_str = "unknown";
-    X509_NAME *name = X509_get_subject_name(cert);
-    if (name && X509_NAME_oneline(name, subject, sizeof(subject))) {
-        subject_str = subject;
-    }
-    if (path) {
-        serverLog(LL_WARNING, "%s TLS certificate is not yet valid (file: %s)", context, path);
-    } else {
-        serverLog(LL_WARNING, "%s TLS certificate is not yet valid: subject=%s", context, subject_str);
-    }
+    serverLog(LL_WARNING, "%s TLS certificate is not yet valid.", context);
 }
 
 /* Check a single X509 certificate validity */
-static bool isCertValid(X509 *cert, const char *context, const char *path) {
+static bool isCertValid(X509 *cert, const char *context) {
     if (!cert) return false;
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after = X509_get0_notAfter(cert);
@@ -504,11 +477,11 @@ static bool isCertValid(X509 *cert, const char *context, const char *path) {
     int not_before_cmp = X509_cmp_current_time(not_before);
     int not_after_cmp = X509_cmp_current_time(not_after);
     if (not_before_cmp > 0) {
-        logNotYetValidCert(context, cert, path);
+        logNotYetValidCert(context, cert);
         return false;
     }
     if (not_after_cmp < 0) {
-        logExpiredCert(context, cert, path);
+        logExpiredCert(context, cert);
         return false;
     }
     return true;
@@ -575,7 +548,7 @@ static bool areAllCaCertsValid(SSL_CTX *ctx) {
         int type = X509_OBJECT_get_type(obj);
         if (type == X509_LU_X509) {
             X509 *ca_cert = X509_OBJECT_get0_X509(obj);
-            if (ca_cert && !isCertValid(ca_cert, "CA", NULL)) {
+            if (ca_cert && !isCertValid(ca_cert, "CA")) {
                 return false;
             }
         }
@@ -628,12 +601,9 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
     }
 
     X509 *server_cert = SSL_CTX_get0_certificate(ctx);
-    int expired = isCertExpired(server_cert);
-    if (!isCertValid(server_cert, client ? "Client" : "Server", cert_file)) {
-        if (!expired) {
-            serverLog(LL_WARNING, "%s TLS certificate is invalid. Aborting TLS configuration.",
-                      client ? "Client" : "Server");
-        }
+    if (!isCertValid(server_cert, client ? "Client" : "Server")) {
+        serverLog(LL_WARNING, "%s TLS certificate is invalid. Aborting TLS configuration.",
+                  client ? "Client" : "Server");
         goto error;
     }
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -458,14 +458,13 @@ static int tlsPasswordCallback(char *buf, int size, int rwflag, void *u) {
     return (int)pass_len;
 }
 
-static const char *getCertSerialString(X509 *cert, char *buf, size_t buf_len);
-
 static void logCertIssue(const char *context, X509 *cert, const char *issue) {
     if (!context || !issue) return;
     if (cert) {
-        char serial_buf[128];
-        const char *serial_str = getCertSerialString(cert, serial_buf, sizeof(serial_buf));
+        sds serial_sds = tlsX509SerialToSds(cert);
+        const char *serial_str = serial_sds ? serial_sds : "unknown";
         serverLog(LL_WARNING, "%s TLS certificate %s (serial %s).", context, issue, serial_str);
+        if (serial_sds) sdsfree(serial_sds);
     } else {
         serverLog(LL_WARNING, "%s TLS certificate %s.", context, issue);
     }
@@ -487,23 +486,6 @@ static void logMissingCert(const char *context) {
 
 static void logInvalidValidityCert(const char *context, X509 *cert) {
     logCertIssue(context, cert, "has invalid validity period");
-}
-
-static const char *getCertSerialString(X509 *cert, char *buf, size_t buf_len) {
-    if (!cert || !buf || buf_len == 0) return "unknown";
-    ASN1_INTEGER *serial = X509_get_serialNumber(cert);
-    if (!serial) return "unknown";
-    BIGNUM *bn = ASN1_INTEGER_to_BN(serial, NULL);
-    if (!bn) return "unknown";
-    char *hex = BN_bn2hex(bn);
-    if (!hex) {
-        BN_free(bn);
-        return "unknown";
-    }
-    snprintf(buf, buf_len, "%s", hex);
-    OPENSSL_free(hex);
-    BN_free(bn);
-    return buf;
 }
 
 static void logExpiredCertIfNeeded(const char *label, X509 *cert) {
@@ -1112,10 +1094,7 @@ void tlsLogCertValidityIfNeeded(void) {
                 X509 *ca_cert = X509_OBJECT_get0_X509(obj);
                 const ASN1_TIME *not_after = X509_get0_notAfter(ca_cert);
                 if (!not_after) continue;
-                int days = 0, secs = 0;
-                if (!ASN1_TIME_diff(&days, &secs, NULL, not_after)) continue;
-                long long remaining = (long long)days * 86400 + secs;
-                if (remaining <= 0) {
+                if (X509_cmp_current_time(not_after) < 0) {
                     expired_ca_count++;
                     if (logged < max_log) {
                         logExpiredCert("CA", ca_cert);

--- a/src/tls.c
+++ b/src/tls.c
@@ -458,6 +458,28 @@ static int tlsPasswordCallback(char *buf, int size, int rwflag, void *u) {
     return (int)pass_len;
 }
 
+static int isCertExpired(X509 *cert) {
+    if (!cert) return 0;
+    const ASN1_TIME *not_after = X509_get0_notAfter(cert);
+    if (!not_after) return 0;
+    return X509_cmp_current_time(not_after) < 0;
+}
+
+static void logExpiredCert(const char *context, X509 *cert, const char *path) {
+    if (!isCertExpired(cert)) return;
+    char subject[256];
+    const char *subject_str = "unknown";
+    X509_NAME *name = X509_get_subject_name(cert);
+    if (name && X509_NAME_oneline(name, subject, sizeof(subject))) {
+        subject_str = subject;
+    }
+    if (path) {
+        serverLog(LL_WARNING, "%s TLS certificate has expired (file: %s)", context, path);
+    } else {
+        serverLog(LL_WARNING, "%s TLS certificate has expired: subject=%s", context, subject_str);
+    }
+}
+
 /* Check a single X509 certificate validity */
 static bool isCertValid(X509 *cert) {
     if (!cert) return false;
@@ -532,8 +554,11 @@ static bool areAllCaCertsValid(SSL_CTX *ctx) {
         int type = X509_OBJECT_get_type(obj);
         if (type == X509_LU_X509) {
             X509 *ca_cert = X509_OBJECT_get0_X509(obj);
-            if (ca_cert && !isCertValid(ca_cert)) {
-                return false;
+            if (ca_cert) {
+                logExpiredCert("CA", ca_cert, NULL);
+                if (!isCertValid(ca_cert)) {
+                    return false;
+                }
             }
         }
     }
@@ -584,8 +609,16 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
         goto error;
     }
 
-    if (!isCertValid(SSL_CTX_get0_certificate(ctx))) {
-        serverLog(LL_WARNING, "%s TLS certificate is invalid. Aborting TLS configuration.", client ? "Client" : "Server");
+    X509 *server_cert = SSL_CTX_get0_certificate(ctx);
+    int expired = isCertExpired(server_cert);
+    if (expired) {
+        logExpiredCert(client ? "Client" : "Server", server_cert, cert_file);
+    }
+    if (!isCertValid(server_cert)) {
+        if (!expired) {
+            serverLog(LL_WARNING, "%s TLS certificate is invalid. Aborting TLS configuration.",
+                      client ? "Client" : "Server");
+        }
         goto error;
     }
 

--- a/src/tls.h
+++ b/src/tls.h
@@ -12,6 +12,7 @@
 void tlsReconfigureIfNeeded(void);
 void tlsApplyPendingReload(void);
 void tlsConfigureAsync(void);
+void tlsLogCertValidityIfNeeded(void);
 #endif
 
 #endif /* __VALKEY_TLS_H */

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -155,6 +155,16 @@ start_server {tags {"tls"}} {
             r config set tls-key-file $keyfile_encrypted
         }
 
+        test {TLS: Expired certificate logs warning} {
+            set logline [count_log_lines 0]
+            set expired_crt [format "%s/tests/tls/server-expired.crt" [pwd]]
+
+            catch {r config set tls-cert-file $expired_crt} e
+            assert_match {*Unable to update TLS*} $e
+
+            wait_for_log_messages 0 {"*TLS certificate has expired*"} $logline 100 10
+        }
+
         test {TLS: Auto-authenticate using tls-auth-clients-user (CN)} {
             # Create a user matching the CN in the client certificate (CN=Client-only)
             r ACL SETUSER {Client-only} on >clientpass allcommands allkeys

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -155,14 +155,14 @@ start_server {tags {"tls"}} {
             r config set tls-key-file $keyfile_encrypted
         }
 
-        test {TLS: Expired certificate logs warning} {
+        test {TLS: Expired certificate logs warning includes serial} {
             set logline [count_log_lines 0]
             set expired_crt [format "%s/tests/tls/server-expired.crt" [pwd]]
 
             catch {r config set tls-cert-file $expired_crt} e
             assert_match {*Unable to update TLS*} $e
 
-            wait_for_log_messages 0 {"*Server TLS certificate has expired.*"} $logline 100 10
+            wait_for_log_messages 0 {"*Server TLS certificate has expired (serial *).*"} $logline 100 10
         }
 
         test {TLS: Auto-authenticate using tls-auth-clients-user (CN)} {
@@ -387,28 +387,28 @@ start_server {tags {"tls"}} {
             set tlsdir [file normalize ./tests/tls]
 
             # Expired server certificate
-            test_tls_cert_rejection server $tlsdir/server-expired.crt {*Server TLS certificate has expired.*}
+            test_tls_cert_rejection server $tlsdir/server-expired.crt {*Server TLS certificate has expired (serial *).*}
 
             # Not-yet-valid server certificate
-            test_tls_cert_rejection server $tlsdir/server-notyet.crt {*Server TLS certificate is not yet valid.*}
+            test_tls_cert_rejection server $tlsdir/server-notyet.crt {*Server TLS certificate is not yet valid (serial *).*}
 
             # Expired client certificate
-            test_tls_cert_rejection client $tlsdir/client-expired.crt {*Client TLS certificate has expired.*}
+            test_tls_cert_rejection client $tlsdir/client-expired.crt {*Client TLS certificate has expired (serial *).*}
 
             # Not-yet-valid client certificate
-            test_tls_cert_rejection client $tlsdir/client-notyet.crt {*Client TLS certificate is not yet valid.*}
+            test_tls_cert_rejection client $tlsdir/client-notyet.crt {*Client TLS certificate is not yet valid (serial *).*}
 
             # Expired CA certificate file
-            test_tls_cert_rejection ca-file $tlsdir/ca-expired.crt {*One or more loaded CA certificates are invalid*}
+            test_tls_cert_rejection ca-file $tlsdir/ca-expired.crt {*CA TLS certificate has expired (serial *).*}
 
             # Not-yet-valid CA certificate file
-            test_tls_cert_rejection ca-file $tlsdir/ca-notyet.crt {*One or more loaded CA certificates are invalid*}
+            test_tls_cert_rejection ca-file $tlsdir/ca-notyet.crt {*CA TLS certificate is not yet valid (serial *).*}
 
             # Expired CA certificate directory
-            test_tls_cert_rejection ca-dir $tlsdir/ca-expired {*One or more loaded CA certificates are invalid*}
+            test_tls_cert_rejection ca-dir $tlsdir/ca-expired {*CA TLS certificate has expired (serial *).*}
 
             # Not-yet-valid CA certificate directory
-            test_tls_cert_rejection ca-dir $tlsdir/ca-notyet {*One or more loaded CA certificates are invalid*}
+            test_tls_cert_rejection ca-dir $tlsdir/ca-notyet {*CA TLS certificate is not yet valid (serial *).*}
         }
 
         proc test_tls_cert_rejection_runtime {r cert_type cert_path} {

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -387,16 +387,16 @@ start_server {tags {"tls"}} {
             set tlsdir [file normalize ./tests/tls]
 
             # Expired server certificate
-            test_tls_cert_rejection server $tlsdir/server-expired.crt {*Server TLS certificate is invalid*}
+            test_tls_cert_rejection server $tlsdir/server-expired.crt {*Server TLS certificate has expired*}
 
             # Not-yet-valid server certificate
-            test_tls_cert_rejection server $tlsdir/server-notyet.crt {*Server TLS certificate is invalid*}
+            test_tls_cert_rejection server $tlsdir/server-notyet.crt {*Server TLS certificate is not yet valid*}
 
             # Expired client certificate
-            test_tls_cert_rejection client $tlsdir/client-expired.crt {*Client TLS certificate is invalid*}
+            test_tls_cert_rejection client $tlsdir/client-expired.crt {*Client TLS certificate has expired*}
 
             # Not-yet-valid client certificate
-            test_tls_cert_rejection client $tlsdir/client-notyet.crt {*Client TLS certificate is invalid*}
+            test_tls_cert_rejection client $tlsdir/client-notyet.crt {*Client TLS certificate is not yet valid*}
 
             # Expired CA certificate file
             test_tls_cert_rejection ca-file $tlsdir/ca-expired.crt {*One or more loaded CA certificates are invalid*}

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -155,16 +155,6 @@ start_server {tags {"tls"}} {
             r config set tls-key-file $keyfile_encrypted
         }
 
-        test {TLS: Expired certificate logs warning includes serial} {
-            set logline [count_log_lines 0]
-            set expired_crt [format "%s/tests/tls/server-expired.crt" [pwd]]
-
-            catch {r config set tls-cert-file $expired_crt} e
-            assert_match {*Unable to update TLS*} $e
-
-            wait_for_log_messages 0 {"*Server TLS certificate has expired (serial *).*"} $logline 100 10
-        }
-
         test {TLS: Auto-authenticate using tls-auth-clients-user (CN)} {
             # Create a user matching the CN in the client certificate (CN=Client-only)
             r ACL SETUSER {Client-only} on >clientpass allcommands allkeys
@@ -411,7 +401,8 @@ start_server {tags {"tls"}} {
             test_tls_cert_rejection ca-dir $tlsdir/ca-notyet {*CA TLS certificate is not yet valid (serial *).*}
         }
 
-        proc test_tls_cert_rejection_runtime {r cert_type cert_path} {
+        proc test_tls_cert_rejection_runtime {r cert_type cert_path {validity ""}} {
+            set logline [count_log_lines 0]
             switch -- $cert_type {
                 server {
                     catch {$r CONFIG SET tls-cert-file $cert_path} err
@@ -427,34 +418,49 @@ start_server {tags {"tls"}} {
                 }
             }
             assert_match {*Unable to update TLS*} $err
+            if {$validity ne ""} {
+                switch -- $cert_type {
+                    server { set label "Server" }
+                    client { set label "Client" }
+                    default { set label "CA" }
+                }
+                if {$validity eq "expired"} {
+                    set expected "*$label TLS certificate has expired (serial *).*"
+                } elseif {$validity eq "notyet"} {
+                    set expected "*$label TLS certificate is not yet valid (serial *).*"
+                } else {
+                    fail "Unknown validity flag: $validity"
+                }
+                wait_for_log_messages 0 $expected $logline 100 10
+            }
         }
 
         test {TLS: Fail-fast on invalid certificates at runtime} {
             set tlsdir [file normalize ./tests/tls]
 
             # Expired server certificate
-            test_tls_cert_rejection_runtime r server $tlsdir/server-expired.crt
+            test_tls_cert_rejection_runtime r server $tlsdir/server-expired.crt expired
 
             # Not-yet-valid server certificate
-            test_tls_cert_rejection_runtime r server $tlsdir/server-notyet.crt
+            test_tls_cert_rejection_runtime r server $tlsdir/server-notyet.crt notyet
 
             # Expired client certificate
-            test_tls_cert_rejection_runtime r client $tlsdir/client-expired.crt
+            test_tls_cert_rejection_runtime r client $tlsdir/client-expired.crt expired
 
             # Not-yet-valid client certificate
-            test_tls_cert_rejection_runtime r client $tlsdir/client-notyet.crt
+            test_tls_cert_rejection_runtime r client $tlsdir/client-notyet.crt notyet
 
             # Expired CA certificate file
-            test_tls_cert_rejection_runtime r ca-file $tlsdir/ca-expired.crt
+            test_tls_cert_rejection_runtime r ca-file $tlsdir/ca-expired.crt expired
 
             # Not-yet-valid CA certificate file
-            test_tls_cert_rejection_runtime r ca-file $tlsdir/ca-notyet.crt
+            test_tls_cert_rejection_runtime r ca-file $tlsdir/ca-notyet.crt notyet
 
             # Expired CA certificate directory
-            test_tls_cert_rejection_runtime r ca-dir $tlsdir/ca-expired
+            test_tls_cert_rejection_runtime r ca-dir $tlsdir/ca-expired expired
 
             # Not-yet-valid CA certificate directory
-            test_tls_cert_rejection_runtime r ca-dir $tlsdir/ca-notyet
+            test_tls_cert_rejection_runtime r ca-dir $tlsdir/ca-notyet notyet
         }
     }
 }

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -162,7 +162,7 @@ start_server {tags {"tls"}} {
             catch {r config set tls-cert-file $expired_crt} e
             assert_match {*Unable to update TLS*} $e
 
-            wait_for_log_messages 0 {"*TLS certificate has expired*"} $logline 100 10
+            wait_for_log_messages 0 {"*Server TLS certificate has expired.*"} $logline 100 10
         }
 
         test {TLS: Auto-authenticate using tls-auth-clients-user (CN)} {
@@ -387,16 +387,16 @@ start_server {tags {"tls"}} {
             set tlsdir [file normalize ./tests/tls]
 
             # Expired server certificate
-            test_tls_cert_rejection server $tlsdir/server-expired.crt {*Server TLS certificate has expired*}
+            test_tls_cert_rejection server $tlsdir/server-expired.crt {*Server TLS certificate has expired.*}
 
             # Not-yet-valid server certificate
-            test_tls_cert_rejection server $tlsdir/server-notyet.crt {*Server TLS certificate is not yet valid*}
+            test_tls_cert_rejection server $tlsdir/server-notyet.crt {*Server TLS certificate is not yet valid.*}
 
             # Expired client certificate
-            test_tls_cert_rejection client $tlsdir/client-expired.crt {*Client TLS certificate has expired*}
+            test_tls_cert_rejection client $tlsdir/client-expired.crt {*Client TLS certificate has expired.*}
 
             # Not-yet-valid client certificate
-            test_tls_cert_rejection client $tlsdir/client-notyet.crt {*Client TLS certificate is not yet valid*}
+            test_tls_cert_rejection client $tlsdir/client-notyet.crt {*Client TLS certificate is not yet valid.*}
 
             # Expired CA certificate file
             test_tls_cert_rejection ca-file $tlsdir/ca-expired.crt {*One or more loaded CA certificates are invalid*}


### PR DESCRIPTION
**Goal**
Provide clear, consistent logging for expired server owned TLS certs (server/client/CA) at startup/reload and during runtime.

**What changed**

- Added an hourly cron check that scans server‑owned TLS certs (server/client/CA) and logs only expired certs, including the cert serial for identification.

- Refined startup/reload validation to emit one specific warning per validity issue (expired / not‑yet‑valid / invalid validity period), removing generic error logs.

- CA expiry logging is now capped at three per interval, with a count summary for additional expired CAs.

Example logs:
```
20766:M 02 Feb 2026 19:08:26.180 # Server TLS certificate has expired (serial 01).
21020:M 02 Feb 2026 19:09:21.441 # Client TLS certificate has expired (serial 02).
21108:M 02 Feb 2026 19:09:43.388 # CA TLS certificate has expired (serial 05).
```
for multiple ca cert invalid: 
```
# CA TLS certificate has expired (serial 05).
# CA TLS certificate has expired (serial 07).
# CA TLS certificate has expired (serial 09).
# CA TLS certificates expired: 5 (logged 3).
```