### PR TITLE
Support using base aof for full synchronization

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -46,7 +46,7 @@ off_t getAppendOnlyFileSize(sds filename, int *status);
 off_t getBaseAndIncrAppendOnlyFilesSize(aofManifest *am, int *status);
 int getBaseAndIncrAppendOnlyFilesNum(aofManifest *am);
 int aofFileExist(char *filename);
-int rewriteAppendOnlyFile(char *filename);
+int rewriteAppendOnlyFile(char *filename, int req);
 aofManifest *aofLoadManifestFromFile(sds am_filepath);
 void aofManifestFreeAndUpdate(aofManifest *am);
 void aof_background_fsync_and_close(int fd);
@@ -715,7 +715,7 @@ void aofOpenIfNeededOnServerStart(void) {
     if (!server.aof_manifest->base_aof_info && !incr_aof_len) {
         sds base_name = getNewBaseFileNameAndMarkPreAsHistory(server.aof_manifest, server.aof_use_rdb_preamble);
         sds base_filepath = makePath(server.aof_dirname, base_name);
-        if (rewriteAppendOnlyFile(base_filepath) != C_OK) {
+        if (rewriteAppendOnlyFile(base_filepath, REPLICA_REQ_NONE) != C_OK) {
             exit(1);
         }
         sdsfree(base_filepath);
@@ -914,18 +914,21 @@ void aof_background_fsync_and_close(int fd) {
 }
 
 /* Kills an AOFRW child process if exists */
-void killAppendOnlyChild(void) {
+void killAppendOnlyChild(bool async) {
     int statloc;
     /* No AOFRW child? return. */
     if (server.child_type != CHILD_TYPE_AOF) return;
     /* Kill AOFRW child, wait for child exit. */
     serverLog(LL_NOTICE, "Killing running AOF rewrite child: %ld", (long)server.child_pid);
-    if (kill(server.child_pid, SIGUSR1) != -1) {
-        while (waitpid(-1, &statloc, 0) != server.child_pid);
+    int ret = kill(server.child_pid, SIGUSR1);
+    if (!async) {
+        if (ret != -1) {
+            while (waitpid(-1, &statloc, 0) != server.child_pid);
+        }
+        aofRemoveTempFile(server.child_pid, 0);
+        resetChildState();
+        server.aof_rewrite_time_start = -1;
     }
-    aofRemoveTempFile(server.child_pid, 0);
-    resetChildState();
-    server.aof_rewrite_time_start = -1;
 }
 
 /* Called when the user switches from "appendonly yes" to "appendonly no"
@@ -953,7 +956,7 @@ void stopAppendOnly(void) {
     server.aof_last_incr_fsync_offset = 0;
     server.fsynced_reploff = -1;
     atomic_store_explicit(&server.fsynced_reploff_pending, 0, memory_order_relaxed);
-    killAppendOnlyChild();
+    killAppendOnlyChild(false);
     sdsfree(server.aof_buf);
     server.aof_buf = sdsempty();
 }
@@ -979,10 +982,10 @@ int startAppendOnly(void) {
         if (server.child_type == CHILD_TYPE_AOF) {
             serverLog(LL_NOTICE, "AOF was enabled but there is already an AOF rewriting in background. Stopping "
                                  "background AOF and starting a rewrite now.");
-            killAppendOnlyChild();
+            killAppendOnlyChild(false);
         }
 
-        if (rewriteAppendOnlyFileBackground() == C_ERR) {
+        if (rewriteAppendOnlyFileBackground(false, REPLICA_REQ_NONE) == C_ERR) {
             server.aof_state = AOF_OFF;
             serverLog(LL_WARNING, "The server needs to enable the AOF but can't trigger a background AOF rewrite "
                                   "operation. Check the above logs for more info about the error.");
@@ -2318,7 +2321,7 @@ int rewriteSlotToAppendOnlyFileRio(rio *aof, int db_num, int hashslot, size_t *k
     return C_OK;
 }
 
-int rewriteAppendOnlyFileRio(rio *aof) {
+int rewriteAppendOnlyFileRio(rio *aof, int req) {
     int j;
     long key_count = 0;
     long long updated_time = 0;
@@ -2334,8 +2337,9 @@ int rewriteAppendOnlyFileRio(rio *aof) {
         sdsfree(ts);
     }
 
-    if (rewriteFunctions(aof) == C_ERR) goto werr;
+    if (!(req & REPLICA_REQ_RDB_EXCLUDE_FUNCTIONS) && rewriteFunctions(aof) == C_ERR) goto werr;
 
+    if ((req & REPLICA_REQ_RDB_EXCLUDE_DATA)) return C_OK;
     for (j = 0; j < server.dbnum; j++) {
         if (dbHasNoKeys(j)) continue;
         serverDb *db = server.db[j];
@@ -2371,6 +2375,24 @@ werr:
     return C_ERR;
 }
 
+int rewriteRioWithEOFMark(rio *aof, int req) {
+    char eofmark[RDB_EOF_MARK_SIZE];
+
+    startSaving(RDBFLAGS_REPLICATION);
+    getRandomHexChars(eofmark, RDB_EOF_MARK_SIZE);
+    if (rioWrite(aof, "$EOF:", 5) == 0) goto werr;
+    if (rioWrite(aof, eofmark, RDB_EOF_MARK_SIZE) == 0) goto werr;
+    if (rioWrite(aof, "\r\n", 2) == 0) goto werr;
+    if (rewriteAppendOnlyFileRio(aof, req) == C_ERR) goto werr;
+    if (rioWrite(aof, eofmark, RDB_EOF_MARK_SIZE) == 0) goto werr;
+    stopSaving(1);
+    return C_OK;
+
+werr: /* Write error. */
+    stopSaving(0);
+    return C_ERR;
+}
+
 /* Write a sequence of commands able to fully rebuild the dataset into
  * "filename". Used both by REWRITEAOF and BGREWRITEAOF.
  *
@@ -2378,7 +2400,7 @@ werr:
  * log, the server uses variadic commands when possible, such as RPUSH, SADD
  * and ZADD. However at max AOF_REWRITE_ITEMS_PER_CMD items per time
  * are inserted using a single command. */
-int rewriteAppendOnlyFile(char *filename) {
+int rewriteAppendOnlyFile(char *filename, int req) {
     rio aof;
     FILE *fp = NULL;
     char tmpfile[256];
@@ -2408,7 +2430,7 @@ int rewriteAppendOnlyFile(char *filename) {
             goto werr;
         }
     } else {
-        if (rewriteAppendOnlyFileRio(&aof) == C_ERR) goto werr;
+        if (rewriteAppendOnlyFileRio(&aof, req) == C_ERR) goto werr;
     }
 
     /* Make sure data will not remain on the OS's output buffers */
@@ -2461,7 +2483,7 @@ werr:
  *    4d) persist AOF manifest file
  *    4e) Delete the history files use bio
  */
-int rewriteAppendOnlyFileBackground(void) {
+int rewriteAppendOnlyFileBackground(bool for_replication, int req) {
     pid_t childpid;
 
     if (hasActiveChildProcess()) return C_ERR;
@@ -2508,7 +2530,10 @@ int rewriteAppendOnlyFileBackground(void) {
         }
         serverSetCpuAffinity(server.aof_rewrite_cpulist);
         snprintf(tmpfile, 256, "temp-rewriteaof-bg-%d.aof", (int)getpid());
-        if (rewriteAppendOnlyFile(tmpfile) == C_OK) {
+
+        /* Do not use RDB format for fullsync-aof replication */
+        if (for_replication) server.aof_use_rdb_preamble = 0;
+        if (rewriteAppendOnlyFile(tmpfile, req) == C_OK) {
             serverLog(LL_NOTICE, "Successfully created the temporary AOF base file %s", tmpfile);
             sendChildCowInfo(CHILD_INFO_TYPE_AOF_COW_SIZE, "AOF rewrite");
             exitFromChild(0);
@@ -2525,10 +2550,153 @@ int rewriteAppendOnlyFileBackground(void) {
         serverLog(LL_NOTICE, "Background append only file rewriting started by pid %ld", (long)childpid);
         server.aof_rewrite_scheduled = 0;
         server.aof_rewrite_time_start = time(NULL);
-        server.aof_rewrite_use_rdb_preamble = server.aof_use_rdb_preamble;
+        server.aof_rewrite_use_rdb_preamble = for_replication ? 0 : server.aof_use_rdb_preamble;
+        server.rdb_child_type = SNAPSHOT_CHILD_TYPE_DISK;
         return C_OK;
     }
     return C_OK; /* unreached */
+}
+
+/* For fullsync-aof replication, rewrite the AOF to the replica sockets.
+ * Almost the same logic as rdbSaveToReplicasSockets. */
+int rewriteAppendOnlyFileToReplicasSockets(int req) {
+    listNode *ln;
+    listIter li;
+    pid_t childpid;
+    int pipefds[2], aof_pipe_write = -1, safe_to_exit_pipe = -1;
+    int dual_channel = (req & REPLICA_REQ_RDB_CHANNEL);
+
+    if (hasActiveChildProcess()) return C_ERR;
+    serverAssert(server.rdb_pipe_read == -1 && server.rdb_child_exit_pipe == -1);
+
+    if (server.rdb_pipe_conns) return C_ERR;
+
+    if (!dual_channel) {
+        if (anetPipe(pipefds, O_NONBLOCK, 0) == -1) return C_ERR;
+        server.rdb_pipe_read = pipefds[0];
+        aof_pipe_write = pipefds[1];
+
+        if (anetPipe(pipefds, 0, 0) == -1) {
+            close(aof_pipe_write);
+            close(server.rdb_pipe_read);
+            return C_ERR;
+        }
+        safe_to_exit_pipe = pipefds[0];
+        server.rdb_child_exit_pipe = pipefds[1];
+    }
+
+    int connsnum = 0;
+    connection **conns = zmalloc(sizeof(connection *) * listLength(server.replicas));
+    server.rdb_pipe_conns = NULL;
+    if (!dual_channel) {
+        server.rdb_pipe_conns = conns;
+        server.rdb_pipe_numconns = 0;
+        server.rdb_pipe_numconns_writing = 0;
+    }
+
+    listRewind(server.replicas, &li);
+    while ((ln = listNext(&li))) {
+        client *replica = ln->value;
+        if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_START) {
+            if (replica->repl_data->replica_req != req) continue;
+
+            conns[connsnum++] = replica->conn;
+            if (dual_channel) {
+                connSendTimeout(replica->conn, server.repl_timeout * 1000);
+                sendCurrentOffsetToReplica(replica, true);
+                addRdbReplicaToPsyncWait(replica);
+                connBlock(replica->conn);
+            } else {
+                server.rdb_pipe_numconns++;
+            }
+            replicationSetupReplicaForFullResync(replica, getPsyncInitialOffset(), true);
+        }
+    }
+
+    if ((childpid = serverFork(CHILD_TYPE_AOF)) == 0) {
+        int retval, dummy;
+        rio aof;
+        if (dual_channel) {
+            rioInitWithConnset(&aof, conns, connsnum);
+        } else {
+            rioInitWithFd(&aof, aof_pipe_write);
+        }
+
+        if (!dual_channel) close(server.rdb_pipe_read);
+        if (strstr(server.exec_argv[0], "redis-server") != NULL) {
+            serverSetProcTitle("redis-aof-to-slaves");
+        } else {
+            serverSetProcTitle("valkey-aof-to-replicas");
+        }
+        serverSetCpuAffinity(server.aof_rewrite_cpulist);
+
+        server.aof_use_rdb_preamble = 0;
+        retval = rewriteRioWithEOFMark(&aof, req);
+
+        if (retval == C_OK && rioFlush(&aof) == 0) retval = C_ERR;
+
+        if (retval == C_OK) {
+            sendChildCowInfo(CHILD_INFO_TYPE_AOF_COW_SIZE, "AOF rewrite");
+            if (dual_channel) {
+                sendChildInfoGeneric(CHILD_INFO_TYPE_REPL_OUTPUT_BYTES, 0, aof.processed_bytes, -1, "AOF");
+            }
+        }
+        if (dual_channel) {
+            rioFreeConnset(&aof);
+        } else {
+            rioFreeFd(&aof);
+            close(aof_pipe_write);
+            close(server.rdb_child_exit_pipe);
+        }
+        zfree(conns);
+        if (!dual_channel) dummy = read(safe_to_exit_pipe, pipefds, 1);
+        UNUSED(dummy);
+        exitFromChild((retval == C_OK) ? 0 : 1);
+    } else {
+        if (childpid == -1) {
+            serverLog(LL_WARNING, "Can't rewrite in background: fork: %s", strerror(errno));
+
+            listRewind(server.replicas, &li);
+            while ((ln = listNext(&li))) {
+                client *replica = ln->value;
+                if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_END) {
+                    replica->repl_data->repl_state = REPLICA_STATE_WAIT_BGREWRITE_START;
+                }
+            }
+            if (!dual_channel) {
+                close(aof_pipe_write);
+                close(server.rdb_pipe_read);
+                close(server.rdb_child_exit_pipe);
+            }
+            zfree(conns);
+            if (dual_channel) {
+                closeChildInfoPipe();
+            } else {
+                server.rdb_pipe_conns = NULL;
+                server.rdb_pipe_numconns = 0;
+                server.rdb_pipe_numconns_writing = 0;
+            }
+        } else {
+            serverLog(LL_NOTICE, "Background AOF transfer started by pid %ld to %s",
+                      (long)childpid,
+                      dual_channel ? "direct socket to replica" : "pipe through parent process");
+
+            server.rdb_save_time_start = time(NULL);
+            server.rdb_child_type = SNAPSHOT_CHILD_TYPE_SOCKET;
+            if (dual_channel) {
+                zfree(conns);
+            } else {
+                close(aof_pipe_write);
+                if (aeCreateFileEvent(server.el, server.rdb_pipe_read, AE_READABLE, rdbPipeReadHandler, NULL) ==
+                    AE_ERR) {
+                    serverPanic("Unrecoverable error creating server.rdb_pipe_read file event.");
+                }
+            }
+        }
+        if (!dual_channel) close(safe_to_exit_pipe);
+        return (childpid == -1) ? C_ERR : C_OK;
+    }
+    return C_OK;
 }
 
 void bgrewriteaofCommand(client *c) {
@@ -2541,7 +2709,7 @@ void bgrewriteaofCommand(client *c) {
         server.stat_aofrw_consecutive_failures = 0;
         serverLog(LL_NOTICE, "Background append only file rewriting scheduled.");
         addReplyStatus(c, "Background append only file rewriting scheduled");
-    } else if (rewriteAppendOnlyFileBackground() == C_OK) {
+    } else if (rewriteAppendOnlyFileBackground(false, REPLICA_REQ_NONE) == C_OK) {
         addReplyStatus(c, "Background append only file rewriting started");
     } else {
         addReplyError(c, "Can't execute an AOF background rewriting. "
@@ -2640,9 +2808,37 @@ int getBaseAndIncrAppendOnlyFilesNum(aofManifest *am) {
     return num;
 }
 
+void backgroundRewriteDoneHandlerSocket(int exitcode, int bysignal) {
+    if (!bysignal && exitcode == 0) {
+        serverLog(LL_NOTICE, "Background AOF transfer terminated with success");
+    } else if (!bysignal && exitcode != 0) {
+        serverLog(LL_WARNING, "Background AOF transfer error");
+    } else {
+        serverLog(LL_WARNING, "Background AOF transfer terminated by signal %d", bysignal);
+    }
+
+    /* Same cleanup as RDB diskless pipe mode. */
+    if (server.rdb_child_exit_pipe != -1) close(server.rdb_child_exit_pipe);
+    if (server.rdb_pipe_read > 0) {
+        aeDeleteFileEvent(server.el, server.rdb_pipe_read, AE_READABLE);
+        close(server.rdb_pipe_read);
+    }
+    server.rdb_child_exit_pipe = -1;
+    server.rdb_pipe_read = -1;
+
+    zfree(server.rdb_pipe_conns);
+    server.rdb_pipe_conns = NULL;
+    server.rdb_pipe_numconns = 0;
+    server.rdb_pipe_numconns_writing = 0;
+
+    zfree(server.rdb_pipe_buff);
+    server.rdb_pipe_buff = NULL;
+    server.rdb_pipe_bufflen = 0;
+}
+
 /* A background append only file rewriting (BGREWRITEAOF) terminated its work.
  * Handle this. */
-void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
+void backgroundRewriteDoneHandlerDisk(int exitcode, int bysignal) {
     if (!bysignal && exitcode == 0) {
         char tmpfile[256];
         long long now = ustime();
@@ -2675,8 +2871,10 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
             sdsfree(new_base_filepath);
             server.aof_lastbgrewrite_status = C_ERR;
             server.stat_aofrw_consecutive_failures++;
-            goto cleanup;
+            return;
         }
+        sdsfree(server.repl_transfer_fullsync_aof_name);
+        server.repl_transfer_fullsync_aof_name = sdsdup(new_base_filepath);
         latencyEndMonitor(latency);
         latencyAddSampleIfNeeded("aof-rename", latency);
         latencyTraceIfNeeded(aof, aof_rename, latency);
@@ -2702,7 +2900,7 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
                 sdsfree(temp_incr_aof_name);
                 server.aof_lastbgrewrite_status = C_ERR;
                 server.stat_aofrw_consecutive_failures++;
-                goto cleanup;
+                return;
             }
             latencyEndMonitor(latency);
             latencyAddSampleIfNeeded("aof-rename", latency);
@@ -2728,7 +2926,7 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
             }
             server.aof_lastbgrewrite_status = C_ERR;
             server.stat_aofrw_consecutive_failures++;
-            goto cleanup;
+            return;
         }
         sdsfree(new_base_filepath);
         if (new_incr_filepath) sdsfree(new_incr_filepath);
@@ -2778,8 +2976,17 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
 
         serverLog(LL_WARNING, "Background AOF rewrite terminated by signal %d", bysignal);
     }
+}
 
-cleanup:
+void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
+    switch (server.rdb_child_type) {
+    case SNAPSHOT_CHILD_TYPE_DISK: backgroundRewriteDoneHandlerDisk(exitcode, bysignal); break;
+    case SNAPSHOT_CHILD_TYPE_SOCKET: backgroundRewriteDoneHandlerSocket(exitcode, bysignal); break;
+    default: serverPanic("Unknown BGREWRITE child type."); break;
+    }
+
+    updateReplicasWaitingBgSnapshotGenerate((!bysignal && exitcode == 0) ? C_OK : C_ERR, server.rdb_child_type, true);
+    server.rdb_child_type = SNAPSHOT_CHILD_TYPE_NONE;
     aofRemoveTempFile(server.child_pid, 0);
     /* Clear AOF buffer and delete temp incr aof for next rewrite. */
     if (server.aof_state == AOF_WAIT_REWRITE) {
@@ -2791,4 +2998,332 @@ cleanup:
     server.aof_rewrite_time_start = -1;
     /* Schedule a new rewrite if we are waiting for it to switch the AOF ON. */
     if (server.aof_state == AOF_WAIT_REWRITE) server.aof_rewrite_scheduled = 1;
+}
+
+/* Track loading progress in order to serve clients from time to time. */
+void aofLoadProgressCallback(rio *r, const void *buf, size_t len) {
+    UNUSED(buf);
+    if (server.loading_process_events_interval_bytes &&
+        (r->processed_bytes + len) / server.loading_process_events_interval_bytes >
+            r->processed_bytes / server.loading_process_events_interval_bytes) {
+        if (server.primary_host && server.repl_state == REPL_STATE_TRANSFER) replicationSendNewlineToPrimary();
+        loadingAbsProgress(r->processed_bytes);
+        processEventsWhileBlocked();
+        processModuleLoadingProgressEvent(1);
+    }
+    if (server.repl_state == REPL_STATE_TRANSFER && rioCheckType(r) == RIO_TYPE_CONN) {
+        server.stat_net_repl_input_bytes += len;
+    }
+}
+
+static int rioReadLineTail(rio *r, char *buf, size_t buflen) {
+    /* Reads bytes until '\r\n', stores content excluding CRLF into buf (NUL terminated).
+     * Returns 1 on success, 0 on read error/EOF. */
+    size_t i = 0;
+    while (i < buflen - 1) {
+        char c;
+        if (rioRead(r, &c, 1) == 0) return 0;
+        buf[i++] = c;
+        if (i >= 2 && buf[i - 2] == '\r' && buf[i - 1] == '\n') {
+            buf[i - 2] = '\0';
+            return 1;
+        }
+    }
+    buf[buflen - 1] = '\0';
+    serverLog(LL_WARNING, "AOF line is too long");
+    return 0; /* line too long => caller should treat as error */
+}
+
+static int rioReadBulkWithCRLF(rio *r, sds *out, unsigned long len) {
+    sds s = sdsnewlen(SDS_NOINIT, len);
+    if (len && rioRead(r, s, len) == 0) {
+        sdsfree(s);
+        return 0;
+    }
+    char crlf[2];
+    if (rioRead(r, crlf, 2) == 0 || crlf[0] != '\r' || crlf[1] != '\n') {
+        sdsfree(s);
+        return 0;
+    }
+    *out = s;
+    return 1;
+}
+
+int loadSnapshotAofFromRio(rio *r, char *eofmark, int usemark) {
+    client *fakeClient = NULL;
+    client *old_cur_client = server.current_client;
+    client *old_exec_client = server.executing_client;
+    char buf[AOF_ANNOTATION_LINE_MAX_LEN];
+
+    fakeClient = createAOFClient();
+    server.current_client = server.executing_client = fakeClient;
+
+    int ret = AOF_OK;
+    r->update_cksum = aofLoadProgressCallback;
+    r->max_processing_chunk = server.loading_process_events_interval_bytes;
+
+    while (1) {
+        char first;
+
+        if (rioRead(r, &first, 1) == 0) {
+            ret = AOF_OK;
+            break;
+        }
+
+        if (first == '#') {
+            if (!rioReadLineTail(r, buf, sizeof(buf))) {
+                ret = AOF_FAILED;
+                break;
+            }
+            continue;
+        }
+
+        if (first != '*') {
+            /* check EOF mark. */
+            if (!usemark) {
+                ret = AOF_FAILED;
+                break;
+            }
+
+            buf[0] = first;
+            if (rioRead(r, buf + 1, RDB_EOF_MARK_SIZE - 1) == 0) {
+                ret = AOF_FAILED;
+                break;
+            }
+            if (memcmp(buf, eofmark, RDB_EOF_MARK_SIZE) != 0) {
+                ret = AOF_FAILED;
+                break;
+            }
+
+            ret = AOF_OK;
+            break;
+        }
+
+        if (!rioReadLineTail(r, buf, sizeof(buf))) {
+            ret = AOF_FAILED;
+            break;
+        }
+        int argc = atoi(buf);
+        if (argc < 1 || (size_t)argc > SIZE_MAX / sizeof(robj *)) {
+            ret = AOF_FAILED;
+            break;
+        }
+
+        robj **argv = zmalloc(sizeof(robj *) * argc);
+        fakeClient->argc = argc;
+        fakeClient->argv = argv;
+        fakeClient->argv_len = argc;
+
+        for (int j = 0; j < argc; j++) {
+            if (rioRead(r, buf, 1) == 0 || buf[0] != '$') {
+                fakeClient->argc = j;
+                freeClientArgv(fakeClient);
+                ret = AOF_FAILED;
+                goto cleanup;
+            }
+            if (!rioReadLineTail(r, buf, sizeof(buf))) {
+                fakeClient->argc = j;
+                freeClientArgv(fakeClient);
+                ret = AOF_FAILED;
+                goto cleanup;
+            }
+            unsigned long blen = strtoul(buf, NULL, 10);
+            sds arg;
+            if (!rioReadBulkWithCRLF(r, &arg, blen)) {
+                fakeClient->argc = j;
+                freeClientArgv(fakeClient);
+                ret = AOF_FAILED;
+                goto cleanup;
+            }
+            argv[j] = createObject(OBJ_STRING, arg);
+        }
+
+        sds err = NULL;
+        struct serverCommand *cmd = lookupCommand(fakeClient->argv, fakeClient->argc);
+        if ((!cmd && !commandCheckExistence(fakeClient, &err)) ||
+            (cmd && !commandCheckArity(cmd, fakeClient->argc, &err))) {
+            serverLog(LL_WARNING, "Error loading BASE AOF stream: %s", err);
+            sdsfree(err);
+            freeClientArgv(fakeClient);
+            ret = AOF_FAILED;
+            goto cleanup;
+        }
+
+        fakeClient->cmd = fakeClient->lastcmd = cmd;
+
+        if (fakeClient->flag.multi && cmd->proc != execCommand) {
+            queueMultiCommand(fakeClient, cmd->flags);
+        } else {
+            cmd->proc(fakeClient);
+        }
+
+        serverAssert(fakeClient->bufpos == 0 && listLength(fakeClient->reply) == 0);
+        serverAssert(fakeClient->flag.blocked == 0);
+
+        freeClientArgv(fakeClient);
+        if (server.key_load_delay) debugDelay(server.key_load_delay);
+    }
+
+    if (fakeClient->flag.multi) {
+        ret = AOF_FAILED;
+        goto cleanup;
+    }
+
+    serverLog(LL_WARNING, "Done loading AOF for replication.");
+
+cleanup:
+    if (fakeClient) freeClient(fakeClient);
+    server.current_client = old_cur_client;
+    server.executing_client = old_exec_client;
+    return ret;
+}
+
+int loadSnapshotAofFromRioScopedAOF(rio *aof, char *eofmark, int usemark) {
+    rio *prev_rio = server.loading_rio;
+    server.loading_rio = aof;
+    int retval = loadSnapshotAofFromRio(aof, eofmark, usemark);
+    server.loading_rio = prev_rio;
+    return retval;
+}
+
+/* Raw-load an AOF format file from disk. */
+int loadSnapshotAofFromPath(const char *path) {
+    FILE *fp = NULL;
+    long loops = 0;
+    off_t last_progress_report_size = 0;
+    struct valkey_stat sb;
+    client *fakeClient = NULL;
+    client *old_cur_client = server.current_client;
+    client *old_exec_client = server.executing_client;
+
+    int ret = AOF_OK;
+
+    fp = fopen(path, "r");
+    if (fp == NULL) {
+        int en = errno;
+        if (valkey_stat(path, &sb) == 0 || errno != ENOENT) {
+            serverLog(LL_WARNING, "Can't open AOF file %s for reading: %s", path, strerror(en));
+            return AOF_OPEN_ERR;
+        }
+        serverLog(LL_WARNING, "AOF file %s doesn't exist: %s", path, strerror(errno));
+        return AOF_NOT_EXIST;
+    }
+
+    if (valkey_fstat(fileno(fp), &sb) != -1 && sb.st_size == 0) {
+        fclose(fp);
+        serverLog(LL_NOTICE, "Done loading AOF for replication.");
+        return AOF_OK;
+    }
+
+    startLoading(sb.st_size, RDBFLAGS_AOF_PREAMBLE, 0);
+    fakeClient = createAOFClient();
+    server.current_client = server.executing_client = fakeClient;
+
+    while (1) {
+        int argc, j;
+        unsigned long len;
+        robj **argv;
+        char buf[AOF_ANNOTATION_LINE_MAX_LEN];
+        struct serverCommand *cmd;
+        sds err = NULL;
+
+        /* Serve the clients from time to time */
+        if (!(loops++ % 1024)) {
+            off_t progress_delta = ftello(fp) - last_progress_report_size;
+            loadingIncrProgress(progress_delta);
+            last_progress_report_size += progress_delta;
+            processEventsWhileBlocked();
+            processModuleLoadingProgressEvent(1);
+        }
+
+        if (fgets(buf, sizeof(buf), fp) == NULL) {
+            if (feof(fp)) break;
+            ret = AOF_FAILED;
+            goto cleanup;
+        }
+
+        if (buf[0] == '#') continue;
+        if (buf[0] != '*') {
+            ret = AOF_FAILED;
+            goto cleanup;
+        }
+
+        argc = atoi(buf + 1);
+        if (argc < 1 || (size_t)argc > SIZE_MAX / sizeof(robj *)) {
+            ret = AOF_FAILED;
+            goto cleanup;
+        }
+
+        argv = zmalloc(sizeof(robj *) * argc);
+        fakeClient->argc = argc;
+        fakeClient->argv = argv;
+        fakeClient->argv_len = argc;
+
+        for (j = 0; j < argc; j++) {
+            if (fgets(buf, sizeof(buf), fp) == NULL || buf[0] != '$') {
+                fakeClient->argc = j;
+                freeClientArgv(fakeClient);
+                ret = AOF_FAILED;
+                goto cleanup;
+            }
+            len = strtoul(buf + 1, NULL, 10);
+
+            sds argsds = sdsnewlen(SDS_NOINIT, len);
+            if (len && fread(argsds, len, 1, fp) == 0) {
+                sdsfree(argsds);
+                fakeClient->argc = j;
+                freeClientArgv(fakeClient);
+                ret = AOF_FAILED;
+                goto cleanup;
+            }
+            argv[j] = createObject(OBJ_STRING, argsds);
+
+            /* Discard CRLF */
+            if (fread(buf, 2, 1, fp) == 0) {
+                fakeClient->argc = j + 1;
+                freeClientArgv(fakeClient);
+                ret = AOF_FAILED;
+                goto cleanup;
+            }
+        }
+
+        fakeClient->cmd = fakeClient->lastcmd = cmd = lookupCommand(fakeClient->argv, fakeClient->argc);
+        if ((!cmd && !commandCheckExistence(fakeClient, &err)) ||
+            (cmd && !commandCheckArity(cmd, fakeClient->argc, &err))) {
+            serverLog(LL_WARNING, "Error loading AOF file %s: %s", path, err);
+            sdsfree(err);
+            freeClientArgv(fakeClient);
+            ret = AOF_FAILED;
+            goto cleanup;
+        }
+
+        if (fakeClient->flag.multi && cmd->proc != execCommand) {
+            queueMultiCommand(fakeClient, cmd->flags);
+        } else {
+            cmd->proc(fakeClient);
+        }
+
+        serverAssert(fakeClient->bufpos == 0 && listLength(fakeClient->reply) == 0);
+        serverAssert(fakeClient->flag.blocked == 0);
+
+        freeClientArgv(fakeClient);
+
+        if (server.key_load_delay) debugDelay(server.key_load_delay);
+    }
+
+    if (fakeClient->flag.multi) {
+        ret = AOF_FAILED;
+        goto cleanup;
+    }
+
+    loadingIncrProgress(ftello(fp) - last_progress_report_size);
+    serverLog(LL_NOTICE, "Done loading AOF for replication.");
+
+cleanup:
+    if (fakeClient) freeClient(fakeClient);
+    server.current_client = old_cur_client;
+    server.executing_client = old_exec_client;
+    if (fp) fclose(fp);
+    stopLoading(ret == AOF_OK);
+    return ret;
 }

--- a/src/aof.c
+++ b/src/aof.c
@@ -46,7 +46,7 @@ off_t getAppendOnlyFileSize(sds filename, int *status);
 off_t getBaseAndIncrAppendOnlyFilesSize(aofManifest *am, int *status);
 int getBaseAndIncrAppendOnlyFilesNum(aofManifest *am);
 int aofFileExist(char *filename);
-int rewriteAppendOnlyFile(char *filename, int req);
+int rewriteAppendOnlyFile(char *filename, int req, int aofflags);
 aofManifest *aofLoadManifestFromFile(sds am_filepath);
 void aofManifestFreeAndUpdate(aofManifest *am);
 void aof_background_fsync_and_close(int fd);
@@ -715,7 +715,7 @@ void aofOpenIfNeededOnServerStart(void) {
     if (!server.aof_manifest->base_aof_info && !incr_aof_len) {
         sds base_name = getNewBaseFileNameAndMarkPreAsHistory(server.aof_manifest, server.aof_use_rdb_preamble);
         sds base_filepath = makePath(server.aof_dirname, base_name);
-        if (rewriteAppendOnlyFile(base_filepath, REPLICA_REQ_NONE) != C_OK) {
+        if (rewriteAppendOnlyFile(base_filepath, REPLICA_REQ_NONE, RDBFLAGS_NONE) != C_OK) {
             exit(1);
         }
         sdsfree(base_filepath);
@@ -2400,7 +2400,7 @@ werr: /* Write error. */
  * log, the server uses variadic commands when possible, such as RPUSH, SADD
  * and ZADD. However at max AOF_REWRITE_ITEMS_PER_CMD items per time
  * are inserted using a single command. */
-int rewriteAppendOnlyFile(char *filename, int req) {
+int rewriteAppendOnlyFile(char *filename, int req, int aofflags) {
     rio aof;
     FILE *fp = NULL;
     char tmpfile[256];
@@ -2418,10 +2418,10 @@ int rewriteAppendOnlyFile(char *filename, int req) {
 
     if (server.aof_rewrite_incremental_fsync) {
         rioSetAutoSync(&aof, REDIS_AUTOSYNC_BYTES);
-        rioSetReclaimCache(&aof, 1);
+        if (!(aofflags & RDBFLAGS_KEEP_CACHE)) rioSetReclaimCache(&aof, 1);
     }
 
-    startSaving(RDBFLAGS_AOF_PREAMBLE);
+    startSaving(RDBFLAGS_AOF_PREAMBLE | aofflags);
 
     if (server.aof_use_rdb_preamble) {
         int error;
@@ -2436,7 +2436,7 @@ int rewriteAppendOnlyFile(char *filename, int req) {
     /* Make sure data will not remain on the OS's output buffers */
     if (fflush(fp)) goto werr;
     if (fsync(fileno(fp))) goto werr;
-    if (reclaimFilePageCache(fileno(fp), 0, 0) == -1) {
+    if (!(aofflags & RDBFLAGS_KEEP_CACHE) && reclaimFilePageCache(fileno(fp), 0, 0) == -1) {
         /* A minor error. Just log to know what happens */
         serverLog(LL_NOTICE, "Unable to reclaim page cache: %s", strerror(errno));
     }
@@ -2530,7 +2530,7 @@ int rewriteAppendOnlyFileBackground(void) {
         }
         serverSetCpuAffinity(server.aof_rewrite_cpulist);
         snprintf(tmpfile, 256, "temp-rewriteaof-bg-%d.aof", (int)getpid());
-        if (rewriteAppendOnlyFile(tmpfile, REPLICA_REQ_NONE) == C_OK) {
+        if (rewriteAppendOnlyFile(tmpfile, REPLICA_REQ_NONE, RDBFLAGS_NONE) == C_OK) {
             serverLog(LL_NOTICE, "Successfully created the temporary AOF base file %s", tmpfile);
             sendChildCowInfo(CHILD_INFO_TYPE_AOF_COW_SIZE, "AOF rewrite");
             exitFromChild(0);
@@ -2548,6 +2548,7 @@ int rewriteAppendOnlyFileBackground(void) {
         server.aof_rewrite_scheduled = 0;
         server.aof_rewrite_time_start = time(NULL);
         server.aof_rewrite_use_rdb_preamble = server.aof_use_rdb_preamble;
+        server.rdb_child_type = SNAPSHOT_CHILD_TYPE_DISK;
         return C_OK;
     }
     return C_OK; /* unreached */
@@ -2559,49 +2560,23 @@ int rewriteAppendOnlyFileBackground(void) {
  * that writes the dataset as AOF commands into a temporary file using
  * rewriteRioWithEOFMark(). The temp file is used to send data to replicas and
  * then cleaned up. */
-int rewriteAofBackgroundForReplication(int req) {
+int rewriteAofBackgroundForReplication(int req, int aofflags) {
     pid_t childpid;
 
     if (hasActiveChildProcess()) return C_ERR;
 
     if ((childpid = serverFork(CHILD_TYPE_AOF)) == 0) {
         /* Child */
-        char tmpfile[256];
-        rio aof;
-        FILE *fp;
-        int retval;
-
-        serverSetProcTitle("valkey-aof-for-replication");
+        serverSetProcTitle("valkey-aof-rewrite-for-replication");
         serverSetCpuAffinity(server.aof_rewrite_cpulist);
-        snprintf(tmpfile, 256, "temp-rewriteaof-bg-%d.aof", (int)getpid());
-
-        fp = fopen(tmpfile, "w");
-        if (!fp) {
-            serverLog(LL_WARNING, "Opening the temp file for AOF replication: %s", strerror(errno));
-            exitFromChild(1);
-        }
-
         server.aof_use_rdb_preamble = 0;
-        rioInitWithFile(&aof, fp);
+        server.aof_timestamp_enabled = 0;
 
-        if (server.aof_rewrite_incremental_fsync) {
-            rioSetAutoSync(&aof, REDIS_AUTOSYNC_BYTES);
-            rioSetReclaimCache(&aof, 1);
-        }
-
-        retval = rewriteRioWithEOFMark(&aof, req);
-
-        if (retval == C_OK && fflush(fp) == EOF) retval = C_ERR;
-        if (retval == C_OK && fsync(fileno(fp)) == -1) retval = C_ERR;
-        if (retval == C_OK) reclaimFilePageCache(fileno(fp), 0, 0);
-        if (fclose(fp) == EOF && retval == C_OK) retval = C_ERR;
-
-        if (retval == C_OK) {
-            serverLog(LL_NOTICE, "Successfully created the temporary AOF file %s for replication", tmpfile);
+        if (rewriteAppendOnlyFile(server.fullsync_aof_name, req, aofflags) == C_OK) {
+            serverLog(LL_NOTICE, "Successfully created the AOF base file %s for replication", server.fullsync_aof_name);
             sendChildCowInfo(CHILD_INFO_TYPE_AOF_COW_SIZE, "AOF rewrite");
             exitFromChild(0);
         } else {
-            unlink(tmpfile);
             exitFromChild(1);
         }
     } else {
@@ -2909,8 +2884,6 @@ void backgroundRewriteDoneHandlerDisk(int exitcode, int bysignal) {
         /* For replication, just record the temp file path.
          * Don't touch AOF manifest or rename to base-aof. */
         if (server.aof_rewrite_for_replication) {
-            sdsfree(server.repl_transfer_fullsync_aof_name);
-            server.repl_transfer_fullsync_aof_name = sdsnew(tmpfile);
             serverLog(LL_NOTICE, "Background AOF for replication terminated with success");
             return;
         }

--- a/src/aof.c
+++ b/src/aof.c
@@ -985,7 +985,7 @@ int startAppendOnly(void) {
             killAppendOnlyChild(false);
         }
 
-        if (rewriteAppendOnlyFileBackground(false, REPLICA_REQ_NONE) == C_ERR) {
+        if (rewriteAppendOnlyFileBackground() == C_ERR) {
             server.aof_state = AOF_OFF;
             serverLog(LL_WARNING, "The server needs to enable the AOF but can't trigger a background AOF rewrite "
                                   "operation. Check the above logs for more info about the error.");
@@ -2483,7 +2483,7 @@ werr:
  *    4d) persist AOF manifest file
  *    4e) Delete the history files use bio
  */
-int rewriteAppendOnlyFileBackground(bool for_replication, int req) {
+int rewriteAppendOnlyFileBackground(void) {
     pid_t childpid;
 
     if (hasActiveChildProcess()) return C_ERR;
@@ -2530,10 +2530,7 @@ int rewriteAppendOnlyFileBackground(bool for_replication, int req) {
         }
         serverSetCpuAffinity(server.aof_rewrite_cpulist);
         snprintf(tmpfile, 256, "temp-rewriteaof-bg-%d.aof", (int)getpid());
-
-        /* Do not use RDB format for fullsync-aof replication */
-        if (for_replication) server.aof_use_rdb_preamble = 0;
-        if (rewriteAppendOnlyFile(tmpfile, req) == C_OK) {
+        if (rewriteAppendOnlyFile(tmpfile, REPLICA_REQ_NONE) == C_OK) {
             serverLog(LL_NOTICE, "Successfully created the temporary AOF base file %s", tmpfile);
             sendChildCowInfo(CHILD_INFO_TYPE_AOF_COW_SIZE, "AOF rewrite");
             exitFromChild(0);
@@ -2550,8 +2547,73 @@ int rewriteAppendOnlyFileBackground(bool for_replication, int req) {
         serverLog(LL_NOTICE, "Background append only file rewriting started by pid %ld", (long)childpid);
         server.aof_rewrite_scheduled = 0;
         server.aof_rewrite_time_start = time(NULL);
-        server.aof_rewrite_use_rdb_preamble = for_replication ? 0 : server.aof_use_rdb_preamble;
+        server.aof_rewrite_use_rdb_preamble = server.aof_use_rdb_preamble;
+        return C_OK;
+    }
+    return C_OK; /* unreached */
+}
+
+/* Simplified AOF rewrite for replication only.
+ * Unlike rewriteAppendOnlyFileBackground(), this function does NOT modify the
+ * AOF manifest, create INCR AOFs, or change AOF state. It simply forks a child
+ * that writes the dataset as AOF commands into a temporary file using
+ * rewriteRioWithEOFMark(). The temp file is used to send data to replicas and
+ * then cleaned up. */
+int rewriteAofBackgroundForReplication(int req) {
+    pid_t childpid;
+
+    if (hasActiveChildProcess()) return C_ERR;
+
+    if ((childpid = serverFork(CHILD_TYPE_AOF)) == 0) {
+        /* Child */
+        char tmpfile[256];
+        rio aof;
+        FILE *fp;
+        int retval;
+
+        serverSetProcTitle("valkey-aof-for-replication");
+        serverSetCpuAffinity(server.aof_rewrite_cpulist);
+        snprintf(tmpfile, 256, "temp-rewriteaof-bg-%d.aof", (int)getpid());
+
+        fp = fopen(tmpfile, "w");
+        if (!fp) {
+            serverLog(LL_WARNING, "Opening the temp file for AOF replication: %s", strerror(errno));
+            exitFromChild(1);
+        }
+
+        server.aof_use_rdb_preamble = 0;
+        rioInitWithFile(&aof, fp);
+
+        if (server.aof_rewrite_incremental_fsync) {
+            rioSetAutoSync(&aof, REDIS_AUTOSYNC_BYTES);
+            rioSetReclaimCache(&aof, 1);
+        }
+
+        retval = rewriteRioWithEOFMark(&aof, req);
+
+        if (retval == C_OK && fflush(fp) == EOF) retval = C_ERR;
+        if (retval == C_OK && fsync(fileno(fp)) == -1) retval = C_ERR;
+        if (retval == C_OK) reclaimFilePageCache(fileno(fp), 0, 0);
+        if (fclose(fp) == EOF && retval == C_OK) retval = C_ERR;
+
+        if (retval == C_OK) {
+            serverLog(LL_NOTICE, "Successfully created the temporary AOF file %s for replication", tmpfile);
+            sendChildCowInfo(CHILD_INFO_TYPE_AOF_COW_SIZE, "AOF rewrite");
+            exitFromChild(0);
+        } else {
+            unlink(tmpfile);
+            exitFromChild(1);
+        }
+    } else {
+        /* Parent */
+        if (childpid == -1) {
+            serverLog(LL_WARNING, "Can't rewrite AOF for replication: fork: %s", strerror(errno));
+            return C_ERR;
+        }
+        serverLog(LL_NOTICE, "Background AOF for replication started by pid %ld", (long)childpid);
+        server.aof_rewrite_time_start = time(NULL);
         server.rdb_child_type = SNAPSHOT_CHILD_TYPE_DISK;
+        server.aof_rewrite_for_replication = 1;
         return C_OK;
     }
     return C_OK; /* unreached */
@@ -2681,7 +2743,7 @@ int rewriteAppendOnlyFileToReplicasSockets(int req) {
                       (long)childpid,
                       dual_channel ? "direct socket to replica" : "pipe through parent process");
 
-            server.rdb_save_time_start = time(NULL);
+            server.aof_rewrite_time_start = time(NULL);
             server.rdb_child_type = SNAPSHOT_CHILD_TYPE_SOCKET;
             if (dual_channel) {
                 zfree(conns);
@@ -2709,7 +2771,7 @@ void bgrewriteaofCommand(client *c) {
         server.stat_aofrw_consecutive_failures = 0;
         serverLog(LL_NOTICE, "Background append only file rewriting scheduled.");
         addReplyStatus(c, "Background append only file rewriting scheduled");
-    } else if (rewriteAppendOnlyFileBackground(false, REPLICA_REQ_NONE) == C_OK) {
+    } else if (rewriteAppendOnlyFileBackground() == C_OK) {
         addReplyStatus(c, "Background append only file rewriting started");
     } else {
         addReplyError(c, "Can't execute an AOF background rewriting. "
@@ -2841,6 +2903,18 @@ void backgroundRewriteDoneHandlerSocket(int exitcode, int bysignal) {
 void backgroundRewriteDoneHandlerDisk(int exitcode, int bysignal) {
     if (!bysignal && exitcode == 0) {
         char tmpfile[256];
+
+        snprintf(tmpfile, 256, "temp-rewriteaof-bg-%d.aof", (int)server.child_pid);
+
+        /* For replication, just record the temp file path.
+         * Don't touch AOF manifest or rename to base-aof. */
+        if (server.aof_rewrite_for_replication) {
+            sdsfree(server.repl_transfer_fullsync_aof_name);
+            server.repl_transfer_fullsync_aof_name = sdsnew(tmpfile);
+            serverLog(LL_NOTICE, "Background AOF for replication terminated with success");
+            return;
+        }
+
         long long now = ustime();
         sds new_base_filepath = NULL;
         sds new_incr_filepath = NULL;
@@ -2848,8 +2922,6 @@ void backgroundRewriteDoneHandlerDisk(int exitcode, int bysignal) {
         mstime_t latency;
 
         serverLog(LL_NOTICE, "Background AOF rewrite terminated with success");
-
-        snprintf(tmpfile, 256, "temp-rewriteaof-bg-%d.aof", (int)server.child_pid);
 
         serverAssert(server.aof_manifest != NULL);
 
@@ -2873,8 +2945,6 @@ void backgroundRewriteDoneHandlerDisk(int exitcode, int bysignal) {
             server.stat_aofrw_consecutive_failures++;
             return;
         }
-        sdsfree(server.repl_transfer_fullsync_aof_name);
-        server.repl_transfer_fullsync_aof_name = sdsdup(new_base_filepath);
         latencyEndMonitor(latency);
         latencyAddSampleIfNeeded("aof-rename", latency);
         latencyTraceIfNeeded(aof, aof_rename, latency);
@@ -2988,14 +3058,21 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
     updateReplicasWaitingBgSnapshotGenerate((!bysignal && exitcode == 0) ? C_OK : C_ERR, server.rdb_child_type, true);
     server.rdb_child_type = SNAPSHOT_CHILD_TYPE_NONE;
     aofRemoveTempFile(server.child_pid, 0);
+
+    server.aof_rewrite_time_last = time(NULL) - server.aof_rewrite_time_start;
+    server.aof_rewrite_time_start = -1;
+    if (server.aof_rewrite_for_replication) {
+        /* Replication path: don't touch AOF state. Just clean up and return. */
+        server.aof_rewrite_for_replication = 0;
+        return;
+    }
+
     /* Clear AOF buffer and delete temp incr aof for next rewrite. */
     if (server.aof_state == AOF_WAIT_REWRITE) {
         sdsfree(server.aof_buf);
         server.aof_buf = sdsempty();
         aofDelTempIncrAofFile();
     }
-    server.aof_rewrite_time_last = time(NULL) - server.aof_rewrite_time_start;
-    server.aof_rewrite_time_start = -1;
     /* Schedule a new rewrite if we are waiting for it to switch the AOF ON. */
     if (server.aof_state == AOF_WAIT_REWRITE) server.aof_rewrite_scheduled = 1;
 }

--- a/src/aof.c
+++ b/src/aof.c
@@ -3119,13 +3119,13 @@ int loadSnapshotAofFromRio(rio *r, char *eofmark, int usemark) {
                 fakeClient->argc = j;
                 freeClientArgv(fakeClient);
                 ret = AOF_FAILED;
-                break;
+                goto cleanup;
             }
             if (!rioReadLineTail(r, buf, sizeof(buf))) {
                 fakeClient->argc = j;
                 freeClientArgv(fakeClient);
                 ret = AOF_FAILED;
-                break;
+                goto cleanup;
             }
             unsigned long blen = strtoul(buf, NULL, 10);
             sds arg;
@@ -3133,7 +3133,7 @@ int loadSnapshotAofFromRio(rio *r, char *eofmark, int usemark) {
                 fakeClient->argc = j;
                 freeClientArgv(fakeClient);
                 ret = AOF_FAILED;
-                break;
+                goto cleanup;
             }
             argv[j] = createObject(OBJ_STRING, arg);
         }
@@ -3168,6 +3168,7 @@ int loadSnapshotAofFromRio(rio *r, char *eofmark, int usemark) {
         ret = AOF_FAILED;
     }
 
+cleanup:
     serverLog(LL_WARNING, "Done loading AOF for replication.");
     if (fakeClient) freeClient(fakeClient);
     server.current_client = old_cur_client;

--- a/src/aof.c
+++ b/src/aof.c
@@ -3066,7 +3066,7 @@ int loadSnapshotAofFromRio(rio *r, char *eofmark, int usemark) {
         char first;
 
         if (rioRead(r, &first, 1) == 0) {
-            ret = AOF_OK;
+            ret = AOF_FAILED;
             break;
         }
 
@@ -3119,13 +3119,13 @@ int loadSnapshotAofFromRio(rio *r, char *eofmark, int usemark) {
                 fakeClient->argc = j;
                 freeClientArgv(fakeClient);
                 ret = AOF_FAILED;
-                goto cleanup;
+                break;
             }
             if (!rioReadLineTail(r, buf, sizeof(buf))) {
                 fakeClient->argc = j;
                 freeClientArgv(fakeClient);
                 ret = AOF_FAILED;
-                goto cleanup;
+                break;
             }
             unsigned long blen = strtoul(buf, NULL, 10);
             sds arg;
@@ -3133,7 +3133,7 @@ int loadSnapshotAofFromRio(rio *r, char *eofmark, int usemark) {
                 fakeClient->argc = j;
                 freeClientArgv(fakeClient);
                 ret = AOF_FAILED;
-                goto cleanup;
+                break;
             }
             argv[j] = createObject(OBJ_STRING, arg);
         }
@@ -3146,7 +3146,7 @@ int loadSnapshotAofFromRio(rio *r, char *eofmark, int usemark) {
             sdsfree(err);
             freeClientArgv(fakeClient);
             ret = AOF_FAILED;
-            goto cleanup;
+            break;
         }
 
         fakeClient->cmd = fakeClient->lastcmd = cmd;
@@ -3166,12 +3166,9 @@ int loadSnapshotAofFromRio(rio *r, char *eofmark, int usemark) {
 
     if (fakeClient->flag.multi) {
         ret = AOF_FAILED;
-        goto cleanup;
     }
 
     serverLog(LL_WARNING, "Done loading AOF for replication.");
-
-cleanup:
     if (fakeClient) freeClient(fakeClient);
     server.current_client = old_cur_client;
     server.executing_client = old_exec_client;
@@ -3317,9 +3314,9 @@ int loadSnapshotAofFromPath(const char *path) {
     }
 
     loadingIncrProgress(ftello(fp) - last_progress_report_size);
-    serverLog(LL_NOTICE, "Done loading AOF for replication.");
 
 cleanup:
+    serverLog(LL_NOTICE, "Done loading AOF for replication.");
     if (fakeClient) freeClient(fakeClient);
     server.current_client = old_cur_client;
     server.executing_client = old_exec_client;

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -129,6 +129,7 @@ int getSlotOrReply(client *c, robj *o);
 int getNodeDefaultReplicationPort(clusterNode *node);
 bool isAnySlotInManualImportingState(void);
 bool isAnySlotInManualMigratingState(void);
+bool clusterIsAnySlotMoving(void);
 
 /* functions with shared implementations */
 int clusterNodeIsMyself(clusterNode *n);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -8321,3 +8321,12 @@ bool isAnySlotInManualImportingState(void) {
 bool isAnySlotInManualMigratingState(void) {
     return dictSize(server.cluster->migrating_slots_to) > 0;
 }
+
+bool clusterIsAnySlotMoving(void) {
+    if (!server.cluster_enabled) {
+        return false;
+    }
+    bool atomic = clusterIsAnySlotImporting() || clusterIsAnySlotExporting();
+    bool manual = isAnySlotInManualImportingState() || isAnySlotInManualMigratingState();
+    return atomic || manual;
+}

--- a/src/config.c
+++ b/src/config.c
@@ -177,6 +177,10 @@ configEnum rdb_version_check_enum[] = {{"strict", RDB_VERSION_CHECK_STRICT},
                                        {"relaxed", RDB_VERSION_CHECK_RELAXED},
                                        {NULL, 0}};
 
+configEnum repl_fullsync_format_enum[] = {{"RDB", REPL_FULLSYNC_RDB},
+                                          {"AOF", REPL_FULLSYNC_AOF},
+                                          {NULL, 0}};
+
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
     {0, 0, 0},                                 /* normal */
@@ -3253,7 +3257,6 @@ standardConfig static_configs[] = {
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 1, NULL, NULL),
     createBoolConfig("lua-enable-insecure-api", "lua-enable-deprecated-api", MODIFIABLE_CONFIG | HIDDEN_CONFIG | PROTECTED_CONFIG, server.lua_enable_insecure_api, 0, NULL, updateLuaEnableInsecureApi),
     createBoolConfig("import-mode", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.import_mode, 0, NULL, NULL),
-    createBoolConfig("fullsync-aof", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.fullsync_aof_replication, 1, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),
@@ -3270,6 +3273,7 @@ standardConfig static_configs[] = {
     createStringConfig("cluster-announce-human-nodename", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_human_nodename, NULL, isValidAnnouncedNodename, updateClusterHumanNodename),
     createStringConfig("syslog-ident", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.syslog_ident, SERVER_NAME, NULL, NULL),
     createStringConfig("dbfilename", NULL, MODIFIABLE_CONFIG | PROTECTED_CONFIG, ALLOW_EMPTY_STRING, server.rdb_filename, "dump.rdb", isValidDBfilename, NULL),
+    createStringConfig("fullsync-aof-name", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.fullsync_aof_name, "fullsync.aof", isValidAOFfilename, NULL),
     createStringConfig("appendfilename", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.aof_filename, "appendonly.aof", isValidAOFfilename, NULL),
     createStringConfig("appenddirname", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.aof_dirname, "appendonlydir", isValidAOFdirname, NULL),
     createStringConfig("server-cpulist", "server_cpulist", IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.server_cpulist, NULL, NULL, NULL),
@@ -3312,6 +3316,7 @@ standardConfig static_configs[] = {
     createEnumConfig("log-format", NULL, MODIFIABLE_CONFIG, log_format_enum, server.log_format, LOG_FORMAT_LEGACY, NULL, NULL),
     createEnumConfig("log-timestamp-format", NULL, MODIFIABLE_CONFIG, log_timestamp_format_enum, server.log_timestamp_format, LOG_TIMESTAMP_LEGACY, NULL, NULL),
     createEnumConfig("rdb-version-check", NULL, MODIFIABLE_CONFIG, rdb_version_check_enum, server.rdb_version_check, RDB_VERSION_CHECK_STRICT, NULL, NULL),
+    createEnumConfig("repl-fullsync-format", NULL, MODIFIABLE_CONFIG, repl_fullsync_format_enum, server.repl_fullsync_format, REPL_FULLSYNC_AOF, NULL, NULL),
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases, 16, INTEGER_CONFIG, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3206,7 +3206,7 @@ standardConfig static_configs[] = {
     createBoolConfig("always-show-logo", NULL, IMMUTABLE_CONFIG, server.always_show_logo, 0, NULL, NULL),
     createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 1, NULL, NULL),
     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, server.rdb_compression, 1, NULL, NULL),
-    createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
+    createBoolConfig("rdb-del-sync-files", "snapshot-del-sync-files", MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
     createBoolConfig("activerehashing", NULL, MODIFIABLE_CONFIG, server.activerehashing, 1, NULL, NULL),
     createBoolConfig("stop-writes-on-bgsave-error", NULL, MODIFIABLE_CONFIG, server.stop_writes_on_bgsave_err, 1, NULL, NULL),
     createBoolConfig("set-proc-title", NULL, IMMUTABLE_CONFIG, server.set_proc_title, 1, NULL, NULL), /* Should setproctitle be used? */
@@ -3253,6 +3253,7 @@ standardConfig static_configs[] = {
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 1, NULL, NULL),
     createBoolConfig("lua-enable-insecure-api", "lua-enable-deprecated-api", MODIFIABLE_CONFIG | HIDDEN_CONFIG | PROTECTED_CONFIG, server.lua_enable_insecure_api, 0, NULL, updateLuaEnableInsecureApi),
     createBoolConfig("import-mode", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.import_mode, 0, NULL, NULL),
+    createBoolConfig("fullsync-aof", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.fullsync_aof_replication, 1, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/networking.c
+++ b/src/networking.c
@@ -1933,7 +1933,8 @@ void unlinkClient(client *c) {
          * snapshot child may take some time to die, during which the migration will continue past
          * the snapshot state. */
         if (c->repl_data && server.rdb_pipe_conns &&
-            ((c->flag.replica && c->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END))) {
+            ((c->flag.replica &&
+              (c->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END || c->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_END)))) {
             int i;
             int still_alive = 0;
             for (i = 0; i < server.rdb_pipe_numconns; i++) {
@@ -1946,6 +1947,7 @@ void unlinkClient(client *c) {
             if (still_alive == 0) {
                 serverLog(LL_NOTICE, "Diskless rdb transfer, last replica dropped, killing fork child.");
                 killRDBChild();
+                killAppendOnlyChild(true);
             }
         }
         /* Check if this is the slot migration client we are writing to in a

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1694,7 +1694,7 @@ int rdbSaveBackground(int req, char *filename, rdbSaveInfo *rsi, int rdbflags) {
         }
         serverLog(LL_NOTICE, "Background saving started by pid %ld", (long)childpid);
         server.rdb_save_time_start = time(NULL);
-        server.rdb_child_type = RDB_CHILD_TYPE_DISK;
+        server.rdb_child_type = SNAPSHOT_CHILD_TYPE_DISK;
         return C_OK;
     }
     return C_OK; /* unreached */
@@ -3685,17 +3685,17 @@ void backgroundSaveDoneHandler(int exitcode, int bysignal) {
     time_t save_end = time(NULL);
 
     switch (server.rdb_child_type) {
-    case RDB_CHILD_TYPE_DISK: backgroundSaveDoneHandlerDisk(exitcode, bysignal, save_end); break;
-    case RDB_CHILD_TYPE_SOCKET: backgroundSaveDoneHandlerSocket(exitcode, bysignal); break;
+    case SNAPSHOT_CHILD_TYPE_DISK: backgroundSaveDoneHandlerDisk(exitcode, bysignal, save_end); break;
+    case SNAPSHOT_CHILD_TYPE_SOCKET: backgroundSaveDoneHandlerSocket(exitcode, bysignal); break;
     default: serverPanic("Unknown RDB child type."); break;
     }
 
-    server.rdb_child_type = RDB_CHILD_TYPE_NONE;
+    server.rdb_child_type = SNAPSHOT_CHILD_TYPE_NONE;
     server.rdb_save_time_last = save_end - server.rdb_save_time_start;
     server.rdb_save_time_start = -1;
     /* Possibly there are replicas waiting for a BGSAVE in order to be served
      * (the first stage of SYNC is a bulk transfer of dump.rdb) */
-    updateReplicasWaitingBgsave((!bysignal && exitcode == 0) ? C_OK : C_ERR, type);
+    updateReplicasWaitingBgSnapshotGenerate((!bysignal && exitcode == 0) ? C_OK : C_ERR, type, false);
 }
 
 /* Kill the RDB saving child using SIGUSR1 (so that the parent will know
@@ -3780,7 +3780,7 @@ int rdbSaveToReplicasSockets(int req, int rdbver, rdbSaveInfo *rsi) {
                 connSendTimeout(replica->conn, server.repl_timeout * 1000);
                 /* This replica uses diskless dual channel sync, hence we need
                  * to inform it with the save end offset.*/
-                sendCurrentOffsetToReplica(replica);
+                sendCurrentOffsetToReplica(replica, false);
                 /* Make sure repl traffic is appended to the replication backlog */
                 addRdbReplicaToPsyncWait(replica);
                 /* Put the socket in blocking mode to simplify RDB transfer. */
@@ -3788,7 +3788,7 @@ int rdbSaveToReplicasSockets(int req, int rdbver, rdbSaveInfo *rsi) {
             } else {
                 server.rdb_pipe_numconns++;
             }
-            replicationSetupReplicaForFullResync(replica, getPsyncInitialOffset());
+            replicationSetupReplicaForFullResync(replica, getPsyncInitialOffset(), false);
         }
 
         // do not skip RDB checksum on the primary if connection doesn't have integrity check or if the replica doesn't support it
@@ -3876,7 +3876,7 @@ int rdbSaveToReplicasSockets(int req, int rdbver, rdbSaveInfo *rsi) {
                       skip_rdb_checksum ? " while skipping RDB checksum for this transfer" : "");
 
             server.rdb_save_time_start = time(NULL);
-            server.rdb_child_type = RDB_CHILD_TYPE_SOCKET;
+            server.rdb_child_type = SNAPSHOT_CHILD_TYPE_SOCKET;
             if (dual_channel) {
                 /* For dual channel sync, the main process no longer requires these RDB connections. */
                 zfree(conns);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1025,7 +1025,7 @@ int startGenerateSnapshotForReplication(int mincapa, int req, int rdbver) {
             if (socket_target) {
                 retval = rewriteAppendOnlyFileToReplicasSockets(req);
             } else {
-                retval = rewriteAppendOnlyFileBackground(true, req);
+                retval = rewriteAofBackgroundForReplication(req);
             }
         } else {
             if (socket_target)
@@ -1048,7 +1048,7 @@ int startGenerateSnapshotForReplication(int mincapa, int req, int rdbver) {
      * that we don't set the flag to 1 if the feature is disabled, otherwise
      * it would never be cleared: the file is not deleted. This way if
      * the user enables it later with CONFIG SET, we are fine. */
-    if (retval == C_OK && !socket_target && server.rdb_del_sync_files) SnapshotGeneratedByReplication = 1;
+    if (retval == C_OK && !socket_target && !fullsync_aof && server.rdb_del_sync_files) SnapshotGeneratedByReplication = 1;
 
     /* If we failed to BGSAVE, remove the replicas waiting for a full
      * resynchronization from the list of replicas, inform them with
@@ -1523,7 +1523,8 @@ void replconfCommand(client *c) {
                 c->flag.repl_rdbonly = 1;
             else
                 c->flag.repl_rdbonly = 0;
-        } else if (!strcasecmp(objectGetVal(c->argv[j]), "rdb-filter-only")) {
+        } else if (!strcasecmp(objectGetVal(c->argv[j]), "rdb-filter-only") ||
+                   !strcasecmp(objectGetVal(c->argv[j]), "snapshot-filter-only")) {
             /* REPLCONFG RDB-FILTER-ONLY is used to define "include" filters
              * for the RDB snapshot. Currently we only support a single
              * include filter: "functions". In the future we may want to add

--- a/src/replication.c
+++ b/src/replication.c
@@ -69,7 +69,7 @@ void syncWithPrimary(connection *conn);
 /* We take a global flag to remember if this instance generated an RDB
  * because of replication, so that we can remove the RDB file in case
  * the instance is configured to have no persistence. */
-int SnapshotGeneratedByReplication = 0;
+int RDBGeneratedByReplication = 0;
 
 /* --------------------------- Utility functions ---------------------------- */
 ConnectionType *connTypeOfReplication(void) {
@@ -1025,7 +1025,7 @@ int startGenerateSnapshotForReplication(int mincapa, int req, int rdbver) {
             if (socket_target) {
                 retval = rewriteAppendOnlyFileToReplicasSockets(req);
             } else {
-                retval = rewriteAofBackgroundForReplication(req);
+                retval = rewriteAofBackgroundForReplication(req, RDBFLAGS_REPLICATION | RDBFLAGS_KEEP_CACHE);
             }
         } else {
             if (socket_target)
@@ -1048,7 +1048,7 @@ int startGenerateSnapshotForReplication(int mincapa, int req, int rdbver) {
      * that we don't set the flag to 1 if the feature is disabled, otherwise
      * it would never be cleared: the file is not deleted. This way if
      * the user enables it later with CONFIG SET, we are fine. */
-    if (retval == C_OK && !socket_target && !fullsync_aof && server.rdb_del_sync_files) SnapshotGeneratedByReplication = 1;
+    if (retval == C_OK && !socket_target && !fullsync_aof && server.rdb_del_sync_files) RDBGeneratedByReplication = 1;
 
     /* If we failed to BGSAVE, remove the replicas waiting for a full
      * resynchronization from the list of replicas, inform them with
@@ -1473,7 +1473,7 @@ void replconfCommand(client *c) {
                 }
             } else if (!strcasecmp(objectGetVal(c->argv[j + 1]), "fullsync-aof")) {
                 /* AOF do not have aux field to support slot migration. */
-                if (server.fullsync_aof_replication && !(c->repl_data->replica_capa & REPLICA_CAPA_DUAL_CHANNEL) && !clusterIsAnySlotMoving()) {
+                if (server.repl_fullsync_format == REPL_FULLSYNC_AOF && !(c->repl_data->replica_capa & REPLICA_CAPA_DUAL_CHANNEL) && !clusterIsAnySlotMoving()) {
                     c->repl_data->replica_capa |= REPLICA_CAPA_FULLSYNC_AOF;
                 }
             } else if (!strcasecmp(objectGetVal(c->argv[j + 1]), REPLICA_CAPA_SKIP_RDB_CHECKSUM_STR))
@@ -1659,40 +1659,38 @@ void replicaStartCommandStream(client *replica) {
  * without any persistence. We don't want instances without persistence
  * to take RDB files around, this violates certain policies in certain
  * environments. */
-void removeSnapshotUsedToSyncReplicas(void) {
+void removeRDBUsedToSyncReplicas(void) {
     /* If the feature is disabled, return ASAP but also clear the
-     * SnapshotGeneratedByReplication flag in case it was set. Otherwise if the
+     * RDBGeneratedByReplication flag in case it was set. Otherwise if the
      * feature was enabled, but gets disabled later with CONFIG SET, the
      * flag may remain set to one: then next time the feature is re-enabled
      * via CONFIG SET we have it set even if no RDB was generated
      * because of replication recently. */
     if (!server.rdb_del_sync_files) {
-        SnapshotGeneratedByReplication = 0;
+        RDBGeneratedByReplication = 0;
         return;
     }
 
-    if (allPersistenceDisabled() && SnapshotGeneratedByReplication) {
+    if (allPersistenceDisabled() && RDBGeneratedByReplication) {
         client *replica;
         listNode *ln;
         listIter li;
 
-        int del_snapshot = 1;
+        int delrdb = 1;
         listRewind(server.replicas, &li);
         while ((ln = listNext(&li))) {
             replica = ln->value;
             if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START ||
                 replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END ||
-                replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_START ||
-                replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_END ||
                 replica->repl_data->repl_state == REPLICA_STATE_SEND_BULK) {
-                del_snapshot = 0;
+                delrdb = 0;
                 break; /* No need to check the other replicas. */
             }
         }
-        if (del_snapshot) {
+        if (delrdb) {
             struct stat sb;
             if (lstat(server.rdb_filename, &sb) != -1) {
-                SnapshotGeneratedByReplication = 0;
+                RDBGeneratedByReplication = 0;
                 serverLog(LL_NOTICE, "Removing the RDB file used to feed replicas "
                                      "in a persistence-less instance");
                 bg_unlink(server.rdb_filename);
@@ -2064,7 +2062,7 @@ void updateReplicasWaitingBgSnapshotGenerate(int bgerr, int type, bool use_aof) 
                 }
                 replica->repl_data->repl_start_cmd_stream_on_ack = 1;
             } else {
-                repldbfd = open(use_aof ? server.repl_transfer_fullsync_aof_name : server.rdb_filename, O_RDONLY);
+                repldbfd = open(use_aof ? server.fullsync_aof_name : server.rdb_filename, O_RDONLY);
                 if (repldbfd == -1) {
                     freeClientAsync(replica);
                     serverLog(LL_WARNING, "SYNC failed. Can't open DB after %s: %s", method, strerror(errno));
@@ -3161,7 +3159,7 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     }
     /* Send replica listening port to primary for clarification */
     sds portstr = getReplicaPortString();
-    if (server.fullsync_aof_replication && server.repl_diskless_load != REPL_DISKLESS_LOAD_SWAPDB) {
+    if (server.repl_fullsync_format == REPL_FULLSYNC_AOF && server.repl_diskless_load != REPL_DISKLESS_LOAD_SWAPDB) {
         *err = sendCommand(conn, "REPLCONF", "capa", "eof", "capa", "fullsync-aof", "rdb-only", "1", "rdb-channel", "1", "listening-port", portstr,
                            NULL);
     } else {
@@ -4025,7 +4023,7 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
         argc++;
     }
     /* swapdb in fullsync-aof is not supported now . */
-    if (server.fullsync_aof_replication && server.repl_diskless_load != REPL_DISKLESS_LOAD_SWAPDB) {
+    if (server.repl_fullsync_format == REPL_FULLSYNC_AOF && server.repl_diskless_load != REPL_DISKLESS_LOAD_SWAPDB) {
         argv[argc] = "capa";
         lens[argc] = strlen("capa");
         argc++;
@@ -5563,7 +5561,7 @@ void replicationCron(void) {
 
     /* Remove the RDB file used for replication if the server is not running
      * with any persistence. */
-    removeSnapshotUsedToSyncReplicas();
+    removeRDBUsedToSyncReplicas();
 
     /* Sanity check replication buffer, the first block of replication buffer blocks
      * must be referenced by someone, since it will be freed when not referenced,

--- a/src/replication.c
+++ b/src/replication.c
@@ -1005,8 +1005,7 @@ int startGenerateSnapshotForReplication(int mincapa, int req, int rdbver) {
     fullsync_aof = mincapa & REPLICA_CAPA_FULLSYNC_AOF;
     socket_target = (mincapa & REPLICA_CAPA_EOF) && (server.repl_diskless_sync ||
                                                      (req & REPLICA_REQ_RDB_MASK) ||
-                                                     rdbver != RDB_VERSION ||
-                                                     fullsync_aof);
+                                                     rdbver != RDB_VERSION);
     /* `SYNC` should have failed with error if we don't support socket and require a filter, assert this here */
     serverAssert(socket_target || !(req & REPLICA_REQ_RDB_MASK));
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2765,7 +2765,7 @@ read_from_socket:
     replicaBeforeLoadPrimaryRDB(conn, 1);
     if (server.repl_transfer_format == REPL_SNAPSHOT_AOF) {
         if (replicaLoadPrimarySnapshotAOFFromSocket(conn, eofmark, &usemark) == C_ERR) {
-            serverLog(LL_WARNING, "Failed to load SNAPSHOT AOF");
+            serverLog(LL_WARNING, "Failed to load Snapshot AOF");
             cancelReplicationHandshake(1);
             return;
         }
@@ -4005,8 +4005,8 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
 
     // we can ignore primary's conditions when sending capa (is_primary_stream_verified=1)
     int send_skip_rdb_checksum_capa = replicationSupportSkipRDBChecksum(conn, useDisklessLoad(), 1);
-    char *argv[9] = {"REPLCONF", "capa", "eof", "capa", "psync2", NULL, NULL, NULL, NULL};
-    size_t lens[9] = {8, 4, 3, 4, 6, 0, 0, 0, 0};
+    char *argv[11] = {"REPLCONF", "capa", "eof", "capa", "psync2", NULL, NULL, NULL, NULL, NULL, NULL};
+    size_t lens[11] = {8, 4, 3, 4, 6, 0, 0, 0, 0, 0, 0};
     int argc = 5;
     if (send_skip_rdb_checksum_capa) {
         argv[argc] = "capa";

--- a/src/replication.c
+++ b/src/replication.c
@@ -69,7 +69,7 @@ void syncWithPrimary(connection *conn);
 /* We take a global flag to remember if this instance generated an RDB
  * because of replication, so that we can remove the RDB file in case
  * the instance is configured to have no persistence. */
-int RDBGeneratedByReplication = 0;
+int SnapshotGeneratedByReplication = 0;
 
 /* --------------------------- Utility functions ---------------------------- */
 ConnectionType *connTypeOfReplication(void) {
@@ -324,7 +324,7 @@ int canFeedReplicaReplBuffer(client *replica) {
     if (replica->flag.repl_rdbonly) return 0;
 
     /* Don't feed replicas that are still waiting for BGSAVE to start. */
-    if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START) return 0;
+    if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START || replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_START) return 0;
 
     return 1;
 }
@@ -821,12 +821,12 @@ long long getPsyncInitialOffset(void) {
  * Normally this function should be called immediately after a successful
  * BGSAVE for replication was started, or when there is one already in
  * progress that we attached our replica to. */
-int replicationSetupReplicaForFullResync(client *replica, long long offset) {
+int replicationSetupReplicaForFullResync(client *replica, long long offset, bool fullsync_aof) {
     char buf[128];
     int buflen;
 
     replica->repl_data->psync_initial_offset = offset;
-    replica->repl_data->repl_state = REPLICA_STATE_WAIT_BGSAVE_END;
+    replica->repl_data->repl_state = fullsync_aof ? REPLICA_STATE_WAIT_BGREWRITE_END : REPLICA_STATE_WAIT_BGSAVE_END;
     /* We are going to accumulate the incremental changes for this
      * replica as well. Set replicas_eldb to -1 in order to force to re-emit
      * a SELECT statement in the replication stream. */
@@ -835,7 +835,12 @@ int replicationSetupReplicaForFullResync(client *replica, long long offset) {
     /* Don't send this reply to replicas that approached us with
      * the old SYNC command. */
     if (!(replica->flag.pre_psync)) {
-        buflen = snprintf(buf, sizeof(buf), "+FULLRESYNC %s %lld\r\n", server.replid, offset);
+        if (fullsync_aof) {
+            /* AOF do not have aux field, so we send dbid here. */
+            buflen = snprintf(buf, sizeof(buf), "+FULLRESYNC %s %lld AOF %d\r\n", server.replid, offset, server.repl_stream_dbid);
+        } else {
+            buflen = snprintf(buf, sizeof(buf), "+FULLRESYNC %s %lld\r\n", server.replid, offset);
+        }
         if (connWrite(replica->conn, buf, buflen) != buflen) {
             freeClientAsync(replica);
             return C_ERR;
@@ -983,45 +988,59 @@ need_full_resync:
  *    started.
  *
  * Returns C_OK on success or C_ERR otherwise. */
-int startBgsaveForReplication(int mincapa, int req, int rdbver) {
+int startGenerateSnapshotForReplication(int mincapa, int req, int rdbver) {
     int retval;
-    int socket_target = 0;
+    int socket_target = 0, fullsync_aof = 0;
     listIter li;
     listNode *ln;
 
     /* We use a socket target if replica can handle the EOF marker and we're
      * configured to do diskless syncs.
      *
-     * Note that in case we're creating a "filtered" RDB (functions-only, for
+     * Note that in case we're creating a "filtered" RDB/AOF (functions-only, for
      * example) or an older RDB version, we also force socket replication to
-     * avoid overwriting the snapshot RDB file, which needs to be usable by
-     * other replicas (not using filtered RDB or older versions) in disk-based
+     * avoid overwriting the snapshot RDB/AOF file, which needs to be usable by
+     * other replicas (not using filtered RDB/AOF or older versions) in disk-based
      * full sync. */
+    fullsync_aof = mincapa & REPLICA_CAPA_FULLSYNC_AOF;
     socket_target = (mincapa & REPLICA_CAPA_EOF) && (server.repl_diskless_sync ||
                                                      (req & REPLICA_REQ_RDB_MASK) ||
-                                                     rdbver != RDB_VERSION);
+                                                     rdbver != RDB_VERSION ||
+                                                     fullsync_aof);
     /* `SYNC` should have failed with error if we don't support socket and require a filter, assert this here */
     serverAssert(socket_target || !(req & REPLICA_REQ_RDB_MASK));
 
-    serverLog(LL_NOTICE, "Starting BGSAVE for SYNC with target: %s using: %s",
+    serverLog(LL_NOTICE, "Starting %s for SYNC with target: %s using: %s",
+              fullsync_aof ? "BGREWRITE" : "BGSAVE",
               socket_target ? "replicas sockets" : "disk",
               (req & REPLICA_REQ_RDB_CHANNEL) ? "dual-channel" : "normal sync");
+
 
     rdbSaveInfo rsi, *rsiptr;
     rsiptr = rdbPopulateSaveInfo(&rsi);
     /* Only do rdbSave* when rsiptr is not NULL,
      * otherwise replica will miss repl-stream-db. */
     if (rsiptr) {
-        if (socket_target)
-            retval = rdbSaveToReplicasSockets(req, rdbver, rsiptr);
-        else {
-            /* Keep the page cache since it'll get used soon */
-            retval = rdbSaveBackground(req, server.rdb_filename, rsiptr, RDBFLAGS_REPLICATION | RDBFLAGS_KEEP_CACHE);
+        server.repl_stream_dbid = rsiptr->repl_stream_db;
+        if (fullsync_aof) {
+            if (socket_target) {
+                retval = rewriteAppendOnlyFileToReplicasSockets(req);
+            } else {
+                retval = rewriteAppendOnlyFileBackground(true, req);
+            }
+        } else {
+            if (socket_target)
+                retval = rdbSaveToReplicasSockets(req, rdbver, rsiptr);
+            else {
+                /* Keep the page cache since it'll get used soon */
+                retval = rdbSaveBackground(req, server.rdb_filename, rsiptr, RDBFLAGS_REPLICATION | RDBFLAGS_KEEP_CACHE);
+            }
         }
         if (server.debug_pause_after_fork) debugPauseProcess();
     } else {
-        serverLog(LL_WARNING, "BGSAVE for replication: replication information not available, can't generate the RDB "
-                              "file right now. Try later.");
+        serverLog(LL_WARNING, "%s for replication: replication information not available, can't generate the RDB "
+                              "file right now. Try later.",
+                  fullsync_aof ? "BGREWRITE" : "BGSAVE");
         retval = C_ERR;
     }
 
@@ -1030,40 +1049,42 @@ int startBgsaveForReplication(int mincapa, int req, int rdbver) {
      * that we don't set the flag to 1 if the feature is disabled, otherwise
      * it would never be cleared: the file is not deleted. This way if
      * the user enables it later with CONFIG SET, we are fine. */
-    if (retval == C_OK && !socket_target && server.rdb_del_sync_files) RDBGeneratedByReplication = 1;
+    if (retval == C_OK && !socket_target && server.rdb_del_sync_files) SnapshotGeneratedByReplication = 1;
 
     /* If we failed to BGSAVE, remove the replicas waiting for a full
      * resynchronization from the list of replicas, inform them with
      * an error about what happened, close the connection ASAP. */
     if (retval == C_ERR) {
-        serverLog(LL_WARNING, "BGSAVE for replication failed");
+        serverLog(LL_WARNING, "Generate snapshot for replication failed");
         listRewind(server.replicas, &li);
         while ((ln = listNext(&li))) {
             client *replica = ln->value;
 
-            if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START) {
+            if ((replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START && !fullsync_aof) || (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_START && fullsync_aof)) {
                 replica->repl_data->repl_state = REPL_STATE_NONE;
                 replica->flag.replica = 0;
                 listDelNode(server.replicas, ln);
-                addReplyError(replica, "BGSAVE failed, replication can't continue");
+                addReplyError(replica, "Generate snapshot failed, replication can't continue");
                 replica->flag.close_after_reply = 1;
             }
         }
         return retval;
     }
 
-    /* If the target is socket, rdbSaveToReplicasSockets() already setup
-     * the replicas for a full resync. Otherwise for disk target do it now.*/
+    /* If the target is socket, rdbSaveToReplicasSockets() and rewriteAppendOnlyFileToReplicasSockets()
+     * already setup the replicas for a full resync. Otherwise for disk target do it now.*/
     if (!socket_target) {
         listRewind(server.replicas, &li);
         while ((ln = listNext(&li))) {
             client *replica = ln->value;
-
-            if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START) {
+            if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_START && fullsync_aof) {
+                if (replica->repl_data->replica_req != req) continue;
+                replicationSetupReplicaForFullResync(replica, getPsyncInitialOffset(), true);
+            } else if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START && !fullsync_aof) {
                 /* Check replica has the exact requirements */
                 if (replica->repl_data->replica_req != req) continue;
                 if (replicaRdbVersion(replica) != rdbver) continue;
-                replicationSetupReplicaForFullResync(replica, getPsyncInitialOffset());
+                replicationSetupReplicaForFullResync(replica, getPsyncInitialOffset(), false);
             }
         }
     }
@@ -1188,9 +1209,10 @@ void syncCommand(client *c) {
     /* Full resynchronization. */
     server.stat_sync_full++;
 
+    bool use_fullsync_aof = (c->repl_data->replica_capa & REPLICA_CAPA_FULLSYNC_AOF);
     /* Setup the replica as one waiting for BGSAVE to start. The following code
      * paths will change the state if we handle the replica differently. */
-    c->repl_data->repl_state = REPLICA_STATE_WAIT_BGSAVE_START;
+    c->repl_data->repl_state = use_fullsync_aof ? REPLICA_STATE_WAIT_BGREWRITE_START : REPLICA_STATE_WAIT_BGSAVE_START;
     if (server.repl_disable_tcp_nodelay) anetDisableTcpNoDelay(NULL, c->conn->fd); /* Non critical if it fails. */
     c->repl_data->repldbfd = -1;
     c->flag.replica = 1;
@@ -1211,7 +1233,7 @@ void syncCommand(client *c) {
     }
 
     /* CASE 1: BGSAVE is in progress, with disk target. */
-    if (server.child_type == CHILD_TYPE_RDB && server.rdb_child_type == RDB_CHILD_TYPE_DISK) {
+    if (((server.child_type == CHILD_TYPE_RDB && !use_fullsync_aof) || (server.child_type == CHILD_TYPE_AOF && use_fullsync_aof)) && server.rdb_child_type == SNAPSHOT_CHILD_TYPE_DISK) {
         /* Ok a background save is in progress. Let's check if it is a good
          * one for replication, i.e. if there is another replica that is
          * registering differences since the server forked to save. */
@@ -1224,7 +1246,7 @@ void syncCommand(client *c) {
             replica = ln->value;
             /* If the client needs a buffer of commands, we can't use
              * a replica without replication buffer. */
-            if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END &&
+            if ((replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END || replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_END) &&
                 (!(replica->flag.repl_rdbonly) || (c->flag.repl_rdbonly)))
                 break;
         }
@@ -1237,55 +1259,55 @@ void syncCommand(client *c) {
              * another replica. Set the right state, and copy the buffer.
              * We don't copy buffer if clients don't want. */
             if (!c->flag.repl_rdbonly) copyReplicaOutputBuffer(c, replica);
-            replicationSetupReplicaForFullResync(c, replica->repl_data->psync_initial_offset);
-            serverLog(LL_NOTICE, "Waiting for end of BGSAVE for SYNC");
+            replicationSetupReplicaForFullResync(c, replica->repl_data->psync_initial_offset, use_fullsync_aof);
+            serverLog(LL_NOTICE, "Waiting for end of generating snapshot for SYNC");
         } else {
-            /* No way, we need to wait for the next BGSAVE in order to
+            /* No way, we need to wait for the next BGSAVE/BGREWRITE in order to
              * register differences. */
-            serverLog(LL_NOTICE, "Can't attach the replica to the current BGSAVE. Waiting for next BGSAVE for SYNC");
+            serverLog(LL_NOTICE, "Can't attach the replica to the current BGSAVE/BGREWRITE. Waiting for next BGSAVE/BGREWRITE for SYNC");
         }
 
         /* CASE 2: BGSAVE is in progress, with socket target. */
-    } else if (server.child_type == CHILD_TYPE_RDB && server.rdb_child_type == RDB_CHILD_TYPE_SOCKET) {
-        /* There is an RDB child process but it is writing directly to
-         * children sockets. We need to wait for the next BGSAVE
+    } else if ((server.child_type == CHILD_TYPE_RDB || server.child_type == CHILD_TYPE_AOF) && server.rdb_child_type == SNAPSHOT_CHILD_TYPE_SOCKET) {
+        /* There is an RDB/AOF child process but it is writing directly to
+         * children sockets. We need to wait for the next BGSAVE/BGREWRITE
          * in order to synchronize. */
-        serverLog(LL_NOTICE, "Current BGSAVE has socket target. Waiting for next BGSAVE for SYNC");
+        serverLog(LL_NOTICE, "Current snapshot has socket target. Waiting for next BGSAVE/BGREWRITE for SYNC");
 
         /* CASE 3: There is no BGSAVE is in progress. */
     } else {
         if (server.repl_diskless_sync && (c->repl_data->replica_capa & REPLICA_CAPA_EOF) && server.repl_diskless_sync_delay) {
-            /* Diskless replication RDB child is created inside
+            /* Diskless replication RDB/AOF child is created inside
              * replicationCron() since we want to delay its start a
              * few seconds to wait for more replicas to arrive. */
-            serverLog(LL_NOTICE, "Delay next BGSAVE for diskless SYNC");
+            serverLog(LL_NOTICE, "Delay next BGSAVE/BGREWRITE for diskless SYNC");
         } else {
             /* We don't have a BGSAVE in progress, let's start one. Diskless
              * or disk-based mode is determined by replica's capacity. */
             if (!hasActiveChildProcess()) {
-                startBgsaveForReplication(c->repl_data->replica_capa,
-                                          c->repl_data->replica_req,
-                                          replicaRdbVersion(c));
+                startGenerateSnapshotForReplication(c->repl_data->replica_capa,
+                                                    c->repl_data->replica_req,
+                                                    replicaRdbVersion(c));
             } else {
-                serverLog(LL_NOTICE, "No BGSAVE in progress, but another BG operation is active. "
-                                     "BGSAVE for replication delayed");
+                serverLog(LL_NOTICE, "Another BG operation is active. "
+                                     "BGSAVE/BGREWRITE for replication delayed");
             }
         }
     }
     return;
 }
 
-/* Check if there is any other replica waiting dumping RDB finished expect me.
- * This function is useful to judge current dumping RDB can be used for full
+/* Check if there is any other replica waiting dumping RDB/AOF finished expect me.
+ * This function is useful to judge current dumping RDB/AOF can be used for full
  * synchronization or not. */
-int anyOtherReplicaWaitRdb(client *except_me) {
+int anyOtherReplicaWaitSnapshot(client *except_me, int state) {
     listIter li;
     listNode *ln;
 
     listRewind(server.replicas, &li);
     while ((ln = listNext(&li))) {
         client *replica = ln->value;
-        if (replica != except_me && replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END) {
+        if (replica != except_me && replica->repl_data->repl_state == state) {
             return 1;
         }
     }
@@ -1311,10 +1333,16 @@ void freeClientReplicationData(client *c) {
          * should not remove directly since that means RDB is important for users
          * to keep data safe and we may delay configured 'save' for full sync. */
         if (server.saveparamslen == 0 && c->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END &&
-            server.child_type == CHILD_TYPE_RDB && server.rdb_child_type == RDB_CHILD_TYPE_DISK &&
-            anyOtherReplicaWaitRdb(c) == 0) {
+            server.child_type == CHILD_TYPE_RDB && server.rdb_child_type == SNAPSHOT_CHILD_TYPE_DISK &&
+            anyOtherReplicaWaitSnapshot(c, REPLICA_STATE_WAIT_BGSAVE_END) == 0) {
             serverLog(LL_NOTICE, "Background saving, persistence disabled, last replica dropped, killing fork child.");
             killRDBChild();
+        }
+        if (server.aof_enabled == 0 && c->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_END &&
+            server.child_type == CHILD_TYPE_AOF && server.rdb_child_type == SNAPSHOT_CHILD_TYPE_DISK &&
+            anyOtherReplicaWaitSnapshot(c, REPLICA_STATE_WAIT_BGREWRITE_END) == 0) {
+            serverLog(LL_NOTICE, "Background rewriting, appendonly disabled, last replica dropped, killing fork child.");
+            killAppendOnlyChild(true);
         }
         if (c->repl_data->repl_state == REPLICA_STATE_SEND_BULK) {
             if (c->repl_data->repldbfd != -1) close(c->repl_data->repldbfd);
@@ -1356,13 +1384,14 @@ void freeClientReplicationData(client *c) {
  * the primary can accurately lists replicas and their listening ports in the
  * INFO output.
  *
- * - capa <eof|psync2|dual-channel|skip-rdb-checksum>
+ * - capa <eof|psync2|dual-channel|skip-rdb-checksum|fullsync-aof>
  * What is the capabilities of this instance.
  * eof: supports EOF-style RDB transfer for diskless replication.
  * psync2: supports PSYNC v2, so understands +CONTINUE <new repl ID>.
  * dual-channel: supports full sync using rdb channel.
  * skip-rdb-checksum: supports skipping RDB checksum calculations during diskless sync using
  *                    a connection that has integrity checks (such as TLS).
+ * fullsync-aof: using AOF instead of RDB for full synchronization
  *
  * - ack <offset> [fack <aofofs>]
  * Replica informs the primary the amount of replication stream that it
@@ -1437,10 +1466,16 @@ void replconfCommand(client *c) {
                  * replconf option. */
                 if (server.repl_diskless_sync) {
                     c->repl_data->replica_capa |= REPLICA_CAPA_DUAL_CHANNEL;
+                    c->repl_data->replica_capa &= ~REPLICA_CAPA_FULLSYNC_AOF; // reset fullsync-aof and wait rdb-channel to shake again
                 } else {
                     /* repl-diskless-sync is disabled, unable to use the dual channel replication,
                      * print a log so that user will get to know that they are missing something. */
                     serverLog(LL_NOTICE, "Dual channel capability ignored: repl-diskless-sync disabled");
+                }
+            } else if (!strcasecmp(objectGetVal(c->argv[j + 1]), "fullsync-aof")) {
+                /* AOF do not have aux field to support slot migration. */
+                if (server.fullsync_aof_replication && !(c->repl_data->replica_capa & REPLICA_CAPA_DUAL_CHANNEL) && !clusterIsAnySlotMoving()) {
+                    c->repl_data->replica_capa |= REPLICA_CAPA_FULLSYNC_AOF;
                 }
             } else if (!strcasecmp(objectGetVal(c->argv[j + 1]), REPLICA_CAPA_SKIP_RDB_CHECKSUM_STR))
                 c->repl_data->replica_capa |= REPLICA_CAPA_SKIP_RDB_CHECKSUM;
@@ -1466,7 +1501,8 @@ void replconfCommand(client *c) {
              * There's a chance the ACK got to us before we detected that the
              * bgsave is done (since that depends on cron ticks), so run a
              * quick check first (instead of waiting for the next ACK. */
-            if (server.child_type == CHILD_TYPE_RDB && c->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END)
+            if ((server.child_type == CHILD_TYPE_RDB && c->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END) ||
+                (server.child_type == CHILD_TYPE_AOF && c->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_END))
                 checkChildrenDone();
             if (c->repl_data->repl_start_cmd_stream_on_ack && c->repl_data->repl_state == REPLICA_STATE_ONLINE) replicaStartCommandStream(c);
             if (c->repl_data->repl_state == REPLICA_STATE_BG_RDB_LOAD) {
@@ -1623,38 +1659,40 @@ void replicaStartCommandStream(client *replica) {
  * without any persistence. We don't want instances without persistence
  * to take RDB files around, this violates certain policies in certain
  * environments. */
-void removeRDBUsedToSyncReplicas(void) {
+void removeSnapshotUsedToSyncReplicas(void) {
     /* If the feature is disabled, return ASAP but also clear the
-     * RDBGeneratedByReplication flag in case it was set. Otherwise if the
+     * SnapshotGeneratedByReplication flag in case it was set. Otherwise if the
      * feature was enabled, but gets disabled later with CONFIG SET, the
      * flag may remain set to one: then next time the feature is re-enabled
      * via CONFIG SET we have it set even if no RDB was generated
      * because of replication recently. */
     if (!server.rdb_del_sync_files) {
-        RDBGeneratedByReplication = 0;
+        SnapshotGeneratedByReplication = 0;
         return;
     }
 
-    if (allPersistenceDisabled() && RDBGeneratedByReplication) {
+    if (allPersistenceDisabled() && SnapshotGeneratedByReplication) {
         client *replica;
         listNode *ln;
         listIter li;
 
-        int delrdb = 1;
+        int del_snapshot = 1;
         listRewind(server.replicas, &li);
         while ((ln = listNext(&li))) {
             replica = ln->value;
             if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START ||
                 replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END ||
+                replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_START ||
+                replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_END ||
                 replica->repl_data->repl_state == REPLICA_STATE_SEND_BULK) {
-                delrdb = 0;
+                del_snapshot = 0;
                 break; /* No need to check the other replicas. */
             }
         }
-        if (delrdb) {
+        if (del_snapshot) {
             struct stat sb;
             if (lstat(server.rdb_filename, &sb) != -1) {
-                RDBGeneratedByReplication = 0;
+                SnapshotGeneratedByReplication = 0;
                 serverLog(LL_NOTICE, "Removing the RDB file used to feed replicas "
                                      "in a persistence-less instance");
                 bg_unlink(server.rdb_filename);
@@ -1802,6 +1840,7 @@ void rdbPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *clientData,
                 server.rdb_pipe_conns[i] = NULL;
             }
             killRDBChild();
+            killAppendOnlyChild(true);
             return;
         }
 
@@ -1960,10 +1999,11 @@ void slotMigrationPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *c
  * otherwise C_ERR is passed to the function.
  * The 'type' argument is the type of the child that terminated
  * (if it had a disk or socket target). */
-void updateReplicasWaitingBgsave(int bgsaveerr, int type) {
+void updateReplicasWaitingBgSnapshotGenerate(int bgerr, int type, bool use_aof) {
     listNode *ln;
     listIter li;
-
+    int state = use_aof ? REPLICA_STATE_WAIT_BGREWRITE_END : REPLICA_STATE_WAIT_BGSAVE_END;
+    char *method = use_aof ? "BGREWRITEAOF" : "BGSAVE";
     /* Note: there's a chance we got here from within the REPLCONF ACK command
      * so we must avoid using freeClient, otherwise we'll crash on our way up. */
 
@@ -1971,15 +2011,15 @@ void updateReplicasWaitingBgsave(int bgsaveerr, int type) {
     while ((ln = listNext(&li))) {
         client *replica = ln->value;
 
-        if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END) {
+        if (replica->repl_data->repl_state == state) {
             int repldbfd;
             struct valkey_stat buf;
 
-            if (bgsaveerr != C_OK) {
-                /* If bgsaveerr is error, there is no need to protect the rdb channel. */
+            if (bgerr != C_OK) {
+                /* If error, there is no need to protect the rdb channel. */
                 replica->flag.protected_rdb_channel = 0;
                 freeClientAsync(replica);
-                serverLog(LL_WARNING, "SYNC failed. BGSAVE child returned an error");
+                serverLog(LL_WARNING, "SYNC failed. %s child returned an error", method);
                 continue;
             }
 
@@ -1988,11 +2028,11 @@ void updateReplicasWaitingBgsave(int bgsaveerr, int type) {
              * already an RDB -> Replicas socket transfer, used in the case of
              * diskless replication, our work is trivial, we can just put
              * the replica online. */
-            if (type == RDB_CHILD_TYPE_SOCKET) {
+            if (type == SNAPSHOT_CHILD_TYPE_SOCKET) {
                 serverLog(LL_NOTICE,
-                          "Streamed RDB transfer with replica %s succeeded (socket). Waiting for REPLCONF ACK from "
+                          "Streamed %s transfer with replica %s succeeded (socket). Waiting for REPLCONF ACK from "
                           "replica to enable streaming",
-                          replicationGetReplicaName(replica));
+                          use_aof ? "AOF" : "RDB", replicationGetReplicaName(replica));
                 /* Note: we wait for a REPLCONF ACK message from the replica in
                  * order to really put it online (install the write handler
                  * so that the accumulated data can be transferred). However
@@ -2024,15 +2064,15 @@ void updateReplicasWaitingBgsave(int bgsaveerr, int type) {
                 }
                 replica->repl_data->repl_start_cmd_stream_on_ack = 1;
             } else {
-                repldbfd = open(server.rdb_filename, O_RDONLY);
+                repldbfd = open(use_aof ? server.repl_transfer_fullsync_aof_name : server.rdb_filename, O_RDONLY);
                 if (repldbfd == -1) {
                     freeClientAsync(replica);
-                    serverLog(LL_WARNING, "SYNC failed. Can't open DB after BGSAVE: %s", strerror(errno));
+                    serverLog(LL_WARNING, "SYNC failed. Can't open DB after %s: %s", method, strerror(errno));
                     continue;
                 }
                 if (valkey_fstat(repldbfd, &buf) == -1) {
                     freeClientAsync(replica);
-                    serverLog(LL_WARNING, "SYNC failed. Can't stat DB after BGSAVE: %s", strerror(errno));
+                    serverLog(LL_WARNING, "SYNC failed. Can't stat DB after %s: %s", method, strerror(errno));
                     close(repldbfd);
                     continue;
                 }
@@ -2596,6 +2636,92 @@ int replicaLoadPrimaryRDBFromDisk(rdbSaveInfo *rsi) {
     return C_OK;
 }
 
+int replicaLoadPrimarySnapshotAOFFromSocket(connection *conn, char *eofmark, int *usemark) {
+    rio aofrio;
+    int empty_db_flags = server.repl_replica_lazy_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS;
+
+    replicationAttachToNewPrimary();
+
+    rioInitWithConn(&aofrio, conn, server.repl_transfer_size);
+    connBlock(conn);
+    connRecvTimeout(conn, server.repl_timeout * 1000);
+
+    serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Flushing old data before loading BASE AOF");
+    emptyData(-1, empty_db_flags, replicationEmptyDbCallback);
+
+    serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Loading DB in memory");
+    startLoading(server.repl_transfer_size, RDBFLAGS_REPLICATION, 0);
+
+    int ret = loadSnapshotAofFromRioScopedAOF(&aofrio, eofmark, *usemark);
+
+    rioFreeConn(&aofrio, NULL);
+    if (ret == AOF_FAILED) {
+        serverLog(LL_WARNING, "Failed trying to load the PRIMARY synchronization DB "
+                              "from socket, check server logs.");
+        stopLoading(0);
+        serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Discarding the half-loaded data (BASE AOF load failed)");
+        emptyData(-1, empty_db_flags, replicationEmptyDbCallback);
+        return C_ERR;
+    }
+
+    server.dirty++;
+    stopLoading(1);
+
+    connNonBlock(conn);
+    connRecvTimeout(conn, 0);
+    return C_OK;
+}
+
+int replicaLoadPrimaryAOFFromDisk(void) {
+    int ret = C_OK;
+    int empty_db_flags = server.repl_replica_lazy_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS;
+
+    /* Ensure the downloaded temp file is fully synced to disk. */
+    if (fsync(server.repl_transfer_fd) == -1) {
+        serverLog(LL_WARNING,
+                  "Failed trying to sync the temp BASE AOF to disk in "
+                  "PRIMARY <-> REPLICA synchronization: %s",
+                  strerror(errno));
+        ret = C_ERR;
+        goto cleanup;
+    }
+
+    /* Replication history is about to change, discard cached primary and
+     * force resync of sub-replicas. */
+    replicationAttachToNewPrimary();
+
+    /* We must explicitly flush old dataset before applying the base AOF. */
+    serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Flushing old data before loading BASE AOF");
+    emptyData(-1, empty_db_flags, replicationEmptyDbCallback);
+
+    serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Loading DB in memory");
+    int aofret = loadSnapshotAofFromPath(server.repl_transfer_tmpfile);
+
+    if (aofret != AOF_OK) {
+        serverLog(LL_WARNING, "Failed trying to load the PRIMARY synchronization "
+                              "DB from disk, check server logs.");
+
+        /* Remove the half-loaded dataset to avoid an inconsistent state. */
+        serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Discarding the half-loaded data (BASE AOF load failed)");
+        emptyData(-1, empty_db_flags, replicationEmptyDbCallback);
+        ret = C_ERR;
+    }
+
+cleanup:
+    /* Cleanup transfer resources (temp file is no longer needed). */
+    if (server.repl_transfer_tmpfile) {
+        bg_unlink(server.repl_transfer_tmpfile);
+        zfree(server.repl_transfer_tmpfile);
+        server.repl_transfer_tmpfile = NULL;
+    }
+    if (server.repl_transfer_fd != -1) {
+        close(server.repl_transfer_fd);
+        server.repl_transfer_fd = -1;
+    }
+
+    return ret;
+}
+
 /* Asynchronously read the SYNC payload we receive from a primary, parse it,
  * and load it directly to memory without going through the disk */
 void replicaReceiveRDBFromPrimaryToMemory(connection *conn) {
@@ -2637,10 +2763,19 @@ read_from_socket:
     }
 
     replicaBeforeLoadPrimaryRDB(conn, 1);
-    if (replicaLoadPrimaryRDBFromSocket(conn, buf, eofmark, &usemark, &rsi) == C_ERR) {
-        serverLog(LL_WARNING, "Failed to load RDB");
-        cancelReplicationHandshake(1);
-        return;
+    if (server.repl_transfer_format == REPL_SNAPSHOT_AOF) {
+        if (replicaLoadPrimarySnapshotAOFFromSocket(conn, eofmark, &usemark) == C_ERR) {
+            serverLog(LL_WARNING, "Failed to load SNAPSHOT AOF");
+            cancelReplicationHandshake(1);
+            return;
+        }
+        rsi.repl_stream_db = server.repl_replica_stream_dbid;
+    } else {
+        if (replicaLoadPrimaryRDBFromSocket(conn, buf, eofmark, &usemark, &rsi) == C_ERR) {
+            serverLog(LL_WARNING, "Failed to load RDB");
+            cancelReplicationHandshake(1);
+            return;
+        }
     }
     replicaAfterLoadPrimaryRDB(conn, &rsi);
 }
@@ -2970,15 +3105,16 @@ void replicationAbortDualChannelSyncTransfer(void) {
 
 /* Replication: Primary side.
  * Send current replication offset to replica. Use the following structure:
- * $ENDOFF:<repl-offset> <primary-repl-id> <current-db-id> <client-id> */
-int sendCurrentOffsetToReplica(client *replica) {
+ * $ENDOFF:<repl-offset> <primary-repl-id> <current-db-id> <client-id> <aof> */
+int sendCurrentOffsetToReplica(client *replica, bool fullsync_aof) {
     char buf[128];
     int buflen;
-    buflen = snprintf(buf, sizeof(buf), "$ENDOFF:%lld %s %d %llu\r\n", server.primary_repl_offset, server.replid,
-                      server.replicas_eldb, (long long unsigned int)replica->id);
-    dualChannelServerLog(LL_NOTICE, "Sending to replica %s RDB end offset %lld and client-id %llu",
+    char *format = fullsync_aof ? "aof" : "rdb";
+    buflen = snprintf(buf, sizeof(buf), "$ENDOFF:%lld %s %d %llu %s\r\n", server.primary_repl_offset, server.replid,
+                      server.repl_stream_dbid, (long long unsigned int)replica->id, format);
+    dualChannelServerLog(LL_NOTICE, "Sending to replica %s RDB end offset %lld client-id %llu format %s and dbid %d.",
                          replicationGetReplicaName(replica), server.primary_repl_offset,
-                         (long long unsigned int)replica->id);
+                         (long long unsigned int)replica->id, format, server.repl_stream_dbid);
     if (connSyncWrite(replica->conn, buf, buflen, server.repl_syncio_timeout * 1000) != buflen) {
         freeClientAsync(replica);
         return C_ERR;
@@ -3025,8 +3161,14 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     }
     /* Send replica listening port to primary for clarification */
     sds portstr = getReplicaPortString();
-    *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1", "rdb-channel", "1", "listening-port", portstr,
-                       NULL);
+    if (server.fullsync_aof_replication && server.repl_diskless_load != REPL_DISKLESS_LOAD_SWAPDB) {
+        *err = sendCommand(conn, "REPLCONF", "capa", "eof", "capa", "fullsync-aof", "rdb-only", "1", "rdb-channel", "1", "listening-port", portstr,
+                           NULL);
+    } else {
+        *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1", "rdb-channel", "1", "listening-port", portstr,
+                           NULL);
+    }
+
     sdsfree(portstr);
     if (*err) {
         dualChannelServerLog(LL_WARNING, "Sending command to primary in dual channel replication handshake: %s", *err);
@@ -3099,6 +3241,18 @@ static int dualChannelReplHandleReplconfReply(connection *conn, sds *err) {
     return C_OK;
 }
 
+void syncWithPrimaryHandleError(connection **conn) {
+    connClose(*conn);
+    *conn = NULL;
+    server.repl_transfer_s = NULL;
+    if (server.repl_rdb_transfer_s) {
+        connClose(server.repl_rdb_transfer_s);
+        server.repl_rdb_transfer_s = NULL;
+    }
+    replicationAbortSyncTransfer();
+    server.repl_state = REPL_STATE_CONNECT;
+}
+
 static int dualChannelReplHandleEndOffsetResponse(connection *conn, sds *err) {
     uint64_t rdb_client_id;
     *err = receiveSynchronousResponse(conn);
@@ -3113,14 +3267,25 @@ static int dualChannelReplHandleEndOffsetResponse(connection *conn, sds *err) {
     long long reploffset;
     char primary_replid[CONFIG_RUN_ID_SIZE + 1];
     int dbid;
+    char fmt[8] = {0};
     /* Parse end offset response */
-    char *endoff_format = "$ENDOFF:%lld %40s %d %llu";
-    if (sscanf(*err, endoff_format, &reploffset, primary_replid, &dbid, &rdb_client_id) != 4) {
+    char *endoff_format = "$ENDOFF:%lld %40s %d %llu %7s";
+    int n = sscanf(*err, endoff_format, &reploffset, primary_replid, &dbid, &rdb_client_id, fmt);
+    if (n < 4) {
         dualChannelServerLog(LL_WARNING, "Received unexpected $ENDOFF response: %s", *err);
         return C_ERR;
     }
     server.rdb_client_id = rdb_client_id;
     server.primary_initial_offset = reploffset;
+    if (n == 4) {
+        server.repl_transfer_format = REPL_SNAPSHOT_RDB;
+    } else {
+        if (!strcasecmp(fmt, "aof"))
+            server.repl_transfer_format = REPL_SNAPSHOT_AOF;
+        else
+            server.repl_transfer_format = REPL_SNAPSHOT_RDB;
+    }
+    serverLog(LL_NOTICE, "Dual channel snapshot format: %s", server.repl_transfer_format == REPL_SNAPSHOT_AOF ? "AOF" : "RDB");
 
     /* Initiate repl_provisional_primary to act as this replica temp primary until RDB is loaded */
     server.repl_provisional_primary.conn = server.repl_transfer_s;
@@ -3527,6 +3692,7 @@ int replicaProcessPsyncReply(connection *conn) {
     connSetReadHandler(conn, NULL);
 
     if (!strncmp(reply, "+FULLRESYNC", 11)) {
+        server.repl_transfer_format = REPL_SNAPSHOT_RDB;
         char *replid = NULL, *offset = NULL;
 
         /* FULL RESYNC, parse the reply in order to extract the replid
@@ -3548,8 +3714,21 @@ int replicaProcessPsyncReply(connection *conn) {
             memcpy(server.primary_replid, replid, offset - replid - 1);
             server.primary_replid[CONFIG_RUN_ID_SIZE] = '\0';
             server.primary_initial_offset = strtoll(offset, NULL, 10);
-            serverLog(LL_NOTICE, "Full resync from primary: %s:%lld", server.primary_replid,
-                      server.primary_initial_offset);
+
+            char *p = offset;
+            if (*p == '-') p++;
+            while (*p >= '0' && *p <= '9') p++;
+            while (*p == ' ') p++;
+            if (!strncasecmp(p, "AOF", 3)) {
+                server.repl_transfer_format = REPL_SNAPSHOT_AOF;
+                p += 3;
+                while (*p == ' ') p++;
+                long long dbid_ll = strtoll(p, NULL, 10);
+                server.repl_replica_stream_dbid = (int)dbid_ll;
+            }
+
+            serverLog(LL_NOTICE, "Full resync from primary: %s:%lld, format:%s, dbid:%d", server.primary_replid,
+                      server.primary_initial_offset, server.repl_transfer_format == REPL_SNAPSHOT_AOF ? "AOF" : "RDB", server.repl_replica_stream_dbid);
         }
         sdsfree(reply);
         return PSYNC_FULLRESYNC;
@@ -3845,6 +4024,15 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
         lens[argc] = strlen("dual-channel");
         argc++;
     }
+    /* swapdb in fullsync-aof is not supported now . */
+    if (server.fullsync_aof_replication && server.repl_diskless_load != REPL_DISKLESS_LOAD_SWAPDB) {
+        argv[argc] = "capa";
+        lens[argc] = strlen("capa");
+        argc++;
+        argv[argc] = "fullsync-aof";
+        lens[argc] = strlen("fullsync-aof");
+        argc++;
+    }
     err = sendCommandArgv(conn, argc, argv, lens);
     if (err) goto err;
 
@@ -3966,18 +4154,6 @@ int syncWithPrimaryHandleSendPsyncState(connection *conn) {
         return C_ERR;
     }
     return C_OK;
-}
-
-void syncWithPrimaryHandleError(connection **conn) {
-    connClose(*conn);
-    *conn = NULL;
-    server.repl_transfer_s = NULL;
-    if (server.repl_rdb_transfer_s) {
-        connClose(server.repl_rdb_transfer_s);
-        server.repl_rdb_transfer_s = NULL;
-    }
-    replicationAbortSyncTransfer();
-    server.repl_state = REPL_STATE_CONNECT;
 }
 
 /*
@@ -5178,10 +5354,10 @@ void handleBioThreadFinishedRDBDownload(void) {
     int bio_repl_transfer_read = server.bio_repl_transfer_read;
     resetBioRDBSaveState();
 
-    serverLog(LL_NOTICE, "Replica main thread detected RDB download completion in Bio thread");
+    serverLog(LL_NOTICE, "Replica main thread detected %s download completion in Bio thread", server.repl_transfer_format == REPL_SNAPSHOT_AOF ? "AOF" : "RDB");
 
     /* Handle Bio sync success */
-    serverLog(LL_NOTICE, "Loading the RDB and finalizing primary-replica sync...");
+    serverLog(LL_NOTICE, "Loading the Snapshot and finalizing primary-replica sync...");
     rdbSaveInfo rsi = RDB_SAVE_INFO_INIT;
     connection *conn;
     if (server.repl_rdb_channel_state != REPL_DUAL_CHANNEL_STATE_NONE) {
@@ -5195,10 +5371,19 @@ void handleBioThreadFinishedRDBDownload(void) {
     debugServerAssert(conn);
 
     replicaBeforeLoadPrimaryRDB(conn, 0);
-    if (replicaLoadPrimaryRDBFromDisk(&rsi) == C_ERR) {
-        serverLog(LL_WARNING, "Failed to load RDB");
-        cancelReplicationHandshake(1);
-        return;
+    if (server.repl_transfer_format == REPL_SNAPSHOT_AOF) {
+        if (replicaLoadPrimaryAOFFromDisk() == C_ERR) {
+            serverLog(LL_WARNING, "Failed to load Snapshot AOF");
+            cancelReplicationHandshake(1);
+            return;
+        }
+        rsi.repl_stream_db = server.repl_replica_stream_dbid;
+    } else {
+        if (replicaLoadPrimaryRDBFromDisk(&rsi) == C_ERR) {
+            serverLog(LL_WARNING, "Failed to load RDB");
+            cancelReplicationHandshake(1);
+            return;
+        }
     }
     replicaAfterLoadPrimaryRDB(conn, &rsi);
     server.repl_transfer_size = bio_repl_transfer_size;
@@ -5292,7 +5477,9 @@ void replicationCron(void) {
 
         int is_presync =
             (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START ||
-             (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END && server.rdb_child_type != RDB_CHILD_TYPE_SOCKET));
+             replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_START ||
+             ((replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END || replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_END) &&
+              server.rdb_child_type != SNAPSHOT_CHILD_TYPE_SOCKET));
 
         if (is_presync) {
             connWrite(replica->conn, "\n", 1);
@@ -5320,8 +5507,8 @@ void replicationCron(void) {
             /* We consider disconnecting only diskless replicas because disk-based replicas aren't fed
              * by the fork child so if a disk-based replica is stuck it doesn't prevent the fork child
              * from terminating. */
-            if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END &&
-                server.rdb_child_type == RDB_CHILD_TYPE_SOCKET) {
+            if ((replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END || replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_END) &&
+                server.rdb_child_type == SNAPSHOT_CHILD_TYPE_SOCKET) {
                 if (replica->repl_data->repl_last_partial_write != 0 &&
                     (server.unixtime - replica->repl_data->repl_last_partial_write) > server.repl_timeout) {
                     serverLog(LL_WARNING, "Disconnecting timedout replica (full sync): %s",
@@ -5376,7 +5563,7 @@ void replicationCron(void) {
 
     /* Remove the RDB file used for replication if the server is not running
      * with any persistence. */
-    removeRDBUsedToSyncReplicas();
+    removeSnapshotUsedToSyncReplicas();
 
     /* Sanity check replication buffer, the first block of replication buffer blocks
      * must be referenced by someone, since it will be freed when not referenced,
@@ -5413,7 +5600,7 @@ int shouldStartChildReplication(int *mincapa_out, int *req_out, int *rdbver_out)
         listRewind(server.replicas, &li);
         while ((ln = listNext(&li))) {
             client *replica = ln->value;
-            if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START) {
+            if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START || replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGREWRITE_START) {
                 if (first) {
                     /* Get first replica's requirements */
                     req = replica->repl_data->replica_req;
@@ -5454,7 +5641,7 @@ void replicationStartPendingFork(void) {
         /* Start the BGSAVE. The called function may start a
          * BGSAVE with socket target or disk target depending on the
          * configuration and replicas capabilities and requirements. */
-        startBgsaveForReplication(mincapa, req, rdbver);
+        startGenerateSnapshotForReplication(mincapa, req, rdbver);
     }
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -2325,6 +2325,8 @@ void initServerConfig(void) {
     server.dict_resizing = 1;
     server.import_mode = 0;
     server.repl_stream_dbid = -1;
+    server.repl_replica_stream_dbid = -1;
+    server.repl_transfer_format = REPL_SNAPSHOT_RDB;
 
     server.latency_tracking_info_percentiles_len = 3;
     server.latency_tracking_info_percentiles = zmalloc(sizeof(double) * (server.latency_tracking_info_percentiles_len));

--- a/src/server.c
+++ b/src/server.c
@@ -1590,7 +1590,7 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
     /* Start a scheduled AOF rewrite if this was requested by the user while
      * a BGSAVE was in progress. */
     if (!hasActiveChildProcess() && server.aof_rewrite_scheduled && !aofRewriteLimited()) {
-        rewriteAppendOnlyFileBackground();
+        rewriteAppendOnlyFileBackground(false, REPLICA_REQ_NONE);
     }
 
     /* Check if a background saving or AOF rewrite in progress terminated. */
@@ -1625,7 +1625,7 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
             long long growth = (server.aof_current_size * 100 / base) - 100;
             if (growth >= server.aof_rewrite_perc && !aofRewriteLimited()) {
                 serverLog(LL_NOTICE, "Starting automatic rewriting of AOF on %lld%% growth", growth);
-                rewriteAppendOnlyFileBackground();
+                rewriteAppendOnlyFileBackground(false, REPLICA_REQ_NONE);
             }
         }
     }
@@ -2324,6 +2324,7 @@ void initServerConfig(void) {
     server.pause_cron = 0;
     server.dict_resizing = 1;
     server.import_mode = 0;
+    server.repl_stream_dbid = -1;
 
     server.latency_tracking_info_percentiles_len = 3;
     server.latency_tracking_info_percentiles = zmalloc(sizeof(double) * (server.latency_tracking_info_percentiles_len));
@@ -2985,7 +2986,7 @@ void initServer(void) {
     server.client_pause_in_transaction = 0;
     server.child_pid = -1;
     server.child_type = CHILD_TYPE_NONE;
-    server.rdb_child_type = RDB_CHILD_TYPE_NONE;
+    server.rdb_child_type = SNAPSHOT_CHILD_TYPE_NONE;
     server.rdb_pipe_conns = NULL;
     server.rdb_pipe_numconns = 0;
     server.rdb_pipe_numconns_writing = 0;
@@ -4805,7 +4806,7 @@ int finishShutdown(void) {
             }
         }
         serverLog(LL_WARNING, "There is a child rewriting the AOF. Killing it!");
-        killAppendOnlyChild();
+        killAppendOnlyChild(false);
     }
     if (server.aof_state != AOF_OFF) {
         /* Append only file: flush buffers and fsync() the AOF at exit */
@@ -5764,6 +5765,8 @@ const char *replstateToString(int replstate) {
     switch (replstate) {
     case REPLICA_STATE_WAIT_BGSAVE_START:
     case REPLICA_STATE_WAIT_BGSAVE_END: return "wait_bgsave";
+    case REPLICA_STATE_WAIT_BGREWRITE_START:
+    case REPLICA_STATE_WAIT_BGREWRITE_END: return "wait_bgrewrite";
     case REPLICA_STATE_BG_RDB_LOAD: return "bg_transfer";
     case REPLICA_STATE_SEND_BULK: return "send_bulk";
     case REPLICA_STATE_ONLINE: return "online";

--- a/src/server.c
+++ b/src/server.c
@@ -1590,7 +1590,7 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
     /* Start a scheduled AOF rewrite if this was requested by the user while
      * a BGSAVE was in progress. */
     if (!hasActiveChildProcess() && server.aof_rewrite_scheduled && !aofRewriteLimited()) {
-        rewriteAppendOnlyFileBackground(false, REPLICA_REQ_NONE);
+        rewriteAppendOnlyFileBackground();
     }
 
     /* Check if a background saving or AOF rewrite in progress terminated. */
@@ -1625,7 +1625,7 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
             long long growth = (server.aof_current_size * 100 / base) - 100;
             if (growth >= server.aof_rewrite_perc && !aofRewriteLimited()) {
                 serverLog(LL_NOTICE, "Starting automatic rewriting of AOF on %lld%% growth", growth);
-                rewriteAppendOnlyFileBackground(false, REPLICA_REQ_NONE);
+                rewriteAppendOnlyFileBackground();
             }
         }
     }

--- a/src/server.h
+++ b/src/server.h
@@ -557,6 +557,10 @@ typedef enum {
 #define REPL_DISKLESS_LOAD_SWAPDB 2
 #define REPL_DISKLESS_LOAD_FLUSH_BEFORE_LOAD 3
 
+/* Replication fullsync format */
+#define REPL_FULLSYNC_RDB 0
+#define REPL_FULLSYNC_AOF 1
+
 /* TLS Client Authentication */
 #define TLS_CLIENT_AUTH_NO 0
 #define TLS_CLIENT_AUTH_YES 1
@@ -2043,7 +2047,6 @@ struct valkeyServer {
     int aof_load_truncated;             /* Don't stop on unexpected AOF EOF. */
     int aof_use_rdb_preamble;           /* Specify base AOF to use RDB encoding on AOF rewrites. */
     int aof_rewrite_use_rdb_preamble;   /* Base AOF to use RDB encoding on AOF rewrites start. */
-    int aof_rewrite_for_replication;    /* Current AOF child is for replication, not normal AOFRW. */
     _Atomic int aof_bio_fsync_status;   /* Status of AOF fsync in bio job. */
     _Atomic int aof_bio_fsync_errno;    /* Errno of AOF fsync in bio job. */
     aofManifest *aof_manifest;          /* Used to track AOFs. */
@@ -2119,6 +2122,7 @@ struct valkeyServer {
                                         fsynced_reploff only when AOF state is AOF_ON
                                         (not during the initial rewrite) */
     long long fsynced_reploff;                 /* Largest replication offset that has been confirmed to be fsynced */
+    int aof_rewrite_for_replication;           /* Current AOF child is for replication, not normal AOFRW. */
     int replicas_eldb;                         /* Last SELECTed DB in replication output */
     int repl_ping_replica_period;              /* Primary pings the replica every N seconds */
     replBacklog *repl_backlog;                 /* Replication backlog for partial syncs */
@@ -2139,7 +2143,7 @@ struct valkeyServer {
                                                 * delay (start sooner if they all connect). */
     int dual_channel_replication;              /* Config used to determine if the replica should
                                                 * use dual channel replication for full syncs. */
-    int fullsync_aof_replication;              /* Config used to determine if the primary should
+    int repl_fullsync_format;                  /* Config used to determine if the primary should
                                                 * use the base aof for full syncs. */
     _Atomic int replica_bio_disk_save_state;   /* Flag set by the bio thread to indicate that the
                                                 * RDB save to disk has completed, or failed */
@@ -2184,7 +2188,7 @@ struct valkeyServer {
     connection *repl_transfer_s;        /* Replica -> Primary SYNC connection */
     connection *repl_rdb_transfer_s;    /* Primary FULL SYNC connection (RDB download) */
     replSnapshotType repl_transfer_format;
-    sds repl_transfer_fullsync_aof_name;
+    char *fullsync_aof_name;
     int repl_stream_dbid;
     int repl_replica_stream_dbid;
     int repl_transfer_fd;                /* Replica -> Primary SYNC temp file descriptor */
@@ -3271,7 +3275,7 @@ void feedAppendOnlyFile(int dictid, robj **argv, int argc);
 void aofRemoveTempFile(pid_t childpid, int from_signal);
 int rewriteAppendOnlyFileToReplicasSockets(int req);
 int rewriteAppendOnlyFileBackground(void);
-int rewriteAofBackgroundForReplication(int req);
+int rewriteAofBackgroundForReplication(int req, int aofflags);
 int loadAppendOnlyFiles(aofManifest *am);
 void stopAppendOnly(void);
 int startAppendOnly(void);

--- a/src/server.h
+++ b/src/server.h
@@ -470,18 +470,25 @@ typedef enum {
                              * PSYNC FAILOVER request. */
 } failover_state;
 
+typedef enum {
+    REPL_SNAPSHOT_RDB,
+    REPL_SNAPSHOT_AOF
+} replSnapshotType;
+
 
 /* State of replicas from the POV of the primary. Used in client->replstate.
  * In SEND_BULK and ONLINE state the replica receives new updates
  * in its output queue. In the WAIT_BGSAVE states instead the server is waiting
  * to start the next background saving in order to send updates to it. */
-#define REPLICA_STATE_WAIT_BGSAVE_START 6 /* We need to produce a new RDB file. */
-#define REPLICA_STATE_WAIT_BGSAVE_END 7   /* Waiting RDB file creation to finish. */
-#define REPLICA_STATE_SEND_BULK 8         /* Sending RDB file to replica. */
-#define REPLICA_STATE_ONLINE 9            /* RDB file transmitted, sending just updates. */
-#define REPLICA_STATE_RDB_TRANSMITTED 10  /* RDB file transmitted - This state is used only for \
-                                           * a replica that only wants RDB without replication buffer  */
-#define REPLICA_STATE_BG_RDB_LOAD 11      /* Main channel of a replica which uses dual channel replication. */
+#define REPLICA_STATE_WAIT_BGSAVE_START 6     /* We need to produce a new RDB file. */
+#define REPLICA_STATE_WAIT_BGSAVE_END 7       /* Waiting RDB file creation to finish. */
+#define REPLICA_STATE_SEND_BULK 8             /* Sending RDB file to replica. */
+#define REPLICA_STATE_ONLINE 9                /* RDB file transmitted, sending just updates. */
+#define REPLICA_STATE_RDB_TRANSMITTED 10      /* RDB file transmitted - This state is used only for \
+                                               * a replica that only wants RDB without replication buffer  */
+#define REPLICA_STATE_BG_RDB_LOAD 11          /* Main channel of a replica which uses dual channel replication. */
+#define REPLICA_STATE_WAIT_BGREWRITE_START 12 /* We need to produce a new base aof file. */
+#define REPLICA_STATE_WAIT_BGREWRITE_END 13   /* Waiting base aof rewrite to finish. */
 
 /* Replica capability flags */
 #define REPLICA_CAPA_NONE 0
@@ -489,6 +496,7 @@ typedef enum {
 #define REPLICA_CAPA_PSYNC2 (1 << 1)            /* Supports PSYNC2 protocol. */
 #define REPLICA_CAPA_DUAL_CHANNEL (1 << 2)      /* Supports dual channel replication sync */
 #define REPLICA_CAPA_SKIP_RDB_CHECKSUM (1 << 3) /* Supports skipping RDB checksum for sync requests. */
+#define REPLICA_CAPA_FULLSYNC_AOF (1 << 4)      /* Supports fullsync AOF */
 
 /* Replica capability strings */
 #define REPLICA_CAPA_SKIP_RDB_CHECKSUM_STR "skip-rdb-checksum" /* Supports skipping RDB checksum for sync requests. */
@@ -676,10 +684,10 @@ typedef enum {
     CLUSTER_ENDPOINT_TYPE_UNKNOWN_ENDPOINT /* Show NULL or empty */
 } cluster_endpoint_type;
 
-/* RDB active child save type. */
-#define RDB_CHILD_TYPE_NONE 0
-#define RDB_CHILD_TYPE_DISK 1   /* RDB is written to disk. */
-#define RDB_CHILD_TYPE_SOCKET 2 /* RDB is written to replica socket. */
+/* Snapshot active child save type. */
+#define SNAPSHOT_CHILD_TYPE_NONE 0
+#define SNAPSHOT_CHILD_TYPE_DISK 1   /* RDB/AOF is written to disk. */
+#define SNAPSHOT_CHILD_TYPE_SOCKET 2 /* RDB/AOF is written to replica socket. */
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes. */
@@ -2130,6 +2138,8 @@ struct valkeyServer {
                                                 * delay (start sooner if they all connect). */
     int dual_channel_replication;              /* Config used to determine if the replica should
                                                 * use dual channel replication for full syncs. */
+    int fullsync_aof_replication;              /* Config used to determine if the primary should
+                                                * use the base aof for full syncs. */
     _Atomic int replica_bio_disk_save_state;   /* Flag set by the bio thread to indicate that the
                                                 * RDB save to disk has completed, or failed */
     _Atomic bool replica_bio_abort_save;       /* Flag set by main thread, used to signal to replica's
@@ -2162,16 +2172,20 @@ struct valkeyServer {
         long long read_reploff;
         int dbid;
     } repl_provisional_primary;
-    client *cached_primary;              /* Cached primary to be reused for PSYNC. */
-    rio *loading_rio;                    /* Pointer to the rio object currently used for loading data. */
-    int repl_syncio_timeout;             /* Timeout for synchronous I/O calls */
-    int repl_state;                      /* Replication status if the instance is a replica */
-    int repl_rdb_channel_state;          /* State of the replica's rdb channel during dual-channel-replication */
-    off_t repl_transfer_size;            /* Size of RDB to read from primary during sync. */
-    off_t repl_transfer_read;            /* Amount of RDB read from primary during sync. */
-    off_t repl_transfer_last_fsync_off;  /* Offset when we fsync-ed last time. */
-    connection *repl_transfer_s;         /* Replica -> Primary SYNC connection */
-    connection *repl_rdb_transfer_s;     /* Primary FULL SYNC connection (RDB download) */
+    client *cached_primary;             /* Cached primary to be reused for PSYNC. */
+    rio *loading_rio;                   /* Pointer to the rio object currently used for loading data. */
+    int repl_syncio_timeout;            /* Timeout for synchronous I/O calls */
+    int repl_state;                     /* Replication status if the instance is a replica */
+    int repl_rdb_channel_state;         /* State of the replica's rdb channel during dual-channel-replication */
+    off_t repl_transfer_size;           /* Size of RDB to read from primary during sync. */
+    off_t repl_transfer_read;           /* Amount of RDB read from primary during sync. */
+    off_t repl_transfer_last_fsync_off; /* Offset when we fsync-ed last time. */
+    connection *repl_transfer_s;        /* Replica -> Primary SYNC connection */
+    connection *repl_rdb_transfer_s;    /* Primary FULL SYNC connection (RDB download) */
+    replSnapshotType repl_transfer_format;
+    sds repl_transfer_fullsync_aof_name;
+    int repl_stream_dbid;
+    int repl_replica_stream_dbid;
     int repl_transfer_fd;                /* Replica -> Primary SYNC temp file descriptor */
     char *repl_transfer_tmpfile;         /* Replica-> Primary SYNC temp file name */
     _Atomic time_t repl_transfer_lastio; /* Unix time of the latest read, for timeout */
@@ -3179,7 +3193,7 @@ void resetReplicationBuffer(void);
 void feedReplicationBuffer(char *buf, size_t len);
 void freeReplicaReferencedReplBuffer(client *replica);
 void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv, int argc);
-void updateReplicasWaitingBgsave(int bgsaveerr, int type);
+void updateReplicasWaitingBgSnapshotGenerate(int bgerr, int type, bool use_aof);
 void replicationCron(void);
 void replicationStartPendingFork(void);
 void replicationHandlePrimaryDisconnection(void);
@@ -3197,7 +3211,7 @@ void replicationSendNewlineToPrimary(void);
 long long replicationGetReplicaOffset(void);
 char *replicationGetReplicaName(client *c);
 long long getPsyncInitialOffset(void);
-int replicationSetupReplicaForFullResync(client *replica, long long offset);
+int replicationSetupReplicaForFullResync(client *replica, long long offset, bool fullsync_aof);
 void changeReplicationId(void);
 void clearReplicationId2(void);
 void createReplicationBacklog(void);
@@ -3217,7 +3231,7 @@ void updateFailoverStatus(void);
 void abortFailover(const char *err);
 const char *getFailoverStateString(void);
 sds getReplicaPortString(void);
-int sendCurrentOffsetToReplica(client *replica);
+int sendCurrentOffsetToReplica(client *replica, bool fullsync_aof);
 int replicaRdbVersion(client *replica);
 void addRdbReplicaToPsyncWait(client *replica);
 void initClientReplicationData(client *c);
@@ -3254,12 +3268,13 @@ int bg_unlink(const char *filename);
 void flushAppendOnlyFile(int force);
 void feedAppendOnlyFile(int dictid, robj **argv, int argc);
 void aofRemoveTempFile(pid_t childpid, int from_signal);
-int rewriteAppendOnlyFileBackground(void);
+int rewriteAppendOnlyFileToReplicasSockets(int req);
+int rewriteAppendOnlyFileBackground(bool for_replication, int req);
 int loadAppendOnlyFiles(aofManifest *am);
 void stopAppendOnly(void);
 int startAppendOnly(void);
 void backgroundRewriteDoneHandler(int exitcode, int bysignal);
-void killAppendOnlyChild(void);
+void killAppendOnlyChild(bool async);
 void restartAOFAfterSYNC(void);
 void aofLoadManifestFromDisk(void);
 void aofOpenIfNeededOnServerStart(void);
@@ -3267,6 +3282,8 @@ void aofManifestFree(aofManifest *am);
 int aofDelHistoryFiles(void);
 int aofRewriteLimited(void);
 int rewriteSlotToAppendOnlyFileRio(rio *aof, int db_num, int hashslot, size_t *key_count);
+int loadSnapshotAofFromPath(const char *path);
+int loadSnapshotAofFromRioScopedAOF(rio *aof, char *eofmark, int usemark);
 
 /* Child info */
 void openChildInfoPipe(void);

--- a/src/server.h
+++ b/src/server.h
@@ -2043,6 +2043,7 @@ struct valkeyServer {
     int aof_load_truncated;             /* Don't stop on unexpected AOF EOF. */
     int aof_use_rdb_preamble;           /* Specify base AOF to use RDB encoding on AOF rewrites. */
     int aof_rewrite_use_rdb_preamble;   /* Base AOF to use RDB encoding on AOF rewrites start. */
+    int aof_rewrite_for_replication;    /* Current AOF child is for replication, not normal AOFRW. */
     _Atomic int aof_bio_fsync_status;   /* Status of AOF fsync in bio job. */
     _Atomic int aof_bio_fsync_errno;    /* Errno of AOF fsync in bio job. */
     aofManifest *aof_manifest;          /* Used to track AOFs. */
@@ -3269,7 +3270,8 @@ void flushAppendOnlyFile(int force);
 void feedAppendOnlyFile(int dictid, robj **argv, int argc);
 void aofRemoveTempFile(pid_t childpid, int from_signal);
 int rewriteAppendOnlyFileToReplicasSockets(int req);
-int rewriteAppendOnlyFileBackground(bool for_replication, int req);
+int rewriteAppendOnlyFileBackground(void);
+int rewriteAofBackgroundForReplication(int req);
 int loadAppendOnlyFiles(aofManifest *am);
 void stopAppendOnly(void);
 int startAppendOnly(void);

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -54,7 +54,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
         test "Test dual-channel-replication-enabled enters wait_bgsave" {
             wait_for_condition 50 1000 {
-                [string match *state=wait_bgsave* [$primary info replication]]
+                [string match *state=wait_bg* [$primary info replication]]
             } else {
                 fail "Replica does not enter wait_bgsave state"
             }
@@ -296,16 +296,16 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                     # wait for sync to start
                     if {$enable == "yes"} {
                         wait_for_condition 500 1000 {
-                            [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                            [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
                             [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
-                            [s 0 rdb_bgsave_in_progress] eq 1
+                            (([s 0 rdb_bgsave_in_progress] eq 1) || ([s 0 aof_rewrite_in_progress] eq 1))
                         } else {
                             fail "replica didn't start a dual-channel sync session in time"
                         }
                     } else {
                         wait_for_condition 500 1000 {
-                            [string match "*slave*,state=wait_bgsave*,type=replica*" [$primary info replication]] &&
-                            [s 0 rdb_bgsave_in_progress] eq 1
+                            [string match "*slave*,state=wait_bg*,type=replica*" [$primary info replication]] &&
+                            (([s 0 rdb_bgsave_in_progress] eq 1) || ([s 0 aof_rewrite_in_progress] eq 1))
                         } else {
                             fail "replica didn't start a normal full sync session in time"
                         }
@@ -325,17 +325,17 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
                     if {$enable == "yes"} {
                         # Verify that dual channel replication sync is still in progress
-                        assert [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]]
+                        assert [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]]
                         assert [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]]
-                        assert {[s 0 rdb_bgsave_in_progress] eq 1}
+                        assert {(([s 0 rdb_bgsave_in_progress] eq 1) || ([s 0 aof_rewrite_in_progress] eq 1))}
                     } else {
                         # Verify that normal sync is still in progress
-                        assert [string match "*slave*,state=wait_bgsave*,type=replica*" [$primary info replication]]
-                        assert {[s 0 rdb_bgsave_in_progress] eq 1}
+                        assert [string match "*slave*,state=wait_bg*,type=replica*" [$primary info replication]]
+                        assert {(([s 0 rdb_bgsave_in_progress] eq 1) || ([s 0 aof_rewrite_in_progress] eq 1))}
                     }
                     $replica replicaof no one
                     wait_for_condition 500 1000 {
-                        [s -1 rdb_bgsave_in_progress] eq 0
+                        (([s -1 rdb_bgsave_in_progress] eq 0) && ([s -1 aof_rewrite_in_progress] eq 0))
                     } else {
                         fail "Primary should abort sync"
                     }
@@ -378,9 +378,11 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             test "dual-channel-replication with multiple replicas" {
                 $replica1 replicaof $primary_host $primary_port
                 $replica2 replicaof $primary_host $primary_port
-                verify_replica_online $primary 0 500
-                verify_replica_online $primary 1 500
-
+                wait_for_condition 50 1000 {
+                    [status $replica1 master_link_status] == "up" && [status $replica2 master_link_status] == "up"
+                } else {
+                    fail "Replica 1 is not synced"
+                }
                 wait_for_value_to_propagate_to_replica $primary $replica1 "key1"
                 wait_for_value_to_propagate_to_replica $primary $replica2 "key1"
 
@@ -398,15 +400,13 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             test "Test diverse replica sync: dual-channel on/off" {
                 $replica1 replicaof $primary_host $primary_port
                 $replica2 replicaof $primary_host $primary_port
-                verify_replica_online $primary 0 500
-                verify_replica_online $primary 1 500
+                wait_for_condition 50 1000 {
+                    [status $replica1 master_link_status] == "up" && [status $replica2 master_link_status] == "up"
+                } else {
+                    fail "Replica 1 is not synced"
+                }
                 wait_for_value_to_propagate_to_replica $primary $replica1 "key2"
                 wait_for_value_to_propagate_to_replica $primary $replica2 "key2"
-                wait_for_condition 50 1000 {
-                    [status $replica1 master_link_status] == "up"
-                } else {
-                    fail "Replica is not synced"
-                }
             }
 
             $replica1 replicaof no one
@@ -450,7 +450,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $primary config set rdb-key-save-delay 0
 
             wait_for_condition 500 1000 {
-                [s 0 rdb_bgsave_in_progress] eq 0
+                (([s 0 rdb_bgsave_in_progress] eq 0) && ([s 0 aof_rewrite_in_progress] eq 0))
             } else {
                 fail "can't kill rdb child"
             }
@@ -500,7 +500,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
         test "Test dual-channel-replication sync- psync established after rdb load" {
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages -1 {"*Done loading RDB*"} 0 20 100
+            wait_for_log_messages -1 {"*Done loading*"} 0 20 100
             wait_and_resume_process 0
 
             verify_replica_online $primary 0 500
@@ -695,7 +695,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # 5. Replica resumes operation.
             # Expected outcome: Primary maintains RDB channel until replica establishes PSYNC connection.
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 100 100
+            wait_for_log_messages 0 {"*Done loading*"} $loglines 100 100
             pause_process $replica_pid
             wait_and_resume_process -1
             wait_for_condition 50 100 {
@@ -756,7 +756,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # 4. Primary resumes operation and detects closed RDB channel.
             # Expected outcome: Primary drops the RDB channel after grace period is done.
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 100 100
+            wait_for_log_messages 0 {"*Done loading*"} $loglines 100 100
             pause_process $replica_pid
             wait_and_resume_process -1
             wait_for_condition 50 100 {
@@ -812,7 +812,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # Pause primary main process after fork
             $primary debug pause-after-fork 1
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} 0 5000 10
+            wait_for_log_messages 0 {"*Done loading*"} 0 5000 10
 
             # At this point rdb is loaded but psync hasn't been established yet. 
             # Pause the replica so the primary main process will wake up while the
@@ -837,13 +837,13 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         }
         # Waiting for the primary to enter the paused state, that is, make sure that bgsave is triggered.
         wait_process_paused -1
-        wait_for_log_messages 0 {"*Done loading RDB*"} $replica_loglines 5000 10
+        wait_for_log_messages 0 {"*Done loading*"} $replica_loglines 5000 10
         $replica replicaof no one
         # Resume the primary and make sure the sync is dropped.
         resume_process [srv -1 pid]
         $primary debug pause-after-fork 0
         wait_for_condition 500 1000 {
-            [s -1 rdb_bgsave_in_progress] eq 0
+            (([s -1 rdb_bgsave_in_progress] eq 0) && ([s -1 aof_rewrite_in_progress] eq 0))
         } else {
             fail "Primary should abort sync"
         }
@@ -949,7 +949,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 $replica2 replicaof $primary_host $primary_port
 
                 wait_for_condition 50 1000 {
-                    [status $primary rdb_bgsave_in_progress] == 1
+                    (([status $primary rdb_bgsave_in_progress] == 1) || ([status $primary aof_rewrite_in_progress] == 1))
                 } else {
                     fail "Sync did not start"
                 }
@@ -982,7 +982,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 $replica2 replicaof $primary_host $primary_port
 
                 wait_for_condition 50 1000 {
-                    [status $primary rdb_bgsave_in_progress] == 1
+                    (([status $primary rdb_bgsave_in_progress] == 1) || ([status $primary aof_rewrite_in_progress] == 1))
                 } else {
                     fail "Sync did not start"
                 }
@@ -995,7 +995,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
                 catch {$replica2 shutdown nosave}
                 wait_for_condition 50 1000 {
-                    [status $primary rdb_bgsave_in_progress] == 0
+                    (([status $primary rdb_bgsave_in_progress] == 0) && ([status $primary aof_rewrite_in_progress] == 0))
                 } else {
                     fail "Primary should abort the sync"
                 }
@@ -1035,9 +1035,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $replica replicaof $primary_host $primary_port
             # Wait for sync session to start
             wait_for_condition 500 1000 {
-                [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
                 [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
-                [s -1 rdb_bgsave_in_progress] eq 1
+                (([s -1 rdb_bgsave_in_progress] eq 1) || ([s -1 aof_rewrite_in_progress] eq 1))
             } else {
                 fail "replica didn't start sync session in time"
             }            
@@ -1054,13 +1054,13 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
+            wait_for_log_messages -1 {"*Background * transfer error*"} $loglines 100 100
         }
 
         test "Test dual channel replication slave of no one after main conn kill" {
             $replica replicaof no one
             wait_for_condition 500 1000 {
-                [s -1 rdb_bgsave_in_progress] eq 0
+                (([s -1 rdb_bgsave_in_progress] eq 0) && ([s -1 aof_rewrite_in_progress] eq 0))
             } else {
                 fail "Primary should abort sync"
             }
@@ -1071,9 +1071,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $replica replicaof $primary_host $primary_port
             # Wait for sync session to start
             wait_for_condition 500 1000 {
-                [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
                 [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
-                [s -1 rdb_bgsave_in_progress] eq 1
+                (([s -1 rdb_bgsave_in_progress] eq 1) || ([s -1 aof_rewrite_in_progress] eq 1))
             } else {
                 fail "replica didn't start sync session in time"
             }            
@@ -1085,13 +1085,13 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $primary config set repl-diskless-sync-delay 5; # allow catch failed sync before retry
             $primary client kill id $replica_rdb_channel_id
             # Wait for primary to abort the sync
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
+            wait_for_log_messages -1 {"*Background * transfer error*"} $loglines 100 100
         }
 
         test "Test dual channel replication slave of no one after rdb conn kill" {
             $replica replicaof no one
             wait_for_condition 500 1000 {
-                [s -1 rdb_bgsave_in_progress] eq 0
+                (([s -1 rdb_bgsave_in_progress] eq 0) && ([s -1 aof_rewrite_in_progress] eq 0))
             } else {
                 fail "Primary should abort sync"
             }
@@ -1104,8 +1104,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $replica replicaof $primary_host $primary_port
             # Wait for sync session to start
             wait_for_condition 500 1000 {
-                [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
-                [s -1 rdb_bgsave_in_progress] eq 1
+                [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
+                (([s -1 rdb_bgsave_in_progress] eq 1) || ([s -1 aof_rewrite_in_progress] eq 1))
             } else {
                 fail "replica didn't start sync session in time"
             }
@@ -1118,7 +1118,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # Wait for primary to abort the sync
             wait_and_resume_process 0
             wait_for_condition 10000000 10 {
-                [s -1 rdb_bgsave_in_progress] eq 0 &&
+                (([s -1 rdb_bgsave_in_progress] eq 0) && ([s -1 aof_rewrite_in_progress] eq 0)) &&
                 [string match {*replicas_waiting_psync:0*} [$primary info replication]]
             } else {
                 fail "Primary should abort sync"
@@ -1170,12 +1170,12 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 $replica_1 replicaof $primary_host $primary_port
                 # Wait for sync session to start
                 wait_for_condition 50 100 {
-                    [s -2 rdb_bgsave_in_progress] eq 1
+                    (([s -2 rdb_bgsave_in_progress] eq 1) || ([s -2 aof_rewrite_in_progress] eq 1))
                 } else {
                     fail "replica didn't start sync session in time1"
                 }
                 $replica_2 replicaof $primary_host $primary_port
-                wait_for_log_messages -2 {"*Current BGSAVE has socket target. Waiting for next BGSAVE for SYNC*"} $loglines 100 1000
+                wait_for_log_messages -2 {"*Current snapshot has socket target. Waiting for next BGSAVE/BGREWRITE for SYNC*"} $loglines 100 1000
             }
             stop_write_load $load_handle
         }
@@ -1212,9 +1212,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $replica replicaof $primary_host $primary_port
             # Wait for sync session to start
             wait_for_condition 500 1000 {
-                [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
                 [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
-                [s -1 rdb_bgsave_in_progress] eq 1
+                (([s -1 rdb_bgsave_in_progress] eq 1) || ([s -1 aof_rewrite_in_progress] eq 1))
             } else {
                 fail "replica didn't start sync session in time"
             }            
@@ -1232,12 +1232,12 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 fail "Primary did not free repl buf block after sync failure"
             }
             $primary config set repl-diskless-sync-delay 0
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
+            wait_for_log_messages -1 {"*Background * transfer error*"} $loglines 100 100
             # Replica should retry
             wait_for_condition 500 1000 {
-                [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
                 [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
-                [s -1 rdb_bgsave_in_progress] eq 1
+                (([s -1 rdb_bgsave_in_progress] eq 1) || ([s -1 aof_rewrite_in_progress] eq 1))
             } else {
                 fail "replica didn't retry after connection close"
             }
@@ -1276,9 +1276,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $replica replicaof $primary_host $primary_port
             # Wait for sync session to start
             wait_for_condition 500 1000 {
-                [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
                 [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
-                [s -1 rdb_bgsave_in_progress] eq 1
+                (([s -1 rdb_bgsave_in_progress] eq 1) || ([s -1 aof_rewrite_in_progress] eq 1))
             } else {
                 fail "replica didn't start sync session in time"
             }            
@@ -1295,12 +1295,12 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 fail "Primary did not free repl buf block after sync failure"
             }
             $primary config set repl-diskless-sync-delay 0
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
+            wait_for_log_messages -1 {"*Background * transfer error*"} $loglines 100 100
             # Replica should retry
             wait_for_condition 500 1000 {
-                [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
                 [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
-                [s -1 rdb_bgsave_in_progress] eq 1
+                (([s -1 rdb_bgsave_in_progress] eq 1) || ([s -1 aof_rewrite_in_progress] eq 1))
             } else {
                 fail "replica didn't retry after connection close"
             }    
@@ -1349,13 +1349,13 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $replica replicaof $primary_host $primary_port
             # Wait for sync session to start
             wait_for_condition 500 1000 {
-                [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
                 [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
-                [s -1 rdb_bgsave_in_progress] eq 1
+                (([s -1 rdb_bgsave_in_progress] eq 1) || ([s -1 aof_rewrite_in_progress] eq 1))
             } else {
                 fail "replica didn't start sync session in time"
             }
-            wait_for_log_messages 0 {"*Loading RDB produced by Valkey version*"} $loglines 100 100
+            wait_for_log_messages 0 {"*PRIMARY <-> REPLICA sync: Loading DB in memory*"} $loglines 100 100
             $primary set key val
             set replica_main_conn_id [get_client_id_by_last_cmd $primary "psync"]
             $primary config set repl-diskless-sync-delay 5; # allow catch failed sync before retry
@@ -1370,7 +1370,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
-            wait_for_log_messages 0 {"*Failed trying to load the PRIMARY synchronization DB from socket*"} $loglines $max_tries 10
+            wait_for_log_messages 0 {"*Failed trying to load the PRIMARY synchronization DB from socket*"} $loglines $max_tries 20
             verify_replica_online $primary 0 $max_tries
         }
     }
@@ -1397,9 +1397,9 @@ test "Test dual-channel-replication replica can lazyfree the local buffer" {
             # Wait for sync session to start
             $replica replicaof $primary_host $primary_port
             wait_for_condition 1000 50 {
-                [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
                 [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
-                [s -1 rdb_bgsave_in_progress] eq 1
+                (([s -1 rdb_bgsave_in_progress] eq 1) || ([s -1 aof_rewrite_in_progress] eq 1))
             } else {
                 fail "replica didn't start sync session in time"
             }
@@ -1446,9 +1446,9 @@ test "Test dual-channel-replication replica can lazyfree the local buffer" {
             # Wait for sync session to start
             $replica replicaof $primary_host $primary_port
             wait_for_condition 1000 50 {
-                [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
                 [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
-                [s -1 rdb_bgsave_in_progress] eq 1
+                (([s -1 rdb_bgsave_in_progress] eq 1) || ([s -1 aof_rewrite_in_progress] eq 1))
             } else {
                 fail "replica didn't start sync session in time"
             }

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -52,11 +52,11 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             }
         }
 
-        test "Test dual-channel-replication-enabled enters wait_bgsave" {
+        test "Test dual-channel-replication-enabled enters wait_bgsave/wait_bgrewrite" {
             wait_for_condition 50 1000 {
                 [string match *state=wait_bg* [$primary info replication]]
             } else {
-                fail "Replica does not enter wait_bgsave state"
+                fail "Replica does not enter wait_bgsave/wait_bgrewrite state"
             }
         }
 
@@ -1495,11 +1495,11 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         test "dual-channel-replication rdb-channel reports replica-announce-ip" {
             $replica replicaof $primary_host $primary_port
 
-            # Wait for replica to enter wait_bgsave state (rdb-channel established)
+            # Wait for replica to enter wait_bgsave/wait_bgrewrite state (rdb-channel established)
             wait_for_condition 50 1000 {
-                [string match *state=wait_bgsave* [$primary info replication]]
+                [string match *state=wait_bg* [$primary info replication]]
             } else {
-                fail "Replica does not enter wait_bgsave state"
+                fail "Replica does not enter wait_bgsave/wait_bgrewrite state"
             }
 
             # Verify the rdb-channel shows the announced IP, not connection IP
@@ -1551,9 +1551,9 @@ test "Dual channel replication buffer memory fields" {
 
             # Ensure that all states meet our expectations.
             wait_for_condition 1000 50 {
-                [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                [string match "*slave*,state=wait_bg*,type=rdb-channel*" [$primary info replication]] &&
                 [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
-                [s $primary_srv_id rdb_bgsave_in_progress] eq 1 &&
+                (([s -1 rdb_bgsave_in_progress] eq 1) || ([s -1 aof_rewrite_in_progress] eq 1)) &&
                 [s $replica_srv_id master_sync_in_progress] eq 1
             } else {
                 fail "replica didn't start a dual-channel sync session in time"

--- a/tests/integration/replication-buffer.tcl
+++ b/tests/integration/replication-buffer.tcl
@@ -40,7 +40,7 @@ start_server {} {
     $replica1 replicaof $master_host $master_port
     $replica2 replicaof $master_host $master_port
     wait_for_condition 50 100 {
-        ([s rdb_bgsave_in_progress] == 1) &&
+        (([s rdb_bgsave_in_progress] == 1) || ([s aof_rewrite_in_progress == 1])) &&
         [lindex [$replica1 role] 3] eq {sync} &&
         [lindex [$replica2 role] 3] eq {sync}
     } else {
@@ -147,7 +147,7 @@ start_server {} {
         $replica2 replicaof $master_host $master_port
         # Make sure replica2 is waiting bgsave
         wait_for_condition 5000 100 {
-            ([s rdb_bgsave_in_progress] == 1) &&
+            (([s rdb_bgsave_in_progress] == 1) || ([s aof_rewrite_in_progress == 1])) &&
             [lindex [$replica2 role] 3] eq {sync}
         } else {
             fail "fail to sync with replicas"
@@ -179,7 +179,7 @@ start_server {} {
         }
 
         # replica2 still waits for bgsave ending
-        assert {[s rdb_bgsave_in_progress] eq {1} && [lindex [$replica2 role] 3] eq {sync}}
+        assert {(([s rdb_bgsave_in_progress] eq {1}) || ([s aof_rewrite_in_progress] eq {1})) && [lindex [$replica2 role] 3] eq {sync}}
         # master accepted replica1 partial resync
         if { $dualchannel == "yes" } {
             # 2 psync using main channel
@@ -210,7 +210,7 @@ start_server {} {
         wait_for_condition 100 100 {
             [s connected_slaves] eq {1} ||
             ([s connected_slaves] eq {2} &&
-            [string match {*slave*state=wait_bgsave*type=rdb-channel*} [$master info]])
+            [string match {*slave*state=wait_bg*type=rdb-channel*} [$master info]])
         } else {
             fail "master didn't disconnect with replica2"
         }

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1221,7 +1221,7 @@ test {Kill rdb child process if its dumping RDB is not useful} {
                 $master config set rdb-key-save-delay 1000000
                 $master config set repl-diskless-sync no
                 $master config set save ""
-                $master config set fullsync-aof no
+                $master config set repl-fullsync-format RDB
 
                 $slave1 slaveof $master_host $master_port
                 $slave2 slaveof $master_host $master_port
@@ -1567,7 +1567,7 @@ start_server {tags {"repl external:skip"}} {
         set primary_host [srv 0 host]
         set primary_port [srv 0 port]
         $primary set primary_key primary_value
-        $primary config set fullsync-aof no
+        $primary config set repl-fullsync-format RDB
 
         test {Replica keep the old data if RDB file save fails in disk-based replication} {
             # Create a folder called 'dump.rdb' to trigger temp-rdb rename failure

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -33,7 +33,7 @@ start_server {tags {"repl network external:skip"}} {
 
         test {Slave enters wait_bgsave} {
             wait_for_condition 50 1000 {
-                [string match *state=wait_bgsave* [$master info replication]]
+                [string match *state=wait_bg* [$master info replication]]
             } else {
                 fail "Replica does not enter wait_bgsave state"
             }
@@ -912,7 +912,7 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                     # it's enough for just one replica to be slow, and have it's write handler enabled
                     # so that the whole rdb generation process is bound to that
                     set loglines [count_log_lines -2]
-                    [lindex $replicas 0] config set repl-diskless-load swapdb
+                    [lindex $replicas 0] config set repl-diskless-load flush-before-load
                     [lindex $replicas 0] config set key-load-delay 100 ;# 20k keys and 100 microseconds sleep means at least 2 seconds
                     [lindex $replicas 0] replicaof $master_host $master_port
                     [lindex $replicas 1] replicaof $master_host $master_port
@@ -952,7 +952,7 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
 
                     # wait for rdb child to exit
                     wait_for_condition 500 100 {
-                        [s -2 rdb_bgsave_in_progress] == 0
+                        (([s -2 rdb_bgsave_in_progress] == 0) && ([s -2 aof_rewrite_in_progress] == 0))
                     } else {
                         fail "rdb child didn't terminate"
                     }
@@ -1063,7 +1063,7 @@ test "diskless replication child being killed is collected" {
 
             # wait for the parent to notice the child have exited
             wait_for_condition 50 100 {
-                [s -1 rdb_bgsave_in_progress] == 0
+                (([s -1 rdb_bgsave_in_progress] == 0) && ([s -1 aof_rewrite_in_progress] == 0))
             } else {
                 fail "rdb child didn't terminate"
             }
@@ -1094,7 +1094,7 @@ foreach mdl {yes no} dualchannel {yes no} {
 
                 # wait for rdb child to start
                 wait_for_condition 5000 10 {
-                    [s -1 rdb_bgsave_in_progress] == 1
+                    (([s -1 rdb_bgsave_in_progress] == 1) || ([s -1 aof_rewrite_in_progress] == 1))
                 } else {
                     fail "rdb child didn't start"
                 }
@@ -1221,15 +1221,16 @@ test {Kill rdb child process if its dumping RDB is not useful} {
                 $master config set rdb-key-save-delay 1000000
                 $master config set repl-diskless-sync no
                 $master config set save ""
+                $master config set fullsync-aof no
 
                 $slave1 slaveof $master_host $master_port
                 $slave2 slaveof $master_host $master_port
 
                 # Wait for starting child
                 wait_for_condition 50 100 {
-                    ([s 0 rdb_bgsave_in_progress] == 1) &&
-                    ([string match "*wait_bgsave*" [s 0 slave0]]) &&
-                    ([string match "*wait_bgsave*" [s 0 slave1]])
+                    (([s 0 rdb_bgsave_in_progress] == 1) || ([s 0 aof_rewrite_in_progress] == 1)) &&
+                    ([string match "*wait_bg*" [s 0 slave0]]) &&
+                    ([string match "*wait_bg*" [s 0 slave1]])
                 } else {
                     fail "rdb child didn't start"
                 }
@@ -1238,13 +1239,13 @@ test {Kill rdb child process if its dumping RDB is not useful} {
                 $slave1 slaveof no one
                 # Shouldn't kill child since another slave wait for rdb
                 after 100
-                assert {[s 0 rdb_bgsave_in_progress] == 1}
+                assert {(([s 0 rdb_bgsave_in_progress] == 1) || ([s 0 aof_rewrite_in_progress] == 1))}
 
                 # Slave2 disconnect with master
                 $slave2 slaveof no one
                 # Should kill child
                 wait_for_condition 100 10 {
-                    [s 0 rdb_bgsave_in_progress] eq 0
+                    (([s 0 rdb_bgsave_in_progress] eq 0) && ([s 0 aof_rewrite_in_progress] eq 0))
                 } else {
                     fail "can't kill rdb child"
                 }
@@ -1254,16 +1255,16 @@ test {Kill rdb child process if its dumping RDB is not useful} {
                 $slave1 slaveof $master_host $master_port
                 $slave2 slaveof $master_host $master_port
                 wait_for_condition 50 100 {
-                    ([s 0 rdb_bgsave_in_progress] == 1) &&
-                    ([string match "*wait_bgsave*" [s 0 slave0]]) &&
-                    ([string match "*wait_bgsave*" [s 0 slave1]])
+                    (([s 0 rdb_bgsave_in_progress] == 1) || ([s 0 aof_rewrite_in_progress] == 1)) &&
+                    ([string match "*wait_bg*" [s 0 slave0]]) &&
+                    ([string match "*wait_bg*" [s 0 slave1]])
                 } else {
                     fail "rdb child didn't start"
                 }
                 $slave1 slaveof no one
                 $slave2 slaveof no one
                 after 200
-                assert {[s 0 rdb_bgsave_in_progress] == 1}
+                assert {(([s 0 rdb_bgsave_in_progress] == 1) || ([s 0 aof_rewrite_in_progress] == 1))}
                 catch {$master shutdown nosave}
             }
         }
@@ -1306,8 +1307,8 @@ foreach dualchannel {yes no} {
                     # Full sync with master2, and then kill master2 before finishing dumping RDB
                     r slaveof $master2_host $master2_port
                     wait_for_condition 50 100 {
-                        ([s -2 rdb_bgsave_in_progress] == 1) &&
-                        ([string match "*wait_bgsave*" [s -2 slave0]])
+                        (([s -2 rdb_bgsave_in_progress] == 1) || ([s -2 aof_rewrite_in_progress] == 1)) &&
+                        ([string match "*wait_bg*" [s -2 slave0]])
                     } else {
                         fail "full sync didn't start"
                     }
@@ -1566,6 +1567,7 @@ start_server {tags {"repl external:skip"}} {
         set primary_host [srv 0 host]
         set primary_port [srv 0 port]
         $primary set primary_key primary_value
+        $primary config set fullsync-aof no
 
         test {Replica keep the old data if RDB file save fails in disk-based replication} {
             # Create a folder called 'dump.rdb' to trigger temp-rdb rename failure

--- a/tests/integration/skip-rdb-checksum.tcl
+++ b/tests/integration/skip-rdb-checksum.tcl
@@ -31,7 +31,7 @@ start_server {tags {"repl tls cluster:skip external:skip"} overrides {save {}}} 
     set primary_host [srv 0 host]
     set primary_port [srv 0 port]
     set primary_skipped_rdb_checksum_counter 0
-    $primary config set fullsync-aof no
+    $primary config set repl-fullsync-format RDB
     if {$::tls} {
         foreach primary_diskless_sync {no yes} {
             foreach replica_diskless_load {disabled on-empty-db swapdb flush-before-load} {

--- a/tests/integration/skip-rdb-checksum.tcl
+++ b/tests/integration/skip-rdb-checksum.tcl
@@ -31,6 +31,7 @@ start_server {tags {"repl tls cluster:skip external:skip"} overrides {save {}}} 
     set primary_host [srv 0 host]
     set primary_port [srv 0 port]
     set primary_skipped_rdb_checksum_counter 0
+    $primary config set fullsync-aof no
     if {$::tls} {
         foreach primary_diskless_sync {no yes} {
             foreach replica_diskless_load {disabled on-empty-db swapdb flush-before-load} {

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -105,6 +105,12 @@ proc test_migrated_replica {type} {
         # Make sure the key exists and is consistent.
         R 3 readonly
         R 7 readonly
+        wait_for_condition 50 1000 {
+            [getInfoProperty [R 3 info replication] master_link_status] eq "up" &&
+                [getInfoProperty [R 7 info replication] master_link_status] eq "up"
+        } else {
+            fail "Replica 1 is not synced"
+        }
         wait_for_condition 1000 50 {
             [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
             [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
@@ -200,6 +206,11 @@ proc test_nonempty_replica {type} {
 
         # Make sure the key exists and is consistent.
         R 7 readonly
+        wait_for_condition 50 1000 {
+            [getInfoProperty [R 7 info replication] master_link_status] eq "up"
+        } else {
+            fail "Replica 1 is not synced"
+        }
         wait_for_condition 1000 50 {
             [R 4 get key_991803] == 1024 &&
             [R 7 get key_991803] == 1024
@@ -324,6 +335,12 @@ proc test_sub_replica {type} {
         # Make sure the key exists and is consistent.
         R 3 readonly
         R 7 readonly
+        wait_for_condition 50 1000 {
+            [getInfoProperty [R 3 info replication] master_link_status] eq "up" &&
+                [getInfoProperty [R 7 info replication] master_link_status] eq "up"
+        } else {
+            fail "Replica 1 is not synced"
+        }
         wait_for_condition 1000 50 {
             [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
             [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&


### PR DESCRIPTION
This PR implements [Allow using AOF (the collection of commands) instead of RDB for full synchronization](https://github.com/valkey-io/valkey/issues/59). 

Add an alternative full-sync payload format: AOF command stream (pure command collection, no RDB preamble). Migration tools can request this format via `REPLCONF capa fullsync-aof`, so they can forward commands directly without parsing RDB, avoiding frequent breakages caused by RDB version/encoding changes.

It is currently compatible with diskless load (except `swapdb`) and dual-channel replication.

Happy to iterate based on feedback and extend coverage where needed.