### PR TITLE
Add AUTH options to CLUSTER MIGRATESLOTS

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -8804,7 +8804,7 @@ const char **clusterCommandExtendedHelp(void) {
         "LINKS",
         "    Return information about all network links between this node and its peers.",
         "    Output format is an array where each array element is a map containing attributes of a link",
-        "MIGRATESLOTS SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id [SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id ...]",
+        "MIGRATESLOTS SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id [AUTH password | AUTH2 username password] [SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id [AUTH password | AUTH2 username password] ...]",
         "    Migrate the specified slot ranges from this node to the specified node.",
         "CANCELSLOTMIGRATIONS ALL",
         "    Cancel all migrations.",

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -8334,7 +8334,7 @@ const char **clusterCommandExtendedHelp(void) {
         "LINKS",
         "    Return information about all network links between this node and its peers.",
         "    Output format is an array where each array element is a map containing attributes of a link",
-        "MIGRATESLOTS SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id [SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id ...]",
+        "MIGRATESLOTS SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id [AUTH password | AUTH2 username password] [SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id [AUTH password | AUTH2 username password] ...]",
         "    Migrate the specified slot ranges from this node to the specified node.",
         "CANCELSLOTMIGRATIONS ALL",
         "    Cancel all migrations.",

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -8804,7 +8804,7 @@ const char **clusterCommandExtendedHelp(void) {
         "LINKS",
         "    Return information about all network links between this node and its peers.",
         "    Output format is an array where each array element is a map containing attributes of a link",
-        "MIGRATESLOTS SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id [AUTH password | AUTH2 username password] [SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id [AUTH password | AUTH2 username password] ...]",
+        "MIGRATESLOTS SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id [AUTH username password] [SLOTSRANGE start-slot end-slot [start-slot end-slot ...] NODE node-id [AUTH username password] ...]",
         "    Migrate the specified slot ranges from this node to the specified node.",
         "CANCELSLOTMIGRATIONS ALL",
         "    Cancel all migrations.",

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -8,6 +8,8 @@
 #include "bio.h"
 #include "module.h"
 #include "functions.h"
+#include "sds.h"
+#include "server.h"
 
 #include <sys/wait.h>
 #include <fcntl.h>
@@ -88,6 +90,8 @@ typedef struct slotMigrationJob {
     /* State needed during client establishment */
     connection *conn; /* Connection to slot import source node. */
     sds response_buf;
+    sds auth_user; /* User used for AUTH of the export job. */
+    sds auth_password; /* Password used for AUTH of the export job */
 } slotMigrationJob;
 
 static bool isSlotMigrationJobFinished(slotMigrationJob *job);
@@ -103,7 +107,7 @@ static void updateSlotMigrationJobState(slotMigrationJob *job,
 static void sendSyncSlotsMessage(slotMigrationJob *job, const char *subcommand);
 static void proceedWithSlotMigration(slotMigrationJob *job);
 static slotMigrationJob *createSlotExportJob(clusterNode *target_node,
-                                             list *slot_ranges);
+                                             list *slot_ranges, sds auth_user, sds auth_password);
 static bool isSlotExportPauseTimedOut(slotMigrationJob *job);
 static void resetSlotMigrationJob(slotMigrationJob *job);
 static void finishSlotMigrationJob(slotMigrationJob *job,
@@ -1153,6 +1157,8 @@ void clusterCommandMigrateSlots(client *c) {
     list *new_slot_migrations = listCreate();
     listSetFreeMethod(new_slot_migrations, freeSlotMigrationJob);
     list *slot_ranges = NULL;
+    sds auth_user = NULL;
+    sds auth_pass = NULL;
 
     while (curr_index < c->argc) {
         if (strcasecmp(objectGetVal(c->argv[curr_index]), "slotsrange")) {
@@ -1219,9 +1225,34 @@ void clusterCommandMigrateSlots(client *c) {
         }
         curr_index++;
 
-        slotMigrationJob *job = createSlotExportJob(target_node, slot_ranges);
+        if (curr_index < c->argc) {
+            sds token = objectGetVal(c->argv[curr_index]);
+            if (!strcasecmp(token, "auth")) {
+                if (curr_index + 1 >= c->argc) {
+                    addReplyErrorObject(c, shared.syntaxerr);
+                    goto cleanup;
+                }
+                auth_pass = sdsdup(objectGetVal(c->argv[curr_index + 1]));
+                redactClientCommandArgument(c, curr_index + 1);
+                curr_index += 2;
+            } else if (!strcasecmp(token, "auth2")) {
+                if (curr_index + 2 >= c->argc) {
+                    addReplyErrorObject(c, shared.syntaxerr);
+                    goto cleanup;
+                }
+                auth_user = sdsdup(objectGetVal(c->argv[curr_index + 1]));
+                redactClientCommandArgument(c, curr_index + 1);
+                auth_pass = sdsdup(objectGetVal(c->argv[curr_index + 2]));
+                redactClientCommandArgument(c, curr_index + 2);
+                curr_index +=3;
+            }
+        }
+
+        slotMigrationJob *job = createSlotExportJob(target_node, slot_ranges, auth_user, auth_pass);
         listAddNodeHead(new_slot_migrations, job);
         slot_ranges = NULL;
+        auth_user = NULL;
+        auth_pass = NULL;
     }
 
     /* If we reach here, we have successfully parsed all arguments */
@@ -1249,6 +1280,13 @@ void clusterCommandMigrateSlots(client *c) {
 cleanup:
     if (slot_ranges) listRelease(slot_ranges);
     listRelease(new_slot_migrations);
+    if (auth_user) {
+        sdsfree(auth_user);
+    }
+    if (auth_pass) {
+        memset(auth_pass, 0, sdslen(auth_pass));
+        sdsfree(auth_pass);
+    }
 }
 
 slotMigrationJob *clusterLookupMigrationJob(sds name) {
@@ -1367,9 +1405,11 @@ void slotMigrationJobReadAuthResponse(connection *conn) {
  * job's connection. */
 void slotMigrationJobSendAuth(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
-    serverAssert(server.primary_auth);
+    sds user = job->auth_user ? job->auth_user : server.primary_user;
+    sds pass = job->auth_password ? job->auth_password : server.primary_auth;
+    serverAssert(pass);
 
-    sds err = replicationSendAuth(job->conn);
+    sds err = replicationSendAuth(job->conn, user, pass, sdslen(pass));
     if (err) {
         sds status_msg = sdscatfmt(sdsempty(), "Failed to send AUTH command to target node: %s", err);
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status_msg);
@@ -1857,7 +1897,7 @@ size_t clusterGetTotalSlotExportBufferMemory(void) {
 
 /* Create a slot export job with the given target and slot ranges. */
 slotMigrationJob *createSlotExportJob(clusterNode *target_node,
-                                      list *slot_ranges) {
+                                      list *slot_ranges,  sds auth_user, sds auth_password) {
     slotMigrationJob *job = zcalloc(sizeof(slotMigrationJob));
 
     job->ctime = server.unixtime;
@@ -1871,6 +1911,8 @@ slotMigrationJob *createSlotExportJob(clusterNode *target_node,
     memcpy(job->target_node_name, target_node->name, CLUSTER_NAMELEN);
     memcpy(job->source_node_name, server.cluster->myself->name, CLUSTER_NAMELEN);
     job->description = generateSlotMigrationJobDescription(job, target_node);
+    job->auth_user =  auth_user;
+    job->auth_password = auth_password;
     return job;
 }
 
@@ -2007,7 +2049,7 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             if (!completed) return;
             serverLog(LL_NOTICE, "Slot migration %s connection established.",
                       job->description);
-            if (server.primary_auth) {
+            if (job->auth_password || server.primary_auth) {
                 updateSlotMigrationJobState(job, SLOT_EXPORT_SEND_AUTH);
             } else {
                 updateSlotMigrationJobState(job, SLOT_EXPORT_SEND_ESTABLISH);
@@ -2165,6 +2207,13 @@ void freeSlotMigrationJob(void *o) {
     sdsfree(job->status_msg);
     sdsfree(job->response_buf);
     sdsfree(job->description);
+    if (job->auth_user) {
+        sdsfree(job->auth_user);
+    }
+    if (job->auth_password) {
+        memset(job->auth_password, 0, sdslen(job->auth_password));
+        sdsfree(job->auth_password);
+    }
     zfree(o);
 }
 

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -8,8 +8,6 @@
 #include "bio.h"
 #include "module.h"
 #include "functions.h"
-#include "sds.h"
-#include "server.h"
 
 #include <sys/wait.h>
 #include <fcntl.h>
@@ -90,7 +88,7 @@ typedef struct slotMigrationJob {
     /* State needed during client establishment */
     connection *conn; /* Connection to slot import source node. */
     sds response_buf;
-    sds auth_user; /* User used for AUTH of the export job. */
+    sds auth_user;     /* User used for AUTH of the export job. */
     sds auth_password; /* Password used for AUTH of the export job */
 } slotMigrationJob;
 
@@ -107,7 +105,9 @@ static void updateSlotMigrationJobState(slotMigrationJob *job,
 static void sendSyncSlotsMessage(slotMigrationJob *job, const char *subcommand);
 static void proceedWithSlotMigration(slotMigrationJob *job);
 static slotMigrationJob *createSlotExportJob(clusterNode *target_node,
-                                             list *slot_ranges, sds auth_user, sds auth_password);
+                                             list *slot_ranges,
+                                             sds auth_user,
+                                             sds auth_password);
 static bool isSlotExportPauseTimedOut(slotMigrationJob *job);
 static void resetSlotMigrationJob(slotMigrationJob *job);
 static void finishSlotMigrationJob(slotMigrationJob *job,
@@ -1244,7 +1244,7 @@ void clusterCommandMigrateSlots(client *c) {
                 redactClientCommandArgument(c, curr_index + 1);
                 auth_pass = sdsdup(objectGetVal(c->argv[curr_index + 2]));
                 redactClientCommandArgument(c, curr_index + 2);
-                curr_index +=3;
+                curr_index += 3;
             }
         }
 
@@ -1409,7 +1409,7 @@ void slotMigrationJobSendAuth(slotMigrationJob *job) {
     sds pass = job->auth_password ? job->auth_password : server.primary_auth;
     serverAssert(pass);
 
-    sds err = replicationSendAuth(job->conn, user, pass, sdslen(pass));
+    sds err = replicationSendAuth(job->conn, user, pass);
     if (err) {
         sds status_msg = sdscatfmt(sdsempty(), "Failed to send AUTH command to target node: %s", err);
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status_msg);
@@ -1897,7 +1897,9 @@ size_t clusterGetTotalSlotExportBufferMemory(void) {
 
 /* Create a slot export job with the given target and slot ranges. */
 slotMigrationJob *createSlotExportJob(clusterNode *target_node,
-                                      list *slot_ranges,  sds auth_user, sds auth_password) {
+                                      list *slot_ranges,
+                                      sds auth_user,
+                                      sds auth_password) {
     slotMigrationJob *job = zcalloc(sizeof(slotMigrationJob));
 
     job->ctime = server.unixtime;
@@ -1911,7 +1913,7 @@ slotMigrationJob *createSlotExportJob(clusterNode *target_node,
     memcpy(job->target_node_name, target_node->name, CLUSTER_NAMELEN);
     memcpy(job->source_node_name, server.cluster->myself->name, CLUSTER_NAMELEN);
     job->description = generateSlotMigrationJobDescription(job, target_node);
-    job->auth_user =  auth_user;
+    job->auth_user = auth_user;
     job->auth_password = auth_password;
     return job;
 }

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -8,6 +8,8 @@
 #include "bio.h"
 #include "module.h"
 #include "functions.h"
+#include "sds.h"
+#include "server.h"
 
 #include <sys/wait.h>
 #include <fcntl.h>
@@ -1280,9 +1282,7 @@ void clusterCommandMigrateSlots(client *c) {
 cleanup:
     if (slot_ranges) listRelease(slot_ranges);
     listRelease(new_slot_migrations);
-    if (auth_user) {
-        sdsfree(auth_user);
-    }
+    sdsfree(auth_user);
     if (auth_pass) {
         memset(auth_pass, 0, sdslen(auth_pass));
         sdsfree(auth_pass);
@@ -1405,11 +1405,19 @@ void slotMigrationJobReadAuthResponse(connection *conn) {
  * job's connection. */
 void slotMigrationJobSendAuth(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
-    sds user = job->auth_user ? job->auth_user : server.primary_user;
+    const char *user = NULL;
+    size_t user_len = 0;
+    if (job->auth_user) {
+        user = job->auth_user;
+        user_len = sdslen(job->auth_user);
+    } else if (server.primary_user) {
+        user = server.primary_user;
+        user_len = strlen(server.primary_user);
+    }
     sds pass = job->auth_password ? job->auth_password : server.primary_auth;
     serverAssert(pass);
 
-    sds err = replicationSendAuth(job->conn, user, pass);
+    sds err = replicationSendAuth(job->conn, user, user_len, pass, sdslen(pass));
     if (err) {
         sds status_msg = sdscatfmt(sdsempty(), "Failed to send AUTH command to target node: %s", err);
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status_msg);
@@ -2209,9 +2217,7 @@ void freeSlotMigrationJob(void *o) {
     sdsfree(job->status_msg);
     sdsfree(job->response_buf);
     sdsfree(job->description);
-    if (job->auth_user) {
-        sdsfree(job->auth_user);
-    }
+    sdsfree(job->auth_user);
     if (job->auth_password) {
         memset(job->auth_password, 0, sdslen(job->auth_password));
         sdsfree(job->auth_password);

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -9,8 +9,6 @@
 #include "io_threads.h"
 #include "module.h"
 #include "functions.h"
-#include "sds.h"
-#include "server.h"
 
 #include <sys/wait.h>
 #include <fcntl.h>
@@ -91,7 +89,7 @@ typedef struct slotMigrationJob {
     /* State needed during client establishment */
     connection *conn; /* Connection to slot import source node. */
     sds response_buf;
-    sds auth_user; /* User used for AUTH of the export job. */
+    sds auth_user;     /* User used for AUTH of the export job. */
     sds auth_password; /* Password used for AUTH of the export job */
 } slotMigrationJob;
 
@@ -108,7 +106,9 @@ static void updateSlotMigrationJobState(slotMigrationJob *job,
 static void sendSyncSlotsMessage(slotMigrationJob *job, const char *subcommand);
 static void proceedWithSlotMigration(slotMigrationJob *job);
 static slotMigrationJob *createSlotExportJob(clusterNode *target_node,
-                                             list *slot_ranges, sds auth_user, sds auth_password);
+                                             list *slot_ranges,
+                                             sds auth_user,
+                                             sds auth_password);
 static bool isSlotExportPauseTimedOut(slotMigrationJob *job);
 static void resetSlotMigrationJob(slotMigrationJob *job);
 static void finishSlotMigrationJob(slotMigrationJob *job,
@@ -1267,7 +1267,7 @@ void clusterCommandMigrateSlots(client *c) {
                 redactClientCommandArgument(c, curr_index + 1);
                 auth_pass = sdsdup(objectGetVal(c->argv[curr_index + 2]));
                 redactClientCommandArgument(c, curr_index + 2);
-                curr_index +=3;
+                curr_index += 3;
             }
         }
 
@@ -1439,7 +1439,7 @@ void slotMigrationJobSendAuth(slotMigrationJob *job) {
     sds pass = job->auth_password ? job->auth_password : server.primary_auth;
     serverAssert(pass);
 
-    sds err = replicationSendAuth(job->conn, user, pass, sdslen(pass));
+    sds err = replicationSendAuth(job->conn, user, pass);
     if (err) {
         sds status_msg = sdscatfmt(sdsempty(), "Failed to send AUTH command to target node: %s", err);
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status_msg);
@@ -1936,7 +1936,9 @@ size_t clusterGetTotalSlotExportBufferMemory(void) {
 
 /* Create a slot export job with the given target and slot ranges. */
 slotMigrationJob *createSlotExportJob(clusterNode *target_node,
-                                      list *slot_ranges,  sds auth_user, sds auth_password) {
+                                      list *slot_ranges,
+                                      sds auth_user,
+                                      sds auth_password) {
     slotMigrationJob *job = zcalloc(sizeof(slotMigrationJob));
 
     job->ctime = server.unixtime;
@@ -1950,7 +1952,7 @@ slotMigrationJob *createSlotExportJob(clusterNode *target_node,
     memcpy(job->target_node_name, target_node->name, CLUSTER_NAMELEN);
     memcpy(job->source_node_name, server.cluster->myself->name, CLUSTER_NAMELEN);
     job->description = generateSlotMigrationJobDescription(job, target_node);
-    job->auth_user =  auth_user;
+    job->auth_user = auth_user;
     job->auth_password = auth_password;
     return job;
 }

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -9,6 +9,8 @@
 #include "io_threads.h"
 #include "module.h"
 #include "functions.h"
+#include "sds.h"
+#include "server.h"
 
 #include <sys/wait.h>
 #include <fcntl.h>
@@ -89,6 +91,8 @@ typedef struct slotMigrationJob {
     /* State needed during client establishment */
     connection *conn; /* Connection to slot import source node. */
     sds response_buf;
+    sds auth_user; /* User used for AUTH of the export job. */
+    sds auth_password; /* Password used for AUTH of the export job */
 } slotMigrationJob;
 
 static bool isSlotMigrationJobFinished(slotMigrationJob *job);
@@ -104,7 +108,7 @@ static void updateSlotMigrationJobState(slotMigrationJob *job,
 static void sendSyncSlotsMessage(slotMigrationJob *job, const char *subcommand);
 static void proceedWithSlotMigration(slotMigrationJob *job);
 static slotMigrationJob *createSlotExportJob(clusterNode *target_node,
-                                             list *slot_ranges);
+                                             list *slot_ranges, sds auth_user, sds auth_password);
 static bool isSlotExportPauseTimedOut(slotMigrationJob *job);
 static void resetSlotMigrationJob(slotMigrationJob *job);
 static void finishSlotMigrationJob(slotMigrationJob *job,
@@ -1176,6 +1180,8 @@ void clusterCommandMigrateSlots(client *c) {
     list *new_slot_migrations = listCreate();
     listSetFreeMethod(new_slot_migrations, freeSlotMigrationJob);
     list *slot_ranges = NULL;
+    sds auth_user = NULL;
+    sds auth_pass = NULL;
 
     while (curr_index < c->argc) {
         if (strcasecmp(objectGetVal(c->argv[curr_index]), "slotsrange")) {
@@ -1242,9 +1248,34 @@ void clusterCommandMigrateSlots(client *c) {
         }
         curr_index++;
 
-        slotMigrationJob *job = createSlotExportJob(target_node, slot_ranges);
+        if (curr_index < c->argc) {
+            sds token = objectGetVal(c->argv[curr_index]);
+            if (!strcasecmp(token, "auth")) {
+                if (curr_index + 1 >= c->argc) {
+                    addReplyErrorObject(c, shared.syntaxerr);
+                    goto cleanup;
+                }
+                auth_pass = sdsdup(objectGetVal(c->argv[curr_index + 1]));
+                redactClientCommandArgument(c, curr_index + 1);
+                curr_index += 2;
+            } else if (!strcasecmp(token, "auth2")) {
+                if (curr_index + 2 >= c->argc) {
+                    addReplyErrorObject(c, shared.syntaxerr);
+                    goto cleanup;
+                }
+                auth_user = sdsdup(objectGetVal(c->argv[curr_index + 1]));
+                redactClientCommandArgument(c, curr_index + 1);
+                auth_pass = sdsdup(objectGetVal(c->argv[curr_index + 2]));
+                redactClientCommandArgument(c, curr_index + 2);
+                curr_index +=3;
+            }
+        }
+
+        slotMigrationJob *job = createSlotExportJob(target_node, slot_ranges, auth_user, auth_pass);
         listAddNodeHead(new_slot_migrations, job);
         slot_ranges = NULL;
+        auth_user = NULL;
+        auth_pass = NULL;
     }
 
     /* If we reach here, we have successfully parsed all arguments */
@@ -1272,6 +1303,13 @@ void clusterCommandMigrateSlots(client *c) {
 cleanup:
     if (slot_ranges) listRelease(slot_ranges);
     listRelease(new_slot_migrations);
+    if (auth_user) {
+        sdsfree(auth_user);
+    }
+    if (auth_pass) {
+        memset(auth_pass, 0, sdslen(auth_pass));
+        sdsfree(auth_pass);
+    }
 }
 
 slotMigrationJob *clusterLookupMigrationJob(sds name) {
@@ -1397,9 +1435,11 @@ void slotMigrationJobReadAuthResponse(connection *conn) {
  * job's connection. */
 void slotMigrationJobSendAuth(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
-    serverAssert(server.primary_auth);
+    sds user = job->auth_user ? job->auth_user : server.primary_user;
+    sds pass = job->auth_password ? job->auth_password : server.primary_auth;
+    serverAssert(pass);
 
-    sds err = replicationSendAuth(job->conn);
+    sds err = replicationSendAuth(job->conn, user, pass, sdslen(pass));
     if (err) {
         sds status_msg = sdscatfmt(sdsempty(), "Failed to send AUTH command to target node: %s", err);
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status_msg);
@@ -1896,7 +1936,7 @@ size_t clusterGetTotalSlotExportBufferMemory(void) {
 
 /* Create a slot export job with the given target and slot ranges. */
 slotMigrationJob *createSlotExportJob(clusterNode *target_node,
-                                      list *slot_ranges) {
+                                      list *slot_ranges,  sds auth_user, sds auth_password) {
     slotMigrationJob *job = zcalloc(sizeof(slotMigrationJob));
 
     job->ctime = server.unixtime;
@@ -1910,6 +1950,8 @@ slotMigrationJob *createSlotExportJob(clusterNode *target_node,
     memcpy(job->target_node_name, target_node->name, CLUSTER_NAMELEN);
     memcpy(job->source_node_name, server.cluster->myself->name, CLUSTER_NAMELEN);
     job->description = generateSlotMigrationJobDescription(job, target_node);
+    job->auth_user =  auth_user;
+    job->auth_password = auth_password;
     return job;
 }
 
@@ -2055,7 +2097,7 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             if (!completed) return;
             serverLog(LL_NOTICE, "Slot migration %s connection established.",
                       job->description);
-            if (server.primary_auth) {
+            if (job->auth_password || server.primary_auth) {
                 updateSlotMigrationJobState(job, SLOT_EXPORT_SEND_AUTH);
             } else {
                 updateSlotMigrationJobState(job, SLOT_EXPORT_SEND_ESTABLISH);
@@ -2217,6 +2259,13 @@ void freeSlotMigrationJob(void *o) {
     sdsfree(job->status_msg);
     sdsfree(job->response_buf);
     sdsfree(job->description);
+    if (job->auth_user) {
+        sdsfree(job->auth_user);
+    }
+    if (job->auth_password) {
+        memset(job->auth_password, 0, sdslen(job->auth_password));
+        sdsfree(job->auth_password);
+    }
     zfree(o);
 }
 

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1176,6 +1176,16 @@ bool clusterSlotFailoverGranted(int slot) {
  * source will attempt to migrate the slot ranges to the specified target
  * node. */
 void clusterCommandMigrateSlots(client *c) {
+    /* Redact credentials before validation so errors cannot expose them
+     * in the command log. */
+    for (int i = 2; i < c->argc; i++) {
+        if (!strcasecmp(objectGetVal(c->argv[i]), "auth")) {
+            if (i + 1 < c->argc) redactClientCommandArgument(c, i + 1);
+            if (i + 2 < c->argc) redactClientCommandArgument(c, i + 2);
+            i += 2;
+        }
+    }
+
     if (validateSlotMigrationCanStartOrReply(c) == C_ERR) return;
 
     int curr_index = 2;
@@ -1258,9 +1268,7 @@ void clusterCommandMigrateSlots(client *c) {
                     goto cleanup;
                 }
                 auth_user = sdsdup(objectGetVal(c->argv[curr_index + 1]));
-                redactClientCommandArgument(c, curr_index + 1);
                 auth_pass = sdsdup(objectGetVal(c->argv[curr_index + 2]));
-                redactClientCommandArgument(c, curr_index + 2);
                 curr_index += 3;
             }
         }

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -112,6 +112,7 @@ static slotMigrationJob *createSlotExportJob(clusterNode *target_node,
                                              sds auth_user,
                                              sds auth_password);
 static bool isSlotExportPauseTimedOut(slotMigrationJob *job);
+static void freeSlotMigrationJobAuth(slotMigrationJob *job);
 static void resetSlotMigrationJob(slotMigrationJob *job);
 static void finishSlotMigrationJob(slotMigrationJob *job,
                                    slotMigrationJobState state,
@@ -1451,6 +1452,8 @@ void slotMigrationJobSendAuth(slotMigrationJob *job) {
     serverAssert(pass);
 
     sds err = replicationSendAuth(job->conn, user, user_len, pass, sdslen(pass));
+    /* AUTH is never retried, so the job no longer needs its credentials. */
+    freeSlotMigrationJobAuth(job);
     if (err) {
         sds status_msg = sdscatfmt(sdsempty(), "Failed to send AUTH command to target node: %s", err);
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status_msg);
@@ -2246,7 +2249,18 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
     }
 }
 
-/* Reset the client and connection information associated with the job, leaving
+/* Release job-owned credentials without retaining the password in migration history. */
+static void freeSlotMigrationJobAuth(slotMigrationJob *job) {
+    sdsfree(job->auth_user);
+    job->auth_user = NULL;
+    if (job->auth_password) {
+        memset(job->auth_password, 0, sdslen(job->auth_password));
+        sdsfree(job->auth_password);
+        job->auth_password = NULL;
+    }
+}
+
+/* Reset the client, connection and authentication information associated with the job, leaving
  * the migration related metadata. */
 void resetSlotMigrationJob(slotMigrationJob *job) {
     /* Only one of client or conn should be set. */
@@ -2262,6 +2276,7 @@ void resetSlotMigrationJob(slotMigrationJob *job) {
 
     sdsfree(job->response_buf);
     job->response_buf = NULL;
+    freeSlotMigrationJobAuth(job);
 }
 
 void freeSlotMigrationJob(void *o) {
@@ -2272,11 +2287,6 @@ void freeSlotMigrationJob(void *o) {
     sdsfree(job->status_msg);
     sdsfree(job->response_buf);
     sdsfree(job->description);
-    sdsfree(job->auth_user);
-    if (job->auth_password) {
-        memset(job->auth_password, 0, sdslen(job->auth_password));
-        sdsfree(job->auth_password);
-    }
     zfree(o);
 }
 

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1253,14 +1253,6 @@ void clusterCommandMigrateSlots(client *c) {
         if (curr_index < c->argc) {
             sds token = objectGetVal(c->argv[curr_index]);
             if (!strcasecmp(token, "auth")) {
-                if (curr_index + 1 >= c->argc) {
-                    addReplyErrorObject(c, shared.syntaxerr);
-                    goto cleanup;
-                }
-                auth_pass = sdsdup(objectGetVal(c->argv[curr_index + 1]));
-                redactClientCommandArgument(c, curr_index + 1);
-                curr_index += 2;
-            } else if (!strcasecmp(token, "auth2")) {
                 if (curr_index + 2 >= c->argc) {
                     addReplyErrorObject(c, shared.syntaxerr);
                     goto cleanup;
@@ -1435,16 +1427,19 @@ void slotMigrationJobReadAuthResponse(connection *conn) {
  * job's connection. */
 void slotMigrationJobSendAuth(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
+    serverAssert((job->auth_user == NULL) == (job->auth_password == NULL));
     const char *user = NULL;
     size_t user_len = 0;
+    sds pass;
     if (job->auth_user) {
         user = job->auth_user;
         user_len = sdslen(job->auth_user);
-    } else if (server.primary_user) {
+        pass = job->auth_password;
+    } else {
         user = server.primary_user;
-        user_len = strlen(server.primary_user);
+        user_len = user ? strlen(server.primary_user) : 0;
+        pass = server.primary_auth;
     }
-    sds pass = job->auth_password ? job->auth_password : server.primary_auth;
     serverAssert(pass);
 
     sds err = replicationSendAuth(job->conn, user, user_len, pass, sdslen(pass));

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -9,6 +9,8 @@
 #include "io_threads.h"
 #include "module.h"
 #include "functions.h"
+#include "sds.h"
+#include "server.h"
 
 #include <sys/wait.h>
 #include <fcntl.h>
@@ -1303,9 +1305,7 @@ void clusterCommandMigrateSlots(client *c) {
 cleanup:
     if (slot_ranges) listRelease(slot_ranges);
     listRelease(new_slot_migrations);
-    if (auth_user) {
-        sdsfree(auth_user);
-    }
+    sdsfree(auth_user);
     if (auth_pass) {
         memset(auth_pass, 0, sdslen(auth_pass));
         sdsfree(auth_pass);
@@ -1435,11 +1435,19 @@ void slotMigrationJobReadAuthResponse(connection *conn) {
  * job's connection. */
 void slotMigrationJobSendAuth(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
-    sds user = job->auth_user ? job->auth_user : server.primary_user;
+    const char *user = NULL;
+    size_t user_len = 0;
+    if (job->auth_user) {
+        user = job->auth_user;
+        user_len = sdslen(job->auth_user);
+    } else if (server.primary_user) {
+        user = server.primary_user;
+        user_len = strlen(server.primary_user);
+    }
     sds pass = job->auth_password ? job->auth_password : server.primary_auth;
     serverAssert(pass);
 
-    sds err = replicationSendAuth(job->conn, user, pass);
+    sds err = replicationSendAuth(job->conn, user, user_len, pass, sdslen(pass));
     if (err) {
         sds status_msg = sdscatfmt(sdsempty(), "Failed to send AUTH command to target node: %s", err);
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status_msg);
@@ -2261,9 +2269,7 @@ void freeSlotMigrationJob(void *o) {
     sdsfree(job->status_msg);
     sdsfree(job->response_buf);
     sdsfree(job->description);
-    if (job->auth_user) {
-        sdsfree(job->auth_user);
-    }
+    sdsfree(job->auth_user);
     if (job->auth_password) {
         memset(job->auth_password, 0, sdslen(job->auth_password));
         sdsfree(job->auth_password);

--- a/src/commands.def
+++ b/src/commands.def
@@ -773,17 +773,30 @@ struct COMMAND_ARG CLUSTER_MIGRATESLOTS_migration_group_range_Subargs[] = {
 {MAKE_ARG("end-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
+/* CLUSTER MIGRATESLOTS migration_group authentication auth2 argument table */
+struct COMMAND_ARG CLUSTER_MIGRATESLOTS_migration_group_authentication_auth2_Subargs[] = {
+{MAKE_ARG("username",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("password",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* CLUSTER MIGRATESLOTS migration_group authentication argument table */
+struct COMMAND_ARG CLUSTER_MIGRATESLOTS_migration_group_authentication_Subargs[] = {
+{MAKE_ARG("auth",ARG_TYPE_STRING,-1,"AUTH",NULL,"9.1.0",CMD_ARG_NONE,0,NULL),.display_text="password"},
+{MAKE_ARG("auth2",ARG_TYPE_BLOCK,-1,"AUTH2",NULL,"9.1.0",CMD_ARG_NONE,2,NULL),.subargs=CLUSTER_MIGRATESLOTS_migration_group_authentication_auth2_Subargs},
+};
+
 /* CLUSTER MIGRATESLOTS migration_group argument table */
 struct COMMAND_ARG CLUSTER_MIGRATESLOTS_migration_group_Subargs[] = {
 {MAKE_ARG("slotsrange-token",ARG_TYPE_PURE_TOKEN,-1,"SLOTSRANGE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=CLUSTER_MIGRATESLOTS_migration_group_range_Subargs},
 {MAKE_ARG("node-token",ARG_TYPE_PURE_TOKEN,-1,"NODE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("node-id",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("authentication",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=CLUSTER_MIGRATESLOTS_migration_group_authentication_Subargs},
 };
 
 /* CLUSTER MIGRATESLOTS argument table */
 struct COMMAND_ARG CLUSTER_MIGRATESLOTS_Args[] = {
-{MAKE_ARG("migration-group",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,4,NULL),.subargs=CLUSTER_MIGRATESLOTS_migration_group_Subargs},
+{MAKE_ARG("migration-group",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,5,NULL),.subargs=CLUSTER_MIGRATESLOTS_migration_group_Subargs},
 };
 
 /********** CLUSTER MYID ********************/

--- a/src/commands.def
+++ b/src/commands.def
@@ -773,16 +773,10 @@ struct COMMAND_ARG CLUSTER_MIGRATESLOTS_migration_group_range_Subargs[] = {
 {MAKE_ARG("end-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
-/* CLUSTER MIGRATESLOTS migration_group authentication auth2 argument table */
-struct COMMAND_ARG CLUSTER_MIGRATESLOTS_migration_group_authentication_auth2_Subargs[] = {
+/* CLUSTER MIGRATESLOTS migration_group auth argument table */
+struct COMMAND_ARG CLUSTER_MIGRATESLOTS_migration_group_auth_Subargs[] = {
 {MAKE_ARG("username",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("password",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-};
-
-/* CLUSTER MIGRATESLOTS migration_group authentication argument table */
-struct COMMAND_ARG CLUSTER_MIGRATESLOTS_migration_group_authentication_Subargs[] = {
-{MAKE_ARG("auth",ARG_TYPE_STRING,-1,"AUTH",NULL,"9.1.0",CMD_ARG_NONE,0,NULL),.display_text="password"},
-{MAKE_ARG("auth2",ARG_TYPE_BLOCK,-1,"AUTH2",NULL,"9.1.0",CMD_ARG_NONE,2,NULL),.subargs=CLUSTER_MIGRATESLOTS_migration_group_authentication_auth2_Subargs},
 };
 
 /* CLUSTER MIGRATESLOTS migration_group argument table */
@@ -791,7 +785,7 @@ struct COMMAND_ARG CLUSTER_MIGRATESLOTS_migration_group_Subargs[] = {
 {MAKE_ARG("range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=CLUSTER_MIGRATESLOTS_migration_group_range_Subargs},
 {MAKE_ARG("node-token",ARG_TYPE_PURE_TOKEN,-1,"NODE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("node-id",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("authentication",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=CLUSTER_MIGRATESLOTS_migration_group_authentication_Subargs},
+{MAKE_ARG("auth",ARG_TYPE_BLOCK,-1,"AUTH",NULL,"9.2.0",CMD_ARG_OPTIONAL,2,NULL),.subargs=CLUSTER_MIGRATESLOTS_migration_group_auth_Subargs},
 };
 
 /* CLUSTER MIGRATESLOTS argument table */

--- a/src/commands/cluster-migrateslots.json
+++ b/src/commands/cluster-migrateslots.json
@@ -51,6 +51,36 @@
                         "type": "string",
                         "pattern": "^[0-9a-fA-F]{40}$",
                         "description": "40 character node name of the node to migrate to"
+                    },
+                    {
+                        "name": "authentication",
+                        "type": "oneof",
+                        "optional": true,
+                        "arguments": [
+                            {
+                                "token": "AUTH",
+                                "name": "auth",
+                                "display": "password",
+                                "type": "string",
+                                "since": "9.1.0"
+                            },
+                            {
+                                "token": "AUTH2",
+                                "name": "auth2",
+                                "type": "block",
+                                "since": "9.1.0",
+                                "arguments": [
+                                    {
+                                        "name": "username",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        ]
                     }
                 ]
             }

--- a/src/commands/cluster-migrateslots.json
+++ b/src/commands/cluster-migrateslots.json
@@ -53,32 +53,19 @@
                         "description": "40 character node name of the node to migrate to"
                     },
                     {
-                        "name": "authentication",
-                        "type": "oneof",
+                        "token": "AUTH",
+                        "name": "auth",
+                        "type": "block",
                         "optional": true,
+                        "since": "9.2.0",
                         "arguments": [
                             {
-                                "token": "AUTH",
-                                "name": "auth",
-                                "display": "password",
-                                "type": "string",
-                                "since": "9.1.0"
+                                "name": "username",
+                                "type": "string"
                             },
                             {
-                                "token": "AUTH2",
-                                "name": "auth2",
-                                "type": "block",
-                                "since": "9.1.0",
-                                "arguments": [
-                                    {
-                                        "name": "username",
-                                        "type": "string"
-                                    },
-                                    {
-                                        "name": "password",
-                                        "type": "string"
-                                    }
-                                ]
+                                "name": "password",
+                                "type": "string"
                             }
                         ]
                     }

--- a/src/replication.c
+++ b/src/replication.c
@@ -33,6 +33,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "sds.h"
 #include "server.h"
 #include "cluster.h"
 #include "cluster_slot_stats.h"
@@ -43,6 +44,7 @@
 #include "cluster_migrateslots.h"
 
 #include <memory.h>
+#include <stddef.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -3002,17 +3004,17 @@ int sendCurrentOffsetToReplica(client *replica) {
     return C_OK;
 }
 
-sds replicationSendAuth(connection *conn, const char *user, const char *pass) {
+sds replicationSendAuth(connection *conn, const char *user, size_t user_len, const char *pass, size_t pass_len) {
     char *args[] = {"AUTH", NULL, NULL};
     size_t lens[] = {4, 0, 0};
     int argc = 1;
     if (user) {
         args[argc] = (char *)user;
-        lens[argc] = strlen(user);
+        lens[argc] = user_len;
         argc++;
     }
     args[argc] = (char *)pass;
-    lens[argc] = strlen(pass);
+    lens[argc] = pass_len;
     argc++;
     return sendCommandArgv(conn, argc, args, lens);
 }
@@ -3033,7 +3035,9 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     dualChannelServerLog(LL_DEBUG, "Received first reply from primary using rdb connection.");
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        *err = replicationSendAuth(conn, server.primary_user, server.primary_auth);
+        const char *user = server.primary_user;
+        size_t user_len = user ? strlen(user) : 0;
+        *err = replicationSendAuth(conn, user, user_len, server.primary_auth, sdslen(server.primary_auth));
         if (*err) {
             dualChannelServerLog(LL_WARNING, "Sending command to primary in dual channel replication handshake: %s", *err);
             return C_ERR;
@@ -3807,7 +3811,9 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
     sds err;
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        err = replicationSendAuth(conn, server.primary_user, server.primary_auth);
+        const char *user = server.primary_user;
+        size_t user_len = user ? strlen(user) : 0;
+        err = replicationSendAuth(conn, user, user_len, server.primary_auth, sdslen(server.primary_auth));
         if (err) goto err;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -3002,7 +3002,7 @@ int sendCurrentOffsetToReplica(client *replica) {
     return C_OK;
 }
 
-sds replicationSendAuth(connection *conn, const char *user, const char *pass, size_t pass_len) {
+sds replicationSendAuth(connection *conn, const char *user, const char *pass) {
     char *args[] = {"AUTH", NULL, NULL};
     size_t lens[] = {4, 0, 0};
     int argc = 1;
@@ -3012,7 +3012,7 @@ sds replicationSendAuth(connection *conn, const char *user, const char *pass, si
         argc++;
     }
     args[argc] = (char *)pass;
-    lens[argc] = pass_len;
+    lens[argc] = strlen(pass);
     argc++;
     return sendCommandArgv(conn, argc, args, lens);
 }
@@ -3033,7 +3033,7 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     dualChannelServerLog(LL_DEBUG, "Received first reply from primary using rdb connection.");
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        *err = replicationSendAuth(conn, server.primary_user, server.primary_auth, sdslen(server.primary_auth));
+        *err = replicationSendAuth(conn, server.primary_user, server.primary_auth);
         if (*err) {
             dualChannelServerLog(LL_WARNING, "Sending command to primary in dual channel replication handshake: %s", *err);
             return C_ERR;
@@ -3807,7 +3807,7 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
     sds err;
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        err = replicationSendAuth(conn, server.primary_user, server.primary_auth, sdslen(server.primary_auth));
+        err = replicationSendAuth(conn, server.primary_user, server.primary_auth);
         if (err) goto err;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -3002,17 +3002,17 @@ int sendCurrentOffsetToReplica(client *replica) {
     return C_OK;
 }
 
-sds replicationSendAuth(connection *conn) {
+sds replicationSendAuth(connection *conn, const char *user, const char *pass, size_t pass_len) {
     char *args[] = {"AUTH", NULL, NULL};
     size_t lens[] = {4, 0, 0};
     int argc = 1;
-    if (server.primary_user) {
-        args[argc] = server.primary_user;
-        lens[argc] = strlen(server.primary_user);
+    if (user) {
+        args[argc] = (char *)user;
+        lens[argc] = strlen(user);
         argc++;
     }
-    args[argc] = server.primary_auth;
-    lens[argc] = sdslen(server.primary_auth);
+    args[argc] = (char *)pass;
+    lens[argc] = pass_len;
     argc++;
     return sendCommandArgv(conn, argc, args, lens);
 }
@@ -3033,7 +3033,7 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     dualChannelServerLog(LL_DEBUG, "Received first reply from primary using rdb connection.");
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        *err = replicationSendAuth(conn);
+        *err = replicationSendAuth(conn, server.primary_user, server.primary_auth, sdslen(server.primary_auth));
         if (*err) {
             dualChannelServerLog(LL_WARNING, "Sending command to primary in dual channel replication handshake: %s", *err);
             return C_ERR;
@@ -3807,7 +3807,7 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
     sds err;
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        err = replicationSendAuth(conn);
+        err = replicationSendAuth(conn, server.primary_user, server.primary_auth, sdslen(server.primary_auth));
         if (err) goto err;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -33,8 +33,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "sds.h"
 #include "server.h"
+#include "sds.h"
 #include "cluster.h"
 #include "cluster_slot_stats.h"
 #include "bio.h"

--- a/src/replication.c
+++ b/src/replication.c
@@ -33,6 +33,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "sds.h"
 #include "server.h"
 #include "cluster.h"
 #include "cluster_slot_stats.h"
@@ -43,6 +44,7 @@
 #include "cluster_migrateslots.h"
 
 #include <memory.h>
+#include <stddef.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -3089,17 +3091,17 @@ int sendCurrentOffsetToReplica(client *replica) {
     return C_OK;
 }
 
-sds replicationSendAuth(connection *conn, const char *user, const char *pass) {
+sds replicationSendAuth(connection *conn, const char *user, size_t user_len, const char *pass, size_t pass_len) {
     char *args[] = {"AUTH", NULL, NULL};
     size_t lens[] = {4, 0, 0};
     int argc = 1;
     if (user) {
         args[argc] = (char *)user;
-        lens[argc] = strlen(user);
+        lens[argc] = user_len;
         argc++;
     }
     args[argc] = (char *)pass;
-    lens[argc] = strlen(pass);
+    lens[argc] = pass_len;
     argc++;
     return sendCommandArgv(conn, argc, args, lens);
 }
@@ -3120,7 +3122,9 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     dualChannelServerLog(LL_DEBUG, "Received first reply from primary using rdb connection.");
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        *err = replicationSendAuth(conn, server.primary_user, server.primary_auth);
+        const char *user = server.primary_user;
+        size_t user_len = user ? strlen(user) : 0;
+        *err = replicationSendAuth(conn, user, user_len, server.primary_auth, sdslen(server.primary_auth));
         if (*err) {
             dualChannelServerLog(LL_WARNING, "Sending command to primary in dual channel replication handshake: %s", *err);
             return C_ERR;
@@ -3902,7 +3906,9 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
     sds err;
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        err = replicationSendAuth(conn, server.primary_user, server.primary_auth);
+        const char *user = server.primary_user;
+        size_t user_len = user ? strlen(user) : 0;
+        err = replicationSendAuth(conn, user, user_len, server.primary_auth, sdslen(server.primary_auth));
         if (err) goto err;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -3089,7 +3089,7 @@ int sendCurrentOffsetToReplica(client *replica) {
     return C_OK;
 }
 
-sds replicationSendAuth(connection *conn, const char *user, const char *pass, size_t pass_len) {
+sds replicationSendAuth(connection *conn, const char *user, const char *pass) {
     char *args[] = {"AUTH", NULL, NULL};
     size_t lens[] = {4, 0, 0};
     int argc = 1;
@@ -3099,7 +3099,7 @@ sds replicationSendAuth(connection *conn, const char *user, const char *pass, si
         argc++;
     }
     args[argc] = (char *)pass;
-    lens[argc] = pass_len;
+    lens[argc] = strlen(pass);
     argc++;
     return sendCommandArgv(conn, argc, args, lens);
 }
@@ -3120,7 +3120,7 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     dualChannelServerLog(LL_DEBUG, "Received first reply from primary using rdb connection.");
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        *err = replicationSendAuth(conn, server.primary_user, server.primary_auth, sdslen(server.primary_auth));
+        *err = replicationSendAuth(conn, server.primary_user, server.primary_auth);
         if (*err) {
             dualChannelServerLog(LL_WARNING, "Sending command to primary in dual channel replication handshake: %s", *err);
             return C_ERR;
@@ -3902,7 +3902,7 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
     sds err;
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        err = replicationSendAuth(conn, server.primary_user, server.primary_auth, sdslen(server.primary_auth));
+        err = replicationSendAuth(conn, server.primary_user, server.primary_auth);
         if (err) goto err;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -3089,17 +3089,17 @@ int sendCurrentOffsetToReplica(client *replica) {
     return C_OK;
 }
 
-sds replicationSendAuth(connection *conn) {
+sds replicationSendAuth(connection *conn, const char *user, const char *pass, size_t pass_len) {
     char *args[] = {"AUTH", NULL, NULL};
     size_t lens[] = {4, 0, 0};
     int argc = 1;
-    if (server.primary_user) {
-        args[argc] = server.primary_user;
-        lens[argc] = strlen(server.primary_user);
+    if (user) {
+        args[argc] = (char *)user;
+        lens[argc] = strlen(user);
         argc++;
     }
-    args[argc] = server.primary_auth;
-    lens[argc] = sdslen(server.primary_auth);
+    args[argc] = (char *)pass;
+    lens[argc] = pass_len;
     argc++;
     return sendCommandArgv(conn, argc, args, lens);
 }
@@ -3120,7 +3120,7 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     dualChannelServerLog(LL_DEBUG, "Received first reply from primary using rdb connection.");
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        *err = replicationSendAuth(conn);
+        *err = replicationSendAuth(conn, server.primary_user, server.primary_auth, sdslen(server.primary_auth));
         if (*err) {
             dualChannelServerLog(LL_WARNING, "Sending command to primary in dual channel replication handshake: %s", *err);
             return C_ERR;
@@ -3902,7 +3902,7 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
     sds err;
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        err = replicationSendAuth(conn);
+        err = replicationSendAuth(conn, server.primary_user, server.primary_auth, sdslen(server.primary_auth));
         if (err) goto err;
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -3228,7 +3228,7 @@ void addRdbReplicaToPsyncWait(client *replica);
 void initClientReplicationData(client *c);
 void freeClientReplicationData(client *c);
 void replicaReceiveRDBFromPrimaryToDisk(connection *conn, int is_dual_channel);
-sds replicationSendAuth(connection *conn, const char *user, const char *pass, size_t pass_len);
+sds replicationSendAuth(connection *conn, const char *user, const char *pass);
 sds receiveSynchronousResponse(connection *conn);
 ConnectionType *connTypeOfReplication(void);
 robj *generateSelectCommand(int dictid);

--- a/src/server.h
+++ b/src/server.h
@@ -3228,7 +3228,7 @@ void addRdbReplicaToPsyncWait(client *replica);
 void initClientReplicationData(client *c);
 void freeClientReplicationData(client *c);
 void replicaReceiveRDBFromPrimaryToDisk(connection *conn, int is_dual_channel);
-sds replicationSendAuth(connection *conn, const char *user, const char *pass);
+sds replicationSendAuth(connection *conn, const char *user, size_t user_len, const char *pass, size_t pass_len);
 sds receiveSynchronousResponse(connection *conn);
 ConnectionType *connTypeOfReplication(void);
 robj *generateSelectCommand(int dictid);

--- a/src/server.h
+++ b/src/server.h
@@ -3228,7 +3228,7 @@ void addRdbReplicaToPsyncWait(client *replica);
 void initClientReplicationData(client *c);
 void freeClientReplicationData(client *c);
 void replicaReceiveRDBFromPrimaryToDisk(connection *conn, int is_dual_channel);
-sds replicationSendAuth(connection *conn);
+sds replicationSendAuth(connection *conn, const char *user, const char *pass, size_t pass_len);
 sds receiveSynchronousResponse(connection *conn);
 ConnectionType *connTypeOfReplication(void);
 robj *generateSelectCommand(int dictid);

--- a/src/server.h
+++ b/src/server.h
@@ -3352,7 +3352,7 @@ void addRdbReplicaToPsyncWait(client *replica);
 void initClientReplicationData(client *c);
 void freeClientReplicationData(client *c);
 void replicaReceiveRDBFromPrimaryToDisk(connection *conn, int is_dual_channel);
-sds replicationSendAuth(connection *conn, const char *user, const char *pass, size_t pass_len);
+sds replicationSendAuth(connection *conn, const char *user, const char *pass);
 sds receiveSynchronousResponse(connection *conn);
 ConnectionType *connTypeOfReplication(void);
 robj *generateSelectCommand(int dictid);

--- a/src/server.h
+++ b/src/server.h
@@ -3352,7 +3352,7 @@ void addRdbReplicaToPsyncWait(client *replica);
 void initClientReplicationData(client *c);
 void freeClientReplicationData(client *c);
 void replicaReceiveRDBFromPrimaryToDisk(connection *conn, int is_dual_channel);
-sds replicationSendAuth(connection *conn, const char *user, const char *pass);
+sds replicationSendAuth(connection *conn, const char *user, size_t user_len, const char *pass, size_t pass_len);
 sds receiveSynchronousResponse(connection *conn);
 ConnectionType *connTypeOfReplication(void);
 robj *generateSelectCommand(int dictid);

--- a/src/server.h
+++ b/src/server.h
@@ -3352,7 +3352,7 @@ void addRdbReplicaToPsyncWait(client *replica);
 void initClientReplicationData(client *c);
 void freeClientReplicationData(client *c);
 void replicaReceiveRDBFromPrimaryToDisk(connection *conn, int is_dual_channel);
-sds replicationSendAuth(connection *conn);
+sds replicationSendAuth(connection *conn, const char *user, const char *pass, size_t pass_len);
 sds receiveSynchronousResponse(connection *conn);
 ConnectionType *connTypeOfReplication(void);
 robj *generateSelectCommand(int dictid);

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -1763,31 +1763,13 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         }
     }
 
-    test "MIGRATESLOTS AUTH with WRONGPASS fails cleanly" {
-        assert_does_not_resync {
-            R 0 CONFIG SET requirepass "correctpass"
-
-            # Perform one-shot import with wrong password in AUTH option
-            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH wrongpass]
-            set jobname [get_job_name 2 16383]
-
-            # Should be denied with clear error message
-            wait_for_migration_field 2 $jobname state failed
-            assert_match {*Failed to AUTH to target node*} [dict get [get_migration_by_name 2 $jobname] message]
-
-            # Cleanup for next test
-            R 0 CONFIG SET requirepass ""
-        }
-    }
-
-    test "MIGRATESLOTS with AUTH succeeds when target requires password" {
+    test "CLUSTER MIGRATESLOTS with AUTH succeeds when target requires password" {
         assert_does_not_resync {
             R 0 CONFIG SET requirepass "targetpass"
 
             # Populate data before migration
             populate 1000 "$16383_slot_tag:" 1000 -2
 
-            # AUTH keyword in command overrides primaryauth on source
             assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH targetpass]
             set jobname [get_job_name 2 16383]
             wait_for_migration 0 16383
@@ -1809,11 +1791,27 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
             wait_for_migration 2 16383
             R 0 CONFIG SET requirepass ""
-            R 2 CONFIG SET primaryauth ""
         }
     }
 
-        test "MIGRATESLOTS with AUTH overrides primaryauth" {
+    test "CLUSTER MIGRATESLOTS AUTH with WRONGPASS fails cleanly" {
+        assert_does_not_resync {
+            R 0 CONFIG SET requirepass "correctpass"
+
+            # Perform one-shot import with wrong password in AUTH option
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH wrongpass]
+            set jobname [get_job_name 2 16383]
+
+            # Should be denied with clear error message
+            wait_for_migration_field 2 $jobname state failed
+            assert_match {*Failed to AUTH to target node*} [dict get [get_migration_by_name 2 $jobname] message]
+
+            # Cleanup for next test
+            R 0 CONFIG SET requirepass ""
+        }
+    }
+
+    test "CLUSTER MIGRATESLOTS with AUTH overrides primaryauth" {
         assert_does_not_resync {
             R 0 CONFIG SET requirepass "targetpass"
             R 2 CONFIG SET primaryauth "wrongpass"
@@ -1847,15 +1845,15 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         }
     }
 
-    test "MIGRATESLOTS with AUTH2 succeeds for ACL user" {
+    test "CLUSTER MIGRATESLOTS with AUTH2 succeeds for ACL user" {
         assert_does_not_resync {
-            # Set up ACL user on target with full permissions
+            R 0 CONFIG SET requirepass "mustauth"
             R 0 ACL SETUSER alice on >s3cret ~* &* +@all
 
             # Populate data before migration
             populate 1000 "$16383_slot_tag:" 1000 -2
 
-            # AUTH2 authenticates as the ACL user on the target; source primaryauth is unset
+            # AUTH2 authenticates as the ACL user; bare AUTH or no-auth would fail
             assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH2 alice s3cret]
             set jobname [get_job_name 2 16383]
             wait_for_migration 0 16383
@@ -1877,10 +1875,11 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
             wait_for_migration 2 16383
             R 0 ACL DELUSER alice
+            R 0 CONFIG SET requirepass ""
         }
     }
 
-    test "MIGRATESLOTS per-target AUTH differs in single command" {
+    test "CLUSTER MIGRATESLOTS per-target AUTH differs in single command" {
         # Explicit AUTH pw0 for node0, primaryauth fallback pw1 for node1.
         ensure_slot_on_node 2 16383
         ensure_slot_on_node 2 16382

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -221,6 +221,20 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         assert_error "*No migrations ongoing*" {R 0 CLUSTER CANCELSLOTMIGRATIONS}
     }
 
+    test "CLUSTER MIGRATESLOTS AUTH/AUTH2 syntax errors" {
+        # AUTH with no password
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH}
+
+        # AUTH2 with only a username and no password
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH2 onlyuser}
+
+        # Both AUTH and AUTH2 in the same group — parser sees AUTH2 where it expects SLOTSRANGE
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH pw AUTH2 u p}
+
+        # None of the above started a migration
+        assert_equal {} [R 0 CLUSTER GETSLOTMIGRATIONS]
+    }
+
     test "CLUSTER MIGRATESLOTS already migrating" {
         set_debug_prevent_pause 1
         assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
@@ -1747,6 +1761,211 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             R 0 CONFIG SET requirepass ""
             R 2 CONFIG SET primaryauth ""
         }
+    }
+
+    test "MIGRATESLOTS AUTH with WRONGPASS fails cleanly" {
+        assert_does_not_resync {
+            R 0 CONFIG SET requirepass "correctpass"
+
+            # Perform one-shot import with wrong password in AUTH option
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH wrongpass]
+            set jobname [get_job_name 2 16383]
+
+            # Should be denied with clear error message
+            wait_for_migration_field 2 $jobname state failed
+            assert_match {*Failed to AUTH to target node*} [dict get [get_migration_by_name 2 $jobname] message]
+
+            # Cleanup for next test
+            R 0 CONFIG SET requirepass ""
+        }
+    }
+
+    test "MIGRATESLOTS with AUTH succeeds when target requires password" {
+        assert_does_not_resync {
+            R 0 CONFIG SET requirepass "targetpass"
+
+            # Populate data before migration
+            populate 1000 "$16383_slot_tag:" 1000 -2
+
+            # AUTH keyword in command overrides primaryauth on source
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH targetpass]
+            set jobname [get_job_name 2 16383]
+            wait_for_migration 0 16383
+
+            # Keys successfully migrated
+            assert_match "1000" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+
+            # Also eventually reflected in replicas
+            wait_for_countkeysinslot 3 16383 1000
+            wait_for_countkeysinslot 5 16383 0
+
+            # Migration log shows success on both ends
+            assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
+            assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+
+            # Cleanup for next test
+            assert_match "OK" [R 0 FLUSHDB SYNC]
+            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            wait_for_migration 2 16383
+            R 0 CONFIG SET requirepass ""
+            R 2 CONFIG SET primaryauth ""
+        }
+    }
+
+        test "MIGRATESLOTS with AUTH overrides primaryauth" {
+        assert_does_not_resync {
+            R 0 CONFIG SET requirepass "targetpass"
+            R 2 CONFIG SET primaryauth "wrongpass"
+
+            # Populate data before migration
+            populate 1000 "$16383_slot_tag:" 1000 -2
+
+            # AUTH keyword in command overrides primaryauth on source
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH targetpass]
+            set jobname [get_job_name 2 16383]
+            wait_for_migration 0 16383
+
+            # Keys successfully migrated
+            assert_match "1000" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+
+            # Also eventually reflected in replicas
+            wait_for_countkeysinslot 3 16383 1000
+            wait_for_countkeysinslot 5 16383 0
+
+            # Migration log shows success on both ends
+            assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
+            assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+
+            # Cleanup for next test
+            assert_match "OK" [R 0 FLUSHDB SYNC]
+            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            wait_for_migration 2 16383
+            R 0 CONFIG SET requirepass ""
+            R 2 CONFIG SET primaryauth ""
+        }
+    }
+
+    test "MIGRATESLOTS with AUTH2 succeeds for ACL user" {
+        assert_does_not_resync {
+            # Set up ACL user on target with full permissions
+            R 0 ACL SETUSER alice on >s3cret ~* &* +@all
+
+            # Populate data before migration
+            populate 1000 "$16383_slot_tag:" 1000 -2
+
+            # AUTH2 authenticates as the ACL user on the target; source primaryauth is unset
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH2 alice s3cret]
+            set jobname [get_job_name 2 16383]
+            wait_for_migration 0 16383
+
+            # Keys successfully migrated
+            assert_match "1000" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+
+            # Also eventually reflected in replicas
+            wait_for_countkeysinslot 3 16383 1000
+            wait_for_countkeysinslot 5 16383 0
+
+            # Migration log shows success on both ends
+            assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
+            assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+
+            # Cleanup for next test
+            assert_match "OK" [R 0 FLUSHDB SYNC]
+            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            wait_for_migration 2 16383
+            R 0 ACL DELUSER alice
+        }
+    }
+
+    test "MIGRATESLOTS per-target AUTH differs in single command" {
+        # Explicit AUTH pw0 for node0, primaryauth fallback pw1 for node1.
+        ensure_slot_on_node 2 16383
+        ensure_slot_on_node 2 16382
+        assert_does_not_resync {
+            R 0 CONFIG SET requirepass "pw0"
+            R 1 CONFIG SET requirepass "pw1"
+            R 2 CONFIG SET primaryauth "pw1"
+
+            populate 500 "$16383_slot_tag:" 1000 -2
+            populate 500 "$16382_slot_tag:" 1000 -2
+
+            # One command: explicit AUTH for node0, primaryauth fallback for node1
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH pw0 SLOTSRANGE 16382 16382 NODE $node1_id]
+            set jobname0 [get_job_name 2 16383]
+            set jobname1 [get_job_name 2 16382]
+            wait_for_migration 0 16383
+            wait_for_migration 1 16382
+
+            # Keys migrated to correct targets
+            assert_match "500" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_match "500" [R 1 CLUSTER COUNTKEYSINSLOT 16382]
+            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16382]
+
+            # Replicas reflect the migration
+            wait_for_countkeysinslot 3 16383 500
+            wait_for_countkeysinslot 4 16382 500
+            wait_for_countkeysinslot 5 16383 0
+            wait_for_countkeysinslot 5 16382 0
+
+            # Both migrations succeeded
+            assert {[dict get [get_migration_by_name 0 $jobname0] state] eq "success"}
+            assert {[dict get [get_migration_by_name 2 $jobname0] state] eq "success"}
+            assert {[dict get [get_migration_by_name 1 $jobname1] state] eq "success"}
+            assert {[dict get [get_migration_by_name 2 $jobname1] state] eq "success"}
+
+            # Cleanup for next test
+            assert_match "OK" [R 0 FLUSHDB SYNC]
+            assert_match "OK" [R 1 FLUSHDB SYNC]
+            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            wait_for_migration 2 16383
+            assert_match "OK" [R 1 CLUSTER MIGRATESLOTS SLOTSRANGE 16382 16382 NODE $node2_id]
+            wait_for_migration 2 16382
+            R 0 CONFIG SET requirepass ""
+            R 1 CONFIG SET requirepass ""
+            R 2 CONFIG SET primaryauth ""
+        }
+    }
+
+    test "CLUSTER MIGRATESLOTS AUTH password is redacted in command log" {
+        ensure_slot_on_node 2 16383
+        ensure_slot_on_node 2 16382
+
+        # The commandlog entry is written synchronously when CLUSTER MIGRATESLOTS returns
+        # OK, before any async auth handshake with the target.  No requirepass on node 0
+        # means the async auth attempt will fail, which is fine — we only need the entry.
+        R 2 CONFIG SET commandlog-execution-slower-than 0
+        R 2 COMMANDLOG RESET slow
+        R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH authpwd
+        R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16382 16382 NODE $node0_id AUTH2 aclusr auth2pwd
+        set jobname0 [get_job_name 2 16383]
+        set jobname1 [get_job_name 2 16382]
+        R 2 CONFIG SET commandlog-execution-slower-than -1
+        set slowlog_resp [R 2 COMMANDLOG GET -1 slow]
+
+        # Flatten all logged command args into one searchable string
+        set log_text {}
+        foreach entry $slowlog_resp {
+            append log_text " " [join [lindex $entry 3] " "]
+        }
+
+        # Passwords (and AUTH2 username) must not appear verbatim
+        assert_no_match {*authpwd*} $log_text
+        assert_no_match {*aclusr*} $log_text
+        assert_no_match {*auth2pwd*} $log_text
+
+        # AUTH: password replaced with (redacted)
+        assert_match {*SLOTSRANGE 16383 16383 NODE * AUTH (redacted)*} $log_text
+
+        # AUTH2: username and password both replaced with (redacted)
+        assert_match {*SLOTSRANGE 16382 16382 NODE * AUTH2 (redacted) (redacted)*} $log_text
+
+        # Migrations fail as intended; wait for terminal state
+        wait_for_migration_field 2 $jobname0 state failed
+        wait_for_migration_field 2 $jobname1 state failed
     }
 
     test "Connection drop during import causes failure" {

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -1780,31 +1780,13 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
         }
     }
 
-    test "MIGRATESLOTS AUTH with WRONGPASS fails cleanly" {
-        assert_does_not_resync {
-            R 0 CONFIG SET requirepass "correctpass"
-
-            # Perform one-shot import with wrong password in AUTH option
-            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH wrongpass]
-            set jobname [get_job_name 2 16383]
-
-            # Should be denied with clear error message
-            wait_for_migration_field 2 $jobname state failed
-            assert_match {*Failed to AUTH to target node*} [dict get [get_migration_by_name 2 $jobname] message]
-
-            # Cleanup for next test
-            R 0 CONFIG SET requirepass ""
-        }
-    }
-
-    test "MIGRATESLOTS with AUTH succeeds when target requires password" {
+    test "CLUSTER MIGRATESLOTS with AUTH succeeds when target requires password" {
         assert_does_not_resync {
             R 0 CONFIG SET requirepass "targetpass"
 
             # Populate data before migration
             populate 1000 "$16383_slot_tag:" 1000 -2
 
-            # AUTH keyword in command overrides primaryauth on source
             assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH targetpass]
             set jobname [get_job_name 2 16383]
             wait_for_migration 0 16383
@@ -1826,11 +1808,27 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
             assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
             wait_for_migration 2 16383
             R 0 CONFIG SET requirepass ""
-            R 2 CONFIG SET primaryauth ""
         }
     }
 
-        test "MIGRATESLOTS with AUTH overrides primaryauth" {
+    test "CLUSTER MIGRATESLOTS AUTH with WRONGPASS fails cleanly" {
+        assert_does_not_resync {
+            R 0 CONFIG SET requirepass "correctpass"
+
+            # Perform one-shot import with wrong password in AUTH option
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH wrongpass]
+            set jobname [get_job_name 2 16383]
+
+            # Should be denied with clear error message
+            wait_for_migration_field 2 $jobname state failed
+            assert_match {*Failed to AUTH to target node*} [dict get [get_migration_by_name 2 $jobname] message]
+
+            # Cleanup for next test
+            R 0 CONFIG SET requirepass ""
+        }
+    }
+
+    test "CLUSTER MIGRATESLOTS with AUTH overrides primaryauth" {
         assert_does_not_resync {
             R 0 CONFIG SET requirepass "targetpass"
             R 2 CONFIG SET primaryauth "wrongpass"
@@ -1864,15 +1862,15 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
         }
     }
 
-    test "MIGRATESLOTS with AUTH2 succeeds for ACL user" {
+    test "CLUSTER MIGRATESLOTS with AUTH2 succeeds for ACL user" {
         assert_does_not_resync {
-            # Set up ACL user on target with full permissions
+            R 0 CONFIG SET requirepass "mustauth"
             R 0 ACL SETUSER alice on >s3cret ~* &* +@all
 
             # Populate data before migration
             populate 1000 "$16383_slot_tag:" 1000 -2
 
-            # AUTH2 authenticates as the ACL user on the target; source primaryauth is unset
+            # AUTH2 authenticates as the ACL user; bare AUTH or no-auth would fail
             assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH2 alice s3cret]
             set jobname [get_job_name 2 16383]
             wait_for_migration 0 16383
@@ -1894,10 +1892,11 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
             assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
             wait_for_migration 2 16383
             R 0 ACL DELUSER alice
+            R 0 CONFIG SET requirepass ""
         }
     }
 
-    test "MIGRATESLOTS per-target AUTH differs in single command" {
+    test "CLUSTER MIGRATESLOTS per-target AUTH differs in single command" {
         # Explicit AUTH pw0 for node0, primaryauth fallback pw1 for node1.
         ensure_slot_on_node 2 16383
         ensure_slot_on_node 2 16382

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -247,6 +247,31 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
         assert_equal {} [R 0 CLUSTER GETSLOTMIGRATIONS]
     }
 
+    test "CLUSTER MIGRATESLOTS AUTH credentials are redacted on synchronous failure" {
+        set old_threshold [lindex [R 0 CONFIG GET commandlog-execution-slower-than] 1]
+        R 0 CONFIG SET commandlog-execution-slower-than 0
+        R 0 COMMANDLOG RESET slow
+
+        # An invalid target is rejected before the parser reaches AUTH.
+        assert_error "*Invalid node name*" {
+            R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE invalid AUTH aclusr authpwd
+        }
+
+        R 0 CONFIG SET commandlog-execution-slower-than $old_threshold
+        set slowlog_resp [R 0 COMMANDLOG GET -1 slow]
+        
+        # Flatten all logged command args into one searchable string
+        set log_text {}
+        foreach entry $slowlog_resp {
+            append log_text " " [join [lindex $entry 3] " "]
+        }
+
+        assert_no_match {*aclusr*} $log_text
+        assert_no_match {*authpwd*} $log_text
+        assert_match {*SLOTSRANGE 0 0 NODE invalid AUTH (redacted) (redacted)*} $log_text
+        assert_equal {} [R 0 CLUSTER GETSLOTMIGRATIONS]
+    }
+
     test "CLUSTER MIGRATESLOTS already migrating" {
         set_debug_prevent_pause 1
         assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
@@ -1954,11 +1979,12 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
         # The commandlog entry is written synchronously when CLUSTER MIGRATESLOTS returns
         # OK, before any async auth handshake with the target.  No requirepass on node 0
         # means the async auth attempt will fail, which is fine — we only need the entry.
+        set old_threshold [lindex [R 2 CONFIG GET commandlog-execution-slower-than] 1]
         R 2 CONFIG SET commandlog-execution-slower-than 0
         R 2 COMMANDLOG RESET slow
         R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH aclusr authpwd
         set jobname [get_job_name 2 16383]
-        R 2 CONFIG SET commandlog-execution-slower-than -1
+        R 2 CONFIG SET commandlog-execution-slower-than $old_threshold
         set slowlog_resp [R 2 COMMANDLOG GET -1 slow]
 
         # Flatten all logged command args into one searchable string

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -2558,7 +2558,8 @@ start_cluster 3 0 {tags {logreqres:skip external:skip cluster network}} {
     test "Migration cannot connect to target" {
         # Shutdown to prevent connection success
         catch {R 2 shutdown nosave}
-        assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node2_id]
+        # Exercise credential cleanup when the connection fails before AUTH is sent.
+        assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node2_id AUTH default authpwd]
         set jobname [get_job_name 0 0]
 
         # Connecting will fail

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -233,6 +233,20 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
         assert_error "*No migrations ongoing*" {R 0 CLUSTER CANCELSLOTMIGRATIONS}
     }
 
+    test "CLUSTER MIGRATESLOTS AUTH/AUTH2 syntax errors" {
+        # AUTH with no password
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH}
+
+        # AUTH2 with only a username and no password
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH2 onlyuser}
+
+        # Both AUTH and AUTH2 in the same group — parser sees AUTH2 where it expects SLOTSRANGE
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH pw AUTH2 u p}
+
+        # None of the above started a migration
+        assert_equal {} [R 0 CLUSTER GETSLOTMIGRATIONS]
+    }
+
     test "CLUSTER MIGRATESLOTS already migrating" {
         set_debug_prevent_pause 1
         assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
@@ -1764,6 +1778,211 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
             R 0 CONFIG SET requirepass ""
             R 2 CONFIG SET primaryauth ""
         }
+    }
+
+    test "MIGRATESLOTS AUTH with WRONGPASS fails cleanly" {
+        assert_does_not_resync {
+            R 0 CONFIG SET requirepass "correctpass"
+
+            # Perform one-shot import with wrong password in AUTH option
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH wrongpass]
+            set jobname [get_job_name 2 16383]
+
+            # Should be denied with clear error message
+            wait_for_migration_field 2 $jobname state failed
+            assert_match {*Failed to AUTH to target node*} [dict get [get_migration_by_name 2 $jobname] message]
+
+            # Cleanup for next test
+            R 0 CONFIG SET requirepass ""
+        }
+    }
+
+    test "MIGRATESLOTS with AUTH succeeds when target requires password" {
+        assert_does_not_resync {
+            R 0 CONFIG SET requirepass "targetpass"
+
+            # Populate data before migration
+            populate 1000 "$16383_slot_tag:" 1000 -2
+
+            # AUTH keyword in command overrides primaryauth on source
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH targetpass]
+            set jobname [get_job_name 2 16383]
+            wait_for_migration 0 16383
+
+            # Keys successfully migrated
+            assert_match "1000" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+
+            # Also eventually reflected in replicas
+            wait_for_countkeysinslot 3 16383 1000
+            wait_for_countkeysinslot 5 16383 0
+
+            # Migration log shows success on both ends
+            assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
+            assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+
+            # Cleanup for next test
+            assert_match "OK" [R 0 FLUSHDB SYNC]
+            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            wait_for_migration 2 16383
+            R 0 CONFIG SET requirepass ""
+            R 2 CONFIG SET primaryauth ""
+        }
+    }
+
+        test "MIGRATESLOTS with AUTH overrides primaryauth" {
+        assert_does_not_resync {
+            R 0 CONFIG SET requirepass "targetpass"
+            R 2 CONFIG SET primaryauth "wrongpass"
+
+            # Populate data before migration
+            populate 1000 "$16383_slot_tag:" 1000 -2
+
+            # AUTH keyword in command overrides primaryauth on source
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH targetpass]
+            set jobname [get_job_name 2 16383]
+            wait_for_migration 0 16383
+
+            # Keys successfully migrated
+            assert_match "1000" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+
+            # Also eventually reflected in replicas
+            wait_for_countkeysinslot 3 16383 1000
+            wait_for_countkeysinslot 5 16383 0
+
+            # Migration log shows success on both ends
+            assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
+            assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+
+            # Cleanup for next test
+            assert_match "OK" [R 0 FLUSHDB SYNC]
+            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            wait_for_migration 2 16383
+            R 0 CONFIG SET requirepass ""
+            R 2 CONFIG SET primaryauth ""
+        }
+    }
+
+    test "MIGRATESLOTS with AUTH2 succeeds for ACL user" {
+        assert_does_not_resync {
+            # Set up ACL user on target with full permissions
+            R 0 ACL SETUSER alice on >s3cret ~* &* +@all
+
+            # Populate data before migration
+            populate 1000 "$16383_slot_tag:" 1000 -2
+
+            # AUTH2 authenticates as the ACL user on the target; source primaryauth is unset
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH2 alice s3cret]
+            set jobname [get_job_name 2 16383]
+            wait_for_migration 0 16383
+
+            # Keys successfully migrated
+            assert_match "1000" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+
+            # Also eventually reflected in replicas
+            wait_for_countkeysinslot 3 16383 1000
+            wait_for_countkeysinslot 5 16383 0
+
+            # Migration log shows success on both ends
+            assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
+            assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+
+            # Cleanup for next test
+            assert_match "OK" [R 0 FLUSHDB SYNC]
+            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            wait_for_migration 2 16383
+            R 0 ACL DELUSER alice
+        }
+    }
+
+    test "MIGRATESLOTS per-target AUTH differs in single command" {
+        # Explicit AUTH pw0 for node0, primaryauth fallback pw1 for node1.
+        ensure_slot_on_node 2 16383
+        ensure_slot_on_node 2 16382
+        assert_does_not_resync {
+            R 0 CONFIG SET requirepass "pw0"
+            R 1 CONFIG SET requirepass "pw1"
+            R 2 CONFIG SET primaryauth "pw1"
+
+            populate 500 "$16383_slot_tag:" 1000 -2
+            populate 500 "$16382_slot_tag:" 1000 -2
+
+            # One command: explicit AUTH for node0, primaryauth fallback for node1
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH pw0 SLOTSRANGE 16382 16382 NODE $node1_id]
+            set jobname0 [get_job_name 2 16383]
+            set jobname1 [get_job_name 2 16382]
+            wait_for_migration 0 16383
+            wait_for_migration 1 16382
+
+            # Keys migrated to correct targets
+            assert_match "500" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_match "500" [R 1 CLUSTER COUNTKEYSINSLOT 16382]
+            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16382]
+
+            # Replicas reflect the migration
+            wait_for_countkeysinslot 3 16383 500
+            wait_for_countkeysinslot 4 16382 500
+            wait_for_countkeysinslot 5 16383 0
+            wait_for_countkeysinslot 5 16382 0
+
+            # Both migrations succeeded
+            assert {[dict get [get_migration_by_name 0 $jobname0] state] eq "success"}
+            assert {[dict get [get_migration_by_name 2 $jobname0] state] eq "success"}
+            assert {[dict get [get_migration_by_name 1 $jobname1] state] eq "success"}
+            assert {[dict get [get_migration_by_name 2 $jobname1] state] eq "success"}
+
+            # Cleanup for next test
+            assert_match "OK" [R 0 FLUSHDB SYNC]
+            assert_match "OK" [R 1 FLUSHDB SYNC]
+            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            wait_for_migration 2 16383
+            assert_match "OK" [R 1 CLUSTER MIGRATESLOTS SLOTSRANGE 16382 16382 NODE $node2_id]
+            wait_for_migration 2 16382
+            R 0 CONFIG SET requirepass ""
+            R 1 CONFIG SET requirepass ""
+            R 2 CONFIG SET primaryauth ""
+        }
+    }
+
+    test "CLUSTER MIGRATESLOTS AUTH password is redacted in command log" {
+        ensure_slot_on_node 2 16383
+        ensure_slot_on_node 2 16382
+
+        # The commandlog entry is written synchronously when CLUSTER MIGRATESLOTS returns
+        # OK, before any async auth handshake with the target.  No requirepass on node 0
+        # means the async auth attempt will fail, which is fine — we only need the entry.
+        R 2 CONFIG SET commandlog-execution-slower-than 0
+        R 2 COMMANDLOG RESET slow
+        R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH authpwd
+        R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16382 16382 NODE $node0_id AUTH2 aclusr auth2pwd
+        set jobname0 [get_job_name 2 16383]
+        set jobname1 [get_job_name 2 16382]
+        R 2 CONFIG SET commandlog-execution-slower-than -1
+        set slowlog_resp [R 2 COMMANDLOG GET -1 slow]
+
+        # Flatten all logged command args into one searchable string
+        set log_text {}
+        foreach entry $slowlog_resp {
+            append log_text " " [join [lindex $entry 3] " "]
+        }
+
+        # Passwords (and AUTH2 username) must not appear verbatim
+        assert_no_match {*authpwd*} $log_text
+        assert_no_match {*aclusr*} $log_text
+        assert_no_match {*auth2pwd*} $log_text
+
+        # AUTH: password replaced with (redacted)
+        assert_match {*SLOTSRANGE 16383 16383 NODE * AUTH (redacted)*} $log_text
+
+        # AUTH2: username and password both replaced with (redacted)
+        assert_match {*SLOTSRANGE 16382 16382 NODE * AUTH2 (redacted) (redacted)*} $log_text
+
+        # Migrations fail as intended; wait for terminal state
+        wait_for_migration_field 2 $jobname0 state failed
+        wait_for_migration_field 2 $jobname1 state failed
     }
 
     test "Connection drop during import causes failure" {

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -233,15 +233,15 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
         assert_error "*No migrations ongoing*" {R 0 CLUSTER CANCELSLOTMIGRATIONS}
     }
 
-    test "CLUSTER MIGRATESLOTS AUTH/AUTH2 syntax errors" {
-        # AUTH with no password
+    test "CLUSTER MIGRATESLOTS AUTH syntax errors" {
+        # AUTH with no username or password
         assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH}
 
-        # AUTH2 with only a username and no password
-        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH2 onlyuser}
+        # AUTH with only a username and no password
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH onlyuser}
 
-        # Both AUTH and AUTH2 in the same group — parser sees AUTH2 where it expects SLOTSRANGE
-        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH pw AUTH2 u p}
+        # Duplicate AUTH in the same group
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH u p AUTH u p}
 
         # None of the above started a migration
         assert_equal {} [R 0 CLUSTER GETSLOTMIGRATIONS]
@@ -1787,7 +1787,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
             # Populate data before migration
             populate 1000 "$16383_slot_tag:" 1000 -2
 
-            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH targetpass]
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH default targetpass]
             set jobname [get_job_name 2 16383]
             wait_for_migration 0 16383
 
@@ -1816,7 +1816,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
             R 0 CONFIG SET requirepass "correctpass"
 
             # Perform one-shot import with wrong password in AUTH option
-            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH wrongpass]
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH default wrongpass]
             set jobname [get_job_name 2 16383]
 
             # Should be denied with clear error message
@@ -1828,16 +1828,17 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
         }
     }
 
-    test "CLUSTER MIGRATESLOTS with AUTH overrides primaryauth" {
+    test "CLUSTER MIGRATESLOTS with AUTH overrides primaryuser and primaryauth" {
         assert_does_not_resync {
             R 0 CONFIG SET requirepass "targetpass"
             R 2 CONFIG SET primaryauth "wrongpass"
+            R 2 CONFIG SET primaryuser "wronguser"
 
             # Populate data before migration
             populate 1000 "$16383_slot_tag:" 1000 -2
 
-            # AUTH keyword in command overrides primaryauth on source
-            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH targetpass]
+            # AUTH overrides both configured credentials on the source
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH default targetpass]
             set jobname [get_job_name 2 16383]
             wait_for_migration 0 16383
 
@@ -1859,10 +1860,11 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
             wait_for_migration 2 16383
             R 0 CONFIG SET requirepass ""
             R 2 CONFIG SET primaryauth ""
+            R 2 CONFIG SET primaryuser ""
         }
     }
 
-    test "CLUSTER MIGRATESLOTS with AUTH2 succeeds for ACL user" {
+    test "CLUSTER MIGRATESLOTS with AUTH succeeds for ACL user" {
         assert_does_not_resync {
             R 0 CONFIG SET requirepass "mustauth"
             R 0 ACL SETUSER alice on >s3cret ~* &* +@all
@@ -1870,8 +1872,8 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
             # Populate data before migration
             populate 1000 "$16383_slot_tag:" 1000 -2
 
-            # AUTH2 authenticates as the ACL user; bare AUTH or no-auth would fail
-            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH2 alice s3cret]
+            # Authenticate as the named ACL user
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH alice s3cret]
             set jobname [get_job_name 2 16383]
             wait_for_migration 0 16383
 
@@ -1897,7 +1899,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
     }
 
     test "CLUSTER MIGRATESLOTS per-target AUTH differs in single command" {
-        # Explicit AUTH pw0 for node0, primaryauth fallback pw1 for node1.
+        # Explicit AUTH default pw0 for node0, primaryauth fallback pw1 for node1.
         ensure_slot_on_node 2 16383
         ensure_slot_on_node 2 16382
         assert_does_not_resync {
@@ -1909,7 +1911,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
             populate 500 "$16382_slot_tag:" 1000 -2
 
             # One command: explicit AUTH for node0, primaryauth fallback for node1
-            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH pw0 SLOTSRANGE 16382 16382 NODE $node1_id]
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH default pw0 SLOTSRANGE 16382 16382 NODE $node1_id]
             set jobname0 [get_job_name 2 16383]
             set jobname1 [get_job_name 2 16382]
             wait_for_migration 0 16383
@@ -1946,19 +1948,16 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
         }
     }
 
-    test "CLUSTER MIGRATESLOTS AUTH password is redacted in command log" {
+    test "CLUSTER MIGRATESLOTS AUTH credentials are redacted in command log" {
         ensure_slot_on_node 2 16383
-        ensure_slot_on_node 2 16382
 
         # The commandlog entry is written synchronously when CLUSTER MIGRATESLOTS returns
         # OK, before any async auth handshake with the target.  No requirepass on node 0
         # means the async auth attempt will fail, which is fine — we only need the entry.
         R 2 CONFIG SET commandlog-execution-slower-than 0
         R 2 COMMANDLOG RESET slow
-        R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH authpwd
-        R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16382 16382 NODE $node0_id AUTH2 aclusr auth2pwd
-        set jobname0 [get_job_name 2 16383]
-        set jobname1 [get_job_name 2 16382]
+        R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id AUTH aclusr authpwd
+        set jobname [get_job_name 2 16383]
         R 2 CONFIG SET commandlog-execution-slower-than -1
         set slowlog_resp [R 2 COMMANDLOG GET -1 slow]
 
@@ -1968,20 +1967,15 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
             append log_text " " [join [lindex $entry 3] " "]
         }
 
-        # Passwords (and AUTH2 username) must not appear verbatim
+        # Neither credential may appear verbatim
         assert_no_match {*authpwd*} $log_text
         assert_no_match {*aclusr*} $log_text
-        assert_no_match {*auth2pwd*} $log_text
 
-        # AUTH: password replaced with (redacted)
-        assert_match {*SLOTSRANGE 16383 16383 NODE * AUTH (redacted)*} $log_text
+        # Username and password are both replaced with (redacted)
+        assert_match {*SLOTSRANGE 16383 16383 NODE * AUTH (redacted) (redacted)*} $log_text
 
-        # AUTH2: username and password both replaced with (redacted)
-        assert_match {*SLOTSRANGE 16382 16382 NODE * AUTH2 (redacted) (redacted)*} $log_text
-
-        # Migrations fail as intended; wait for terminal state
-        wait_for_migration_field 2 $jobname0 state failed
-        wait_for_migration_field 2 $jobname1 state failed
+        # Migration fails as intended; wait for terminal state
+        wait_for_migration_field 2 $jobname state failed
     }
 
     test "Connection drop during import causes failure" {


### PR DESCRIPTION
Fixes #2392. 

`CLUSTER MIGRATESLOTS` currently authenticates to target nodes using the
source node's `masteruser`/`masterauth`. This adds optional
per-target AUTH support, matching the existing `MIGRATE` command syntax.

New syntax:
```
CLUSTER MIGRATESLOTS SLOTSRANGE start end NODE node-id [AUTH username password]
```

When AUTH is omitted, behavior is unchanged (falls back to masteruser/masterauth).

Changes:
- [x] added `auth_user`/`auth_password` fields to `slotMigrationJob`
- [x] extend command parser to accept AUTH after each NODE argument
- [x] updated `slotMigrationJobSendAuth` to prefer per-job credentials over globals
- [x] redacted password arguments in slow log / MONITOR (matching MIGRATE behavior)
- [x] zero on free for credentials
- [x] update command JSON schema and help string

Tests:
- [x] test for AUTH happy path
- [x] test for wrong password
- [x] test for syntax errors
- [x] test for per-job auth overriding masterauth
- [x] test for multi-target with mixed  types of credentials
- [x] test for user/password command redaction 

TODO:
- [] PR for valkey-doc repo needed