### PR TITLE
Fail fast on empty CA directory at TLS config load

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -497,6 +497,7 @@ static bool loadCaCertDir(SSL_CTX *ctx, const char *ca_cert_dir) {
         return false;
     }
 
+    int loaded = 0;
     while ((entry = readdir(dir)) != NULL) {
         if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) continue;
 
@@ -519,10 +520,17 @@ static bool loadCaCertDir(SSL_CTX *ctx, const char *ca_cert_dir) {
                 ERR_clear_error();
             }
             X509_free(cert);
+            loaded++;
         }
     }
 
     closedir(dir);
+
+    if (loaded == 0) {
+        serverLog(LL_WARNING, "No CA certificates loaded from directory: %s", ca_cert_dir);
+        return false;
+    }
+
     return true;
 }
 

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -463,6 +463,9 @@ start_server {tags {"tls"}} {
 
             # Not-yet-valid CA certificate directory
             test_tls_cert_rejection ca-dir $tlsdir/ca-notyet {*One or more loaded CA certificates are invalid*}
+
+            # Empty CA certificate directory
+            test_tls_cert_rejection ca-dir $tlsdir/ca-empty {*No CA certificates loaded from directory*}
         }
 
         proc test_tls_cert_rejection_runtime {r cert_type cert_path} {
@@ -509,6 +512,9 @@ start_server {tags {"tls"}} {
 
             # Not-yet-valid CA certificate directory
             test_tls_cert_rejection_runtime r ca-dir $tlsdir/ca-notyet
+
+            # Empty CA certificate directory
+            test_tls_cert_rejection_runtime r ca-dir $tlsdir/ca-empty
         }
     }
 }

--- a/utils/gen-test-certs.sh
+++ b/utils/gen-test-certs.sh
@@ -6,6 +6,7 @@
 #   tests/tls/ca-{expired,notyet}.crt            Self signed invalid CA certificates.
 #   tests/tls/ca-expired/                        Directory containing expired CA certificate.
 #   tests/tls/ca-notyet/                         Directory containing not-yet-valid CA certificate.
+#   tests/tls/ca-empty/                          Empty directory for testing empty dir rejection.
 #   tests/tls/ca-multi.crt                       CA bundle with multiple certs.
 #   tests/tls/ca-dir/                            CA directory with hashed links.
 #   tests/tls/valkey.{crt,key}                   A certificate with no key usage/policy restrictions.
@@ -208,6 +209,7 @@ openssl ca -batch -config "$CA_CONFIG" \
 # Create CA certificate directories for testing tls-ca-cert-dir with invalid certs
 mkdir -p tests/tls/ca-expired
 mkdir -p tests/tls/ca-notyet
+mkdir -p tests/tls/ca-empty
 
 cp tests/tls/ca-expired.crt tests/tls/ca-expired/
 cp tests/tls/ca-notyet.crt tests/tls/ca-notyet/
@@ -215,6 +217,7 @@ cp tests/tls/ca-notyet.crt tests/tls/ca-notyet/
 echo "Created CA certificate test directories:"
 echo "  tests/tls/ca-expired/ (contains expired CA cert)"
 echo "  tests/tls/ca-notyet/ (contains not-yet-valid CA cert)"
+echo "  tests/tls/ca-empty/  (empty, for testing empty dir rejection)"
 
 # Clean up temporary files
 rm -f tests/tls/*-expired.csr tests/tls/*-notyet.csr tests/tls/ca-expired.csr tests/tls/ca-notyet.csr


### PR DESCRIPTION
### Problem

When `tls-ca-cert-dir` is configured to a directory that exists but contains no certificates, the server starts successfully and logs no warning. This is because `SSL_CTX_load_verify_locations` with a directory argument is lazy, OpenSSL registers the path without scanning it, returning success even for an empty directory.

The failure is only discovered at handshake time, when every connecting client sees `Server closed the connection` and the server logs `Error accepting a client connection: error:0A000086:SSL routines::certificate verify failed`.

This is a silent misconfiguration that gives no actionable signal at startup or `CONFIG SET` time.

| Config argument | OpenSSL function | Fails on empty path |
|---|---|---|
| `tls-ca-cert-file` | `SSL_CTX_load_verify_locations` (file) | Yes |
| `tls-ca-cert-dir` | `SSL_CTX_load_verify_locations` (CApath) | No |




### Fix

`loadCaCertDir` (introduced in #2999 for validity checking) already eagerly scans the directory to load certs. This PR extends it to count the certs loaded and fail immediately if zero certs were found. 



### Behavior change

| Scenario | Before | After |
|---|---|---|
| Startup with empty `tls-ca-cert-dir` | Server starts, clients fail at handshake | Server refuses to start with a clear log message |
| `CONFIG SET tls-ca-cert-dir <empty-dir>` | Returns OK, clients fail at handshake | Returns error, previous config preserved |