### PR TITLE
Remove unused dict callback parameter from functionReset and related functions

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -685,8 +685,7 @@ long long emptyData(int dbnum, int flags, void(callback)(hashtable *)) {
 
     if (with_functions) {
         serverAssert(dbnum == -1);
-        /* TODO: fix this callback incompatibility. The arg is not used. */
-        functionReset(async, (void (*)(dict *))callback);
+        functionReset(async);
     }
 
     /* Also fire the end event. Note that this event will fire almost

--- a/src/functions.c
+++ b/src/functions.c
@@ -151,9 +151,9 @@ static void engineLibraryDispose(void *obj) {
 }
 
 /* Clear all the functions from the given library ctx */
-void functionsLibCtxClear(functionsLibCtx *lib_ctx, void(callback)(dict *)) {
-    dictEmpty(lib_ctx->functions, callback);
-    dictEmpty(lib_ctx->libraries, callback);
+void functionsLibCtxClear(functionsLibCtx *lib_ctx) {
+    dictEmpty(lib_ctx->functions, NULL);
+    dictEmpty(lib_ctx->libraries, NULL);
     dictIterator *iter = dictGetIterator(lib_ctx->engines_stats);
     dictEntry *entry = NULL;
     while ((entry = dictNext(iter))) {
@@ -175,13 +175,13 @@ static void resetEngineOrCollectResetCallbacks(scriptingEngine *engine, void *co
     }
 }
 
-void functionsLibCtxReleaseCurrent(int async, void(callback)(dict *)) {
+static void functionsLibCtxReleaseCurrent(int async) {
     if (async) {
         list *engine_callbacks = listCreate();
         scriptingEngineManagerForEachEngine(resetEngineOrCollectResetCallbacks, engine_callbacks);
         freeFunctionsAsync(curr_functions_lib_ctx, engine_callbacks);
     } else {
-        functionsLibCtxFree(curr_functions_lib_ctx, callback, NULL);
+        functionsLibCtxFree(curr_functions_lib_ctx, NULL);
         scriptingEngineManagerForEachEngine(resetEngineOrCollectResetCallbacks, NULL);
     }
 }
@@ -191,18 +191,18 @@ static void functionsLibCtxFreeGeneric(functionsLibCtx *functions_lib_ctx, int a
     if (async) {
         freeFunctionsAsync(functions_lib_ctx, NULL);
     } else {
-        functionsLibCtxFree(functions_lib_ctx, NULL, NULL);
+        functionsLibCtxFree(functions_lib_ctx, NULL);
     }
 }
 
-void functionReset(int async, void(callback)(dict *)) {
-    functionsLibCtxReleaseCurrent(async, callback);
+void functionReset(int async) {
+    functionsLibCtxReleaseCurrent(async);
     functionsInit();
 }
 
 /* Free the given functions ctx */
-void functionsLibCtxFree(functionsLibCtx *functions_lib_ctx, void(callback)(dict *), list *engine_callbacks) {
-    functionsLibCtxClear(functions_lib_ctx, callback);
+void functionsLibCtxFree(functionsLibCtx *functions_lib_ctx, list *engine_callbacks) {
+    functionsLibCtxClear(functions_lib_ctx);
     dictRelease(functions_lib_ctx->functions);
     dictRelease(functions_lib_ctx->libraries);
     dictRelease(functions_lib_ctx->engines_stats);
@@ -420,7 +420,7 @@ libraryJoin(functionsLibCtx *functions_lib_ctx_dst, functionsLibCtx *functions_l
     dictReleaseIterator(iter);
     iter = NULL;
 
-    functionsLibCtxClear(functions_lib_ctx_src, NULL);
+    functionsLibCtxClear(functions_lib_ctx_src);
     if (old_libraries_list) {
         listRelease(old_libraries_list);
         old_libraries_list = NULL;
@@ -854,7 +854,7 @@ void functionFlushCommand(client *c) {
         return;
     }
 
-    functionReset(async, NULL);
+    functionReset(async);
 
     /* Indicate that the command changed the data so it will be replicated and
      * counted as a data change (for persistence configuration) */

--- a/src/functions.h
+++ b/src/functions.h
@@ -90,10 +90,10 @@ dict *functionsLibGet(void);
 size_t functionsLibCtxFunctionsLen(functionsLibCtx *functions_ctx);
 functionsLibCtx *functionsLibCtxGetCurrent(void);
 functionsLibCtx *functionsLibCtxCreate(void);
-void functionsLibCtxFree(functionsLibCtx *functions_lib_ctx, void(callback)(dict *), list *engine_callbacks);
-void functionsLibCtxClear(functionsLibCtx *lib_ctx, void(callback)(dict *));
+void functionsLibCtxFree(functionsLibCtx *functions_lib_ctx, list *engine_callbacks);
+void functionsLibCtxClear(functionsLibCtx *lib_ctx);
 void functionsLibCtxSwapWithCurrent(functionsLibCtx *new_lib_ctx, int async);
-void functionReset(int async, void(callback)(dict *));
+void functionReset(int async);
 
 void functionsRemoveLibFromEngine(scriptingEngine *engine);
 

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -68,7 +68,7 @@ void lazyFreeFunctionsCtx(void *args[]) {
     functionsLibCtx *functions_lib_ctx = args[0];
     list *engine_callbacks = args[1];
     size_t len = functionsLibCtxFunctionsLen(functions_lib_ctx);
-    functionsLibCtxFree(functions_lib_ctx, NULL, engine_callbacks);
+    functionsLibCtxFree(functions_lib_ctx, engine_callbacks);
     atomic_fetch_sub_explicit(&lazyfree_objects, len, memory_order_relaxed);
     atomic_fetch_add_explicit(&lazyfreed_objects, len, memory_order_relaxed);
 }
@@ -264,7 +264,7 @@ void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx, list *engine_callbac
                                   memory_order_relaxed);
         bioCreateLazyFreeJob(lazyFreeFunctionsCtx, 2, functions_lib_ctx, engine_callbacks);
     } else {
-        functionsLibCtxFree(functions_lib_ctx, NULL, engine_callbacks);
+        functionsLibCtxFree(functions_lib_ctx, engine_callbacks);
     }
 }
 


### PR DESCRIPTION
## Summary
This PR removes the unused `void(callback)(dict *)` parameter from `functionReset()` and related functions.

## Changes
The callback parameter in `functionReset()`, `functionsLibCtxFree()`, and `functionsLibCtxClear()` was never actually used - it was always passed as NULL or cast from an incompatible type. This cleanup:

- Removes the `void(callback)(dict *)` parameter from `functionReset()`
- Removes the callback parameter from `functionsLibCtxFree()`
- Removes the callback parameter from `functionsLibCtxClear()`
- Makes `functionsLibCtxReleaseCurrent()` static since it's only used internally
- Removes the TODO comment in db.c about the callback incompatibility
- Updates all call sites to use the simplified function signatures

## Files Changed
- `src/functions.h`: Updated function declarations
- `src/functions.c`: Removed callback parameters and updated implementations
- `src/db.c`: Simplified `functionReset()` call, removed TODO comment
- `src/lazyfree.c`: Updated `functionsLibCtxFree()` calls

## Rationale
The `dictEmpty()` calls now explicitly pass NULL for the callback, which was effectively what was happening before since the parameter was unused. This simplifies the API and removes the need for the type cast workaround that was previously used in db.c.