### PR TITLE
implement replica-announce-name

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2438,6 +2438,15 @@ static int isValidAnnouncedHostname(char *val, const char **err) {
     return 1;
 }
 
+static int isValidReplicaAnnounceName(char *val, const char **err) {
+    if (val[0] == '\0') return 1;
+    if (validateClientAttr(val) == C_ERR) {
+        *err = "replica-announce-name contains invalid characters";
+        return 0;
+    }
+    return 1;
+}
+
 static int isValidIpV4(char *val, const char **err) {
     struct sockaddr_in sa;
     if (val[0] != '\0' && inet_pton(AF_INET, val, &(sa.sin_addr)) == 0) {
@@ -3259,6 +3268,7 @@ standardConfig static_configs[] = {
     createStringConfig("unixsocketgroup", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.unix_ctx_config.group, NULL, NULL, NULL),
     createStringConfig("pidfile", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.pidfile, NULL, NULL, NULL),
     createStringConfig("replica-announce-ip", "slave-announce-ip", MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.replica_announce_ip, NULL, NULL, NULL),
+    createStringConfig("replica-announce-name", "slave-announce-name", MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.replica_announce_name, NULL, isValidReplicaAnnounceName, NULL),
     createStringConfig("primaryuser", "masteruser", MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.primary_user, NULL, NULL, NULL),
     createStringConfig("cluster-announce-ip", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_ip, NULL, NULL, updateClusterIp),
     createStringConfig("cluster-announce-client-ipv4", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_client_ipv4, NULL, isValidIpV4, updateClusterClientIpV4),

--- a/src/replication.c
+++ b/src/replication.c
@@ -1356,6 +1356,9 @@ void freeClientReplicationData(client *c) {
  * the primary can accurately lists replicas and their listening ports in the
  * INFO output.
  *
+ * - client-name <name>
+ * Sets the client name for this replica connection (shown in CLIENT LIST).
+ *
  * - capa <eof|psync2|dual-channel|skip-rdb-checksum>
  * What is the capabilities of this instance.
  * eof: supports EOF-style RDB transfer for diskless replication.
@@ -1424,6 +1427,12 @@ void replconfCommand(client *c) {
                                     "REPLCONF ip-address provided by "
                                     "replica instance is too long: %zd bytes",
                                     sdslen(addr));
+                return;
+            }
+        } else if (!strcasecmp(objectGetVal(c->argv[j]), "client-name")) {
+            const char *err = NULL;
+            if (clientSetName(c, c->argv[j + 1], &err) == C_ERR) {
+                addReplyError(c, err);
                 return;
             }
         } else if (!strcasecmp(objectGetVal(c->argv[j]), "capa")) {
@@ -3024,8 +3033,13 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     }
     /* Send replica listening port to primary for clarification */
     sds portstr = getReplicaPortString();
-    *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1", "rdb-channel", "1", "listening-port", portstr,
-                       NULL);
+    if (server.replica_announce_name) {
+        *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1", "rdb-channel", "1", "listening-port",
+                           portstr, "client-name", server.replica_announce_name, NULL);
+    } else {
+        *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1", "rdb-channel", "1", "listening-port",
+                           portstr, NULL);
+    }
     sdsfree(portstr);
     if (*err) {
         dualChannelServerLog(LL_WARNING, "Sending command to primary in dual channel replication handshake: %s", *err);
@@ -3771,7 +3785,12 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
      * replica listening port correctly. */
     {
         sds portstr = getReplicaPortString();
-        err = sendCommand(conn, "REPLCONF", "listening-port", portstr, NULL);
+        if (server.replica_announce_name) {
+            err = sendCommand(conn, "REPLCONF", "listening-port", portstr, "client-name", server.replica_announce_name,
+                              NULL);
+        } else {
+            err = sendCommand(conn, "REPLCONF", "listening-port", portstr, NULL);
+        }
         sdsfree(portstr);
         if (err) goto err;
     }

--- a/src/replication.c
+++ b/src/replication.c
@@ -3033,13 +3033,8 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     }
     /* Send replica listening port to primary for clarification */
     sds portstr = getReplicaPortString();
-    if (server.replica_announce_name) {
-        *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1", "rdb-channel", "1", "listening-port",
-                           portstr, "client-name", server.replica_announce_name, NULL);
-    } else {
-        *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1", "rdb-channel", "1", "listening-port",
-                           portstr, NULL);
-    }
+    *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1", "rdb-channel", "1", "listening-port",
+                       portstr, NULL);
     sdsfree(portstr);
     if (*err) {
         dualChannelServerLog(LL_WARNING, "Sending command to primary in dual channel replication handshake: %s", *err);
@@ -3785,12 +3780,7 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
      * replica listening port correctly. */
     {
         sds portstr = getReplicaPortString();
-        if (server.replica_announce_name) {
-            err = sendCommand(conn, "REPLCONF", "listening-port", portstr, "client-name", server.replica_announce_name,
-                              NULL);
-        } else {
-            err = sendCommand(conn, "REPLCONF", "listening-port", portstr, NULL);
-        }
+        err = sendCommand(conn, "REPLCONF", "listening-port", portstr, NULL);
         sdsfree(portstr);
         if (err) goto err;
     }
@@ -3851,6 +3841,13 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
         if (err) goto err;
     }
 
+    /* Set the replica client name on the primary if requested.
+     * Keep this as the last REPLCONF in the main handshake for compatibility. */
+    if (server.replica_announce_name) {
+        err = sendCommand(conn, "REPLCONF", "client-name", server.replica_announce_name, NULL);
+        if (err) goto err;
+    }
+
     return C_OK;
 
 err:
@@ -3885,6 +3882,22 @@ int syncWithPrimaryHandleReceivePortReplyState(connection *conn) {
                   err);
     }
     sdsfree(err);
+    return C_OK;
+}
+
+int syncWithPrimaryHandleReceiveNameReplyState(connection *conn) {
+    if (server.replica_announce_name) {
+        sds err = receiveSynchronousResponse(conn);
+        if (err == NULL) return C_ERR;
+        /* Ignore the error if any, older primaries do not support this option. */
+        if (err[0] == '-') {
+            serverLog(LL_NOTICE,
+                      "(Non critical) Primary does not understand "
+                      "REPLCONF client-name: %s",
+                      err);
+        }
+        sdsfree(err);
+    }
     return C_OK;
 }
 
@@ -4134,13 +4147,29 @@ void syncWithPrimary(connection *conn) {
         if (server.cluster_enabled) {
             server.repl_state = REPL_STATE_RECEIVE_NODEID_REPLY;
             return;
-        } else {
-            server.repl_state = REPL_STATE_SEND_PSYNC;
-            goto case_send_psync;
         }
+        if (server.replica_announce_name) {
+            server.repl_state = REPL_STATE_RECEIVE_NAME_REPLY;
+            return;
+        }
+
+        server.repl_state = REPL_STATE_SEND_PSYNC;
+        goto case_send_psync;
     /* Receive REPLCONF SET-CLUSTER-NODE-ID reply. */
     case REPL_STATE_RECEIVE_NODEID_REPLY:
         if (syncWithPrimaryHandleReceiveNodeIDReplyState(conn) == C_ERR) {
+            syncWithPrimaryHandleError(&conn);
+            return;
+        }
+        if (server.replica_announce_name) {
+            server.repl_state = REPL_STATE_RECEIVE_NAME_REPLY;
+            return;
+        }
+        server.repl_state = REPL_STATE_SEND_PSYNC;
+        /* fall through */
+    /* Receive REPLCONF client-name reply. */
+    case REPL_STATE_RECEIVE_NAME_REPLY:
+        if (syncWithPrimaryHandleReceiveNameReplyState(conn) == C_ERR) {
             syncWithPrimaryHandleError(&conn);
             return;
         }

--- a/src/server.h
+++ b/src/server.h
@@ -2174,6 +2174,7 @@ struct valkeyServer {
     int replica_announced;               /* If true, replica is announced by Sentinel */
     int replica_announce_port;           /* Give the primary this listening port. */
     char *replica_announce_ip;           /* Give the primary this ip address. */
+    char *replica_announce_name;         /* Give the primary this client name. */
     int propagation_error_behavior;      /* Configures the behavior of the replica
                                           * when it receives an error on the replication stream */
     int repl_ignore_disk_write_error;    /* Configures whether replicas panic when unable to
@@ -2945,6 +2946,7 @@ int isClientConnIpV6(client *c);
 sds catClientInfoString(sds s, client *client, int hide_user_data);
 sds catClientInfoShortString(sds s, client *client, int hide_user_data);
 sds getAllClientsInfoString(int type, int hide_user_data);
+int validateClientAttr(const char *val);
 int clientSetName(client *c, robj *name, const char **err);
 void rewriteClientCommandVector(client *c, int argc, ...);
 void rewriteClientCommandArgument(client *c, int i, robj *newval);

--- a/src/server.h
+++ b/src/server.h
@@ -432,6 +432,7 @@ typedef enum {
     REPL_STATE_RECEIVE_CAPA_REPLY,    /* Wait for REPLCONF reply */
     REPL_STATE_RECEIVE_VERSION_REPLY, /* Wait for REPLCONF reply */
     REPL_STATE_RECEIVE_NODEID_REPLY,  /* Wait for REPLCONF reply */
+    REPL_STATE_RECEIVE_NAME_REPLY,    /* Wait for REPLCONF reply */
     REPL_STATE_SEND_PSYNC,            /* Send PSYNC */
     REPL_STATE_RECEIVE_PSYNC_REPLY,   /* Wait for PSYNC reply */
     /* --- End of handshake states --- */

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -222,6 +222,39 @@ start_server {tags {"repl external:skip"}} {
 }
 
 start_server {tags {"repl external:skip"}} {
+    set replica [srv 0 client]
+    set replica_host [srv 0 host]
+    set replica_port [srv 0 port]
+    start_server {} {
+        set primary [srv 0 client]
+        set primary_host [srv 0 host]
+        set primary_port [srv 0 port]
+        set repl_name "replica-1"
+
+        test {Replica announces client name via REPLCONF} {
+            $replica config set replica-announce-name $repl_name
+            $replica replicaof $primary_host $primary_port
+            wait_for_condition 50 100 {
+                [lindex [$replica role] 0] eq {slave} &&
+                [string match {*master_link_status:up*} [$replica info replication]]
+            } else {
+                fail "Can't turn the instance into a replica"
+            }
+
+            wait_for_condition 50 100 {
+                [string match "*name=$repl_name*" [$primary client list type replica]]
+            } else {
+                set client_list [$primary client list type replica]
+                puts "CLIENT LIST (replica): $client_list"
+                fail "Replica client name not found in CLIENT LIST: $client_list"
+            }
+            set client_list [$primary client list type replica]
+            puts "CLIENT LIST (replica): $client_list"
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
     r set mykey foo
 
     start_server {} {


### PR DESCRIPTION
Implemented `replica-announce-name` to allow specifying and exposing replica names in `ClientList`

issue : #3158 