### PR TITLE
Implement AOF data integrity check support.

### DIFF
--- a/design-docs/aof-header-spec.md
+++ b/design-docs/aof-header-spec.md
@@ -1,0 +1,138 @@
+# Append Only File (AOF) Metadata Header Specification
+
+This document defines the specification for the metadata header in Valkey's Append Only File (AOF). The header is designed to carry optional block-level metadata, such as replication state (replication ID and offset) for state restoration, and block checksums for data integrity verification.
+
+---
+
+## 1. Format Rationale: Text vs. Base64
+
+To store metadata in the AOF, we propose the header to be formatted as an AOF annotation for backwards compatibility (starting with `#` and ending with `\r\n`). 
+
+### Ruling out Raw Binary
+A raw binary format is ruled out immediately due to backward incompatibility and parsing constraints. Raw binary payloads can naturally contain null bytes (`\0`) or carriage return/line feed sequences (`\r\n`), which would prematurely terminate or corrupt the annotation line when parsed using standard line-oriented functions (like `fgets`) in the AOF loader.
+
+Therefore, the realistic choice is between **Structured Text** and **Base64-Encoded Binary**.
+
+### Size Comparison (Expected Overhead)
+
+To evaluate the size impact, we compare the overhead of storing metadata fields (length, checksum, replication ID, and replication offset) across different formats:
+
+1. **Text Format (Key-Value)**:
+   - Example: `#HDR:v1;len:123456;replid:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2;reploff:123456789012;checksum:12345678901234567890;\r\n`
+   - Estimated size: **~50 to 130 bytes** depending on which optional fields are present.
+
+2. **Base64-Encoded Binary**:
+   - Encoding the binary payload of size `N` bytes: `ceil(N / 3) * 4` characters.
+   - Adding prefix/suffix: `#HDR:v1;<base64_payload>\r\n` -> **~26 to 66 bytes** depending on present fields.
+
+### Trade-off Analysis (Text vs. Base64)
+
+| Metric | Text Format (Key-Value) | Base64-Encoded Binary |
+| :--- | :--- | :--- |
+| **Size Overhead** | High (~50B - 130B) | Medium (~26B - 66B) |
+| **Human Readable** | Yes | No |
+| **Extensibility** | Very High (Trivial to append fields) | Medium (Requires serialization like TLV) |
+
+### Key Design Decisions for Choosing Text:
+
+- **Readability**: Storing metadata in text preserves the ability to inspect, debug, and manually repair AOF files using standard command-line tools (e.g., `grep`, `tail`, `vi`). A Base64 blob is opaque and requires external decoding tools.
+- **Extensibility**: Text-based key-value pairs are trivially extensible. New fields can be appended (`key:value;`), and older parsers will naturally ignore them. Base64 requires packing/unpacking logic (like TLV) to allow older parsers to skip unknown fields.
+- **Amortized Overhead**: Because headers are written once per AOF flush cycle (grouping all commands currently buffered in `server.aof_buf`) and not per individual command, the overhead is amortized. Under high write throughput, the average byte overhead per command is negligible.
+
+---
+
+## 2. Formal Grammar (ABNF)
+
+The AOF metadata header MUST conform to the following Augmented Backus-Naur Form (ABNF) grammar (RFC 5234):
+
+```abnf
+AOF-HEADER      = "#HDR:" VERSION ";len:" BLOCK-LEN ";" *FIELD [ "checksum:" CHECKSUM ";" ] CRLF
+VERSION         = "v1"
+BLOCK-LEN       = 1*DIGIT ; Length of the following RESP command block in bytes
+CHECKSUM        = 1*DIGIT ; CRC64 checksum represented as decimal
+FIELD           = FIELD-KEY ":" FIELD-VALUE ";"
+FIELD-KEY       = "replid" / "reploff" / TOKEN
+FIELD-VALUE     = TOKEN
+TOKEN           = 1*(%x30-39 / %x41-5A / %x61-7A / "-" / "_") 
+                  ; One or more alphanumeric characters, hyphens, or underscores
+CRLF            = %x0D %x0A ; \r\n
+```
+
+### Grammar Constraints:
+1. **Required `len`**: The `len` field is **required** and MUST be the first field in the header (immediately following the version).
+2. **Ordered Checksum**: The `checksum` field, if present, MUST be the **last** field in the header.
+3. **Decimal Representation**: Values for `len`, `checksum`, and `reploff` MUST be represented as decimal integers (adhering to `%x30-39` in `TOKEN` and `1*DIGIT`).
+
+---
+
+## 3. Well-Known Fields
+
+| Field Name | Type | Description |
+| :--- | :--- | :--- |
+| `len` | Decimal Integer | **Required.** The length of the upcoming RESP command block in bytes. |
+| `checksum` | Decimal Integer | **Optional.** The continuous CRC64 checksum of the stream. |
+| `replid` | Hex String (40 chars) | **Optional.** The replication ID associated with this state. |
+| `reploff` | Decimal Integer | **Optional.** The replication offset associated with this state. |
+
+### Header Variants based on Server State:
+
+- **AOF Integrity Enabled (`aof-integrity-check yes`)**:
+  Requires `len` and `checksum`.
+  ```text
+  #HDR:v1;len:45;checksum:1234567890123456789;
+  ```
+
+- **Replication State Restore Enabled (`aof-replication-restore yes`)**:
+  Requires `len` and `reploff`. `replid` is optional.
+  ```text
+  #HDR:v1;len:45;replid:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2;reploff:100500;
+  ```
+
+- **Both Integrity and Replication Restore Enabled**:
+  Requires `len`, `reploff`, and `checksum` (must be last). `replid` is optional.
+  ```text
+  #HDR:v1;len:45;replid:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2;reploff:100500;checksum:1234567890123456789;
+  ```
+
+---
+
+## 4. Checksum Calculation Semantics
+
+If the `checksum` field is present, it MUST be the last field in the header, and its value is calculated as follows:
+
+1. **Scope**: The checksum is a continuous CRC64 of the stream.
+2. **Header Contribution**: The checksum calculation for the current block includes the header prefix and all preceding fields up to the `checksum:` key itself, including the colon.
+   - Specifically, for the header: `#HDR:v1;len:45;replid:abc;checksum:12345;\r\n`
+   - The checksummed header string is: `#HDR:v1;len:45;replid:abc;checksum:`
+3. **Payload Contribution**: The calculation then continues over the payload data of the block (of length specified by `len`).
+4. **Validation**: The loader calculates `CRC64(PreviousChecksum, HeaderString + PayloadData)` and compares it to the parsed `checksum` value. The trailing `;\r\n` of the header is excluded from the checksum calculation.
+
+---
+
+## 5. Versioning and Extensibility
+
+- **Versioning**: The version token (e.g., `v1`) defines the strict grammar. If a breaking change is made (e.g., changing the checksum algorithm), the version MUST be bumped to `v2`. A parser encountering an unknown version MUST fail-fast.
+- **Extensibility**: Within a version (e.g., `v1`), the parser MUST ignore any unrecognized fields. This allows a server running only integrity checks to safely skip `replid` and `reploff` fields, ensuring forward compatibility.
+
+---
+
+## 6. Alternatives Considered: Base64-Encoded Packed Binary
+
+We considered using a packed binary layout encoded in Base64 for maximum storage efficiency.
+
+### How it would work:
+1. **Binary Payload**: Consists of a 1-byte presence bitmask followed by only the active fields appended back-to-back in big-endian format.
+   - Bit 0: `len` (4B)
+   - Bit 1: `checksum` (8B)
+   - Bit 2: `repl_id` (20B raw)
+   - Bit 3: `repl_offset` (8B)
+2. **Base64 Encoding**: The binary payload is encoded to Base64 to make it safe for AOF annotations (e.g., `#HDR:v1:AwAAAA0R2zREVVZndw==\r\n`).
+3. **Extensibility**: Older parsers read the bitmask and unpack only the fields they know, ignoring any trailing bytes in the decoded buffer (which would contain newer fields).
+
+### Trade-off Evaluation:
+* **Pros**: 
+  - **High Storage Efficiency**: Reduces header size by ~45% to 50% (saving ~24 to 62 bytes per header depending on the active fields).
+* **Cons**:
+  - **Loss of Readability**: The header becomes opaque. Administrators cannot easily verify replication offsets or checksums by simply reading the AOF file.
+  - **Parsing Complexity**: Requires a Base64 decoder and bit-shifting logic in the critical path of AOF loading.
+  - **Inconsistency**: If storage efficiency were the primary goal, the entire AOF format (which is verbose RESP text) would need to be optimized (e.g., to a binary AOF format). Optimizing only the header while keeping the rest of the file in RESP text yields diminishing returns and introduces inconsistency.

--- a/src/aof.c
+++ b/src/aof.c
@@ -131,7 +131,7 @@ sds aofInfoFormat(sds buf, aofInfo *ai) {
     sds ret = sdscatprintf(buf, "%s %s %s %lld %s %c", AOF_MANIFEST_KEY_FILE_NAME,
                            filename_repr ? filename_repr : ai->file_name, AOF_MANIFEST_KEY_FILE_SEQ, ai->file_seq,
                            AOF_MANIFEST_KEY_FILE_TYPE, ai->file_type);
-    
+
     if (server.aof_integrity_check) {
         ret = sdscatprintf(ret, " %s %llu", AOF_MANIFEST_KEY_FILE_CHECKSUM, (unsigned long long)ai->last_checksum);
     }
@@ -291,6 +291,8 @@ aofManifest *aofLoadManifestFromFile(sds am_filepath) {
     sds line = NULL;
     int linenum = 0;
     uint64_t calculated_checksum = 0;
+    int saw_file_checksum = 0;
+    int saw_manifest_checksum = 0;
 
     while (1) {
         if (fgets(buf, MANIFEST_MAX_LINE + 1, fp) == NULL) {
@@ -310,6 +312,7 @@ aofManifest *aofLoadManifestFromFile(sds am_filepath) {
         linenum++;
 
         if (server.aof_integrity_check && strncmp(buf, "# manifest-checksum: ", 21) == 0) {
+            saw_manifest_checksum = 1;
             uint64_t file_checksum = strtoull(buf + 21, NULL, 10);
             if (calculated_checksum != file_checksum) {
                 serverLog(LL_WARNING, "\n*** FATAL AOF MANIFEST FILE ERROR ***\n");
@@ -360,6 +363,7 @@ aofManifest *aofLoadManifestFromFile(sds am_filepath) {
                 ai->file_type = (argv[i + 1])[0];
             } else if (!strcasecmp(argv[i], AOF_MANIFEST_KEY_FILE_CHECKSUM)) {
                 ai->last_checksum = strtoull(argv[i + 1], NULL, 10);
+                saw_file_checksum = 1;
             }
             /* else if (!strcasecmp(argv[i], AOF_MANIFEST_KEY_OTHER)) {} */
         }
@@ -398,6 +402,11 @@ aofManifest *aofLoadManifestFromFile(sds am_filepath) {
         sdsfree(line);
         line = NULL;
         ai = NULL;
+    }
+
+    if (server.aof_integrity_check && saw_file_checksum && !saw_manifest_checksum) {
+        err = "Missing AOF manifest checksum";
+        goto loaderr;
     }
 
     fclose(fp);
@@ -824,7 +833,7 @@ int openNewIncrAofForAppend(void) {
     } else {
         /* Dup a temp aof_manifest to modify. */
         temp_am = aofManifestDup(server.aof_manifest);
-        
+
         /* Update the checksum of the current INCR file before opening a new one. */
         if (server.aof_integrity_check) {
             listNode *last_node = listLast(temp_am->incr_aof_list);
@@ -833,7 +842,7 @@ int openNewIncrAofForAppend(void) {
                 last_ai->last_checksum = server.aof_running_checksum;
             }
         }
-        
+
         new_aof_name = sdsdup(getNewIncrAofName(temp_am));
     }
     sds new_aof_filepath = makePath(server.aof_dirname, new_aof_name);
@@ -1203,7 +1212,13 @@ ssize_t aofWrite(int fd, const char *buf, size_t len) {
     return totwritten;
 }
 
-/* Wrapper for writev that handles short writes and EINTR. */
+/**
+ * Write the given iovec array to the AOF file descriptor.
+ * Handles short writes by advancing the iovec array and retrying,
+ * and handles EINTR by retrying the write.
+ *
+ * Returns the total number of bytes written, or -1 on error.
+ */
 ssize_t aofWritev(int fd, struct iovec *iov, int iovcnt) {
     ssize_t nwritten = 0, totwritten = 0;
 
@@ -1216,14 +1231,14 @@ ssize_t aofWritev(int fd, struct iovec *iov, int iovcnt) {
         }
 
         totwritten += nwritten;
-        
+
         /* Advance the iovec array to account for written bytes */
         while (iovcnt > 0 && nwritten >= (ssize_t)iov[0].iov_len) {
             nwritten -= iov[0].iov_len;
             iov++;
             iovcnt--;
         }
-        
+
         /* If a short write happened in the middle of an iovec, adjust it */
         if (nwritten > 0) {
             iov[0].iov_base = (char *)iov[0].iov_base + nwritten;
@@ -1327,13 +1342,13 @@ void flushAppendOnlyFile(int force) {
         latencyStartMonitor(latency);
         nwritten = aofWrite(server.aof_fd, server.aof_retry_buf, sdslen(server.aof_retry_buf));
         latencyEndMonitor(latency);
-        
+
         if (nwritten > 0) {
             server.aof_current_size += nwritten;
             server.aof_last_incr_size += nwritten;
             sdsrange(server.aof_retry_buf, nwritten, -1);
         }
-        
+
         if (sdslen(server.aof_retry_buf) > 0) {
             /* Still have data in retry buffer, means write failed or was short.
              * We can't proceed with aof_buf. */
@@ -1352,14 +1367,14 @@ void flushAppendOnlyFile(int force) {
         char hdr_prefix[64];
         int prefix_len = snprintf(hdr_prefix, sizeof(hdr_prefix), "#HDR:v1;len:%zu;", sdslen(server.aof_buf));
         serverAssert(prefix_len < (int)sizeof(hdr_prefix));
-        
+
         checksum = crc64(server.aof_running_checksum, (unsigned char *)hdr_prefix, prefix_len);
         checksum = crc64(checksum, (unsigned char *)server.aof_buf, sdslen(server.aof_buf));
-        
+
         hdr_len = snprintf(hdr, sizeof(hdr), "%schecksum:%llu;\r\n", hdr_prefix, (unsigned long long)checksum);
         serverAssert(hdr_len < (int)sizeof(hdr));
         expected_len += hdr_len;
-        
+
         server.aof_running_checksum = checksum;
 
         struct iovec iov[2];
@@ -1410,6 +1425,9 @@ void flushAppendOnlyFile(int force) {
                 serverLog(LL_WARNING, "Error writing to the AOF file: %s", strerror(errno));
             }
             server.aof_last_write_errno = errno;
+            if (server.aof_integrity_check) {
+                server.aof_running_checksum = old_checksum;
+            }
         } else {
             if (can_log) {
                 serverLog(LL_WARNING,
@@ -1460,7 +1478,7 @@ void flushAppendOnlyFile(int force) {
             if (nwritten > 0) {
                 server.aof_current_size += nwritten;
                 server.aof_last_incr_size += nwritten;
-                
+
                 if (server.aof_integrity_check) {
                     if ((size_t)nwritten < (size_t)hdr_len) {
                         /* Failed during header write. Save remaining header and all data. */
@@ -2806,6 +2824,11 @@ int rewriteAppendOnlyFileBackground(void) {
      * feedAppendOnlyFile() to issue a SELECT command. */
     server.aof_selected_db = -1;
     flushAppendOnlyFile(1);
+    if (server.aof_last_write_status == C_ERR || sdslen(server.aof_retry_buf) > 0 || sdslen(server.aof_buf) > 0) {
+        serverLog(LL_WARNING, "Can't start AOF rewrite while pending AOF data could not be flushed");
+        server.aof_lastbgrewrite_status = C_ERR;
+        return C_ERR;
+    }
     if (openNewIncrAofForAppend() != C_OK) {
         server.aof_lastbgrewrite_status = C_ERR;
         return C_ERR;
@@ -2826,7 +2849,7 @@ int rewriteAppendOnlyFileBackground(void) {
     }
 
     server.stat_aof_rewrites++;
-    
+
     if (server.aof_integrity_check) {
         server.aof_rewrite_base_checksum = server.aof_running_checksum;
     }

--- a/src/aof.c
+++ b/src/aof.c
@@ -32,6 +32,7 @@
 #include "rio.h"
 #include "functions.h"
 #include "module.h"
+#include "crc64.h"
 
 #include <signal.h>
 #include <fcntl.h>
@@ -94,6 +95,7 @@ void aof_background_fsync_and_close(int fd);
 #define AOF_MANIFEST_KEY_FILE_NAME "file"
 #define AOF_MANIFEST_KEY_FILE_SEQ "seq"
 #define AOF_MANIFEST_KEY_FILE_TYPE "type"
+#define AOF_MANIFEST_KEY_FILE_CHECKSUM "checksum"
 
 /* Create an empty aofInfo. */
 aofInfo *aofInfoCreate(void) {
@@ -114,6 +116,7 @@ aofInfo *aofInfoDup(aofInfo *orig) {
     ai->file_name = sdsdup(orig->file_name);
     ai->file_seq = orig->file_seq;
     ai->file_type = orig->file_type;
+    ai->last_checksum = orig->last_checksum;
     return ai;
 }
 
@@ -125,9 +128,16 @@ sds aofInfoFormat(sds buf, aofInfo *ai) {
 
     if (sdsneedsrepr(ai->file_name)) filename_repr = sdscatrepr(sdsempty(), ai->file_name, sdslen(ai->file_name));
 
-    sds ret = sdscatprintf(buf, "%s %s %s %lld %s %c\n", AOF_MANIFEST_KEY_FILE_NAME,
+    sds ret = sdscatprintf(buf, "%s %s %s %lld %s %c", AOF_MANIFEST_KEY_FILE_NAME,
                            filename_repr ? filename_repr : ai->file_name, AOF_MANIFEST_KEY_FILE_SEQ, ai->file_seq,
                            AOF_MANIFEST_KEY_FILE_TYPE, ai->file_type);
+    
+    if (server.aof_integrity_check) {
+        ret = sdscatprintf(ret, " %s %llu", AOF_MANIFEST_KEY_FILE_CHECKSUM, (unsigned long long)ai->last_checksum);
+    }
+
+    ret = sdscatlen(ret, "\n", 1);
+
     sdsfree(filename_repr);
 
     return ret;
@@ -177,8 +187,8 @@ sds getTempAofManifestFileName(void) {
  * The string is multiple lines separated by '\n', and each line represents
  * an AOF file.
  *
- * Each line is space delimited and contains 6 fields, as follows:
- * "file" [filename] "seq" [sequence] "type" [type]
+ * Each line is space delimited and contains 6 fields (or 8 fields if integrity check is enabled), as follows:
+ * "file" [filename] "seq" [sequence] "type" [type] ["checksum" [checksum]]
  *
  * Where "file", "seq" and "type" are keywords that describe the next value,
  * [filename] and [sequence] describe file name and order, and [type] is one
@@ -212,6 +222,14 @@ sds getAofManifestAsString(aofManifest *am) {
     while ((ln = listNext(&li)) != NULL) {
         aofInfo *ai = (aofInfo *)ln->value;
         buf = aofInfoFormat(buf, ai);
+    }
+
+    if (server.aof_integrity_check) {
+        /* Calculate checksum of manifest content */
+        uint64_t checksum = crc64(0, (unsigned char *)buf, sdslen(buf));
+
+        /* Append checksum line */
+        buf = sdscatprintf(buf, "# manifest-checksum: %llu\n", (unsigned long long)checksum);
     }
 
     return buf;
@@ -272,6 +290,7 @@ aofManifest *aofLoadManifestFromFile(sds am_filepath) {
 
     sds line = NULL;
     int linenum = 0;
+    uint64_t calculated_checksum = 0;
 
     while (1) {
         if (fgets(buf, MANIFEST_MAX_LINE + 1, fp) == NULL) {
@@ -289,6 +308,22 @@ aofManifest *aofLoadManifestFromFile(sds am_filepath) {
         }
 
         linenum++;
+
+        if (server.aof_integrity_check && strncmp(buf, "# manifest-checksum: ", 21) == 0) {
+            uint64_t file_checksum = strtoull(buf + 21, NULL, 10);
+            if (calculated_checksum != file_checksum) {
+                serverLog(LL_WARNING, "\n*** FATAL AOF MANIFEST FILE ERROR ***\n");
+                serverLog(LL_WARNING, "AOF manifest file %s checksum mismatch. Calculated %llu, expected %llu\n",
+                          am_filepath, (unsigned long long)calculated_checksum, (unsigned long long)file_checksum);
+                aofManifestFree(am);
+                exit(1);
+            }
+            break; /* Stop reading file after checksum */
+        }
+
+        if (server.aof_integrity_check) {
+            calculated_checksum = crc64(calculated_checksum, (unsigned char *)buf, strlen(buf));
+        }
 
         /* Skip comments lines */
         if (buf[0] == '#') continue;
@@ -323,6 +358,8 @@ aofManifest *aofLoadManifestFromFile(sds am_filepath) {
                 ai->file_seq = atoll(argv[i + 1]);
             } else if (!strcasecmp(argv[i], AOF_MANIFEST_KEY_FILE_TYPE)) {
                 ai->file_type = (argv[i + 1])[0];
+            } else if (!strcasecmp(argv[i], AOF_MANIFEST_KEY_FILE_CHECKSUM)) {
+                ai->last_checksum = strtoull(argv[i + 1], NULL, 10);
             }
             /* else if (!strcasecmp(argv[i], AOF_MANIFEST_KEY_OTHER)) {} */
         }
@@ -787,6 +824,16 @@ int openNewIncrAofForAppend(void) {
     } else {
         /* Dup a temp aof_manifest to modify. */
         temp_am = aofManifestDup(server.aof_manifest);
+        
+        /* Update the checksum of the current INCR file before opening a new one. */
+        if (server.aof_integrity_check) {
+            listNode *last_node = listLast(temp_am->incr_aof_list);
+            if (last_node) {
+                aofInfo *last_ai = listNodeValue(last_node);
+                last_ai->last_checksum = server.aof_running_checksum;
+            }
+        }
+        
         new_aof_name = sdsdup(getNewIncrAofName(temp_am));
     }
     sds new_aof_filepath = makePath(server.aof_dirname, new_aof_name);
@@ -1156,6 +1203,37 @@ ssize_t aofWrite(int fd, const char *buf, size_t len) {
     return totwritten;
 }
 
+/* Wrapper for writev that handles short writes and EINTR. */
+ssize_t aofWritev(int fd, struct iovec *iov, int iovcnt) {
+    ssize_t nwritten = 0, totwritten = 0;
+
+    while (iovcnt > 0) {
+        nwritten = writev(fd, iov, iovcnt);
+
+        if (nwritten < 0) {
+            if (errno == EINTR) continue;
+            return totwritten ? totwritten : -1;
+        }
+
+        totwritten += nwritten;
+        
+        /* Advance the iovec array to account for written bytes */
+        while (iovcnt > 0 && nwritten >= (ssize_t)iov[0].iov_len) {
+            nwritten -= iov[0].iov_len;
+            iov++;
+            iovcnt--;
+        }
+        
+        /* If a short write happened in the middle of an iovec, adjust it */
+        if (nwritten > 0) {
+            iov[0].iov_base = (char *)iov[0].iov_base + nwritten;
+            iov[0].iov_len -= nwritten;
+        }
+    }
+
+    return totwritten;
+}
+
 /* Write the append only file buffer on disk.
  *
  * Since we are required to write the AOF before replying to the client,
@@ -1180,7 +1258,7 @@ void flushAppendOnlyFile(int force) {
     int sync_in_progress = 0;
     mstime_t latency;
 
-    if (sdslen(server.aof_buf) == 0) {
+    if (sdslen(server.aof_buf) == 0 && sdslen(server.aof_retry_buf) == 0) {
         /* Check if we need to do fsync even the aof buffer is empty,
          * because previously in AOF_FSYNC_EVERYSEC mode, fsync is
          * called only when aof buffer is not empty, so if users
@@ -1244,8 +1322,56 @@ void flushAppendOnlyFile(int force) {
         usleep(server.aof_flush_sleep);
     }
 
+    /* If we have data in retry buffer, try to write it first. */
+    if (sdslen(server.aof_retry_buf) > 0) {
+        latencyStartMonitor(latency);
+        nwritten = aofWrite(server.aof_fd, server.aof_retry_buf, sdslen(server.aof_retry_buf));
+        latencyEndMonitor(latency);
+        
+        if (nwritten > 0) {
+            server.aof_current_size += nwritten;
+            server.aof_last_incr_size += nwritten;
+            sdsrange(server.aof_retry_buf, nwritten, -1);
+        }
+        
+        if (sdslen(server.aof_retry_buf) > 0) {
+            /* Still have data in retry buffer, means write failed or was short.
+             * We can't proceed with aof_buf. */
+            return;
+        }
+    }
+
+    size_t expected_len = sdslen(server.aof_buf);
+    uint64_t old_checksum = server.aof_running_checksum;
+    char hdr[128];
+    int hdr_len = 0;
+
     latencyStartMonitor(latency);
-    nwritten = aofWrite(server.aof_fd, server.aof_buf, sdslen(server.aof_buf));
+    if (server.aof_integrity_check) {
+        uint64_t checksum = 0;
+        char hdr_prefix[64];
+        int prefix_len = snprintf(hdr_prefix, sizeof(hdr_prefix), "#HDR:v1;len:%zu;", sdslen(server.aof_buf));
+        serverAssert(prefix_len < (int)sizeof(hdr_prefix));
+        
+        checksum = crc64(server.aof_running_checksum, (unsigned char *)hdr_prefix, prefix_len);
+        checksum = crc64(checksum, (unsigned char *)server.aof_buf, sdslen(server.aof_buf));
+        
+        hdr_len = snprintf(hdr, sizeof(hdr), "%schecksum:%llu;\r\n", hdr_prefix, (unsigned long long)checksum);
+        serverAssert(hdr_len < (int)sizeof(hdr));
+        expected_len += hdr_len;
+        
+        server.aof_running_checksum = checksum;
+
+        struct iovec iov[2];
+        iov[0].iov_base = hdr;
+        iov[0].iov_len = hdr_len;
+        iov[1].iov_base = server.aof_buf;
+        iov[1].iov_len = sdslen(server.aof_buf);
+
+        nwritten = aofWritev(server.aof_fd, iov, 2);
+    } else {
+        nwritten = aofWrite(server.aof_fd, server.aof_buf, sdslen(server.aof_buf));
+    }
     latencyEndMonitor(latency);
     /* We want to capture different events for delayed writes:
      * when the delay happens with a pending fsync, or with a saving child
@@ -1268,7 +1394,7 @@ void flushAppendOnlyFile(int force) {
     /* We performed the write so reset the postponed flush sentinel to zero. */
     server.aof_flush_postponed_start = 0;
 
-    if (nwritten != (ssize_t)sdslen(server.aof_buf)) {
+    if (nwritten != (ssize_t)expected_len) {
         static time_t last_write_error_log = 0;
         int can_log = 0;
 
@@ -1290,7 +1416,7 @@ void flushAppendOnlyFile(int force) {
                           "Short write while writing to "
                           "the AOF file: (nwritten=%lld, "
                           "expected=%lld)",
-                          (long long)nwritten, (long long)sdslen(server.aof_buf));
+                          (long long)nwritten, (long long)expected_len);
             }
 
             if (ftruncate(server.aof_fd, server.aof_last_incr_size) == -1) {
@@ -1306,6 +1432,9 @@ void flushAppendOnlyFile(int force) {
                 /* If the ftruncate() succeeded we can set nwritten to
                  * -1 since there is no longer partial data into the AOF. */
                 nwritten = -1;
+                if (server.aof_integrity_check) {
+                    server.aof_running_checksum = old_checksum;
+                }
             }
             server.aof_last_write_errno = ENOSPC;
         }
@@ -1331,7 +1460,21 @@ void flushAppendOnlyFile(int force) {
             if (nwritten > 0) {
                 server.aof_current_size += nwritten;
                 server.aof_last_incr_size += nwritten;
-                sdsrange(server.aof_buf, nwritten, -1);
+                
+                if (server.aof_integrity_check) {
+                    if ((size_t)nwritten < (size_t)hdr_len) {
+                        /* Failed during header write. Save remaining header and all data. */
+                        server.aof_retry_buf = sdscatlen(server.aof_retry_buf, hdr + nwritten, hdr_len - nwritten);
+                        server.aof_retry_buf = sdscatlen(server.aof_retry_buf, server.aof_buf, sdslen(server.aof_buf));
+                    } else {
+                        /* Header fully written, failed during data write. */
+                        size_t data_written = nwritten - hdr_len;
+                        server.aof_retry_buf = sdscatlen(server.aof_retry_buf, server.aof_buf + data_written, sdslen(server.aof_buf) - data_written);
+                    }
+                    sdsclear(server.aof_buf);
+                } else {
+                    sdsrange(server.aof_buf, nwritten, -1);
+                }
             }
             return; /* We'll try again on the next call... */
         }
@@ -1529,6 +1672,10 @@ int loadSingleAppendOnlyFile(char *filename) {
     off_t last_progress_report_size = 0;
     int ret = AOF_OK;
 
+    /* integrity_validated_until tracks the file offset up to which data has been verified by a header checksum.
+     * Commands must start before this offset to be considered validated. */
+    off_t integrity_validated_until = 0;
+
     sds aof_filepath = makePath(server.aof_dirname, filename);
     FILE *fp = fopen(aof_filepath, "r");
     if (fp == NULL) {
@@ -1618,8 +1765,62 @@ int loadSingleAppendOnlyFile(char *filename) {
                 goto readerr;
             }
         }
-        if (buf[0] == '#') continue; /* Skip annotations */
+        if (buf[0] == '#') {
+            if (server.aof_integrity_check && !strncmp(buf, "#HDR:v1;", 8)) {
+                size_t hdr_len = 0;
+                uint64_t hdr_checksum = 0;
+                char *field;
+                if ((field = strstr(buf, "len:")) != NULL) hdr_len = strtoull(field + 4, NULL, 10);
+                if ((field = strstr(buf, "checksum:")) != NULL) hdr_checksum = strtoull(field + 9, NULL, 10);
+
+                /* Check data integrity */
+                char *checksum_tag = strstr(buf, "checksum:");
+                if (!checksum_tag) {
+                    serverLog(LL_WARNING, "AOF integrity header in %s lacks a checksum", filename);
+                    goto fmterr;
+                }
+                uint64_t computed_checksum = crc64(server.aof_running_checksum, (unsigned char *)buf, checksum_tag - buf);
+                off_t current_pos = ftello(fp);
+
+                size_t remaining = hdr_len;
+                unsigned char check_buf[16 * 1024];
+                while (remaining > 0) {
+                    size_t to_read = remaining > sizeof(check_buf) ? sizeof(check_buf) : remaining;
+                    if (fread(check_buf, to_read, 1, fp) != 1) {
+                        serverLog(LL_WARNING, "AOF short read detected in %s. Expected %zu more bytes",
+                                  filename, remaining);
+                        goto readerr;
+                    }
+                    computed_checksum = crc64(computed_checksum, check_buf, to_read);
+                    remaining -= to_read;
+                }
+
+                if (computed_checksum != hdr_checksum) {
+                    serverLog(LL_WARNING, "AOF checksum mismatch in %s. Calculated %llu, got %llu", filename,
+                              (unsigned long long)computed_checksum, (unsigned long long)hdr_checksum);
+                    goto fmterr;
+                }
+                if (fseek(fp, current_pos, SEEK_SET) == -1) {
+                    serverLog(LL_WARNING, "Error seeking in AOF file %s: %s", filename, strerror(errno));
+                    goto readerr;
+                }
+                integrity_validated_until = current_pos + hdr_len;
+
+                server.aof_integrity_chain_active = 1;
+                server.aof_running_checksum = computed_checksum;
+            } else if (server.aof_integrity_check && !strncmp(buf, AOF_INTEGRITY_OFF_MARKER, strlen(AOF_INTEGRITY_OFF_MARKER))) {
+                serverLog(LL_NOTICE, "AOF loading: encountered INTEGRITY_OFF");
+                server.aof_integrity_chain_active = 0;
+                server.aof_running_checksum = 0;
+            }
+            continue;
+        }
         if (buf[0] != '*') goto fmterr;
+        if (server.aof_integrity_check && server.aof_integrity_chain_active &&
+            ftello(fp) >= integrity_validated_until) {
+            serverLog(LL_WARNING, "AOF command at offset %lld lacks an integrity header.", (long long)ftello(fp));
+            goto fmterr;
+        }
         if (buf[1] == '\0') goto readerr;
         argc = atoi(buf + 1);
         if (argc < 1) goto fmterr;
@@ -1827,6 +2028,9 @@ int loadAppendOnlyFiles(aofManifest *am) {
         start = ustime();
         ret = loadSingleAppendOnlyFile(aof_name);
         if (ret == AOF_OK || (ret == AOF_TRUNCATED && last_file)) {
+            if (server.aof_integrity_check) {
+                server.aof_running_checksum = am->base_aof_info->last_checksum;
+            }
             serverLog(LL_NOTICE, "DB loaded from base file %s: %.3f seconds", aof_name,
                       (float)(ustime() - start) / 1000000);
         }
@@ -2622,6 +2826,10 @@ int rewriteAppendOnlyFileBackground(void) {
     }
 
     server.stat_aof_rewrites++;
+    
+    if (server.aof_integrity_check) {
+        server.aof_rewrite_base_checksum = server.aof_running_checksum;
+    }
 
     if ((childpid = serverFork(CHILD_TYPE_AOF)) == 0) {
         char tmpfile[256];
@@ -2842,6 +3050,10 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
         /* Change the AOF file type in 'incr_aof_list' from AOF_FILE_TYPE_INCR
          * to AOF_FILE_TYPE_HIST, and move them to the 'history_aof_list'. */
         markRewrittenIncrAofAsHistory(temp_am);
+
+        if (server.aof_integrity_check) {
+            temp_am->base_aof_info->last_checksum = server.aof_rewrite_base_checksum;
+        }
 
         /* Persist our modifications. */
         if (persistAofManifest(temp_am) == C_ERR) {

--- a/src/aof.c
+++ b/src/aof.c
@@ -1365,14 +1365,29 @@ void flushAppendOnlyFile(int force) {
     if (server.aof_integrity_check) {
         uint64_t checksum = 0;
         char hdr_prefix[64];
-        int prefix_len = snprintf(hdr_prefix, sizeof(hdr_prefix), "#HDR:v1;len:%zu;", sdslen(server.aof_buf));
-        serverAssert(prefix_len < (int)sizeof(hdr_prefix));
+        char *p = hdr_prefix;
+        memcpy(p, "#HDR:v1;len:", 12);
+        p += 12;
+        int len_str_len = ull2string(p, sizeof(hdr_prefix) - (p - hdr_prefix), (unsigned long long)sdslen(server.aof_buf));
+        p += len_str_len;
+        *p++ = ';';
+        *p = '\0';
+        int prefix_len = p - hdr_prefix;
 
         checksum = crc64(server.aof_running_checksum, (unsigned char *)hdr_prefix, prefix_len);
         checksum = crc64(checksum, (unsigned char *)server.aof_buf, sdslen(server.aof_buf));
 
-        hdr_len = snprintf(hdr, sizeof(hdr), "%schecksum:%llu;\r\n", hdr_prefix, (unsigned long long)checksum);
-        serverAssert(hdr_len < (int)sizeof(hdr));
+        char *hp = hdr;
+        memcpy(hp, hdr_prefix, prefix_len);
+        hp += prefix_len;
+        memcpy(hp, "checksum:", 9);
+        hp += 9;
+        int checksum_len = ull2string(hp, sizeof(hdr) - (hp - hdr), (unsigned long long)checksum);
+        hp += checksum_len;
+        memcpy(hp, ";\r\n", 3);
+        hp += 3;
+        *hp = '\0';
+        hdr_len = hp - hdr;
         expected_len += hdr_len;
 
         server.aof_running_checksum = checksum;

--- a/src/config.c
+++ b/src/config.c
@@ -2650,7 +2650,23 @@ static int updateAofAutoGCEnabled(const char **err) {
     if (!server.aof_disable_auto_gc) {
         aofDelHistoryFiles();
     }
+    return 1;
+}
 
+/* Support for dynamic toggling of aof-integrity-check.
+ * If disabled at runtime, we inject a marker into the AOF to signal the loader. */
+static int updateAofIntegrityCheck(const char **err) {
+    UNUSED(err);
+    if (!server.aof_integrity_check) {
+        serverLog(LL_NOTICE, "AOF integrity check disabled, resetting running checksum");
+        server.aof_running_checksum = 0;
+        if (server.aof_state == AOF_ON) {
+            sds new_buf = sdsnew(AOF_INTEGRITY_OFF_MARKER);
+            new_buf = sdscatsds(new_buf, server.aof_buf);
+            sdsfree(server.aof_buf);
+            server.aof_buf = new_buf;
+        }
+    }
     return 1;
 }
 
@@ -3309,6 +3325,7 @@ standardConfig static_configs[] = {
     createBoolConfig("aof-load-truncated", NULL, MODIFIABLE_CONFIG, server.aof_load_truncated, 1, NULL, NULL),
     createBoolConfig("aof-use-rdb-preamble", NULL, MODIFIABLE_CONFIG, server.aof_use_rdb_preamble, 1, NULL, NULL),
     createBoolConfig("aof-timestamp-enabled", NULL, MODIFIABLE_CONFIG, server.aof_timestamp_enabled, 0, NULL, NULL),
+    createBoolConfig("aof-integrity-check", NULL, MODIFIABLE_CONFIG, server.aof_integrity_check, 0, NULL, updateAofIntegrityCheck),
     createBoolConfig("cluster-replica-no-failover", "cluster-slave-no-failover", MODIFIABLE_CONFIG, server.cluster_replica_no_failover, 0, NULL, updateClusterFlags), /* Failover by default. */
     createBoolConfig("replica-lazy-flush", "slave-lazy-flush", MODIFIABLE_CONFIG, server.repl_replica_lazy_flush, 1, NULL, NULL),
     createBoolConfig("replica-serve-stale-data", "slave-serve-stale-data", MODIFIABLE_CONFIG, server.repl_serve_stale_data, 1, NULL, NULL),

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1484,7 +1484,9 @@ int rdbSaveRio(int req, int rdbver, rio *rdb, int *error, int rdbflags, rdbSaveI
     long key_counter = 0;
     int j;
 
-    if (server.rdb_checksum) rdb->update_cksum = rioGenericUpdateChecksum;
+    if (server.rdb_checksum || (server.aof_integrity_check && (rdbflags & RDBFLAGS_AOF_PREAMBLE))) {
+        rdb->update_cksum = rioGenericUpdateChecksum;
+    }
     const char *magic_prefix = rdbUseValkeyMagic(rdbver) ? "VALKEY" : "REDIS0";
     serverAssert(rdbver >= 0 && rdbver <= RDB_VERSION);
     snprintf(magic, sizeof(magic), "%s%03d", magic_prefix, rdbver);
@@ -3585,7 +3587,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         uint64_t cksum, expected = rdb->cksum;
 
         if (rioRead(rdb, &cksum, 8) == 0) goto eoferr;
-        if (server.rdb_checksum && !server.skip_checksum_validation) {
+        if ((server.rdb_checksum || (server.aof_integrity_check && (rdbflags & RDBFLAGS_AOF_PREAMBLE))) && !server.skip_checksum_validation) {
             memrev64ifbe(&cksum);
             if (rdb->flags & RIO_FLAG_SKIP_RDB_CHECKSUM) {
                 serverLog(LL_NOTICE, "RDB file was saved with checksum disabled: skipped checksum for this transfer");

--- a/src/server.c
+++ b/src/server.c
@@ -7255,8 +7255,8 @@ void dismissMemoryInChild(void) {
     /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
     if (server.thp_enabled) return;
 
-    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
-     * so we avoid these pointless loops when they're not going to do anything. */
+        /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
+         * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     listIter li;
     listNode *ln;

--- a/src/server.c
+++ b/src/server.c
@@ -2339,6 +2339,9 @@ void initServerConfig(void) {
     server.aof_flush_sleep = 0;
     server.aof_last_fsync = time(NULL) * 1000;
     server.aof_cur_timestamp = 0;
+    server.aof_integrity_check = 0;
+    server.aof_running_checksum = 0;
+    server.aof_integrity_chain_active = 0;
     atomic_store_explicit(&server.aof_bio_fsync_status, C_OK, memory_order_relaxed);
     server.aof_rewrite_time_last = -1;
     server.aof_rewrite_time_start = -1;
@@ -3039,6 +3042,7 @@ void initServer(void) {
     server.child_info_pipe[1] = -1;
     server.child_info_nread = 0;
     server.aof_buf = sdsempty();
+    server.aof_retry_buf = sdsempty();
     server.lastsave = time(NULL); /* At startup we consider the DB saved. */
     server.lastbgsave_try = 0;    /* At startup we never tried to BGSAVE. */
     server.rdb_save_time_last = -1;
@@ -7251,8 +7255,8 @@ void dismissMemoryInChild(void) {
     /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
     if (server.thp_enabled) return;
 
-        /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
-         * so we avoid these pointless loops when they're not going to do anything. */
+    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
+     * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     listIter li;
     listNode *ln;

--- a/src/server.h
+++ b/src/server.h
@@ -149,6 +149,7 @@ struct ValkeyModule;
 #define LOG_MAX_LEN 1024                                      /* Default maximum length of syslog messages.*/
 #define AOF_REWRITE_ITEMS_PER_CMD 64
 #define AOF_ANNOTATION_LINE_MAX_LEN 1024
+#define AOF_INTEGRITY_OFF_MARKER "#INTEGRITY_OFF\r\n"
 #define CONFIG_RUN_ID_SIZE 40
 #define RDB_EOF_MARK_SIZE 40
 #define CONFIG_REPL_BACKLOG_MIN_SIZE (1024 * 16) /* 16k */
@@ -1701,6 +1702,7 @@ typedef struct {
     sds file_name;           /* file name */
     long long file_seq;      /* file sequence */
     aof_file_type file_type; /* file type */
+    uint64_t last_checksum;  /* The last checksum of this AOF file. */
 } aofInfo;
 
 typedef struct {
@@ -2023,6 +2025,12 @@ struct valkeyServer {
     time_t aof_rewrite_time_start;      /* Current AOF rewrite start time. */
     time_t aof_cur_timestamp;           /* Current record timestamp in AOF */
     int aof_timestamp_enabled;          /* Enable record timestamp in AOF */
+    int aof_integrity_check;            /* Enable metadata integrity check in AOF */
+    uint64_t aof_running_checksum;      /* Current AOF running checksum */
+    uint64_t aof_rewrite_base_checksum; /* AOF running checksum at the start of rewrite */
+    sds aof_retry_buf;                  /* Buffer to store data that failed to be written fully during a partial write. */
+    int aof_integrity_chain_active;     /* 1 if we are currently in an active AOF integrity chain.
+                                           This ensures we expect headers even if the checksum is 0. */
     int aof_lastbgrewrite_status;       /* C_OK or C_ERR */
     unsigned long aof_delayed_fsync;    /* delayed AOF fsync() counter */
     int aof_rewrite_incremental_fsync;  /* fsync incrementally while aof rewriting? */

--- a/src/valkey-check-aof.c
+++ b/src/valkey-check-aof.c
@@ -29,6 +29,7 @@
  */
 
 #include "server.h"
+#include "crc64.h"
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -61,6 +62,9 @@ static char error[1044];
 static off_t epos;
 static long long line = 1;
 static time_t to_timestamp = 0;
+static uint64_t expected_running_checksum = 0;
+static int integrity_chain_active = 0;
+static off_t integrity_validated_until = 0;
 
 int consumeNewline(char *buf) {
     if (buf[0] != '\r' || buf[1] != '\n') {
@@ -166,8 +170,7 @@ int processRESP(FILE *fp, char *filename, int *out_multi) {
 }
 
 /* Used to parse an annotation in the AOF file, the annotation starts with '#'
- * in AOF. Currently AOF only contains timestamp annotations, but this function
- * can easily be extended to handle other annotations.
+ * in AOF.
  *
  * The processing rule of time annotation is that once the timestamp is found to
  * be greater than 'to_timestamp', the AOF after the annotation is truncated.
@@ -181,6 +184,55 @@ int processAnnotations(FILE *fp, char *filename, int last_file) {
     if (fgets(buf, sizeof(buf), fp) == NULL) {
         printf("Failed to read annotations from AOF %s, aborting...\n", filename);
         exit(1);
+    }
+
+    if (!strncmp(buf, "#HDR:v1;", 8)) {
+        size_t hdr_len = 0;
+        uint64_t hdr_checksum = 0;
+        char *field;
+        if ((field = strstr(buf, "len:")) != NULL) hdr_len = strtoull(field + 4, NULL, 10);
+        if ((field = strstr(buf, "checksum:")) != NULL) hdr_checksum = strtoull(field + 9, NULL, 10);
+
+        /* Check data integrity */
+        char *checksum_tag = strstr(buf, "checksum:");
+        if (!checksum_tag) {
+            ERROR("AOF integrity header lacks a checksum");
+            printf("%s\n", error);
+            exit(1);
+        }
+        uint64_t computed_checksum = crc64(expected_running_checksum, (unsigned char *)buf, checksum_tag - buf);
+        off_t current_pos = ftello(fp);
+
+        size_t remaining = hdr_len;
+        unsigned char check_buf[16 * 1024];
+        while (remaining > 0) {
+            size_t to_read = remaining > sizeof(check_buf) ? sizeof(check_buf) : remaining;
+            if (fread(check_buf, to_read, 1, fp) != 1) {
+                ERROR("AOF short read detected. Expected %zu more bytes", remaining);
+                printf("%s\n", error);
+                exit(1);
+            }
+            computed_checksum = crc64(computed_checksum, check_buf, to_read);
+            remaining -= to_read;
+        }
+
+        if (computed_checksum != hdr_checksum) {
+            ERROR("AOF checksum mismatch. Calculated %llu, got %llu", (unsigned long long)computed_checksum,
+                  (unsigned long long)hdr_checksum);
+            printf("%s\n", error);
+            exit(1);
+        }
+        if (fseek(fp, current_pos, SEEK_SET) == -1) {
+            printf("Error seeking in AOF file %s: %s\n", filename, strerror(errno));
+            exit(1);
+        }
+        integrity_validated_until = current_pos + hdr_len;
+
+        expected_running_checksum = computed_checksum;
+        integrity_chain_active = 1;
+    } else if (!strncmp(buf, AOF_INTEGRITY_OFF_MARKER, strlen(AOF_INTEGRITY_OFF_MARKER))) {
+        expected_running_checksum = 0;
+        integrity_chain_active = 0;
     }
 
     if (to_timestamp && strncmp(buf, "#TS:", 4) == 0) {
@@ -226,6 +278,10 @@ int checkSingleAof(char *aof_filename, char *aof_filepath, int last_file, int fi
     off_t pos = 0, diff;
     int multi = 0;
     char buf[2];
+
+    /* If expected_running_checksum is already set (e.g. from previous file in manifest), keep it.
+     * Otherwise, processAnnotations will initialize it from first #HDR. */
+    integrity_validated_until = 0;
 
     FILE *fp = fopen(aof_filepath, "r+");
     if (fp == NULL) {
@@ -277,6 +333,10 @@ int checkSingleAof(char *aof_filename, char *aof_filepath, int last_file, int fi
                 return AOF_CHECK_TIMESTAMP_TRUNCATED;
             }
         } else if (buf[0] == '*') {
+            if (integrity_chain_active && ftello(fp) >= integrity_validated_until) {
+                ERROR("AOF command at offset %lld lacks an integrity header", (long long)ftello(fp));
+                break;
+            }
             if (!processRESP(fp, aof_filepath, &multi)) break;
         } else {
             printf("AOF %s format error\n", aof_filename);
@@ -358,10 +418,9 @@ int fileIsRDB(char *filepath) {
         return 0;
     }
 
-    if (size >= 8) { /* There must be at least room for the RDB header. */
-        char sig[5];
-        int rdb_file = fread(sig, sizeof(sig), 1, fp) == 1 && memcmp(sig, "REDIS", sizeof(sig)) == 0;
-        if (rdb_file) {
+    if (size >= 9) { /* There must be at least room for the RDB header. */
+        char sig[6];
+        if (fread(sig, 1, 6, fp) == 6 && (memcmp(sig, "REDIS", 5) == 0 || memcmp(sig, "VALKEY", 6) == 0)) {
             fclose(fp);
             return 1;
         }
@@ -481,6 +540,12 @@ void checkMultiPartAof(char *dirpath, char *manifest_filepath, int fix) {
 
         printf("Start to check BASE AOF (%s format).\n", aof_preamble ? "RDB" : "RESP");
         ret = checkSingleAof(aof_filename, aof_filepath, last_file, fix, aof_preamble);
+        if (aof_preamble && ret == AOF_CHECK_OK) {
+            if (am->base_aof_info && am->base_aof_info->last_checksum) {
+                expected_running_checksum = am->base_aof_info->last_checksum;
+                integrity_chain_active = 1;
+            }
+        }
         printAofStyle(ret, aof_filename, (char *)"BASE AOF");
         sdsfree(aof_filepath);
     }

--- a/src/valkey-check-aof.c
+++ b/src/valkey-check-aof.c
@@ -186,12 +186,25 @@ int processAnnotations(FILE *fp, char *filename, int last_file) {
         exit(1);
     }
 
-    if (!strncmp(buf, "#HDR:v1;", 8)) {
-        size_t hdr_len = 0;
-        uint64_t hdr_checksum = 0;
-        char *field;
-        if ((field = strstr(buf, "len:")) != NULL) hdr_len = strtoull(field + 4, NULL, 10);
-        if ((field = strstr(buf, "checksum:")) != NULL) hdr_checksum = strtoull(field + 9, NULL, 10);
+    if (!strncmp(buf, "#HDR:v1;len:", 12)) {
+        char *ptr = buf + 12;
+        char *endptr;
+        errno = 0;
+        unsigned long long len = strtoull(ptr, &endptr, 10);
+        if (endptr == ptr || errno == ERANGE || strncmp(endptr, ";checksum:", 10) != 0) {
+            ERROR("Malformed AOF integrity header (invalid len)");
+            printf("%s\n", error);
+            exit(1);
+        }
+        ptr = endptr + 10;
+        unsigned long long checksum = strtoull(ptr, &endptr, 10);
+        if (endptr == ptr || errno == ERANGE || (strcmp(endptr, ";\r\n") != 0 && strcmp(endptr, ";\n") != 0)) {
+            ERROR("Malformed AOF integrity header (invalid checksum)");
+            printf("%s\n", error);
+            exit(1);
+        }
+        size_t hdr_len = len;
+        uint64_t hdr_checksum = checksum;
 
         /* Check data integrity */
         char *checksum_tag = strstr(buf, "checksum:");

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -937,4 +937,3 @@ int redis_check_rdb_main(int argc, char **argv, FILE *fp) {
     freeRdbProfile(rdbstate.stats, rdbstate.stats_num);
     exit(retval);
 }
-

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -937,3 +937,4 @@ int redis_check_rdb_main(int argc, char **argv, FILE *fp) {
     freeRdbProfile(rdbstate.stats, rdbstate.stats_num);
     exit(retval);
 }
+

--- a/tests/integration/aof-integrity.tcl
+++ b/tests/integration/aof-integrity.tcl
@@ -250,7 +250,7 @@ tags {"aof-integrity external:skip"} {
             set ::ai6_path [get_last_incr_aof_path $rd]
         }
         
-        catch {exec ./src/valkey-check-aof $::am6_path} output
+        catch {exec $::VALKEY_CHECK_AOF_BIN $::am6_path} output
         assert_match {*All AOF files and manifest are valid*} $output
         
         # Corrupt the NEWEST increment file by appending a manual entry with a wrong checksum.
@@ -261,7 +261,7 @@ tags {"aof-integrity external:skip"} {
         puts -nonewline $fp "#HDR:v1;len:22;checksum:123456789;\r\n*3\r\n\$3\r\nSET\r\n\$1\r\nc\r\n\$1\r\n3\r\n"
         close $fp
         
-        catch {exec ./src/valkey-check-aof $::am6_path} output
+        catch {exec $::VALKEY_CHECK_AOF_BIN $::am6_path} output
         assert_match {*AOF checksum mismatch*} $output
         
         # Test case for missing header
@@ -279,7 +279,7 @@ tags {"aof-integrity external:skip"} {
         puts -nonewline $fp "*3\r\n\$3\r\nSET\r\n\$1\r\nb\r\n\$1\r\n2\r\n"
         close $fp
         
-        catch {exec ./src/valkey-check-aof $am_path} output
+        catch {exec $::VALKEY_CHECK_AOF_BIN $am_path} output
         assert_match {*lacks an integrity header*} $output
     }
 

--- a/tests/integration/aof-integrity.tcl
+++ b/tests/integration/aof-integrity.tcl
@@ -172,6 +172,20 @@ tags {"aof-integrity external:skip"} {
             
             $rd config set aof-integrity-check yes
             $rd set c 3
+            
+            # Wait for the write to hit disk
+            wait_for_condition 50 100 {
+                [file size $ai_path] > 100
+            } else {
+                fail "AOF file not updated after re-enabling"
+            }
+            
+            set fp [open $ai_path r]
+            set content [read $fp]
+            close $fp
+            
+            # Verify that a new #HDR:v1 appears after #INTEGRITY_OFF
+            assert_match {*#INTEGRITY_OFF*#HDR:v1;*set*c*} $content
         }
         
         start_server [list overrides [list dir $sp_actual appendonly yes aof-integrity-check yes]] {
@@ -243,11 +257,30 @@ tags {"aof-integrity external:skip"} {
         set fp [open $::ai6_path a]
         fconfigure $fp -translation binary
         # We use a wrong checksum value here to simulate an integrity failure.
-        puts -nonewline $fp "#HDR:v1;len:22;checksum:123456789\r\n*3\r\n\$3\r\nSET\r\n\$1\r\nc\r\n\$1\r\n3\r\n"
+        # Note the ';' before '\r\n' to ensure the header is well-formed but has a bad checksum.
+        puts -nonewline $fp "#HDR:v1;len:22;checksum:123456789;\r\n*3\r\n\$3\r\nSET\r\n\$1\r\nc\r\n\$1\r\n3\r\n"
         close $fp
         
         catch {exec ./src/valkey-check-aof $::am6_path} output
         assert_match {*AOF checksum mismatch*} $output
+        
+        # Test case for missing header
+        set sp7 [tmpdir server.aof-integrity-tool-missing-hdr]
+        start_server [list overrides [list dir $sp7 appendonly yes appendfsync always aof-integrity-check yes aof-use-rdb-preamble yes] keep_persistence true] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            set am_path [file join [dict get [srv config] dir] "appendonlydir" "appendonly.aof.manifest"]
+            $rd set a 1
+            set incr_path [get_last_incr_aof_path $rd]
+        }
+        
+        # Append a raw RESP command without #HDR
+        set fp [open $incr_path a]
+        fconfigure $fp -translation binary
+        puts -nonewline $fp "*3\r\n\$3\r\nSET\r\n\$1\r\nb\r\n\$1\r\n2\r\n"
+        close $fp
+        
+        catch {exec ./src/valkey-check-aof $am_path} output
+        assert_match {*lacks an integrity header*} $output
     }
 
     test "AOF manifest contains checksums when integrity check is enabled" {

--- a/tests/integration/aof-integrity.tcl
+++ b/tests/integration/aof-integrity.tcl
@@ -1,0 +1,290 @@
+source tests/support/aofmanifest.tcl
+tags {"aof-integrity external:skip"} {
+    
+    test "AOF headers are generated when aof-integrity-check is enabled" {
+        set sp1 [tmpdir server.aof-integrity-1]
+        start_server [list overrides [list dir $sp1 appendonly yes appendfsync always aof-integrity-check yes aof-use-rdb-preamble yes] keep_persistence true] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            set ai1 [file join [dict get [srv config] dir] "appendonlydir" "appendonly.aof.1.incr.aof"]
+            $rd set foo bar
+            $rd set baz qux
+            
+            wait_for_condition 50 100 {
+                [file exists $ai1] && [file size $ai1] > 0
+            } else {
+                fail "AOF file not created"
+            }
+            
+            set fp [open $ai1 r]
+            fconfigure $fp -translation binary
+            set content [read $fp]
+            close $fp
+            
+            assert_match {*#HDR:v1;*checksum:*} $content
+            set sp1_actual [dict get [srv config] dir]
+        }
+
+        # Restart and verify data restoration
+        start_server [list overrides [list dir $sp1_actual appendonly yes aof-integrity-check yes]] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            assert_equal "bar" [$rd get foo]
+            assert_equal "qux" [$rd get baz]
+        }
+    }
+
+    test "Server fails to start if checksum mismatch is detected" {
+        set sp3 [tmpdir server.aof-integrity-3]
+        start_server [list overrides [list dir $sp3 appendonly yes appendfsync always aof-integrity-check yes aof-use-rdb-preamble yes] keep_persistence true] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            set ::ai3_path [file join [dict get [srv config] dir] "appendonlydir" "appendonly.aof.1.incr.aof"]
+            set ::sp3_actual [dict get [srv config] dir]
+            $rd set a 1
+            wait_for_condition 50 100 {
+                [file size $::ai3_path] > 0
+            } else {
+                fail "AOF file not created"
+            }
+        }
+        
+        # Flip a bit in the data to break the checksum
+        set fp [open $::ai3_path r]
+        fconfigure $fp -translation binary
+        set content [read $fp]
+        close $fp
+        
+        set new_content [string map { "\r\na\r\n" "\r\nb\r\n" } $content]
+        
+        set fp [open $::ai3_path w]
+        fconfigure $fp -translation binary
+        puts -nonewline $fp $new_content
+        close $fp
+        
+        start_server [list overrides [list dir $::sp3_actual appendonly yes aof-integrity-check yes aof-use-rdb-preamble yes] wait_ready false] {
+            wait_for_log_messages 0 {"*AOF checksum mismatch*"} 0 10 1000
+            wait_for_condition 50 100 {
+                [is_alive [srv pid]] == 0
+            } else {
+                fail "Server is still running despite AOF checksum mismatch"
+            }
+        }
+        }
+    test "AOF integrity: strict header enforcement fails on missing header" {
+        set sp [tmpdir server.aof-integrity-strict]
+        start_server [list overrides [list dir $sp appendonly yes appendfsync always aof-integrity-check yes aof-use-rdb-preamble yes] keep_persistence true] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            set ai_path [file join [dict get [srv config] dir] "appendonlydir" "appendonly.aof.1.incr.aof"]
+            set sp_actual [dict get [srv config] dir]
+            $rd set a 1
+            wait_for_condition 50 100 {
+                [file exists $ai_path] && [file size $ai_path] > 0
+            } else {
+                fail "AOF file not created"
+            }
+        }
+
+        # Append a command WITHOUT a header
+        set fp [open $ai_path a]
+        fconfigure $fp -translation binary
+        puts -nonewline $fp "*3\r\n\$3\r\nSET\r\n\$1\r\nb\r\n\$1\r\n2\r\n"
+        close $fp
+
+        start_server [list overrides [list dir $sp_actual appendonly yes aof-integrity-check yes] wait_ready false] {
+            wait_for_log_messages 0 {"*lacks an integrity header*"} 0 10 1000
+            wait_for_condition 50 100 {
+                [is_alive [srv pid]] == 0
+            } else {
+                fail "Server is still running despite missing integrity header"
+            }
+        }
+    }
+
+    test "AOF preamble integrity check works even if rdbchecksum is off" {
+        set sp_pre [tmpdir server.aof-integrity-preamble]
+        start_server [list overrides [list dir $sp_pre appendonly yes appendfsync always aof-integrity-check yes aof-use-rdb-preamble yes rdbchecksum no] keep_persistence true] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            set ::sp_pre_actual [dict get [srv config] dir]
+            $rd set x 123
+            $rd bgrewriteaof
+            waitForBgrewriteaof $rd
+            set ::base_path [get_base_aof_path $rd]
+        }
+
+        set fp [open $::base_path r]
+        fconfigure $fp -translation binary
+        set content [read $fp]
+        close $fp
+
+        # Flip a bit in the middle of the RDB preamble
+        set content "[string range $content 0 10]X[string range $content 12 end]"
+
+        set fp [open $::base_path w]
+        fconfigure $fp -translation binary
+        puts -nonewline $fp $content
+        close $fp
+
+        start_server [list overrides [list dir $::sp_pre_actual appendonly yes aof-integrity-check yes aof-use-rdb-preamble yes rdbchecksum no] wait_ready false] {
+            wait_for_log_messages 0 {"*RDB CRC error*"} 0 10 1000
+            wait_for_condition 50 100 {
+                [is_alive [srv pid]] == 0
+            } else {
+                fail "Server is still running despite RDB CRC error in AOF preamble"
+            }
+        }
+    }
+
+    test "AOF integrity: large command incremental CRC verification" {
+        set sp [tmpdir server.aof-integrity-large]
+        start_server [list overrides [list dir $sp appendonly yes appendfsync always aof-integrity-check yes aof-use-rdb-preamble yes] keep_persistence true] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            set large_val [string repeat "A" [expr 1024 * 1024]]
+            $rd set large_key $large_val
+            set sp_actual [dict get [srv config] dir]
+        }
+        
+        start_server [list overrides [list dir $sp_actual appendonly yes aof-integrity-check yes]] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            set large_val [string repeat "A" [expr 1024 * 1024]]
+            assert_equal $large_val [$rd get large_key]
+        }
+    }
+
+    test "AOF integrity: dynamic toggle and disabled marker" {
+        set sp [tmpdir server.aof-integrity-toggle]
+        start_server [list overrides [list dir $sp appendonly yes appendfsync always aof-integrity-check yes aof-use-rdb-preamble yes] keep_persistence true] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            set ai_path [file join [dict get [srv config] dir] "appendonlydir" "appendonly.aof.1.incr.aof"]
+            set sp_actual [dict get [srv config] dir]
+            
+            $rd set a 1
+            $rd config set aof-integrity-check no
+            $rd set b 2
+            
+            wait_for_condition 50 100 {
+                [file size $ai_path] > 50
+            } else {
+                fail "AOF file not updated"
+            }
+            
+            set fp [open $ai_path r]
+            set content [read $fp]
+            close $fp
+            assert_match {*#INTEGRITY_OFF*} $content
+            
+            $rd config set aof-integrity-check yes
+            $rd set c 3
+        }
+        
+        start_server [list overrides [list dir $sp_actual appendonly yes aof-integrity-check yes]] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            assert_equal "1" [$rd get a]
+            assert_equal "2" [$rd get b]
+            assert_equal "3" [$rd get c]
+        }
+    }
+
+    test "aof-integrity-check can be enabled when rdb-preamble is off" {
+        set sp8 [tmpdir server.aof-integrity-8]
+        start_server [list overrides [list dir $sp8 appendonly yes aof-integrity-check yes aof-use-rdb-preamble no]] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            set config_val [lindex [$rd config get aof-integrity-check] 1]
+            assert_equal "yes" $config_val
+        }
+    }
+
+    test "AOF integrity: checksum persistence through AOF rewrite" {
+        set sp [tmpdir server.aof-integrity-lsn-persistence]
+        start_server [list overrides [list dir $sp appendonly yes appendfsync always aof-integrity-check yes aof-use-rdb-preamble yes] keep_persistence true] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            $rd set a 1
+            $rd set b 2
+            $rd bgrewriteaof
+            waitForBgrewriteaof $rd
+            
+            $rd set c 3
+            
+            set incr_path [get_last_incr_aof_path $rd]
+            set fp [open $incr_path r]
+            set content [read $fp]
+            close $fp
+            
+            # set c should have an integrity header.
+            assert_match {*#HDR:v1;*checksum:*} $content
+            set sp_actual [dict get [srv config] dir]
+        }
+
+        # Restart and verify data restoration
+        start_server [list overrides [list dir $sp_actual appendonly yes aof-integrity-check yes]] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            assert_equal "1" [$rd get a]
+            assert_equal "2" [$rd get b]
+            assert_equal "3" [$rd get c]
+        }
+    }
+
+    test "valkey-check-aof detects integrity issues and handles multiple INCR files" {
+        set sp6 [tmpdir server.aof-integrity-tool-multi]
+        start_server [list overrides [list dir $sp6 appendonly yes appendfsync always aof-integrity-check yes aof-use-rdb-preamble yes] keep_persistence true] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            set ::am6_path [file join [dict get [srv config] dir] "appendonlydir" "appendonly.aof.manifest"]
+            $rd set a 1
+            
+            # Trigger rewrite to create a new INCR file
+            $rd bgrewriteaof
+            waitForBgrewriteaof $rd
+            
+            $rd set b 2
+            set ::ai6_path [get_last_incr_aof_path $rd]
+        }
+        
+        catch {exec ./src/valkey-check-aof $::am6_path} output
+        assert_match {*All AOF files and manifest are valid*} $output
+        
+        # Corrupt the NEWEST increment file by appending a manual entry with a wrong checksum.
+        set fp [open $::ai6_path a]
+        fconfigure $fp -translation binary
+        # We use a wrong checksum value here to simulate an integrity failure.
+        puts -nonewline $fp "#HDR:v1;len:22;checksum:123456789\r\n*3\r\n\$3\r\nSET\r\n\$1\r\nc\r\n\$1\r\n3\r\n"
+        close $fp
+        
+        catch {exec ./src/valkey-check-aof $::am6_path} output
+        assert_match {*AOF checksum mismatch*} $output
+    }
+
+    test "AOF manifest contains checksums when integrity check is enabled" {
+        set sp [tmpdir server.aof-integrity-manifest-checksum]
+        start_server [list overrides [list dir $sp appendonly yes appendfsync always aof-integrity-check yes aof-use-rdb-preamble yes] keep_persistence true] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            $rd set x 1
+            $rd bgrewriteaof
+            waitForBgrewriteaof $rd
+            $rd set y 2
+            
+            set manifest_path [file join [dict get [srv config] dir] "appendonlydir" "appendonly.aof.manifest"]
+            set fp [open $manifest_path r]
+            set content [read $fp]
+            close $fp
+            
+            assert {[string match {*# manifest-checksum: *} $content]}
+            assert {[string match {*checksum *} $content]}
+        }
+    }
+
+    test "AOF manifest does not contain checksums when integrity check is disabled" {
+        set sp [tmpdir server.aof-integrity-manifest-no-checksum]
+        start_server [list overrides [list dir $sp appendonly yes appendfsync always aof-integrity-check no aof-use-rdb-preamble yes] keep_persistence true] {
+            set rd [valkey [srv host] [srv port] 0 $::tls]
+            $rd set x 1
+            $rd bgrewriteaof
+            waitForBgrewriteaof $rd
+            $rd set y 2
+            
+            set manifest_path [file join [dict get [srv config] dir] "appendonlydir" "appendonly.aof.manifest"]
+            set fp [open $manifest_path r]
+            set content [read $fp]
+            close $fp
+            
+            assert {! [string match {*# manifest-checksum: *} $content]}
+            assert {! [string match {*checksum *} $content]}
+        }
+    }
+}

--- a/tests/support/aofmanifest.tcl
+++ b/tests/support/aofmanifest.tcl
@@ -44,11 +44,19 @@ proc get_cur_base_aof_name {manifest_filepath} {
         return ""
     }
 
-    set first_line [lindex $lines 0]
-    set aofname [lindex [split $first_line " "] 1]
-    set aoftype [lindex [split $first_line " "] 5]
-    if { $aoftype eq "b" } {
-        return $aofname
+    foreach line $lines {
+        if {[string match "#*" $line]} {
+            continue
+        }
+        set parts [split $line " "]
+        if {[llength $parts] < 6} {
+            continue
+        }
+        set aofname [lindex $parts 1]
+        set aoftype [lindex $parts 5]
+        if { $aoftype eq "b" } {
+            return $aofname
+        }
     }
 
     return ""
@@ -71,12 +79,21 @@ proc get_last_incr_aof_name {manifest_filepath} {
         return ""
     }
 
-    set len [llength $lines]
-    set last_line [lindex $lines [expr $len - 1]]
-    set aofname [lindex [split $last_line " "] 1]
-    set aoftype [lindex [split $last_line " "] 5]
-    if { $aoftype eq "i" } {
-        return $aofname
+    # Iterate backwards to find the last incr file, ignoring comments
+    for {set i [expr [llength $lines] - 1]} {$i >= 0} {incr i -1} {
+        set line [lindex $lines $i]
+        if {[string match "#*" $line]} {
+            continue
+        }
+        set parts [split $line " "]
+        if {[llength $parts] < 6} {
+            continue
+        }
+        set aofname [lindex $parts 1]
+        set aoftype [lindex $parts 5]
+        if { $aoftype eq "i" } {
+            return $aofname
+        }
     }
 
     return ""

--- a/valkey.conf
+++ b/valkey.conf
@@ -1722,6 +1722,16 @@ aof-use-rdb-preamble yes
 # the AOF format in a way that may not be compatible with existing AOF parsers.
 aof-timestamp-enabled no
 
+# The server can record metadata headers in the AOF to ensure strict data integrity.
+# When enabled, each block of accumulated writes is annotated with its length and a continuous
+# running CRC64 checksum, allowing the server to detect bit rot, torn writes,
+# and missing entries during recovery.
+#
+# Note: This is NOT a tamper-detection mechanism. Since it uses an unauthenticated
+# checksum and supports in-stream markers to disable verification, it does not
+# protect against malicious modification of the AOF file.
+aof-integrity-check no
+
 ################################ SHUTDOWN #####################################
 
 # Maximum time to wait for replicas when shutting down, in seconds.

--- a/valkey.conf
+++ b/valkey.conf
@@ -1730,6 +1730,13 @@ aof-timestamp-enabled no
 # Note: This is NOT a tamper-detection mechanism. Since it uses an unauthenticated
 # checksum and supports in-stream markers to disable verification, it does not
 # protect against malicious modification of the AOF file.
+#
+# Runtime Toggle Semantics:
+# - Disabling this setting at runtime inserts an in-stream '#INTEGRITY_OFF' marker,
+#   which suspends integrity verification from that point onward during recovery.
+# - Re-enabling it at runtime starts a new checksum chain from the next flush.
+# - Consequently, an AOF file may contain mixed protected and unprotected regions
+#   until the next AOF rewrite.
 aof-integrity-check no
 
 ################################ SHUTDOWN #####################################


### PR DESCRIPTION
This PR introduces a comprehensive AOF integrity verification system that protects against bit rot, torn writes, and missing log entries. By annotating AOF writes with metadata, the server can detect corruption during recovery.

### How it Works                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                  
When  aof-integrity-check  is enabled, the server annotates each block of accumulated writes (during a flush) with a metadata header:
#HDR:v1;len:<block_len>;checksum:<running_crc64>;\r\n                                                                                                                                                                                          
                                                                                                                                                                                                                                                  
  •  len : The length of the payload block.                                                                                                                                                                                                       
  •  checksum : A continuous running CRC64 checksum of the AOF stream up to the end of this block.                                                                                                                                                
  • Verification: During loading, the server parses these headers and verifies the payload against the checksum. If a mismatch is detected, the server aborts (or handles it based on  aof-load-truncated ).                                      
  • Strict Enforcement: Once an integrity chain is started, the loader expects every subsequent block to have a valid header. If a command is encountered without a header, it is treated as an integrity failure.                                
                                                                                                                                                                                                                                                  
### Key Features                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                  
  1. Dynamic Toggling:  aof-integrity-check  can be enabled or disabled at runtime. If disabled, the server injects an in-stream  #INTEGRITY_OFF\r\n  marker to signal the loader to suspend verification.                                        
  2. Manifest Protection: The AOF manifest file ( appendonly.aof.manifest ) is protected by a  # manifest-checksum: <val>  line appended at the end. The manifest checksum and per-file checksums are only written and verified when  aof-        
  integrity-check  is enabled.                                                                                                                                                                                                                    
  3. Tool Support: The  valkey-check-aof  tool has been updated to fully support parsing and verifying integrity headers, handling multiple INCR files, and recognizing the new  "VALKEY"  RDB preamble signature.                                
  4. Robust Tests: A comprehensive integration test suite ( tests/integration/aof-integrity.tcl ) has been added to cover edge cases, including:                                                                                                  
      • Header generation and data restoration.                                                                                                                                                                                                   
      • Checksum mismatch detection (aborts startup).                                                                                                                                                                                             
      • Strict header enforcement (fails on missing headers).                                                                                                                                                                                     
      • Preamble integrity checks (even if  rdbchecksum  is disabled).                                                                                                                                                                            
      • Large command incremental verification.                                                                                                                                                                                                   
      • Dynamic toggling and disabled markers.                                                                                                                                                                                                    
      • Manifest checksum presence/absence validation.

### Configuration:

A new configuration parameter aof-integrity-check (default: no) has been added to valkey.conf. It can be toggled dynamically.

### Performance

#### Summary

We run benchmarks with write-only workload to compare the performance with aof-integrity-check enabled (vs disabled).

| aof-integrity-check | Data size | Writes/sec | p50 latency (ms) | p99 latency (ms) | Avg. disk usage per write (bytes) |
| :---: | :---: | :---: | :---: | :---: | :---: |
| disabled | 10B | 249676 | 0.6 | 0.91 | 51.8 |
| disabled | 1KB | 195653 | 0.7 | 1.55 | 1043.8 |
| disabled | 10KB | 41757 | 0.53 | 18.81 | 10043.8 |
| enabled | 10B | 245789 (-1.56%) | 0.6 | 0.92 | 52.4 |
| enabled | 1KB | 183392 (-6.25%) | 0.74 | 1.51 | 1044.3 |
| enabled | 10KB | 37943 (-9.13%) | 0.52 | 19.83 | 10044.6 |

#### Flame graphs

With data size 1KB : The flamegraph shows that 4.67% cpu cycles are spent on crc computation

<img width="1024" height="768" alt="Valkey checksumming performance" src="https://github.com/user-attachments/assets/65b8c7b2-fe8a-4929-9ee6-397231312777" />

With data size 10KB: The flamegraph shows that 8.28% cpu cycles are spent on crc computation.

<img width="1024" height="768" alt="Valkey checksumming performance (2)" src="https://github.com/user-attachments/assets/c22b5339-5eee-4297-b1e5-4539366fdd8f" />


#### Follow-ups

Once we offload AOF writes to BIO thread (https://github.com/valkey-io/valkey/issues/3828), the running checksum computation will also be done in the BIO thread to minimize the performance overhead 

Closes https://github.com/valkey-io/valkey/issues/3885