### PR TITLE
empty kvstore when it has empty allocated hashtables

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -619,7 +619,7 @@ long long emptyDbStructure(serverDb **dbarray, int dbnum, int async, void(callba
     }
 
     for (int j = startdb; j <= enddb; j++) {
-        if (dbarray[j] == NULL || kvstoreSize(dbarray[j]->keys) == 0) continue;
+        if (dbarray[j] == NULL || kvstoreNumAllocatedHashtables(dbarray[j]->keys) == 0) continue;
 
         removed += kvstoreSize(dbarray[j]->keys);
         if (async) {


### PR DESCRIPTION
Fix `emptyDbStructure()` to clean up empty allocated hashtables.

`emptyDbStructure()` skips databases where `kvstoreSize() == 0`, meaning it only processes databases that have keys. However, a kvstore can have allocated
hashtables with no keys in them — for example, when `kvstoreHashtableExpand()` or `kvstoreHashtableTryExpand()` are called, they invoke `createHashtableIfNeeded()`
which allocates the hashtable, but no key is necessarily added to it. These empty hashtables can only be freed via `freeHashtableIfNeeded()`, which is called
from `kvstoreEmpty()`, but `emptyDbStructure()` never reaches `kvstoreEmpty()` for these databases since it skips them.

One example where this can happen: RDB slot-info entries pre-expand per-slot hashtables before
keys are loaded. If all keys in a slot expired before the load, the hashtables remain allocated but empty.
Can be reproduce by: 
```
start_cluster 1 0 {tags {external:skip cluster}} {

    test {RDB load with expired keys leaves empty pre-expanded slot hashtable} {
        wait_for_cluster_state ok

        for {set j 0} {$j < 100} {incr j} {
            R 0 setex key:$j 1 val
        }

        assert_equal [R 0 dbsize] 100

        R 0 save

        # Wait for all TTLs to expire before restart
        after 1100

        restart_server 0 true false
        wait_for_cluster_state ok

        # All keys expired during load and were not added.
        assert_equal [R 0 dbsize] 0
    }
}
```