### PR TITLE
ci: add top-level permissions to remaining workflows

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,6 +16,9 @@ concurrency:
   group: clang-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   clang-format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -18,6 +18,9 @@ concurrency:
   group: codecov-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   code-coverage:
     runs-on: ubuntu-22.04

--- a/.github/workflows/trigger-build-release.yml
+++ b/.github/workflows/trigger-build-release.yml
@@ -16,6 +16,9 @@ on:
           - dev
           - prod
 
+permissions:
+  contents: read
+
 jobs:
   trigger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Add top-level workflow token permissions for the three workflows called out in #3264 that currently lack a top-level `permissions` block:

- `.github/workflows/clang-format.yml`
- `.github/workflows/codecov.yml`
- `.github/workflows/trigger-build-release.yml`

Each now explicitly sets:

```yaml
permissions:
  contents: read
```

## Why
This follows the repository's existing least-privilege pattern used in other workflows and addresses the missing top-level permission warnings from Scorecard token-permissions checks.

Fixes #3264