### PR TITLE
Extend CAPA REDIRECT to cover keyless commands on cluster replicas

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -5112,7 +5112,7 @@ void clientHelpCommand(client *c) {
         "CAPA <option> [options...]",
         "    The client claims its some capability options. Options are:",
         "    * REDIRECT",
-        "      The client can handle redirection (standalone failover and keyless reads on replicas).",
+        "      The client can handle redirection (standalone failover and keyless commands on replicas).",
         "GETREDIR",
         "    Return the client ID we are redirecting to when tracking is enabled.",
         "GETNAME",

--- a/src/networking.c
+++ b/src/networking.c
@@ -4891,6 +4891,7 @@ static int validateClientCapaFilter(sds capa) {
         const char capability = capa[i];
         switch (capability) {
         case 'r':
+        case 'k':
             /* Valid capability, do nothing. */
             break;
         default:

--- a/src/networking.c
+++ b/src/networking.c
@@ -4409,7 +4409,7 @@ sds catClientInfoString(sds s, client *client, int hide_user_data) {
 
     p = capa;
     if (client->capa & CLIENT_CAPA_REDIRECT) *p++ = 'r';
-    if (client->capa & CLIENT_CAPA_REDIRECT_KEYLESS) *p++ = 'k';
+    if (client->capa & CLIENT_CAPA_PRIMARY_READ) *p++ = 'k';
     *p = '\0';
 
     /* Compute the total memory consumed by this client. */
@@ -5009,7 +5009,7 @@ static int clientMatchesCapaFilter(client *c, sds capa_filter) {
             if (!(c->capa & CLIENT_CAPA_REDIRECT)) return 0;
             break;
         case 'k': /* client supports keyless redirection */
-            if (!(c->capa & CLIENT_CAPA_REDIRECT_KEYLESS)) return 0;
+            if (!(c->capa & CLIENT_CAPA_PRIMARY_READ)) return 0;
             break;
         default:
             /* Invalid capa, return false */
@@ -5118,7 +5118,7 @@ void clientHelpCommand(client *c) {
         "    The client claims its some capability options. Options are:",
         "    * REDIRECT",
         "      The client can handle redirection during primary and replica failover in standalone mode.",
-        "    * REDIRECT-KEYLESS",
+        "    * PRIMARY-READ",
         "      Redirect keyless read commands to the primary when the replica is not in READONLY mode.",
         "GETREDIR",
         "    Return the client ID we are redirecting to when tracking is enabled.",
@@ -5725,8 +5725,8 @@ void clientCapaCommand(client *c) {
     for (int i = 2; i < c->argc; i++) {
         if (!strcasecmp(objectGetVal(c->argv[i]), "redirect")) {
             c->capa |= CLIENT_CAPA_REDIRECT;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "redirect-keyless")) {
-            c->capa |= CLIENT_CAPA_REDIRECT_KEYLESS;
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "primary-read")) {
+            c->capa |= CLIENT_CAPA_PRIMARY_READ;
         }
     }
     addReply(c, shared.ok);

--- a/src/networking.c
+++ b/src/networking.c
@@ -4409,6 +4409,7 @@ sds catClientInfoString(sds s, client *client, int hide_user_data) {
 
     p = capa;
     if (client->capa & CLIENT_CAPA_REDIRECT) *p++ = 'r';
+    if (client->capa & CLIENT_CAPA_REDIRECT_KEYLESS) *p++ = 'k';
     *p = '\0';
 
     /* Compute the total memory consumed by this client. */
@@ -5006,6 +5007,9 @@ static int clientMatchesCapaFilter(client *c, sds capa_filter) {
         case 'r': /* client supports redirection */
             if (!(c->capa & CLIENT_CAPA_REDIRECT)) return 0;
             break;
+        case 'k': /* client supports keyless redirection */
+            if (!(c->capa & CLIENT_CAPA_REDIRECT_KEYLESS)) return 0;
+            break;
         default:
             /* Invalid capa, return false */
             return 0;
@@ -5113,6 +5117,8 @@ void clientHelpCommand(client *c) {
         "    The client claims its some capability options. Options are:",
         "    * REDIRECT",
         "      The client can handle redirection during primary and replica failover in standalone mode.",
+        "    * REDIRECT-KEYLESS",
+        "      Redirect keyless read commands to the primary when the replica is not in READONLY mode.",
         "GETREDIR",
         "    Return the client ID we are redirecting to when tracking is enabled.",
         "GETNAME",
@@ -5718,6 +5724,8 @@ void clientCapaCommand(client *c) {
     for (int i = 2; i < c->argc; i++) {
         if (!strcasecmp(objectGetVal(c->argv[i]), "redirect")) {
             c->capa |= CLIENT_CAPA_REDIRECT;
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "redirect-keyless")) {
+            c->capa |= CLIENT_CAPA_REDIRECT_KEYLESS;
         }
     }
     addReply(c, shared.ok);

--- a/src/networking.c
+++ b/src/networking.c
@@ -4409,7 +4409,6 @@ sds catClientInfoString(sds s, client *client, int hide_user_data) {
 
     p = capa;
     if (client->capa & CLIENT_CAPA_REDIRECT) *p++ = 'r';
-    if (client->capa & CLIENT_CAPA_PRIMARY_READ) *p++ = 'k';
     *p = '\0';
 
     /* Compute the total memory consumed by this client. */
@@ -4891,7 +4890,6 @@ static int validateClientCapaFilter(sds capa) {
         const char capability = capa[i];
         switch (capability) {
         case 'r':
-        case 'k':
             /* Valid capability, do nothing. */
             break;
         default:
@@ -5008,9 +5006,6 @@ static int clientMatchesCapaFilter(client *c, sds capa_filter) {
         case 'r': /* client supports redirection */
             if (!(c->capa & CLIENT_CAPA_REDIRECT)) return 0;
             break;
-        case 'k': /* client supports keyless redirection */
-            if (!(c->capa & CLIENT_CAPA_PRIMARY_READ)) return 0;
-            break;
         default:
             /* Invalid capa, return false */
             return 0;
@@ -5117,9 +5112,7 @@ void clientHelpCommand(client *c) {
         "CAPA <option> [options...]",
         "    The client claims its some capability options. Options are:",
         "    * REDIRECT",
-        "      The client can handle redirection during primary and replica failover in standalone mode.",
-        "    * PRIMARY-READ",
-        "      Redirect keyless read commands to the primary when the replica is not in READONLY mode.",
+        "      The client can handle redirection (standalone failover and keyless reads on replicas).",
         "GETREDIR",
         "    Return the client ID we are redirecting to when tracking is enabled.",
         "GETNAME",
@@ -5725,8 +5718,6 @@ void clientCapaCommand(client *c) {
     for (int i = 2; i < c->argc; i++) {
         if (!strcasecmp(objectGetVal(c->argv[i]), "redirect")) {
             c->capa |= CLIENT_CAPA_REDIRECT;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "primary-read")) {
-            c->capa |= CLIENT_CAPA_PRIMARY_READ;
         }
     }
     addReply(c, shared.ok);

--- a/src/server.c
+++ b/src/server.c
@@ -4457,14 +4457,14 @@ int processCommand(client *c) {
         }
     }
 
-    /* If the client has the primary-read capability, redirect keyless
+    /* If the client has the redirect capability, redirect keyless
      * read commands to the primary when this is a replica and the client
      * has not opted into replica reads with READONLY. EXEC with all-keyless
      * queued commands is also considered keyless (c->slot remains -1 as set
      * by prepareCommand when no keys are found). */
     int is_keyless_exec = is_exec && c->slot == -1;
     if (server.cluster_enabled && !obey_client && (is_keyless || is_keyless_exec) && is_read_command &&
-        (c->capa & CLIENT_CAPA_PRIMARY_READ) && !c->flag.readonly) {
+        (c->capa & CLIENT_CAPA_REDIRECT) && !c->flag.readonly) {
         clusterNode *myself = getMyClusterNode();
         if (clusterNodeIsReplica(myself)) {
             clusterNode *primary = clusterNodeGetPrimary(myself);

--- a/src/server.c
+++ b/src/server.c
@@ -4460,8 +4460,8 @@ int processCommand(client *c) {
     /* If the client has the primary-read capability, redirect keyless
      * read commands to the primary when this is a replica and the client
      * has not opted into replica reads with READONLY. EXEC with all-keyless
-     * queued commands is also considered keyless (c->slot remains -1 after
-     * getNodeByQuery). */
+     * queued commands is also considered keyless (c->slot remains -1 as set
+     * by prepareCommand when no keys are found). */
     int is_keyless_exec = is_exec && c->slot == -1;
     if (server.cluster_enabled && !obey_client && (is_keyless || is_keyless_exec) && is_read_command &&
         (c->capa & CLIENT_CAPA_PRIMARY_READ) && !c->flag.readonly) {
@@ -4478,6 +4478,7 @@ int processCommand(client *c) {
                                              clusterNodePreferredEndpoint(primary, c), port));
             c->duration = 0;
             c->cmd->rejected_calls++;
+            moduleFireCommandRejectedEvent(c, "-REDIRECT");
             return C_OK;
         }
     }

--- a/src/server.c
+++ b/src/server.c
@@ -4468,7 +4468,12 @@ int processCommand(client *c) {
         clusterNode *myself = getMyClusterNode();
         if (clusterNodeIsReplica(myself)) {
             clusterNode *primary = clusterNodeGetPrimary(myself);
-            // We pass -1 as it does not matter which slot will be passed in MOVED command
+            if (is_keyless_exec) {
+                discardTransaction(c);
+            } else {
+                flagTransaction(c);
+            }
+            /* We pass -1 as it does not matter which slot will be passed in MOVED command */
             clusterRedirectClient(c, primary, -1, CLUSTER_REDIR_MOVED);
             c->duration = 0;
             c->cmd->rejected_calls++;

--- a/src/server.c
+++ b/src/server.c
@@ -4439,8 +4439,8 @@ int processCommand(client *c) {
      * However we don't perform the redirection if:
      * 1) The sender of this command is our primary.
      * 2) The command has no key arguments. */
-    if (server.cluster_enabled && !obey_client &&
-        !(!(c->cmd->flags & CMD_MOVABLE_KEYS) && c->cmd->key_specs_num == 0 && c->cmd->proc != execCommand)) {
+    int is_keyless = !(c->cmd->flags & CMD_MOVABLE_KEYS) && c->cmd->key_specs_num == 0 && c->cmd->proc != execCommand;
+    if (server.cluster_enabled && !obey_client && !is_keyless) {
         int error_code;
         clusterNode *n = getNodeByQuery(c, &error_code);
         if (n == NULL || !clusterNodeIsMyself(n)) {
@@ -4453,6 +4453,25 @@ int processCommand(client *c) {
             c->duration = 0;
             c->cmd->rejected_calls++;
             moduleFireCommandRejectedEvent(c, NULL);
+            return C_OK;
+        }
+    }
+
+    /* If the client has the redirect-keyless capability, redirect keyless
+     * read commands to the primary when this is a replica and the client
+     * has not opted into replica reads with READONLY. EXEC with all-keyless
+     * queued commands is also considered keyless (c->slot remains -1 after
+     * getNodeByQuery). */
+    int is_keyless_exec = is_exec && c->slot == -1;
+    if (server.cluster_enabled && !obey_client && (is_keyless || is_keyless_exec) && is_read_command &&
+        (c->capa & CLIENT_CAPA_REDIRECT_KEYLESS) && !c->flag.readonly) {
+        clusterNode *myself = getMyClusterNode();
+        if (clusterNodeIsReplica(myself)) {
+            clusterNode *primary = clusterNodeGetPrimary(myself);
+            // We pass -1 as it does not matter which slot will be passed in MOVED command
+            clusterRedirectClient(c, primary, -1, CLUSTER_REDIR_MOVED);
+            c->duration = 0;
+            c->cmd->rejected_calls++;
             return C_OK;
         }
     }

--- a/src/server.c
+++ b/src/server.c
@@ -4458,12 +4458,12 @@ int processCommand(client *c) {
     }
 
     /* If the client has the redirect capability, redirect keyless
-     * read commands to the primary when this is a replica and the client
+     * commands to the primary when this is a replica and the client
      * has not opted into replica reads with READONLY. EXEC with all-keyless
      * queued commands is also considered keyless (c->slot remains -1 as set
      * by prepareCommand when no keys are found). */
     int is_keyless_exec = is_exec && c->slot == -1;
-    if (server.cluster_enabled && !obey_client && (is_keyless || is_keyless_exec) && is_read_command &&
+    if (server.cluster_enabled && !obey_client && (is_keyless || is_keyless_exec) && (is_read_command || is_write_command) &&
         (c->capa & CLIENT_CAPA_REDIRECT) && !c->flag.readonly) {
         clusterNode *myself = getMyClusterNode();
         if (clusterNodeIsReplica(myself)) {

--- a/src/server.c
+++ b/src/server.c
@@ -4457,14 +4457,14 @@ int processCommand(client *c) {
         }
     }
 
-    /* If the client has the redirect-keyless capability, redirect keyless
+    /* If the client has the primary-read capability, redirect keyless
      * read commands to the primary when this is a replica and the client
      * has not opted into replica reads with READONLY. EXEC with all-keyless
      * queued commands is also considered keyless (c->slot remains -1 after
      * getNodeByQuery). */
     int is_keyless_exec = is_exec && c->slot == -1;
     if (server.cluster_enabled && !obey_client && (is_keyless || is_keyless_exec) && is_read_command &&
-        (c->capa & CLIENT_CAPA_REDIRECT_KEYLESS) && !c->flag.readonly) {
+        (c->capa & CLIENT_CAPA_PRIMARY_READ) && !c->flag.readonly) {
         clusterNode *myself = getMyClusterNode();
         if (clusterNodeIsReplica(myself)) {
             clusterNode *primary = clusterNodeGetPrimary(myself);
@@ -4473,8 +4473,9 @@ int processCommand(client *c) {
             } else {
                 flagTransaction(c);
             }
-            /* We pass -1 as it does not matter which slot will be passed in MOVED command */
-            clusterRedirectClient(c, primary, -1, CLUSTER_REDIR_MOVED);
+            int port = clusterNodeClientPort(primary, connIsTLS(c->conn), c);
+            addReplyErrorSds(c, sdscatprintf(sdsempty(), "-REDIRECT %s:%d",
+                                             clusterNodePreferredEndpoint(primary, c), port));
             c->duration = 0;
             c->cmd->rejected_calls++;
             return C_OK;

--- a/src/server.c
+++ b/src/server.c
@@ -4439,7 +4439,7 @@ int processCommand(client *c) {
      * However we don't perform the redirection if:
      * 1) The sender of this command is our primary.
      * 2) The command has no key arguments. */
-    int is_keyless = !(c->cmd->flags & CMD_MOVABLE_KEYS) && c->cmd->key_specs_num == 0 && c->cmd->proc != execCommand;
+    int is_keyless = (c->read_flags & READ_FLAGS_NO_KEYS) && c->cmd->proc != execCommand;
     if (server.cluster_enabled && !obey_client && !is_keyless) {
         int error_code;
         clusterNode *n = getNodeByQuery(c, &error_code);

--- a/src/server.h
+++ b/src/server.h
@@ -333,7 +333,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CMD_DOC_SYSCMD (1 << 1)     /* System (internal) command */
 
 /* Client capabilities */
-#define CLIENT_CAPA_REDIRECT (1 << 0) /* Indicate that the client can handle redirection */
+#define CLIENT_CAPA_REDIRECT (1 << 0)          /* Indicate that the client can handle redirection */
+#define CLIENT_CAPA_REDIRECT_KEYLESS (1 << 1)  /* Redirect keyless read commands to primary in cluster mode */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/src/server.h
+++ b/src/server.h
@@ -333,7 +333,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CMD_DOC_SYSCMD (1 << 1)     /* System (internal) command */
 
 /* Client capabilities */
-#define CLIENT_CAPA_REDIRECT (1 << 0)         /* Indicate that the client can handle redirection */
+#define CLIENT_CAPA_REDIRECT (1 << 0)     /* Indicate that the client can handle redirection */
 #define CLIENT_CAPA_PRIMARY_READ (1 << 1) /* Redirect keyless read commands to primary in cluster mode */
 
 /* Client block type (btype field in client structure)

--- a/src/server.h
+++ b/src/server.h
@@ -333,8 +333,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CMD_DOC_SYSCMD (1 << 1)     /* System (internal) command */
 
 /* Client capabilities */
-#define CLIENT_CAPA_REDIRECT (1 << 0)          /* Indicate that the client can handle redirection */
-#define CLIENT_CAPA_REDIRECT_KEYLESS (1 << 1)  /* Redirect keyless read commands to primary in cluster mode */
+#define CLIENT_CAPA_REDIRECT (1 << 0)         /* Indicate that the client can handle redirection */
+#define CLIENT_CAPA_REDIRECT_KEYLESS (1 << 1) /* Redirect keyless read commands to primary in cluster mode */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/src/server.h
+++ b/src/server.h
@@ -334,7 +334,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 
 /* Client capabilities */
 #define CLIENT_CAPA_REDIRECT (1 << 0)         /* Indicate that the client can handle redirection */
-#define CLIENT_CAPA_REDIRECT_KEYLESS (1 << 1) /* Redirect keyless read commands to primary in cluster mode */
+#define CLIENT_CAPA_PRIMARY_READ (1 << 1) /* Redirect keyless read commands to primary in cluster mode */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/src/server.h
+++ b/src/server.h
@@ -333,8 +333,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CMD_DOC_SYSCMD (1 << 1)     /* System (internal) command */
 
 /* Client capabilities */
-#define CLIENT_CAPA_REDIRECT (1 << 0)     /* Indicate that the client can handle redirection */
-#define CLIENT_CAPA_PRIMARY_READ (1 << 1) /* Redirect keyless read commands to primary in cluster mode */
+#define CLIENT_CAPA_REDIRECT (1 << 0) /* Indicate that the client can handle redirection */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/tests/unit/cluster/replica-redirect.tcl
+++ b/tests/unit/cluster/replica-redirect.tcl
@@ -57,7 +57,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd1 close
     }
 
-    test {keyless read commands execute on replica without redirect-keyless capa} {
+    test {keyless read commands execute on replica without primary-read capa} {
         # Without the capa, keyless read commands like SCAN execute locally on the replica
         # After failover, node 0 is the new replica.
         set rd [valkey_deferring_client 0]
@@ -67,26 +67,26 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {keyless read commands are MOVED with redirect-keyless capa} {
+    test {keyless read commands are MOVED with primary-read capa} {
         set rd [valkey_deferring_client 0]
-        $rd CLIENT CAPA redirect-keyless
+        $rd CLIENT CAPA primary-read
         assert_equal OK [$rd read]
 
         $rd DBSIZE
-        assert_error "MOVED *" {$rd read}
+        assert_error "REDIRECT *" {$rd read}
 
         $rd RANDOMKEY
-        assert_error "MOVED *" {$rd read}
+        assert_error "REDIRECT *" {$rd read}
 
         $rd SCAN 0
-        assert_error "MOVED *" {$rd read}
+        assert_error "REDIRECT *" {$rd read}
 
         $rd close
     }
 
-    test {keyless read commands execute on replica with redirect-keyless and READONLY} {
+    test {keyless read commands execute on replica with primary-read and READONLY} {
         set rd [valkey_deferring_client 0]
-        $rd CLIENT CAPA redirect-keyless
+        $rd CLIENT CAPA primary-read
         assert_equal OK [$rd read]
         $rd READONLY
         assert_equal OK [$rd read]
@@ -99,9 +99,9 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {non-read keyless commands are not affected by redirect-keyless capa} {
+    test {non-read keyless commands are not affected by primary-read capa} {
         set rd [valkey_deferring_client 0]
-        $rd CLIENT CAPA redirect-keyless
+        $rd CLIENT CAPA primary-read
         assert_equal OK [$rd read]
 
         # PING is not CMD_READONLY, should still work on replica
@@ -111,9 +111,9 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {CLIENT INFO reports redirect-keyless capa} {
+    test {CLIENT INFO reports primary-read capa} {
         set rd [valkey_deferring_client 0]
-        $rd CLIENT CAPA redirect-keyless
+        $rd CLIENT CAPA primary-read
         assert_equal OK [$rd read]
 
         $rd CLIENT INFO
@@ -122,18 +122,18 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {keyless commands inside MULTI are individually MOVED with redirect-keyless capa} {
+    test {keyless commands inside MULTI are individually MOVED with primary-read capa} {
         set rd [valkey_deferring_client 0]
-        $rd CLIENT CAPA redirect-keyless
+        $rd CLIENT CAPA primary-read
         assert_equal OK [$rd read]
 
         $rd MULTI
         assert_equal OK [$rd read]
         # Individual keyless commands get MOVED, consistent with keyed commands
         $rd DBSIZE
-        assert_error "MOVED -1 *" {$rd read}
+        assert_error "REDIRECT *" {$rd read}
         $rd RANDOMKEY
-        assert_error "MOVED -1 *" {$rd read}
+        assert_error "REDIRECT *" {$rd read}
         # Transaction was flagged dirty, EXEC returns EXECABORT
         $rd EXEC
         assert_error "EXECABORT *" {$rd read}
@@ -144,19 +144,19 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {both redirect and redirect-keyless capas work together} {
+    test {both redirect and primary-read capas work together} {
         set rd [valkey_deferring_client 0]
         $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
-        $rd CLIENT CAPA redirect-keyless
+        $rd CLIENT CAPA primary-read
         assert_equal OK [$rd read]
 
         $rd CLIENT INFO
         assert_match "*capa=rk*" [$rd read]
 
-        # Keyless read is redirected via redirect-keyless
+        # Keyless read is redirected via primary-read
         $rd DBSIZE
-        assert_error "MOVED -1 *" {$rd read}
+        assert_error "REDIRECT *" {$rd read}
 
         # Keyed read is redirected via standard cluster redirect
         $rd GET x

--- a/tests/unit/cluster/replica-redirect.tcl
+++ b/tests/unit/cluster/replica-redirect.tcl
@@ -56,4 +56,69 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd0_ro close
         $rd1 close
     }
+
+    test {keyless read commands execute on replica without redirect-keyless capa} {
+        # Without the capa, keyless read commands like SCAN execute locally on the replica
+        # After failover, node 0 is the new replica.
+        set rd [valkey_deferring_client 0]
+        $rd SCAN 0
+        set reply [$rd read]
+        assert_match "0 *" $reply
+        $rd close
+    }
+
+    test {keyless read commands are MOVED with redirect-keyless capa} {
+        set rd [valkey_deferring_client 0]
+        $rd CLIENT CAPA redirect-keyless
+        assert_equal OK [$rd read]
+
+        $rd DBSIZE
+        assert_error "MOVED *" {$rd read}
+
+        $rd RANDOMKEY
+        assert_error "MOVED *" {$rd read}
+
+        $rd SCAN 0
+        assert_error "MOVED *" {$rd read}
+
+        $rd close
+    }
+
+    test {keyless read commands execute on replica with redirect-keyless and READONLY} {
+        set rd [valkey_deferring_client 0]
+        $rd CLIENT CAPA redirect-keyless
+        assert_equal OK [$rd read]
+        $rd READONLY
+        assert_equal OK [$rd read]
+
+        # With READONLY, keyless reads should execute locally
+        $rd DBSIZE
+        set reply [$rd read]
+        assert {$reply >= 0}
+
+        $rd close
+    }
+
+    test {non-read keyless commands are not affected by redirect-keyless capa} {
+        set rd [valkey_deferring_client 0]
+        $rd CLIENT CAPA redirect-keyless
+        assert_equal OK [$rd read]
+
+        # PING is not CMD_READONLY, should still work on replica
+        $rd PING
+        assert_equal PONG [$rd read]
+
+        $rd close
+    }
+
+    test {CLIENT INFO reports redirect-keyless capa} {
+        set rd [valkey_deferring_client 0]
+        $rd CLIENT CAPA redirect-keyless
+        assert_equal OK [$rd read]
+
+        $rd CLIENT INFO
+        assert_match "*capa=k*" [$rd read]
+
+        $rd close
+    }
 } ;# start_cluster

--- a/tests/unit/cluster/replica-redirect.tcl
+++ b/tests/unit/cluster/replica-redirect.tcl
@@ -57,26 +57,28 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd1 close
     }
 
-    test {keyless read commands execute on replica without redirect capa} {
-        # Without the capa, keyless read commands like SCAN execute locally on the replica
-        # After failover, node 0 is the new replica.
-        set rd [valkey_deferring_client 0]
+    # Determine which node is the replica after failover
+    set ridx [expr {[s 0 role] eq {slave} ? 0 : -1}]
+
+    test {keyless commands execute on replica without redirect capa} {
+        # Without the capa, keyless commands like SCAN execute locally on the replica
+        set rd [valkey_deferring_client $ridx]
         $rd SCAN 0
         set reply [$rd read]
-        assert_match "0 *" $reply
+        assert_no_match "*REDIRECT*" $reply
 
-        # Write keyless commands rejected regardless
+        # Write keyless commands rejected
         $rd FLUSHDB
         assert_error "READONLY You can't write against a read only replica." {$rd read}
         
         $rd close
     }
 
-    test {keyless read commands are redirected with redirect capa} {
-        set rd [valkey_deferring_client 0]
+    test {keyless commands are redirected with redirect capa} {
+        set rd [valkey_deferring_client $ridx]
         $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
-
+        # Read keyless commands redirected
         $rd DBSIZE
         assert_error "REDIRECT *" {$rd read}
 
@@ -86,17 +88,21 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd SCAN 0
         assert_error "REDIRECT *" {$rd read}
 
+        # Write keyless commands also redirected
+        $rd FLUSHDB
+        assert_error "REDIRECT *" {$rd read}
+
         $rd close
     }
 
-    test {keyless read commands execute on replica with redirect capa and READONLY} {
-        set rd [valkey_deferring_client 0]
+    test {keyless commands execute on replica with redirect capa and READONLY} {
+        set rd [valkey_deferring_client $ridx]
         $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
         $rd READONLY
         assert_equal OK [$rd read]
 
-        # With READONLY, keyless reads should execute locally
+        # With READONLY, keyless commands should execute locally
         $rd DBSIZE
         set reply [$rd read]
         assert {$reply >= 0}
@@ -104,12 +110,12 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {non-read keyless commands are not affected by redirect capa} {
-        set rd [valkey_deferring_client 0]
+    test {non-read & non-write keyless commands are not affected by redirect capa} {
+        set rd [valkey_deferring_client $ridx]
         $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
 
-        # PING is not CMD_READONLY, should still work on replica
+        # PING should still work on replica
         $rd PING
         assert_equal PONG [$rd read]
 
@@ -117,7 +123,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
     }
 
     test {CLIENT INFO reports redirect capa} {
-        set rd [valkey_deferring_client 0]
+        set rd [valkey_deferring_client $ridx]
         $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
 
@@ -128,7 +134,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
     }
 
     test {keyless commands inside MULTI are individually redirected with redirect capa} {
-        set rd [valkey_deferring_client 0]
+        set rd [valkey_deferring_client $ridx]
         $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
 
@@ -139,9 +145,9 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         assert_error "REDIRECT *" {$rd read}
         $rd RANDOMKEY
         assert_error "REDIRECT *" {$rd read}
-        # Write keyless commands rejected regardless
+        # Write keyless commands also redirected
         $rd FLUSHDB
-        assert_error "READONLY You can't write against a read only replica." {$rd read}
+        assert_error "REDIRECT *" {$rd read}
         # Transaction was flagged dirty, EXEC returns EXECABORT
         $rd EXEC
         assert_error "EXECABORT *" {$rd read}
@@ -152,23 +158,18 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {EXEC with all-keyless read commands is redirected after failover with redirect capa} {
-        # After the earlier failover, node -1 is primary and node 0 is replica.
-        # Failover back so node 0 is primary again for this test.
-        R 0 CLUSTER FAILOVER
-        wait_for_condition 1000 50 {
-            [s 0 role] eq {master} &&
-            [s -1 role] eq {slave}
-        } else {
-            fail "Failover back did not happen"
-        }
+    test {EXEC with all-keyless commands is redirected after failover with redirect capa} {
+        # Determine current roles (using server indices 0 and 1 for R command)
+        set pidx [expr {[s 0 role] eq {master} ? 0 : -1}]
+        # R command uses absolute server numbers
+        set replica_srv [expr {$pidx == 0 ? 1 : 0}]
 
-        # Connect to node 0 (currently primary) with redirect capa
-        set rd [valkey_deferring_client 0]
+        # Connect to the primary with redirect capa
+        set rd [valkey_deferring_client $pidx]
         $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
 
-        # Queue keyless read commands on the primary — they get QUEUED
+        # Queue keyless commands on the primary — they get QUEUED
         # because we're on a primary (redirect only fires on replicas)
         $rd MULTI
         assert_equal OK [$rd read]
@@ -177,16 +178,15 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd RANDOMKEY
         assert_equal QUEUED [$rd read]
 
-        # Failover: node 0 becomes a replica
-        R 1 CLUSTER FAILOVER
+        # Failover: the replica takes over, primary becomes a replica
+        R $replica_srv CLUSTER FAILOVER
         wait_for_condition 1000 50 {
-            [s 0 role] eq {slave} &&
-            [s -1 role] eq {master}
+            [s $pidx role] eq {slave}
         } else {
             fail "Failover did not happen"
         }
 
-        # EXEC is now on a replica with all-keyless queued read commands.
+        # EXEC is now on a replica with all-keyless queued commands.
         # The transaction should be discarded and REDIRECT returned.
         $rd EXEC
         assert_error "REDIRECT *" {$rd read}
@@ -196,10 +196,13 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         assert_equal PONG [$rd read]
 
         $rd close
+
+        # Update ridx since roles changed
+        set ridx [expr {[s 0 role] eq {slave} ? 0 : -1}]
     }
 
     test {redirect capa handles both keyed and keyless redirects} {
-        set rd [valkey_deferring_client 0]
+        set rd [valkey_deferring_client $ridx]
         $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
 

--- a/tests/unit/cluster/replica-redirect.tcl
+++ b/tests/unit/cluster/replica-redirect.tcl
@@ -144,6 +144,52 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
+    test {EXEC with all-keyless read commands is redirected after failover with primary-read capa} {
+        # After the earlier failover, node -1 is primary and node 0 is replica.
+        # Failover back so node 0 is primary again for this test.
+        R 0 CLUSTER FAILOVER
+        wait_for_condition 1000 50 {
+            [s 0 role] eq {master} &&
+            [s -1 role] eq {slave}
+        } else {
+            fail "Failover back did not happen"
+        }
+
+        # Connect to node 0 (currently primary) with primary-read capa
+        set rd [valkey_deferring_client 0]
+        $rd CLIENT CAPA primary-read
+        assert_equal OK [$rd read]
+
+        # Queue keyless read commands on the primary — they get QUEUED
+        # because we're on a primary (redirect only fires on replicas)
+        $rd MULTI
+        assert_equal OK [$rd read]
+        $rd DBSIZE
+        assert_equal QUEUED [$rd read]
+        $rd RANDOMKEY
+        assert_equal QUEUED [$rd read]
+
+        # Failover: node 0 becomes a replica
+        R 1 CLUSTER FAILOVER
+        wait_for_condition 1000 50 {
+            [s 0 role] eq {slave} &&
+            [s -1 role] eq {master}
+        } else {
+            fail "Failover did not happen"
+        }
+
+        # EXEC is now on a replica with all-keyless queued read commands.
+        # The transaction should be discarded and REDIRECT returned.
+        $rd EXEC
+        assert_error "REDIRECT *" {$rd read}
+
+        # Client should be usable after the discarded transaction
+        $rd PING
+        assert_equal PONG [$rd read]
+
+        $rd close
+    }
+
     test {both redirect and primary-read capas work together} {
         set rd [valkey_deferring_client 0]
         $rd CLIENT CAPA redirect

--- a/tests/unit/cluster/replica-redirect.tcl
+++ b/tests/unit/cluster/replica-redirect.tcl
@@ -57,7 +57,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd1 close
     }
 
-    test {keyless read commands execute on replica without primary-read capa} {
+    test {keyless read commands execute on replica without redirect capa} {
         # Without the capa, keyless read commands like SCAN execute locally on the replica
         # After failover, node 0 is the new replica.
         set rd [valkey_deferring_client 0]
@@ -67,9 +67,9 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {keyless read commands are MOVED with primary-read capa} {
+    test {keyless read commands are redirected with redirect capa} {
         set rd [valkey_deferring_client 0]
-        $rd CLIENT CAPA primary-read
+        $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
 
         $rd DBSIZE
@@ -84,9 +84,9 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {keyless read commands execute on replica with primary-read and READONLY} {
+    test {keyless read commands execute on replica with redirect capa and READONLY} {
         set rd [valkey_deferring_client 0]
-        $rd CLIENT CAPA primary-read
+        $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
         $rd READONLY
         assert_equal OK [$rd read]
@@ -99,9 +99,9 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {non-read keyless commands are not affected by primary-read capa} {
+    test {non-read keyless commands are not affected by redirect capa} {
         set rd [valkey_deferring_client 0]
-        $rd CLIENT CAPA primary-read
+        $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
 
         # PING is not CMD_READONLY, should still work on replica
@@ -111,20 +111,20 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {CLIENT INFO reports primary-read capa} {
+    test {CLIENT INFO reports redirect capa} {
         set rd [valkey_deferring_client 0]
-        $rd CLIENT CAPA primary-read
+        $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
 
         $rd CLIENT INFO
-        assert_match "*capa=k*" [$rd read]
+        assert_match "*capa=r*" [$rd read]
 
         $rd close
     }
 
-    test {keyless commands inside MULTI are individually MOVED with primary-read capa} {
+    test {keyless commands inside MULTI are individually redirected with redirect capa} {
         set rd [valkey_deferring_client 0]
-        $rd CLIENT CAPA primary-read
+        $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
 
         $rd MULTI
@@ -144,7 +144,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {EXEC with all-keyless read commands is redirected after failover with primary-read capa} {
+    test {EXEC with all-keyless read commands is redirected after failover with redirect capa} {
         # After the earlier failover, node -1 is primary and node 0 is replica.
         # Failover back so node 0 is primary again for this test.
         R 0 CLUSTER FAILOVER
@@ -155,9 +155,9 @@ start_cluster 1 1 {tags {external:skip cluster}} {
             fail "Failover back did not happen"
         }
 
-        # Connect to node 0 (currently primary) with primary-read capa
+        # Connect to node 0 (currently primary) with redirect capa
         set rd [valkey_deferring_client 0]
-        $rd CLIENT CAPA primary-read
+        $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
 
         # Queue keyless read commands on the primary — they get QUEUED
@@ -190,17 +190,15 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd close
     }
 
-    test {both redirect and primary-read capas work together} {
+    test {redirect capa handles both keyed and keyless redirects} {
         set rd [valkey_deferring_client 0]
         $rd CLIENT CAPA redirect
         assert_equal OK [$rd read]
-        $rd CLIENT CAPA primary-read
-        assert_equal OK [$rd read]
 
         $rd CLIENT INFO
-        assert_match "*capa=rk*" [$rd read]
+        assert_match "*capa=r*" [$rd read]
 
-        # Keyless read is redirected via primary-read
+        # Keyless read is redirected
         $rd DBSIZE
         assert_error "REDIRECT *" {$rd read}
 

--- a/tests/unit/cluster/replica-redirect.tcl
+++ b/tests/unit/cluster/replica-redirect.tcl
@@ -121,4 +121,47 @@ start_cluster 1 1 {tags {external:skip cluster}} {
 
         $rd close
     }
+
+    test {keyless commands inside MULTI are individually MOVED with redirect-keyless capa} {
+        set rd [valkey_deferring_client 0]
+        $rd CLIENT CAPA redirect-keyless
+        assert_equal OK [$rd read]
+
+        $rd MULTI
+        assert_equal OK [$rd read]
+        # Individual keyless commands get MOVED, consistent with keyed commands
+        $rd DBSIZE
+        assert_error "MOVED -1 *" {$rd read}
+        $rd RANDOMKEY
+        assert_error "MOVED -1 *" {$rd read}
+        # Transaction was flagged dirty, EXEC returns EXECABORT
+        $rd EXEC
+        assert_error "EXECABORT *" {$rd read}
+
+        $rd PING
+        assert_equal PONG [$rd read]
+
+        $rd close
+    }
+
+    test {both redirect and redirect-keyless capas work together} {
+        set rd [valkey_deferring_client 0]
+        $rd CLIENT CAPA redirect
+        assert_equal OK [$rd read]
+        $rd CLIENT CAPA redirect-keyless
+        assert_equal OK [$rd read]
+
+        $rd CLIENT INFO
+        assert_match "*capa=rk*" [$rd read]
+
+        # Keyless read is redirected via redirect-keyless
+        $rd DBSIZE
+        assert_error "MOVED -1 *" {$rd read}
+
+        # Keyed read is redirected via standard cluster redirect
+        $rd GET x
+        assert_error "MOVED *" {$rd read}
+
+        $rd close
+    }
 } ;# start_cluster

--- a/tests/unit/cluster/replica-redirect.tcl
+++ b/tests/unit/cluster/replica-redirect.tcl
@@ -64,6 +64,11 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         $rd SCAN 0
         set reply [$rd read]
         assert_match "0 *" $reply
+
+        # Write keyless commands rejected regardless
+        $rd FLUSHDB
+        assert_error "READONLY You can't write against a read only replica." {$rd read}
+        
         $rd close
     }
 
@@ -134,6 +139,9 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         assert_error "REDIRECT *" {$rd read}
         $rd RANDOMKEY
         assert_error "REDIRECT *" {$rd read}
+        # Write keyless commands rejected regardless
+        $rd FLUSHDB
+        assert_error "READONLY You can't write against a read only replica." {$rd read}
         # Transaction was flagged dirty, EXEC returns EXECABORT
         $rd EXEC
         assert_error "EXECABORT *" {$rd read}

--- a/tests/unit/cluster/replica-redirect.tcl
+++ b/tests/unit/cluster/replica-redirect.tcl
@@ -140,7 +140,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
 
         $rd MULTI
         assert_equal OK [$rd read]
-        # Individual keyless commands get MOVED, consistent with keyed commands
+       # Individual keyless commands get REDIRECT (similar to how keyed commands get MOVED)
         $rd DBSIZE
         assert_error "REDIRECT *" {$rd read}
         $rd RANDOMKEY

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -245,19 +245,10 @@ start_server {tags {"introspection"}} {
         $c1 client setname "client-with-r"
         $c1 client capa redirect
 
-        set c2 [valkey_client]
-        $c2 client setname "client-with-k"
-        $c2 client capa primary-read
-
         set output [r client list capa r capa r]
         assert_match *client-with-r* $output
 
-        set output [r client list capa k]
-        assert_match *client-with-k* $output
-        assert_no_match *client-with-r* $output
-
         catch {$c1 close}
-        catch {$c2 close}
     }
 
     test {CLIENT KILL with IP filter} {
@@ -295,19 +286,9 @@ start_server {tags {"introspection"}} {
         $c1 client setname "killme-capa"
         $c1 client capa redirect
 
-        set c2 [valkey_client]
-        $c2 client setname "killme-capa-k"
-        $c2 client capa primary-read
-
         # Kill using capa r filter
         r client kill capa r skipme yes
         assert_error "*I/O error*" {$c1 ping}
-        # c2 should still be alive (only has k, not r)
-        assert_equal {PONG} [$c2 ping]
-
-        # Now kill using capa k filter
-        r client kill capa k skipme yes
-        assert_error "*I/O error*" {$c2 ping}
     } {}
 
     test {CLIENT KILL with NAME filter} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -245,9 +245,19 @@ start_server {tags {"introspection"}} {
         $c1 client setname "client-with-r"
         $c1 client capa redirect
 
+        set c2 [valkey_client]
+        $c2 client setname "client-with-k"
+        $c2 client capa redirect-keyless
+
         set output [r client list capa r capa r]
         assert_match *client-with-r* $output
+
+        set output [r client list capa k]
+        assert_match *client-with-k* $output
+        assert_no_match *client-with-r* $output
+
         catch {$c1 close}
+        catch {$c2 close}
     }
 
     test {CLIENT KILL with IP filter} {
@@ -285,10 +295,19 @@ start_server {tags {"introspection"}} {
         $c1 client setname "killme-capa"
         $c1 client capa redirect
 
-        # Kill using capa filter
-        r client kill capa r skipme yes
+        set c2 [valkey_client]
+        $c2 client setname "killme-capa-k"
+        $c2 client capa redirect-keyless
 
+        # Kill using capa r filter
+        r client kill capa r skipme yes
         assert_error "*I/O error*" {$c1 ping}
+        # c2 should still be alive (only has k, not r)
+        assert_equal {PONG} [$c2 ping]
+
+        # Now kill using capa k filter
+        r client kill capa k skipme yes
+        assert_error "*I/O error*" {$c2 ping}
     } {}
 
     test {CLIENT KILL with NAME filter} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -247,7 +247,7 @@ start_server {tags {"introspection"}} {
 
         set c2 [valkey_client]
         $c2 client setname "client-with-k"
-        $c2 client capa redirect-keyless
+        $c2 client capa primary-read
 
         set output [r client list capa r capa r]
         assert_match *client-with-r* $output
@@ -297,7 +297,7 @@ start_server {tags {"introspection"}} {
 
         set c2 [valkey_client]
         $c2 client setname "killme-capa-k"
-        $c2 client capa redirect-keyless
+        $c2 client capa primary-read
 
         # Kill using capa r filter
         r client kill capa r skipme yes


### PR DESCRIPTION
When a replica receives a keyless command from a client that has negotiated `CAPA REDIRECT` and has not sent `READONLY`, redirect it to the primary with a `-REDIRECT` response.

Previously, keyless commands like `SCAN, DBSIZE, RANDOMKEY` always executed locally on replicas, and keyless writes like FLUSHDB, FLUSHALL returned -READONLY error with no way for clients to discover the primary.

This reuses the existing `CAPA REDIRECT` capability. The capa signals that the client can handle -REDIRECT responses — it does not prescribe when redirects are sent. Clients that send READONLY opt into local replica execution and are not redirected.

Only commands with CMD_READONLY or CMD_WRITE are redirected, so connection/admin commands (PING, READONLY, CLIENT) remain unaffected. EXEC with all-keyless queued commands (c->slot == -1) is treated as
keyless and the transaction is discarded.

Closes #2991.