### PR TITLE
Fix lua-enable-insecure-api default value cannot be changed to yes

### DIFF
--- a/src/modules/lua/engine_lua.c
+++ b/src/modules/lua/engine_lua.c
@@ -22,6 +22,8 @@
 #define LUA_ENGINE_NAME "LUA"
 #define REGISTRY_ERROR_HANDLER_NAME "__ERROR_HANDLER__"
 
+static int isLuaInsecureAPIEnabled(ValkeyModuleCtx *module_ctx);
+
 /* Adds server.debug() function used by lua debugger
  *
  * Log a string message into the output console.
@@ -201,7 +203,7 @@ static struct luaEngineCtx *createEngineContext(ValkeyModuleCtx *ctx) {
                      &lua_engine_ctx->valkey_version,
                      &lua_engine_ctx->valkey_version_num);
 
-    lua_engine_ctx->lua_enable_insecure_api = 0;
+    lua_engine_ctx->lua_enable_insecure_api = isLuaInsecureAPIEnabled(ctx);
 
     initializeLuaState(lua_engine_ctx, VMSE_EVAL);
     initializeLuaState(lua_engine_ctx, VMSE_FUNCTION);

--- a/src/server.c
+++ b/src/server.c
@@ -7738,6 +7738,12 @@ __attribute__((weak)) int main(int argc, char **argv) {
     }
 #endif
 
+    /* Sync lua_insecure_api_current with the final config value after all
+     * config sources (default, config file, command-line args) have been
+     * applied, so that updateLuaEnableInsecureApi() can correctly detect
+     * subsequent changes via CONFIG SET. */
+    server.lua_insecure_api_current = server.lua_enable_insecure_api;
+
     InitServerLast();
 
     if (!server.sentinel_mode) {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -689,7 +689,7 @@ start_server {tags {"scripting"}} {
         }
     } {} {external:skip}
 
-    start_server {tags {"scripting"} overrides {lua-enable-insecure-api yes}} {
+    start_server {tags {"scripting external:skip"} overrides {lua-enable-insecure-api yes}} {
         test {Dynamic reset of lua engine with insecure API config change - default yes} {
             # Ensure insecure API is available by default
             assert_equal {} [r eval "return getfenv()" 0]
@@ -705,7 +705,7 @@ start_server {tags {"scripting"}} {
         }
     }
 
-    start_server {tags {"scripting"} config {default.conf} overrides {lua-enable-insecure-api no} args {--lua-enable-insecure-api yes}} {
+    start_server {tags {"scripting external:skip"} config {default.conf} overrides {lua-enable-insecure-api no} args {--lua-enable-insecure-api yes}} {
         test {Dynamic reset of lua engine with insecure API config change - command line yes} {
             # Ensure insecure API is available by default
             assert_equal {} [r eval "return getfenv()" 0]

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -689,6 +689,38 @@ start_server {tags {"scripting"}} {
         }
     } {} {external:skip}
 
+    start_server {tags {"scripting"} overrides {lua-enable-insecure-api yes}} {
+        test {Dynamic reset of lua engine with insecure API config change - default yes} {
+            # Ensure insecure API is available by default
+            assert_equal {} [r eval "return getfenv()" 0]
+
+            # Verify that disabling the config `lua-enable-insecure-api` disallows insecure API access
+            r config set lua-enable-insecure-api no
+            assert_error {*Script attempted to access nonexistent global variable 'getfenv'*} {
+                r eval "return getfenv()" 0
+            }
+
+            r config set lua-enable-insecure-api yes
+            assert_equal {} [r eval "return getfenv()" 0]
+        }
+    }
+
+    start_server {tags {"scripting"} config {default.conf} overrides {lua-enable-insecure-api no} args {--lua-enable-insecure-api yes}} {
+        test {Dynamic reset of lua engine with insecure API config change - command line yes} {
+            # Ensure insecure API is available by default
+            assert_equal {} [r eval "return getfenv()" 0]
+
+            # Verify that disabling the config `lua-enable-insecure-api` disallows insecure API access
+            r config set lua-enable-insecure-api no
+            assert_error {*Script attempted to access nonexistent global variable 'getfenv'*} {
+                r eval "return getfenv()" 0
+            }
+
+            r config set lua-enable-insecure-api yes
+            assert_equal {} [r eval "return getfenv()" 0]
+        }
+    }
+
     test {SCRIPTING FLUSH ASYNC} {
         r script flush sync
         for {set j 0} {$j < 100} {incr j} {


### PR DESCRIPTION
The default value of lua-enable-insecure-api cannot be safely changed
from no to yes due to two issues:

1. In createEngineContext(), lua_enable_insecure_api was hardcoded to 0
   before initializing Lua states, so deprecated APIs (newproxy, setfenv,
   getfenv) were never registered in the global table regardless of the
   actual config value. Once the global table is locked, the config
   change has no effect.

2. lua_insecure_api_current was initialized to 0 (struct zero-init) and
   never synced with the final config value. If the default was changed
   to yes(1), a subsequent CONFIG SET no would see both values as 0 and
   skip the evalReset() call in updateLuaEnableInsecureApi().

Fix by reading the real config via isLuaInsecureAPIEnabled() in
createEngineContext() before Lua state initialization, and syncing
lua_insecure_api_current after all config sources (default, config file,
command-line args) are applied.