### PR TITLE
zset: add in-place fast path for score updates in listpack encoding

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1195,6 +1195,58 @@ static unsigned char *zzlInsert(unsigned char *zl, sds ele, double score) {
     return zl;
 }
 
+/* Update the score of an element inside the sorted set listpack.
+ * Note that the element must exist in the listpack. */
+static unsigned char *zzlUpdateScore(unsigned char *zl, unsigned char *eptr, sds ele, double score, double curscore) {
+    unsigned char *sptr = lpNext(zl, eptr);
+    serverAssert(sptr != NULL);
+
+    /* Fast path: if the new score keeps the element in its current slot under
+     * (score, ele) ordering, replace the score entry in place instead of
+     * delete + full re-scan.
+     *
+     * Only the neighbor in the direction of the score change needs to be
+     * checked: if the score increases, the previous neighbor satisfies
+     * (prev_score < score) strictly (since prev_score <= curscore < score), so
+     * only the next neighbor can violate the order. The score-decrease case is
+     * symmetric. */
+    bool keep_position = true;
+    if (score > curscore) {
+        unsigned char *next_eptr = eptr, *next_sptr = sptr;
+        zzlNext(zl, &next_eptr, &next_sptr);
+        if (next_sptr != NULL) {
+            double next_score = zzlGetScore(next_sptr);
+            if (next_score < score ||
+                (next_score == score && zzlCompareElements(next_eptr, (unsigned char *)ele, sdslen(ele)) < 0))
+                keep_position = false;
+        }
+    } else { /* score < curscore */
+        unsigned char *prev_eptr = eptr, *prev_sptr = sptr;
+        zzlPrev(zl, &prev_eptr, &prev_sptr);
+        if (prev_sptr != NULL) {
+            double prev_score = zzlGetScore(prev_sptr);
+            if (prev_score > score ||
+                (prev_score == score && zzlCompareElements(prev_eptr, (unsigned char *)ele, sdslen(ele)) > 0))
+                keep_position = false;
+        }
+    }
+
+    if (keep_position) {
+        long long lscore;
+        if (double2ll(score, &lscore)) {
+            zl = lpReplaceInteger(zl, &sptr, lscore);
+        } else {
+            char scorebuf[MAX_D2STRING_CHARS];
+            int scorelen = d2string(scorebuf, sizeof(scorebuf), score);
+            zl = lpReplace(zl, &sptr, (unsigned char *)scorebuf, scorelen);
+        }
+        return zl;
+    }
+
+    zl = zzlDelete(zl, eptr);
+    return zzlInsert(zl, ele, score);
+}
+
 static unsigned char *zzlDeleteRangeByScore(unsigned char *zl, zrangespec *range, unsigned long *deleted) {
     unsigned char *eptr, *sptr;
     double score;
@@ -1505,58 +1557,8 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 
             if (newscore) *newscore = score;
 
-            /* Remove and re-insert when score changed. */
             if (score != curscore) {
-                unsigned char *zl = objectGetVal(zobj);
-                unsigned char *sptr = lpNext(zl, eptr);
-                serverAssert(sptr != NULL);
-
-                /* Fast path: if the new score keeps the element in its current
-                 * slot under (score, ele) ordering, replace the score entry in
-                 * place instead of delete + full re-scan.
-                 *
-                 * Only the neighbor in the direction of the score change needs
-                 * to be checked: if the score increases, the previous neighbor
-                 * satisfies (prev_score < score) strictly (since prev_score <=
-                 * curscore < score), so only the next neighbor can violate the
-                 * order. The score-decrease case is symmetric. */
-                bool keep_position = true;
-                if (score > curscore) {
-                    unsigned char *next_eptr = eptr, *next_sptr = sptr;
-                    zzlNext(zl, &next_eptr, &next_sptr);
-                    if (next_sptr != NULL) {
-                        double next_score = zzlGetScore(next_sptr);
-                        if (next_score < score ||
-                            (next_score == score &&
-                             zzlCompareElements(next_eptr, (unsigned char *)ele, sdslen(ele)) < 0))
-                            keep_position = false;
-                    }
-                } else { /* score < curscore */
-                    unsigned char *prev_eptr = eptr, *prev_sptr = sptr;
-                    zzlPrev(zl, &prev_eptr, &prev_sptr);
-                    if (prev_sptr != NULL) {
-                        double prev_score = zzlGetScore(prev_sptr);
-                        if (prev_score > score ||
-                            (prev_score == score &&
-                             zzlCompareElements(prev_eptr, (unsigned char *)ele, sdslen(ele)) > 0))
-                            keep_position = false;
-                    }
-                }
-
-                if (keep_position) {
-                    long long lscore;
-                    if (double2ll(score, &lscore)) {
-                        zl = lpReplaceInteger(zl, &sptr, lscore);
-                    } else {
-                        char scorebuf[MAX_D2STRING_CHARS];
-                        int scorelen = d2string(scorebuf, sizeof(scorebuf), score);
-                        zl = lpReplace(zl, &sptr, (unsigned char *)scorebuf, scorelen);
-                    }
-                    objectSetVal(zobj, zl);
-                } else {
-                    objectSetVal(zobj, zzlDelete(zl, eptr));
-                    objectSetVal(zobj, zzlInsert(objectGetVal(zobj), ele, score));
-                }
+                objectSetVal(zobj, zzlUpdateScore(objectGetVal(zobj), eptr, ele, score, curscore));
                 *out_flags |= ZADD_OUT_UPDATED;
             }
             return 1;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1520,7 +1520,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
                  * satisfies (prev_score < score) strictly (since prev_score <=
                  * curscore < score), so only the next neighbor can violate the
                  * order. The score-decrease case is symmetric. */
-                int keep_position = 1;
+                bool keep_position = true;
                 if (score > curscore) {
                     unsigned char *next_eptr = eptr, *next_sptr = sptr;
                     zzlNext(zl, &next_eptr, &next_sptr);
@@ -1529,7 +1529,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
                         if (next_score < score ||
                             (next_score == score &&
                              zzlCompareElements(next_eptr, (unsigned char *)ele, sdslen(ele)) < 0))
-                            keep_position = 0;
+                            keep_position = false;
                     }
                 } else { /* score < curscore */
                     unsigned char *prev_eptr = eptr, *prev_sptr = sptr;
@@ -1539,7 +1539,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
                         if (prev_score > score ||
                             (prev_score == score &&
                              zzlCompareElements(prev_eptr, (unsigned char *)ele, sdslen(ele)) > 0))
-                            keep_position = 0;
+                            keep_position = false;
                     }
                 }
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1507,8 +1507,48 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 
             /* Remove and re-insert when score changed. */
             if (score != curscore) {
-                objectSetVal(zobj, zzlDelete(objectGetVal(zobj), eptr));
-                objectSetVal(zobj, zzlInsert(objectGetVal(zobj), ele, score));
+                unsigned char *zl = objectGetVal(zobj);
+                unsigned char *sptr = lpNext(zl, eptr);
+                serverAssert(sptr != NULL);
+
+                /* Fast path: if the new score keeps the element between its
+                 * current neighbors (by (score, ele) ordering), replace the
+                 * score entry in place instead of delete + full re-scan. */
+                unsigned char *prev_eptr = eptr, *prev_sptr = sptr;
+                zzlPrev(zl, &prev_eptr, &prev_sptr);
+                unsigned char *next_eptr = eptr, *next_sptr = sptr;
+                zzlNext(zl, &next_eptr, &next_sptr);
+
+                int keep_position = 1;
+                if (prev_sptr != NULL) {
+                    double prev_score = zzlGetScore(prev_sptr);
+                    if (prev_score > score ||
+                        (prev_score == score &&
+                         zzlCompareElements(prev_eptr, (unsigned char *)ele, sdslen(ele)) > 0))
+                        keep_position = 0;
+                }
+                if (keep_position && next_sptr != NULL) {
+                    double next_score = zzlGetScore(next_sptr);
+                    if (next_score < score ||
+                        (next_score == score &&
+                         zzlCompareElements(next_eptr, (unsigned char *)ele, sdslen(ele)) < 0))
+                        keep_position = 0;
+                }
+
+                if (keep_position) {
+                    long long lscore;
+                    if (double2ll(score, &lscore)) {
+                        zl = lpReplaceInteger(zl, &sptr, lscore);
+                    } else {
+                        char scorebuf[MAX_D2STRING_CHARS];
+                        int scorelen = d2string(scorebuf, sizeof(scorebuf), score);
+                        zl = lpReplace(zl, &sptr, (unsigned char *)scorebuf, scorelen);
+                    }
+                    objectSetVal(zobj, zl);
+                } else {
+                    objectSetVal(zobj, zzlDelete(zl, eptr));
+                    objectSetVal(zobj, zzlInsert(objectGetVal(zobj), ele, score));
+                }
                 *out_flags |= ZADD_OUT_UPDATED;
             }
             return 1;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1511,28 +1511,36 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
                 unsigned char *sptr = lpNext(zl, eptr);
                 serverAssert(sptr != NULL);
 
-                /* Fast path: if the new score keeps the element between its
-                 * current neighbors (by (score, ele) ordering), replace the
-                 * score entry in place instead of delete + full re-scan. */
-                unsigned char *prev_eptr = eptr, *prev_sptr = sptr;
-                zzlPrev(zl, &prev_eptr, &prev_sptr);
-                unsigned char *next_eptr = eptr, *next_sptr = sptr;
-                zzlNext(zl, &next_eptr, &next_sptr);
-
+                /* Fast path: if the new score keeps the element in its current
+                 * slot under (score, ele) ordering, replace the score entry in
+                 * place instead of delete + full re-scan.
+                 *
+                 * Only the neighbor in the direction of the score change needs
+                 * to be checked: if the score increases, the previous neighbor
+                 * satisfies (prev_score < score) strictly (since prev_score <=
+                 * curscore < score), so only the next neighbor can violate the
+                 * order. The score-decrease case is symmetric. */
                 int keep_position = 1;
-                if (prev_sptr != NULL) {
-                    double prev_score = zzlGetScore(prev_sptr);
-                    if (prev_score > score ||
-                        (prev_score == score &&
-                         zzlCompareElements(prev_eptr, (unsigned char *)ele, sdslen(ele)) > 0))
-                        keep_position = 0;
-                }
-                if (keep_position && next_sptr != NULL) {
-                    double next_score = zzlGetScore(next_sptr);
-                    if (next_score < score ||
-                        (next_score == score &&
-                         zzlCompareElements(next_eptr, (unsigned char *)ele, sdslen(ele)) < 0))
-                        keep_position = 0;
+                if (score > curscore) {
+                    unsigned char *next_eptr = eptr, *next_sptr = sptr;
+                    zzlNext(zl, &next_eptr, &next_sptr);
+                    if (next_sptr != NULL) {
+                        double next_score = zzlGetScore(next_sptr);
+                        if (next_score < score ||
+                            (next_score == score &&
+                             zzlCompareElements(next_eptr, (unsigned char *)ele, sdslen(ele)) < 0))
+                            keep_position = 0;
+                    }
+                } else { /* score < curscore */
+                    unsigned char *prev_eptr = eptr, *prev_sptr = sptr;
+                    zzlPrev(zl, &prev_eptr, &prev_sptr);
+                    if (prev_sptr != NULL) {
+                        double prev_score = zzlGetScore(prev_sptr);
+                        if (prev_score > score ||
+                            (prev_score == score &&
+                             zzlCompareElements(prev_eptr, (unsigned char *)ele, sdslen(ele)) > 0))
+                            keep_position = 0;
+                    }
                 }
 
                 if (keep_position) {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -127,6 +127,80 @@ start_server {tags {"zset"}} {
             assert_equal {y x z} [r zrange ztmp 0 -1]
         }
 
+        if {$encoding == "listpack"} {
+            test "ZADD in-place update handles listpack head, tail, and single element edge cases - $encoding" {
+                r del ztmp
+                r zadd ztmp 1 a 2 b 3 c
+                assert_encoding listpack ztmp
+
+                r zadd ztmp 0.5 a
+                r zadd ztmp 4 c
+                assert_encoding listpack ztmp
+                assert_equal {a 0.5 b 2 c 4} [r zrange ztmp 0 -1 withscores]
+
+                r del ztmp
+                r zadd ztmp 1 a
+                assert_encoding listpack ztmp
+                r zadd ztmp 2 a
+                assert_encoding listpack ztmp
+                assert_equal {a 2} [r zrange ztmp 0 -1 withscores]
+            }
+
+            test "ZADD in-place update handles listpack tie ordering - $encoding" {
+                r del ztmp
+                r zadd ztmp 1 a 2 b 2 c 3 d
+                assert_encoding listpack ztmp
+                r zadd ztmp 2 a
+                assert_equal {a 2 b 2 c 2 d 3} [r zrange ztmp 0 -1 withscores]
+
+                r del ztmp
+                r zadd ztmp 1 c 2 a 2 b 3 d
+                assert_encoding listpack ztmp
+                r zadd ztmp 2 c
+                assert_equal {a 2 b 2 c 2 d 3} [r zrange ztmp 0 -1 withscores]
+
+                r del ztmp
+                r zadd ztmp 1 a 1 b 2 c 3 d
+                assert_encoding listpack ztmp
+                r zadd ztmp 1 c
+                assert_equal {a 1 b 1 c 1 d 3} [r zrange ztmp 0 -1 withscores]
+
+                r del ztmp
+                r zadd ztmp 1 b 1 c 2 a 3 d
+                assert_encoding listpack ztmp
+                r zadd ztmp 1 a
+                assert_equal {a 1 b 1 c 1 d 3} [r zrange ztmp 0 -1 withscores]
+            }
+
+            test "ZADD in-place update handles listpack score encoding transitions - $encoding" {
+                r del ztmp
+                r zadd ztmp 42 a
+                assert_encoding listpack ztmp
+
+                r zadd ztmp 42.5 a
+                assert_encoding listpack ztmp
+                assert_equal 42.5 [r zscore ztmp a]
+
+                r zadd ztmp 42 a
+                assert_encoding listpack ztmp
+                assert_equal {a 42} [r zrange ztmp 0 -1 withscores]
+            }
+
+            test "ZADD in-place update reorders listpack on adjacent boundary violation - $encoding" {
+                r del ztmp
+                r zadd ztmp 1 a 2 b 3 c
+                assert_encoding listpack ztmp
+                r zadd ztmp 2.5 a
+                assert_equal {b 2 a 2.5 c 3} [r zrange ztmp 0 -1 withscores]
+
+                r del ztmp
+                r zadd ztmp 1 a 2 b 3 c
+                assert_encoding listpack ztmp
+                r zadd ztmp 1.5 c
+                assert_equal {a 1 c 1.5 b 2} [r zrange ztmp 0 -1 withscores]
+            }
+        }
+
         test "ZSET element can't be set to NaN with ZADD - $encoding" {
             assert_error "*not*float*" {r zadd myzset nan abc}
         }


### PR DESCRIPTION
Summary

- Before: Updating the score of an existing member in a listpack-encoded zset always performs zzlDelete followed by zzlInsert, which re-scans
from the head to find the new position.
- Change: If the new score keeps the member between its current neighbors under (score, ele) ordering, update the score entry in place via
lpReplaceInteger or lpReplace—no delete, no scan.
- Note: Mirrors the fast path already used by zslUpdateScore on the skiplist side.

Motivation

- Small score adjustments are common (leaderboards, counters, weighted metrics). In these patterns, the member typically stays in place, yet the
current path still pays for delete + O(N/2) re-scan. Avoiding that work makes the hot path much cheaper.

Change

- Two commits:
    - add in-place fast path: when score != curscore, probe neighbors; if ordering holds, replace the score entry with lpReplace*; otherwise fall
back to delete + re-insert.
    - probe only one neighbor: only the neighbor in the direction of the score change can violate ordering.
    - If `score > old`, the previous neighbor is always safe; check only the next.
    - If `score < old`, the next is always safe; check only the previous.
- No protocol, syntax, error, or semantic change. The slow path is unchanged.

Benchmarks

- Setup: 20k ops per run, 5 runs per cell, μs/op (mean ± σ). zset-max-listpack-entries raised to keep listpack encoding. RESP/loopback cost
included.
- small_delta (±0.5): fast path almost always hits.
    - N=128: 3.195 → 1.457 μs/op (~2.19×)
    - N=512: 8.188 → 2.406 μs/op (~3.40×)
- monotonic (increasing, ZINCRBY-like): consistent small gains.
    - N=512: 13.196 → 11.923 μs/op (~1.11×)
- random (adversarial): fast path rarely hits; results ~equal to baseline, variation within ~1σ.
    - N=32: +3.0% (~1σ), others near tie

Safety

- Behaviorally identical: same replies, errors, and tie-break (score, then lex).
- Reallocation-safe: lpReplace* may reallocate; the returned pointer is always written back via objectSetVal.
- Floating-point edge cases: NaN is rejected at zsetAdd entry; +0.0/-0.0 compare equal so the fast path is not taken; ±Inf follows the existing
d2string/double2ll encoding paths.
- Fallback remains: if ordering doesn’t hold, we still do zzlDelete → zzlInsert.

Tests

- Existing zset tests pass. Updates of existing scores (ZADD overwrite, ZINCRBY, ZADD GT/LT) naturally exercise the fast path; reordering cases
exercise the slow path.

## Benchmarks

  Linux, 20k ops per run, 5 runs per cell, mean ± σ (μs/op). `zset-max-listpack-entries` raised to keep listpack encoding. RESP and loopback cost
   included.

  ### small_delta (±0.5 nudge — fast path hits almost always)

  | N   | baseline        | feature         | speedup   |
  |---:|---:|---:|---:|
  |   8 | 1.371 ± 0.030   | 1.214 ± 0.005   | **1.13×** |
  |  16 | 1.476 ± 0.035   | 1.281 ± 0.046   | **1.15×** |
  |  32 | 1.657 ± 0.017   | 1.276 ± 0.023   | **1.30×** |
  |  64 | 2.094 ± 0.073   | 1.340 ± 0.016   | **1.56×** |
  | 128 | 3.195 ± 0.042   | 1.457 ± 0.019   | **2.19×** |
  | 256 | 4.797 ± 0.024   | 1.727 ± 0.021   | **2.78×** |
  | 512 | 8.188 ± 0.084   | 2.406 ± 0.024   | **3.40×** |

  ### monotonic (increasing scores — ZINCRBY-like)

  | N   | baseline        | feature         | speedup |
  |---:|---:|---:|---:|
  |   8 | 1.439 ± 0.018   | 1.439 ± 0.057   | tie     |
  |  16 | 1.685 ± 0.051   | 1.609 ± 0.039   | ~1.05×  |
  |  32 | 2.024 ± 0.065   | 1.978 ± 0.123   | ~1.02×  |
  |  64 | 2.955 ± 0.168   | 2.713 ± 0.148   | ~1.09×  |
  | 128 | 4.634 ± 0.098   | 4.534 ± 0.086   | ~1.02×  |
  | 256 | 7.386 ± 0.145   | 6.927 ± 0.136   | ~1.07×  |
  | 512 | 13.196 ± 0.131  | 11.923 ± 0.183  | **~1.11×** |

  ### random (adversarial — fast path rarely hits)

  | N   | baseline        | feature         | Δ            |
  |---:|---:|---:|---:|
  |   8 | 1.407 ± 0.048   | 1.388 ± 0.010   | −1.4%        |
  |  16 | 1.486 ± 0.044   | 1.484 ± 0.022   | tie          |
  |  32 | 1.653 ± 0.032   | 1.702 ± 0.052   | +3.0% (~1σ)  |
  |  64 | 2.118 ± 0.073   | 2.120 ± 0.038   | tie          |
  | 128 | 3.242 ± 0.067   | 3.229 ± 0.036   | −0.4%        |
  | 256 | 4.808 ± 0.009   | 4.861 ± 0.050   | +1.1% (~1σ)  |
  | 512 | 8.225 ± 0.047   | 8.291 ± 0.052   | +0.8% (~1σ)  |