### PR TITLE
Fix RDMA + IO threads re-entrancy via connection postpone masks (9.0)

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -64,6 +64,9 @@ typedef enum {
 #define CONN_FLAG_WRITE_BARRIER (1 << 1)        /* Write barrier requested */
 #define CONN_FLAG_ALLOW_ACCEPT_OFFLOAD (1 << 2) /* Connection accept can be offloaded to IO threads. */
 
+#define CONN_POSTPONE_READ (1 << 0)
+#define CONN_POSTPONE_WRITE (1 << 1)
+
 typedef enum {
     CONN_TYPE_INVALID = -1,
     CONN_TYPE_SOCKET,
@@ -140,7 +143,7 @@ typedef struct ConnectionType {
 
     /* Postpone update state - with IO threads & TLS we don't want the IO threads to update the event loop events - let
      * the main-thread do it */
-    void (*postpone_update_state)(struct connection *conn, int);
+    void (*postpone_update_state)(struct connection *conn, int postpone_mask);
     /* Called by the main-thread */
     void (*update_state)(struct connection *conn);
 
@@ -514,9 +517,9 @@ static inline void connUpdateState(connection *conn) {
     }
 }
 
-static inline void connSetPostponeUpdateState(connection *conn, int on) {
-    if (conn->type->postpone_update_state) {
-        conn->type->postpone_update_state(conn, on);
+static inline void connSetPostponeUpdateState(connection *conn, int postpone_mask) {
+    if (conn && conn->type && conn->type->postpone_update_state) {
+        conn->type->postpone_update_state(conn, postpone_mask);
     }
 }
 

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -373,8 +373,23 @@ void initIOThreads(void) {
 
 int trySendReadToIOThreads(client *c) {
     if (server.active_io_threads_num <= 1) return C_ERR;
-    /* If IO thread is already reading, return C_OK to make sure the main thread will not handle it. */
-    if (c->io_read_state != CLIENT_IDLE) return C_OK;
+    /* Fake/teardown clients may have no connection. */
+    if (!c->conn) return C_ERR;
+    /* Still reading on an IO thread: refresh postpone mask and leave it there. */
+    if (c->io_read_state == CLIENT_PENDING_IO) {
+        connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c));
+        return C_OK;
+    }
+    /* Completed read waits for processIOThreadsReadDone; refresh postpone mask. */
+    if (c->io_read_state == CLIENT_COMPLETED_IO) {
+        connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c));
+        return C_OK;
+    }
+    /* In-flight write: also postpone READ until processClientIOWriteDone. */
+    if (c->io_write_state != CLIENT_IDLE) {
+        connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c) | CONN_POSTPONE_READ);
+        return C_OK;
+    }
     /* For simplicity, don't offload replica clients reads as read traffic from replica is negligible */
     if (getClientType(c) == CLIENT_TYPE_REPLICA) return C_ERR;
     /* With Lua debug client we may call connWrite directly in the main thread */
@@ -402,7 +417,7 @@ int trySendReadToIOThreads(client *c) {
     c->read_flags |= isReplicatedClient(c) ? READ_FLAGS_REPLICATED : 0;
 
     c->io_read_state = CLIENT_PENDING_IO;
-    connSetPostponeUpdateState(c->conn, 1);
+    connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c));
     IOJobQueue_push(jq, ioThreadReadQueryFromClient, c);
     c->flag.pending_read = 1;
     listLinkNodeTail(server.clients_pending_io_read, &c->pending_read_list_node);
@@ -414,8 +429,11 @@ int trySendReadToIOThreads(client *c) {
  * or C_ERR if the client is not eligible for offloading. */
 int trySendWriteToIOThreads(client *c) {
     if (server.active_io_threads_num <= 1) return C_ERR;
+    if (!c->conn) return C_ERR;
     /* The I/O thread is already writing for this client. */
     if (c->io_write_state != CLIENT_IDLE) return C_OK;
+    /* Serialize with an in-flight read (PENDING or COMPLETED). */
+    if (c->io_read_state != CLIENT_IDLE) return C_ERR;
     /* Nothing to write */
     if (!clientHasPendingReplies(c)) return C_ERR;
     /* For simplicity, avoid offloading non-online replicas */
@@ -472,9 +490,9 @@ int trySendWriteToIOThreads(client *c) {
     serverAssert(c->bufpos > 0 || c->io_last_bufpos > 0 || is_replica);
 
     /* The main-thread will update the client state after the I/O thread completes the write. */
-    connSetPostponeUpdateState(c->conn, 1);
     c->write_flags = is_replica ? WRITE_FLAGS_IS_REPLICA : 0;
     c->io_write_state = CLIENT_PENDING_IO;
+    connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c));
 
     IOJobQueue_push(jq, ioThreadWriteToClient, c);
     return C_OK;
@@ -676,7 +694,7 @@ int trySendAcceptToIOThreads(connection *conn) {
     c->io_read_state = CLIENT_PENDING_IO;
     c->flag.pending_read = 1;
     listLinkNodeTail(server.clients_pending_io_read, &c->pending_read_list_node);
-    connSetPostponeUpdateState(c->conn, 1);
+    connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c));
     server.stat_io_accept_offloaded++;
     IOJobQueue_push(job_queue, ioThreadAccept, c);
 

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -385,9 +385,8 @@ int trySendReadToIOThreads(client *c) {
         connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c));
         return C_OK;
     }
-    /* Serialize READ across an in-flight write only if postpone is honored
-     * (TLS/RDMA). TCP has no postpone_update_state — return C_ERR so the main
-     * thread can still read (e.g. replica ACK). */
+    /* In-flight write: postpone READ on TLS/RDMA. On TCP let the main thread
+     * decide in readQueryFromClient (replicas only). */
     if (c->io_write_state != CLIENT_IDLE) {
         if (c->conn->type && c->conn->type->postpone_update_state) {
             connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c) | CONN_POSTPONE_READ);

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -385,10 +385,15 @@ int trySendReadToIOThreads(client *c) {
         connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c));
         return C_OK;
     }
-    /* In-flight write: also postpone READ until processClientIOWriteDone. */
+    /* Serialize READ across an in-flight write only if postpone is honored
+     * (TLS/RDMA). TCP has no postpone_update_state — return C_ERR so the main
+     * thread can still read (e.g. replica ACK). */
     if (c->io_write_state != CLIENT_IDLE) {
-        connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c) | CONN_POSTPONE_READ);
-        return C_OK;
+        if (c->conn->type && c->conn->type->postpone_update_state) {
+            connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c) | CONN_POSTPONE_READ);
+            return C_OK;
+        }
+        return C_ERR;
     }
     /* For simplicity, don't offload replica clients reads as read traffic from replica is negligible */
     if (getClientType(c) == CLIENT_TYPE_REPLICA) return C_ERR;

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -441,10 +441,8 @@ int trySendWriteToIOThreads(client *c) {
     if (c->io_read_state != CLIENT_IDLE) return C_ERR;
     /* Nothing to write */
     if (!clientHasPendingReplies(c)) return C_ERR;
-    /* Online replicas only; skip write offload while WAIT/WAITAOF need ACKs. */
-    if (getClientType(c) == CLIENT_TYPE_REPLICA &&
-        (c->repl_data->repl_state != REPLICA_STATE_ONLINE || listLength(server.clients_waiting_acks)))
-        return C_ERR;
+    /* For simplicity, avoid offloading non-online replicas */
+    if (getClientType(c) == CLIENT_TYPE_REPLICA && c->repl_data->repl_state != REPLICA_STATE_ONLINE) return C_ERR;
     /* We can't offload debugged clients as the main-thread may read at the same time  */
     if (c->flag.lua_debug) return C_ERR;
 

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -441,8 +441,10 @@ int trySendWriteToIOThreads(client *c) {
     if (c->io_read_state != CLIENT_IDLE) return C_ERR;
     /* Nothing to write */
     if (!clientHasPendingReplies(c)) return C_ERR;
-    /* For simplicity, avoid offloading non-online replicas */
-    if (getClientType(c) == CLIENT_TYPE_REPLICA && c->repl_data->repl_state != REPLICA_STATE_ONLINE) return C_ERR;
+    /* Online replicas only; skip write offload while WAIT/WAITAOF need ACKs. */
+    if (getClientType(c) == CLIENT_TYPE_REPLICA &&
+        (c->repl_data->repl_state != REPLICA_STATE_ONLINE || listLength(server.clients_waiting_acks)))
+        return C_ERR;
     /* We can't offload debugged clients as the main-thread may read at the same time  */
     if (c->flag.lua_debug) return C_ERR;
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -3288,6 +3288,13 @@ int processClientIOWriteDone(client *c, int allow_async_writes) {
     c = lookupClientByID(id);
     if (!c || !c->conn) return 1;
 
+    /* Replica ACK may have arrived while an IO-thread write was in flight. */
+    if (c->flag.replica) {
+        readQueryFromClient(c->conn);
+        c = lookupClientByID(id);
+        if (!c || !c->conn) return 1;
+    }
+
     if (clientHasPendingReplies(c)) {
         if (c->write_flags & WRITE_FLAGS_WRITE_ERROR) {
             /* Install the write handler if there are pending writes in some of the clients as a result of not being
@@ -4355,7 +4362,10 @@ void readQueryFromClient(connection *conn) {
     /* Check if we can send the client to be handled by the IO-thread */
     if (postponeClientRead(c)) return;
 
-    if (c->io_write_state != CLIENT_IDLE || c->io_read_state != CLIENT_IDLE) return;
+    /* Don't race an in-flight IO-thread read. */
+    if (c->io_read_state != CLIENT_IDLE) return;
+    /* TLS/RDMA must serialize with IO-thread write; TCP is full-duplex. */
+    if (c->io_write_state != CLIENT_IDLE && conn->type && conn->type->postpone_update_state) return;
 
     bool repeat = false;
     int iter = 0;

--- a/src/networking.c
+++ b/src/networking.c
@@ -3274,11 +3274,19 @@ int processClientIOWriteDone(client *c, int allow_async_writes) {
     /* Update processed count on server */
     server.stat_io_writes_processed += 1;
 
-    connSetPostponeUpdateState(c->conn, 0);
-    connUpdateState(c->conn);
+    int mask = 0;
+    if (c->io_read_state == CLIENT_PENDING_IO || c->io_read_state == CLIENT_COMPLETED_IO)
+        mask |= CONN_POSTPONE_READ;
+
+    connSetPostponeUpdateState(c->conn, mask);
     if (postWriteToClient(c) == C_ERR) {
         return 1;
     }
+    uint64_t id = c->id;
+    connUpdateState(c->conn);
+
+    c = lookupClientByID(id);
+    if (!c || !c->conn) return 1;
 
     if (clientHasPendingReplies(c)) {
         if (c->write_flags & WRITE_FLAGS_WRITE_ERROR) {
@@ -3312,8 +3320,8 @@ int processIOThreadsWriteDone(void) {
         next = listNextNode(ln);
         client *c = listNodeValue(ln);
 
-        /* Client is still waiting for a pending I/O - skip it */
-        if (c->io_write_state == CLIENT_PENDING_IO || c->io_read_state == CLIENT_PENDING_IO) continue;
+        /* Skip only while the write job is still running. */
+        if (c->io_write_state == CLIENT_PENDING_IO) continue;
 
         processed += processClientIOWriteDone(c, 1);
     }
@@ -3992,6 +4000,10 @@ void parseInputBuffer(client *c) {
     /* The command queue must be emptied before parsing. */
     serverAssert(c->cmd_queue.len == 0);
 
+    /* Postpone READ while parsing so update_state cannot re-enter. */
+    connection *conn = c->conn;
+    if (conn) connSetPostponeUpdateState(conn, clientConnPostponeMaskFromIOState(c) | CONN_POSTPONE_READ);
+
     /* Determine request type when unknown. */
     if (!c->reqtype) {
         if (c->querybuf[c->qb_pos] == '*') {
@@ -4008,6 +4020,9 @@ void parseInputBuffer(client *c) {
     } else {
         serverPanic("Unknown request type");
     }
+
+    /* Restore IO-state postpone; cmd_queue is drained by processInputBuffer. */
+    if (conn) connSetPostponeUpdateState(conn, clientConnPostponeMaskFromIOState(c));
 }
 
 /* Free unused memory in a client's queue of parsed commands. */
@@ -6518,6 +6533,11 @@ int processIOThreadsReadDone(void) {
     int processed = 0;
     listNode *ln;
 
+    /* Ids needing a second connUpdateState after the command batch. Sized to the
+     * current pending list; may grow if clients are re-queued mid-loop. */
+    size_t followup_n = 0, followup_cap = listLength(server.clients_pending_io_read);
+    uint64_t *followup_ids = zmalloc(followup_cap * sizeof(uint64_t));
+
     listNode *next = listFirst(server.clients_pending_io_read);
     while (next) {
         ln = next;
@@ -6550,11 +6570,30 @@ int processIOThreadsReadDone(void) {
 
         /* Save the current conn state, as connUpdateState may modify it */
         int in_accept_state = (connGetState(c->conn) == CONN_STATE_ACCEPTING);
-        connSetPostponeUpdateState(c->conn, 0);
-        connUpdateState(c->conn);
+        int needs_post_read_update = 0;
+
+        /* Keep READ postponed through command batching. */
+        if (c->conn) {
+            int mask = 0;
+            if (!in_accept_state) {
+                mask |= CONN_POSTPONE_READ;
+                if (c->io_write_state != CLIENT_IDLE) mask |= CONN_POSTPONE_WRITE;
+                needs_post_read_update = 1;
+            }
+            connSetPostponeUpdateState(c->conn, mask);
+            connUpdateState(c->conn);
+        }
 
         /* In accept state, no client's data was read - stop here. */
         if (in_accept_state) continue;
+
+        if (needs_post_read_update) {
+            if (followup_n == followup_cap) {
+                followup_cap *= 2;
+                followup_ids = zrealloc(followup_ids, followup_cap * sizeof(uint64_t));
+            }
+            followup_ids[followup_n++] = c->id;
+        }
 
         /* On read error - stop here. */
         if (handleReadResult(c) == C_ERR) {
@@ -6590,6 +6629,20 @@ int processIOThreadsReadDone(void) {
     }
 
     processClientsCommandsBatch();
+
+    /* Apply final postpone mask after draining input and cmd_queue. */
+    for (size_t i = 0; i < followup_n; i++) {
+        client *c = lookupClientByID(followup_ids[i]);
+        if (!c || !c->conn) continue;
+
+        if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
+
+        c = lookupClientByID(followup_ids[i]);
+        if (!c || !c->conn) continue;
+        connSetPostponeUpdateState(c->conn, clientConnPostponeMask(c));
+        connUpdateState(c->conn);
+    }
+    zfree(followup_ids);
 
     return processed;
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -6542,6 +6542,8 @@ int postponeClientRead(client *c) {
     return (trySendReadToIOThreads(c) == C_OK);
 }
 
+#define IO_READ_DONE_BATCH 16
+
 int processIOThreadsReadDone(void) {
     if (ProcessingEventsWhileBlocked) {
         /* When ProcessingEventsWhileBlocked we may call processIOThreadsReadDone recursively.
@@ -6551,121 +6553,118 @@ int processIOThreadsReadDone(void) {
 
     if (listLength(server.clients_pending_io_read) == 0) return 0;
     int processed = 0;
-    listNode *ln;
 
-    /* Ids needing a second connUpdateState after the command batch. Sized to the
-     * current pending list; may grow if clients are re-queued mid-loop. */
-    size_t followup_n = 0, followup_cap = listLength(server.clients_pending_io_read);
-    uint64_t *followup_ids = zmalloc(followup_cap * sizeof(uint64_t));
+    while (1) {
+        uint64_t followup_ids[IO_READ_DONE_BATCH];
+        size_t followup_n = 0;
+        int batch_count = 0;
+        listNode *ln;
+        listNode *next = listFirst(server.clients_pending_io_read);
 
-    listNode *next = listFirst(server.clients_pending_io_read);
-    while (next) {
-        ln = next;
-        next = listNextNode(ln);
-        client *c = listNodeValue(ln);
+        while (next && batch_count < IO_READ_DONE_BATCH) {
+            ln = next;
+            next = listNextNode(ln);
+            client *c = listNodeValue(ln);
 
-        /* Client is still waiting for a pending I/O - skip it */
-        if (c->io_write_state == CLIENT_PENDING_IO || c->io_read_state == CLIENT_PENDING_IO) continue;
-        /* If the write job is done, process it ASAP to free the buffer and handle connection errors */
-        if (c->io_write_state == CLIENT_COMPLETED_IO) {
-            int allow_async_writes = 0; /* Don't send writes for the client to IO threads before processing the reads */
-            processClientIOWriteDone(c, allow_async_writes);
-        }
-        /* memory barrier acquire to get the updated client state */
-        atomic_thread_fence(memory_order_acquire);
-
-        listUnlinkNode(server.clients_pending_io_read, ln);
-        c->flag.pending_read = 0;
-        c->io_read_state = CLIENT_IDLE;
-
-        /* Don't post-process-reads from clients that are going to be closed anyway. */
-        if (c->flag.close_asap) continue;
-
-        /* If a client is protected, don't do anything,
-         * that may trigger read/write error or recreate handler. */
-        if (c->flag.protected) continue;
-
-        processed++;
-        server.stat_io_reads_processed++;
-
-        /* Save the current conn state, as connUpdateState may modify it */
-        int in_accept_state = (connGetState(c->conn) == CONN_STATE_ACCEPTING);
-        int needs_post_read_update = 0;
-
-        /* Keep READ postponed through command batching. */
-        if (c->conn) {
-            int mask = 0;
-            if (!in_accept_state) {
-                mask |= CONN_POSTPONE_READ;
-                if (c->io_write_state != CLIENT_IDLE) mask |= CONN_POSTPONE_WRITE;
-                needs_post_read_update = 1;
+            /* Client is still waiting for a pending I/O - skip it */
+            if (c->io_write_state == CLIENT_PENDING_IO || c->io_read_state == CLIENT_PENDING_IO) continue;
+            /* If the write job is done, process it ASAP to free the buffer and handle connection errors */
+            if (c->io_write_state == CLIENT_COMPLETED_IO) {
+                int allow_async_writes = 0; /* Don't send writes for the client to IO threads before processing the reads */
+                processClientIOWriteDone(c, allow_async_writes);
             }
-            connSetPostponeUpdateState(c->conn, mask);
+            /* memory barrier acquire to get the updated client state */
+            atomic_thread_fence(memory_order_acquire);
+
+            listUnlinkNode(server.clients_pending_io_read, ln);
+            c->flag.pending_read = 0;
+            c->io_read_state = CLIENT_IDLE;
+            batch_count++;
+
+            /* Don't post-process-reads from clients that are going to be closed anyway. */
+            if (c->flag.close_asap) continue;
+
+            /* If a client is protected, don't do anything,
+             * that may trigger read/write error or recreate handler. */
+            if (c->flag.protected) continue;
+
+            processed++;
+            server.stat_io_reads_processed++;
+
+            /* Save the current conn state, as connUpdateState may modify it */
+            int in_accept_state = (connGetState(c->conn) == CONN_STATE_ACCEPTING);
+            int needs_post_read_update = 0;
+
+            /* Keep READ postponed through command batching. */
+            if (c->conn) {
+                int mask = 0;
+                if (!in_accept_state) {
+                    mask |= CONN_POSTPONE_READ;
+                    if (c->io_write_state != CLIENT_IDLE) mask |= CONN_POSTPONE_WRITE;
+                    needs_post_read_update = 1;
+                }
+                connSetPostponeUpdateState(c->conn, mask);
+                connUpdateState(c->conn);
+            }
+
+            /* In accept state, no client's data was read - stop here. */
+            if (in_accept_state) continue;
+
+            if (needs_post_read_update) followup_ids[followup_n++] = c->id;
+
+            /* On read error - stop here. */
+            if (handleReadResult(c) == C_ERR) {
+                continue;
+            }
+
+            if (!(c->read_flags & READ_FLAGS_DONT_PARSE)) {
+                parseResult res = handleParseResults(c);
+                /* On parse error - stop here. */
+                if (res == PARSE_ERR) {
+                    continue;
+                } else if (res == PARSE_NEEDMORE) {
+                    beforeNextClient(c);
+                    continue;
+                }
+            }
+
+            if (c->argc > 0) {
+                c->flag.pending_command = 1;
+            }
+
+            size_t list_length_before_command_execute = listLength(server.clients_pending_io_read);
+            /* try to add the command to the batch */
+            int ret = addCommandToBatchAndProcessIfFull(c);
+            /* If the command was not added to the commands batch, process it immediately */
+            if (ret == C_ERR) {
+                if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
+            }
+            if (list_length_before_command_execute != listLength(server.clients_pending_io_read)) {
+                /* A client was unlink from the list possibly making the next node invalid */
+                next = listFirst(server.clients_pending_io_read);
+            }
+        }
+
+        if (batch_count == 0) break; /* Empty, or only PENDING_IO left. */
+
+        processClientsCommandsBatch();
+
+        /* Apply final postpone mask after draining input and cmd_queue. */
+        for (size_t i = 0; i < followup_n; i++) {
+            client *c = lookupClientByID(followup_ids[i]);
+            if (!c || !c->conn) continue;
+
+            /* Skip blocked clients: pending_command is kept for retry after unblock. */
+            if (!c->flag.blocked && !c->flag.unblocked) {
+                if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
+            }
+
+            c = lookupClientByID(followup_ids[i]);
+            if (!c || !c->conn) continue;
+            connSetPostponeUpdateState(c->conn, clientConnPostponeMask(c));
             connUpdateState(c->conn);
         }
-
-        /* In accept state, no client's data was read - stop here. */
-        if (in_accept_state) continue;
-
-        if (needs_post_read_update) {
-            if (followup_n == followup_cap) {
-                followup_cap *= 2;
-                followup_ids = zrealloc(followup_ids, followup_cap * sizeof(uint64_t));
-            }
-            followup_ids[followup_n++] = c->id;
-        }
-
-        /* On read error - stop here. */
-        if (handleReadResult(c) == C_ERR) {
-            continue;
-        }
-
-        if (!(c->read_flags & READ_FLAGS_DONT_PARSE)) {
-            parseResult res = handleParseResults(c);
-            /* On parse error - stop here. */
-            if (res == PARSE_ERR) {
-                continue;
-            } else if (res == PARSE_NEEDMORE) {
-                beforeNextClient(c);
-                continue;
-            }
-        }
-
-        if (c->argc > 0) {
-            c->flag.pending_command = 1;
-        }
-
-        size_t list_length_before_command_execute = listLength(server.clients_pending_io_read);
-        /* try to add the command to the batch */
-        int ret = addCommandToBatchAndProcessIfFull(c);
-        /* If the command was not added to the commands batch, process it immediately */
-        if (ret == C_ERR) {
-            if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
-        }
-        if (list_length_before_command_execute != listLength(server.clients_pending_io_read)) {
-            /* A client was unlink from the list possibly making the next node invalid */
-            next = listFirst(server.clients_pending_io_read);
-        }
     }
-
-    processClientsCommandsBatch();
-
-    /* Apply final postpone mask after draining input and cmd_queue. */
-    for (size_t i = 0; i < followup_n; i++) {
-        client *c = lookupClientByID(followup_ids[i]);
-        if (!c || !c->conn) continue;
-
-        /* Skip blocked clients: pending_command is kept for retry after unblock. */
-        if (!c->flag.blocked && !c->flag.unblocked) {
-            if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
-        }
-
-        c = lookupClientByID(followup_ids[i]);
-        if (!c || !c->conn) continue;
-        connSetPostponeUpdateState(c->conn, clientConnPostponeMask(c));
-        connUpdateState(c->conn);
-    }
-    zfree(followup_ids);
 
     return processed;
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -3981,6 +3981,10 @@ int processCommandAndResetClient(client *c) {
  * the client. Returns C_ERR if the client is no longer valid after executing
  * the command, and C_OK for all other cases. */
 int processPendingCommandAndInputBuffer(client *c) {
+    /* Blocked clients are resumed via processUnblockedClients(); skip them here
+     * to avoid re-entering processCommand() while pending_command is intentionally left set. */
+    if (c->flag.blocked) return C_OK;
+
     /* Notice, this code is also called from 'processUnblockedClients'.
      * But in case of a module blocked client (see RM_Call 'K' flag) we do not reach this code path.
      * So whenever we change the code here we need to consider if we need this change on module
@@ -6654,10 +6658,7 @@ int processIOThreadsReadDone(void) {
             client *c = lookupClientByID(followup_ids[i]);
             if (!c || !c->conn) continue;
 
-            /* Skip blocked clients: pending_command is kept for retry after unblock. */
-            if (!c->flag.blocked && !c->flag.unblocked) {
-                if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
-            }
+            if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
 
             c = lookupClientByID(followup_ids[i]);
             if (!c || !c->conn) continue;

--- a/src/networking.c
+++ b/src/networking.c
@@ -4372,8 +4372,10 @@ void readQueryFromClient(connection *conn) {
 
     /* Don't race an in-flight IO-thread read. */
     if (c->io_read_state != CLIENT_IDLE) return;
-    /* TLS/RDMA must serialize with IO-thread write; TCP is full-duplex. */
-    if (c->io_write_state != CLIENT_IDLE && conn->type && conn->type->postpone_update_state) return;
+    /* Serialize with IO write, except TCP replicas (need REPLCONF ACK). */
+    if (c->io_write_state != CLIENT_IDLE &&
+        (!c->flag.replica || (conn->type && conn->type->postpone_update_state)))
+        return;
 
     bool repeat = false;
     int iter = 0;

--- a/src/networking.c
+++ b/src/networking.c
@@ -6635,7 +6635,10 @@ int processIOThreadsReadDone(void) {
         client *c = lookupClientByID(followup_ids[i]);
         if (!c || !c->conn) continue;
 
-        if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
+        /* Skip blocked clients: pending_command is kept for retry after unblock. */
+        if (!c->flag.blocked && !c->flag.unblocked) {
+            if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
+        }
 
         c = lookupClientByID(followup_ids[i]);
         if (!c || !c->conn) continue;

--- a/src/networking.c
+++ b/src/networking.c
@@ -3354,8 +3354,7 @@ int handleClientsWithPendingWrites(void) {
     listRewind(server.clients_pending_write, &li);
     while ((ln = listNext(&li))) {
         client *c = listNodeValue(ln);
-        c->flag.pending_write = 0;
-        listUnlinkNode(server.clients_pending_write, ln);
+        serverAssert(c->flag.pending_write);
 
         /* If a client is protected, don't do anything,
          * that may trigger write error or recreate handler. */
@@ -3364,13 +3363,22 @@ int handleClientsWithPendingWrites(void) {
         /* Don't write to clients that are going to be closed anyway. */
         if (c->flag.close_asap) continue;
 
+        /* Stay queued while a read IO job owns this client. */
+        if (c->io_read_state == CLIENT_PENDING_IO) continue;
+
+        c->flag.pending_write = 0;
+        listUnlinkNode(server.clients_pending_write, ln);
+
         if (!clientHasPendingReplies(c)) continue;
 
         /* If we can send the client to the I/O thread, let it handle the write. */
         if (trySendWriteToIOThreads(c) == C_OK) continue;
 
-        /* We can't write to the client while IO operation is in progress. */
-        if (c->io_write_state != CLIENT_IDLE || c->io_read_state != CLIENT_IDLE) continue;
+        /* Can't write while IO is in progress; re-queue to avoid stranding replies. */
+        if (c->io_write_state != CLIENT_IDLE || c->io_read_state != CLIENT_IDLE) {
+            putClientInPendingWriteQueue(c);
+            continue;
+        }
 
         processed++;
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -6546,8 +6546,6 @@ int postponeClientRead(client *c) {
     return (trySendReadToIOThreads(c) == C_OK);
 }
 
-#define IO_READ_DONE_BATCH 16
-
 int processIOThreadsReadDone(void) {
     if (ProcessingEventsWhileBlocked) {
         /* When ProcessingEventsWhileBlocked we may call processIOThreadsReadDone recursively.
@@ -6557,115 +6555,120 @@ int processIOThreadsReadDone(void) {
 
     if (listLength(server.clients_pending_io_read) == 0) return 0;
     int processed = 0;
+    listNode *ln;
 
-    while (1) {
-        uint64_t followup_ids[IO_READ_DONE_BATCH];
-        size_t followup_n = 0;
-        int batch_count = 0;
-        listNode *ln;
-        listNode *next = listFirst(server.clients_pending_io_read);
+    /* Ids needing a second connUpdateState after the command batch. Sized to the
+     * current pending list; may grow if clients are re-queued mid-loop.
+     * Single-pass over the list keeps skipped PENDING_IO clients from being
+     * rescanned (avoids O(n^2) when many in-flight jobs sit at the head). */
+    size_t followup_n = 0, followup_cap = listLength(server.clients_pending_io_read);
+    uint64_t *followup_ids = zmalloc(followup_cap * sizeof(uint64_t));
 
-        while (next && batch_count < IO_READ_DONE_BATCH) {
-            ln = next;
-            next = listNextNode(ln);
-            client *c = listNodeValue(ln);
+    listNode *next = listFirst(server.clients_pending_io_read);
+    while (next) {
+        ln = next;
+        next = listNextNode(ln);
+        client *c = listNodeValue(ln);
 
-            /* Client is still waiting for a pending I/O - skip it */
-            if (c->io_write_state == CLIENT_PENDING_IO || c->io_read_state == CLIENT_PENDING_IO) continue;
-            /* If the write job is done, process it ASAP to free the buffer and handle connection errors */
-            if (c->io_write_state == CLIENT_COMPLETED_IO) {
-                int allow_async_writes = 0; /* Don't send writes for the client to IO threads before processing the reads */
-                processClientIOWriteDone(c, allow_async_writes);
-            }
-            /* memory barrier acquire to get the updated client state */
-            atomic_thread_fence(memory_order_acquire);
-
-            listUnlinkNode(server.clients_pending_io_read, ln);
-            c->flag.pending_read = 0;
-            c->io_read_state = CLIENT_IDLE;
-            batch_count++;
-
-            /* Don't post-process-reads from clients that are going to be closed anyway. */
-            if (c->flag.close_asap) continue;
-
-            /* If a client is protected, don't do anything,
-             * that may trigger read/write error or recreate handler. */
-            if (c->flag.protected) continue;
-
-            processed++;
-            server.stat_io_reads_processed++;
-
-            /* Save the current conn state, as connUpdateState may modify it */
-            int in_accept_state = (connGetState(c->conn) == CONN_STATE_ACCEPTING);
-            int needs_post_read_update = 0;
-
-            /* Keep READ postponed through command batching. */
-            if (c->conn) {
-                int mask = 0;
-                if (!in_accept_state) {
-                    mask |= CONN_POSTPONE_READ;
-                    if (c->io_write_state != CLIENT_IDLE) mask |= CONN_POSTPONE_WRITE;
-                    needs_post_read_update = 1;
-                }
-                connSetPostponeUpdateState(c->conn, mask);
-                connUpdateState(c->conn);
-            }
-
-            /* In accept state, no client's data was read - stop here. */
-            if (in_accept_state) continue;
-
-            if (needs_post_read_update) followup_ids[followup_n++] = c->id;
-
-            /* On read error - stop here. */
-            if (handleReadResult(c) == C_ERR) {
-                continue;
-            }
-
-            if (!(c->read_flags & READ_FLAGS_DONT_PARSE)) {
-                parseResult res = handleParseResults(c);
-                /* On parse error - stop here. */
-                if (res == PARSE_ERR) {
-                    continue;
-                } else if (res == PARSE_NEEDMORE) {
-                    beforeNextClient(c);
-                    continue;
-                }
-            }
-
-            if (c->argc > 0) {
-                c->flag.pending_command = 1;
-            }
-
-            size_t list_length_before_command_execute = listLength(server.clients_pending_io_read);
-            /* try to add the command to the batch */
-            int ret = addCommandToBatchAndProcessIfFull(c);
-            /* If the command was not added to the commands batch, process it immediately */
-            if (ret == C_ERR) {
-                if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
-            }
-            if (list_length_before_command_execute != listLength(server.clients_pending_io_read)) {
-                /* A client was unlink from the list possibly making the next node invalid */
-                next = listFirst(server.clients_pending_io_read);
-            }
+        /* Client is still waiting for a pending I/O - skip it */
+        if (c->io_write_state == CLIENT_PENDING_IO || c->io_read_state == CLIENT_PENDING_IO) continue;
+        /* If the write job is done, process it ASAP to free the buffer and handle connection errors */
+        if (c->io_write_state == CLIENT_COMPLETED_IO) {
+            int allow_async_writes = 0; /* Don't send writes for the client to IO threads before processing the reads */
+            processClientIOWriteDone(c, allow_async_writes);
         }
+        /* memory barrier acquire to get the updated client state */
+        atomic_thread_fence(memory_order_acquire);
 
-        if (batch_count == 0) break; /* Empty, or only PENDING_IO left. */
+        listUnlinkNode(server.clients_pending_io_read, ln);
+        c->flag.pending_read = 0;
+        c->io_read_state = CLIENT_IDLE;
 
-        processClientsCommandsBatch();
+        /* Don't post-process-reads from clients that are going to be closed anyway. */
+        if (c->flag.close_asap) continue;
 
-        /* Apply final postpone mask after draining input and cmd_queue. */
-        for (size_t i = 0; i < followup_n; i++) {
-            client *c = lookupClientByID(followup_ids[i]);
-            if (!c || !c->conn) continue;
+        /* If a client is protected, don't do anything,
+         * that may trigger read/write error or recreate handler. */
+        if (c->flag.protected) continue;
 
-            if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
+        processed++;
+        server.stat_io_reads_processed++;
 
-            c = lookupClientByID(followup_ids[i]);
-            if (!c || !c->conn) continue;
-            connSetPostponeUpdateState(c->conn, clientConnPostponeMask(c));
+        /* Save the current conn state, as connUpdateState may modify it */
+        int in_accept_state = (connGetState(c->conn) == CONN_STATE_ACCEPTING);
+        int needs_post_read_update = 0;
+
+        /* Keep READ postponed through command batching. */
+        if (c->conn) {
+            int mask = 0;
+            if (!in_accept_state) {
+                mask |= CONN_POSTPONE_READ;
+                if (c->io_write_state != CLIENT_IDLE) mask |= CONN_POSTPONE_WRITE;
+                needs_post_read_update = 1;
+            }
+            connSetPostponeUpdateState(c->conn, mask);
             connUpdateState(c->conn);
         }
+
+        /* In accept state, no client's data was read - stop here. */
+        if (in_accept_state) continue;
+
+        if (needs_post_read_update) {
+            if (followup_n == followup_cap) {
+                followup_cap *= 2;
+                followup_ids = zrealloc(followup_ids, followup_cap * sizeof(uint64_t));
+            }
+            followup_ids[followup_n++] = c->id;
+        }
+
+        /* On read error - stop here. */
+        if (handleReadResult(c) == C_ERR) {
+            continue;
+        }
+
+        if (!(c->read_flags & READ_FLAGS_DONT_PARSE)) {
+            parseResult res = handleParseResults(c);
+            /* On parse error - stop here. */
+            if (res == PARSE_ERR) {
+                continue;
+            } else if (res == PARSE_NEEDMORE) {
+                beforeNextClient(c);
+                continue;
+            }
+        }
+
+        if (c->argc > 0) {
+            c->flag.pending_command = 1;
+        }
+
+        size_t list_length_before_command_execute = listLength(server.clients_pending_io_read);
+        /* try to add the command to the batch */
+        int ret = addCommandToBatchAndProcessIfFull(c);
+        /* If the command was not added to the commands batch, process it immediately */
+        if (ret == C_ERR) {
+            if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
+        }
+        if (list_length_before_command_execute != listLength(server.clients_pending_io_read)) {
+            /* A client was unlink from the list possibly making the next node invalid */
+            next = listFirst(server.clients_pending_io_read);
+        }
     }
+
+    processClientsCommandsBatch();
+
+    /* Apply final postpone mask after draining input and cmd_queue. */
+    for (size_t i = 0; i < followup_n; i++) {
+        client *c = lookupClientByID(followup_ids[i]);
+        if (!c || !c->conn) continue;
+
+        if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
+
+        c = lookupClientByID(followup_ids[i]);
+        if (!c || !c->conn) continue;
+        connSetPostponeUpdateState(c->conn, clientConnPostponeMask(c));
+        connUpdateState(c->conn);
+    }
+    zfree(followup_ids);
 
     return processed;
 }

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -82,13 +82,12 @@ typedef enum ValkeyRdmaOpcode {
 #define VALKEY_RDMA_INVALID_OPCODE 0xffff
 #define VALKEY_RDMA_KEEPALIVE_MS 3000
 
-#define RDMA_CONN_FLAG_POSTPONE_UPDATE_STATE (1 << 0)
-
 typedef struct rdma_connection {
     connection c;
     struct rdma_cm_id *cm_id;
     int flags;
     int last_errno;
+    int postpone_mask;
     listNode *pending_list_node;
 } rdma_connection;
 
@@ -733,7 +732,14 @@ static void connRdmaEventHandler(struct aeEventLoop *el, int fd, void *clientDat
     }
 
     /* uplayer should read all */
-    while (!(rdma_conn->flags & RDMA_CONN_FLAG_POSTPONE_UPDATE_STATE) && ctx->rx.pos < ctx->rx.offset) {
+    while (!(rdma_conn->postpone_mask & CONN_POSTPONE_READ) && ctx->rx.pos < ctx->rx.offset) {
+        /* COMPLETED_IO: main still owns the client; postpone READ and stop. */
+        client *c = connGetPrivateData(conn);
+        if (c && c->io_read_state == CLIENT_COMPLETED_IO) {
+            rdma_conn->postpone_mask |= CONN_POSTPONE_READ;
+            break;
+        }
+
         if (conn->read_handler && (callHandler(conn, conn->read_handler) == C_ERR)) {
             return;
         }
@@ -745,7 +751,7 @@ static void connRdmaEventHandler(struct aeEventLoop *el, int fd, void *clientDat
     }
 
     /* RDMA comp channel has no POLLOUT event, try to send remaining buffer */
-    if (!(rdma_conn->flags & RDMA_CONN_FLAG_POSTPONE_UPDATE_STATE) && ctx->tx.offset < ctx->tx.length && conn->write_handler) {
+    if (!(rdma_conn->postpone_mask & CONN_POSTPONE_WRITE) && ctx->tx.offset < ctx->tx.length && conn->write_handler) {
         callHandler(conn, conn->write_handler);
     }
 }
@@ -924,9 +930,6 @@ static void connRdmaAcceptHandler(aeEventLoop *el, int fd, void *privdata, int m
 }
 
 static int connRdmaSetRwHandler(connection *conn) {
-    rdma_connection *rdma_conn = (rdma_connection *)conn;
-    if (rdma_conn->flags & RDMA_CONN_FLAG_POSTPONE_UPDATE_STATE) return C_OK;
-
     /* IB channel only has POLLIN event */
     if (conn->read_handler || conn->write_handler) {
         if (aeCreateFileEvent(server.el, conn->fd, AE_READABLE, conn->type->ae_handler, conn) == AE_ERR) {
@@ -1774,21 +1777,21 @@ static int rdmaProcessPendingData(void) {
     listRewind(pending_list, &li);
     while ((ln = listNext(&li))) {
         rdma_conn = listNodeValue(ln);
-        if (rdma_conn->flags & RDMA_CONN_FLAG_POSTPONE_UPDATE_STATE) continue;
         conn = &rdma_conn->c;
 
         /* a connection can be disconnected by remote peer, CM event mark state as CONN_STATE_CLOSED, kick connection
          * read/write handler to close connection */
         if (conn->state == CONN_STATE_ERROR || conn->state == CONN_STATE_CLOSED) {
+            /* Unlink before callHandler: handler may free the connection. */
+            listDelNode(pending_list, ln);
+            rdma_conn->pending_list_node = NULL;
+
             /* Invoke both read_handler and write_handler, unless read_handler
                returns 0, indicating the connection has closed, in which case
                write_handler will be skipped. */
             if (callHandler(conn, conn->read_handler)) {
                 callHandler(conn, conn->write_handler);
             }
-
-            listDelNode(pending_list, ln);
-            rdma_conn->pending_list_node = NULL;
 
             ++processed;
             continue;
@@ -1801,13 +1804,9 @@ static int rdmaProcessPendingData(void) {
     return processed;
 }
 
-static void postPoneUpdateRdmaState(struct connection *conn, int postpone) {
+static void postPoneUpdateRdmaState(struct connection *conn, int postpone_mask) {
     rdma_connection *rdma_conn = (rdma_connection *)conn;
-    if (postpone) {
-        rdma_conn->flags |= RDMA_CONN_FLAG_POSTPONE_UPDATE_STATE;
-    } else {
-        rdma_conn->flags &= ~RDMA_CONN_FLAG_POSTPONE_UPDATE_STATE;
-    }
+    rdma_conn->postpone_mask = postpone_mask;
 }
 
 static void updateRdmaState(struct connection *conn) {

--- a/src/replication.c
+++ b/src/replication.c
@@ -1078,6 +1078,7 @@ void syncCommand(client *c) {
      * the client about already issued commands. We need a fresh reply
      * buffer registering the differences between the BGSAVE and the current
      * dataset, so that we can copy to other replicas if needed. */
+    processIOThreadsWriteDone(); /* reap COMPLETED_IO left by waitForClientIO() */
     if (clientHasPendingReplies(c)) {
         addReplyError(c, "SYNC and PSYNC are invalid with pending output");
         return;

--- a/src/server.c
+++ b/src/server.c
@@ -1926,6 +1926,8 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     }
 
     processIOThreadsWriteDone();
+    /* Write-done can update replica offsets after blockedBeforeSleep() ran. */
+    if (listLength(server.clients_waiting_acks)) processClientsWaitingReplicas();
 
     /* Record cron time in beforeSleep. This does not include the time consumed by AOF writing and IO writing above. */
     monotime cron_start_time_after_write = getMonotonicUs();

--- a/src/server.h
+++ b/src/server.h
@@ -1370,6 +1370,21 @@ typedef struct client {
 #endif
 } client;
 
+/* Postpone mask derived from IO offload state. */
+static inline int clientConnPostponeMaskFromIOState(client *c) {
+    int mask = 0;
+    if (c->io_read_state != CLIENT_IDLE) mask |= CONN_POSTPONE_READ;
+    if (c->io_write_state != CLIENT_IDLE) mask |= CONN_POSTPONE_WRITE;
+    return mask;
+}
+
+/* IO-state postpone plus READ while cmd_queue still has parsed commands. */
+static inline int clientConnPostponeMask(client *c) {
+    int mask = clientConnPostponeMaskFromIOState(c);
+    if (c->cmd_queue.off < c->cmd_queue.len) mask |= CONN_POSTPONE_READ;
+    return mask;
+}
+
 /* When a command generates a lot of discrete elements to the client output buffer, it is much faster to
  * skip certain types of initialization. This type is used to indicate a client that has been initialized
  * and can be used with addWritePreparedReply* functions. A client can be cast into this type with

--- a/src/tls.c
+++ b/src/tls.c
@@ -601,9 +601,9 @@ static void registerSSLEvent(tls_connection *conn) {
     }
 }
 
-static void postPoneUpdateSSLState(connection *conn_, int postpone) {
+static void postPoneUpdateSSLState(connection *conn_, int postpone_mask) {
     tls_connection *conn = (tls_connection *)conn_;
-    if (postpone) {
+    if (postpone_mask) {
         conn->flags |= TLS_CONN_FLAG_POSTPONE_UPDATE_STATE;
     } else {
         conn->flags &= ~TLS_CONN_FLAG_POSTPONE_UPDATE_STATE;


### PR DESCRIPTION
Fixes #3112
Fixes #3356

Backport of the #3611 approach to 9.0 (`clients_pending_io_read`).

## Problem

RDMA + `io-threads` can hit:
- `#3112`: `c->cmd_queue.len == 0` — CQ / `connUpdateState` re-enters parse while commands are still batched
- `#3356`: `io_last_written` assert — main thread still runs RDMA handlers while an IO thread owns the write path
- hang / busy-loop — edge-triggered CQ leaves buffered RX unconsumed when READ is not postponed

## Fix

Replace boolean postpone with absolute `CONN_POSTPONE_READ` / `CONN_POSTPONE_WRITE`:
- mask from IO offload state (+ residual `cmd_queue`)
- keep READ postponed through the command batch and in-flight writes
- two-phase `processIOThreadsReadDone`: drain residual querybuf, then apply the final mask + `connUpdateState`
- serialize write offload against non-idle read

TCP/TLS remain safe (TLS still uses an internal boolean; TCP only updates epoll).

## Verify (Soft-RoCE)
```bash
make -j4 BUILD_RDMA=yes USE_FAST_FLOAT=yes
./src/valkey-server valkey.conf --rdma-bind 10.0.0.1 --rdma-port 6379 --io-threads 4

./src/valkey-benchmark -h 10.0.0.1 -p 6379 -d 256 \
  --threads 16 -c 500 -P 25 -n 5000000 -t set,get --rdma
```