### PR TITLE
fix: reject bare "(" and empty string as score in ZRANGEBYSCORE

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -634,10 +634,12 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
         char *s = objectGetVal(min);
         size_t len = sdslen(s);
         if (s[0] == '(') {
+            if (len < 2) return C_ERR; /* bare "(" with no number */
             spec->min = valkey_strtod_n(s + 1, len - 1, &eptr);
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
             spec->minex = 1;
         } else {
+            if (len == 0) return C_ERR; /* empty string */
             spec->min = valkey_strtod_n(s, len, &eptr);
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
         }
@@ -648,10 +650,12 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
         char *s = objectGetVal(max);
         size_t len = sdslen(s);
         if (s[0] == '(') {
+            if (len < 2) return C_ERR; /* bare "(" with no number */
             spec->max = valkey_strtod_n(s + 1, len - 1, &eptr);
             if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
             spec->maxex = 1;
         } else {
+            if (len == 0) return C_ERR; /* empty string */
             spec->max = valkey_strtod_n(s, len, &eptr);
             if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
         }


### PR DESCRIPTION
Fixes #3483

## Problem

`ZRANGEBYSCORE` (and `ZCOUNT`, `ZRANGESTORE`, etc.) accepts a bare `(` as a valid score, silently parsing it as `(0.0` (exclusive zero). An empty string `""` is also accepted as `0.0`.

Root cause: when `s = "("` (length 1), `valkey_strtod_n(s + 1, 0, &eptr)` is called with zero length. The parser returns 0.0 and sets `eptr` to the null terminator. The `eptr[0] != 0` check passes.

This was flagged as **Coverity CID 901320** (Out-of-bounds access, High impact).

## Fix

Add length guards in `zslParseRange()`:
- `len < 2` after detecting `(` prefix → `C_ERR` (bare paren, no number)
- `len == 0` for non-prefixed strings → `C_ERR` (empty string)

Applied to both min and max parsing paths.

## Before / After

```
# Before
127.0.0.1:6379> ZRANGEBYSCORE zs ( +inf
1) "pos1"
2) "pos2"

# After
127.0.0.1:6379> ZRANGEBYSCORE zs ( +inf
(error) ERR min or max is not a float
```