### PR TITLE
config: validate cluster-announce-ip input

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2438,6 +2438,18 @@ static int isValidAnnouncedHostname(char *val, const char **err) {
     return 1;
 }
 
+static int isValidClusterAnnounceIp(char *val, const char **err) {
+    struct sockaddr_in sa4;
+    struct sockaddr_in6 sa6;
+
+    if (val[0] == '\0') return 1;
+    if (inet_pton(AF_INET, val, &(sa4.sin_addr)) == 1) return 1;
+    if (inet_pton(AF_INET6, val, &(sa6.sin6_addr)) == 1) return 1;
+
+    *err = "Invalid IP address";
+    return 0;
+}
+
 static int isValidIpV4(char *val, const char **err) {
     struct sockaddr_in sa;
     if (val[0] != '\0' && inet_pton(AF_INET, val, &(sa.sin_addr)) == 0) {
@@ -3261,7 +3273,7 @@ standardConfig static_configs[] = {
     createStringConfig("pidfile", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.pidfile, NULL, NULL, NULL),
     createStringConfig("replica-announce-ip", "slave-announce-ip", MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.replica_announce_ip, NULL, NULL, NULL),
     createStringConfig("primaryuser", "masteruser", MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.primary_user, NULL, NULL, NULL),
-    createStringConfig("cluster-announce-ip", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_ip, NULL, NULL, updateClusterIp),
+    createStringConfig("cluster-announce-ip", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_ip, NULL, isValidClusterAnnounceIp, updateClusterIp),
     createStringConfig("cluster-announce-client-ipv4", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_client_ipv4, NULL, isValidIpV4, updateClusterClientIpV4),
     createStringConfig("cluster-announce-client-ipv6", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_client_ipv6, NULL, isValidIpV6, updateClusterClientIpV6),
     createStringConfig("cluster-config-file", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.cluster_configfile, "nodes.conf", isValidClusterConfigFile, NULL),

--- a/tests/unit/cluster/announced-endpoints.tcl
+++ b/tests/unit/cluster/announced-endpoints.tcl
@@ -92,4 +92,17 @@ start_cluster 2 2 {tags {external:skip cluster}} {
             R 0 config set port $baseport
         }
     }
+
+    test "Test change cluster-announce-ip at runtime" {
+        assert_error "ERR CONFIG SET failed*" {
+            R 0 config set cluster-announce-ip 10.1.131.239:6380
+        }
+        assert_error "ERR CONFIG SET failed*" {
+            R 0 config set cluster-announce-ip NotIPv4NorIPv6
+        }
+        assert_equal OK [R 0 config set cluster-announce-ip 127.0.0.1]
+        assert_equal {cluster-announce-ip 127.0.0.1} [R 0 config get cluster-announce-ip]
+        assert_equal OK [R 0 config set cluster-announce-ip ""]
+        assert_equal {cluster-announce-ip {}} [R 0 config get cluster-announce-ip]
+    }
 }


### PR DESCRIPTION
## Summary
- add config validation for `cluster-announce-ip`
- reject invalid values such as `IP:PORT` or arbitrary non-IP strings
- add a cluster regression test for runtime `CONFIG SET cluster-announce-ip`

## Problem
`cluster-announce-ip` currently accepts unvalidated strings. This can lead to malformed cluster node addresses (e.g. duplicated port fragments) and broken gossip connectivity.

## What changed
- added `isValidClusterAnnounceIp()` in `src/config.c`
  - allows empty value
  - allows valid IPv4 and IPv6 addresses
  - rejects everything else with `Invalid IP address`
- wired this validator into `cluster-announce-ip` config definition
- extended `tests/unit/cluster/announced-endpoints.tcl` with runtime validation checks

## Validation
```sh
make -j$(sysctl -n hw.ncpu)
./runtest --single unit/cluster/announced-endpoints
```

Fixes #3199
