### PR TITLE
Set pending_command flag consistently across all command execution paths

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -731,7 +731,6 @@ static void unblockClientOnKey(client *c, robj *key) {
     /* In case this client was blocked on keys during command
      * we need to re process the command again */
     if (c->flag.pending_command) {
-        c->flag.pending_command = 0;
         c->flag.reexecuting_command = 1;
         /* We want the command processing and the unblock handler (see RM_Call 'K' option)
          * to run atomically, this is why we must enter the execution unit here before
@@ -898,10 +897,7 @@ static bool isClientBlockedInUse(client *c) {
  * The client remains blocked until ALL of its keys are unblocked via
  * unblockClientsInUseOnKey().
  *
- * The caller MUST set c->flag.pending_command = 1 before calling this function.
- * This ensures the pending command is executed when the client is later
- * unblocked via processPendingCommandAndInputBuffer().
- * The caller should then return without executing the command. */
+ * The caller should return without executing the command after calling this. */
 void blockClientInUseOnKeys(client *c, int num_keys, robj *keys[]) {
     serverAssert(!c->flag.blocked && !c->flag.unblocked);
     serverAssert(c->flag.pending_command == 1);

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -495,10 +495,10 @@ void blockForKeys(client *c, int btype, robj **keys, int numkeys, mstime_t timeo
         }
     }
     c->bstate->unblock_on_nokey = unblock_on_nokey;
-    /* Currently we assume key blocking will require reprocessing the command.
-     * However in case of modules, they have a different way to handle the reprocessing
-     * which does not require setting the pending command flag */
-    if (btype != BLOCKED_MODULE) c->flag.pending_command = 1;
+    /* Key-blocked clients require pending_command for reprocessing on unblock.
+     * The caller must have set it (processInputBuffer for real clients,
+     * RM_Call for module fake clients). */
+    serverAssert(c->flag.pending_command == 1);
     blockClient(c, btype);
 }
 
@@ -699,8 +699,7 @@ void blockPostponeClient(client *c) {
     listAddNodeTail(server.postponed_clients, c);
     serverAssert(c->bstate->postponed_list_node == NULL);
     c->bstate->postponed_list_node = listLast(server.postponed_clients);
-    /* Mark this client to execute its command */
-    c->flag.pending_command = 1;
+    serverAssert(c->flag.pending_command == 1);
 }
 
 /* Block client due to shutdown command */

--- a/src/db.c
+++ b/src/db.c
@@ -1469,6 +1469,8 @@ void shutdownCommand(client *c) {
         return;
     }
 
+    /* Clear pending_command to avoid re-execution. */
+    c->flag.pending_command = 0;
     blockClientShutdown(c);
     if (prepareForShutdown(c, flags) == C_OK) exit(0);
     /* If we're here, then shutdown is ongoing (the client is still blocked) or

--- a/src/module.c
+++ b/src/module.c
@@ -6809,6 +6809,9 @@ ValkeyModuleCallReply *VM_Call(ValkeyModuleCtx *ctx, const char *cmdname, const 
         if (!(flags & VALKEYMODULE_ARGV_NO_AOF)) call_flags |= CMD_CALL_PROPAGATE_AOF;
         if (!(flags & VALKEYMODULE_ARGV_NO_REPLICAS)) call_flags |= CMD_CALL_PROPAGATE_REPL;
     }
+    /* Mirror processInputBuffer: set pending_command so that if the command
+     * blocks on keys, unblockClientOnKey will reprocess it on unblock. */
+    c->flag.pending_command = 1;
     call(c, call_flags);
 
     /* Propagate database changes from the temporary client back to the context client
@@ -8171,6 +8174,10 @@ ValkeyModuleBlockedClient *moduleBlockClient(ValkeyModuleCtx *ctx,
             c->bstate->timeout = timeout;
             blockClient(c, BLOCKED_MODULE);
         }
+        /* Module handles its own reply on unblock, so clear pending_command
+         * to prevent re-execution. Auth clients are the exception — they
+         * need re-execution after auth completes. */
+        if (!auth_reply_callback) c->flag.pending_command = 0;
         /* Defer response until after being unblocked for a context originated from
          * keyspace notification events */
         if (is_keyspace_notification) {
@@ -8793,13 +8800,6 @@ void moduleHandleBlockedClients(void) {
              * to NULL, because if we reached this point, the client was
              * properly unblocked by the module. */
             bc->disconnect_callback = NULL;
-            /* pending_command was set in processInputBuffer before the
-             * command executed. By the time we reach here, the module has
-             * already handled the client's reply. Clear it to prevent
-             * re-execution. Exception: module auth clients need
-             * re-execution after auth completes. */
-            if (!clientHasModuleAuthInProgress(c))
-                c->flag.pending_command = 0;
             unblockClient(c, 1);
 
             /* Update the wait offset, we don't know if this blocked client propagated anything,

--- a/src/module.c
+++ b/src/module.c
@@ -8793,6 +8793,13 @@ void moduleHandleBlockedClients(void) {
              * to NULL, because if we reached this point, the client was
              * properly unblocked by the module. */
             bc->disconnect_callback = NULL;
+            /* pending_command was set in processInputBuffer before the
+             * command executed. By the time we reach here, the module has
+             * already handled the client's reply. Clear it to prevent
+             * re-execution. Exception: module auth clients need
+             * re-execution after auth completes. */
+            if (!clientHasModuleAuthInProgress(c))
+                c->flag.pending_command = 0;
             unblockClient(c, 1);
 
             /* Update the wait offset, we don't know if this blocked client propagated anything,

--- a/src/networking.c
+++ b/src/networking.c
@@ -3765,6 +3765,7 @@ void commandProcessed(client *c) {
      *    since we have not applied the command. */
     if (c->flag.blocked) return;
 
+    c->flag.pending_command = 0;
     reqresAppendResponse(c);
     clusterSlotStatsAddNetworkBytesInForUserClient(c);
     resetClient(c);
@@ -3837,7 +3838,6 @@ int processPendingCommandAndInputBuffer(client *c) {
      * blocked client as well */
     if (c->flag.close_asap) return C_ERR;
     if (c->flag.pending_command) {
-        c->flag.pending_command = 0;
         if (processCommandAndResetClient(c) == C_ERR) {
             return C_ERR;
         }
@@ -4108,6 +4108,7 @@ int processInputBuffer(client *c) {
         }
 
         /* We are finally ready to execute the command. */
+        c->flag.pending_command = 1;
         if (processCommandAndResetClient(c) == C_ERR) {
             /* If the client is no longer valid, we avoid exiting this
              * loop and trimming the client buffer later. So we return

--- a/src/replication.c
+++ b/src/replication.c
@@ -5017,7 +5017,10 @@ void waitCommand(client *c) {
     }
 
     /* Otherwise block the client and put it into our list of clients
-     * waiting for ack from replicas. */
+     * waiting for ack from replicas. WAIT handles its own reply in
+     * processClientsWaitingReplicas, so clear pending_command to avoid
+     * being mistaken for a command that needs re-execution. */
+    c->flag.pending_command = 0;
     blockClientForReplicaAck(c, timeout, offset, numreplicas, 0);
 
     /* Make sure that the server will send an ACK request to all the replicas
@@ -5059,7 +5062,10 @@ void waitaofCommand(client *c) {
     }
 
     /* Otherwise block the client and put it into our list of clients
-     * waiting for ack from replicas. */
+     * waiting for ack from replicas. WAITAOF handles its own reply in
+     * processClientsWaitingReplicas, so clear pending_command to avoid
+     * being mistaken for a command that needs re-execution. */
+    c->flag.pending_command = 0;
     blockClientForReplicaAck(c, timeout, offset, numreplicas, numlocal);
 
     /* Make sure that the server will send an ACK request to all the replicas


### PR DESCRIPTION
The `pending_command` flag is documented as indicating a client has a fully parsed command ready for execution. However, it was only set in the IO thread path, not in the main thread `processInputBuffer` path which parses and executes directly without ever setting the flag. This inconsistency meant blocking APIs like `blockClientInUseOnKeys` had to require callers to manually set pending_command = 1 before calling.

This change:
- Sets pending_command = 1 in `processInputBuffer` when the command is fully parsed.
- Clears it in `commandProcessed` after execution completes.
- Removes redundant clears in `processPendingCommandAndInputBuffer` and `unblockClientOnKey`.

Now any command that blocks during processCommand naturally has pending_command = 1 already set, without caller intervention.

Exception: 
- `WAIT` and `WAITAOF` explicitly clear pending_command before blocking, since `processClientsWaitingReplicas` uses it to distinguish reply commands (pending_command = 0) from re-execution commands like CLUSTER SETSLOT (pending_command = 1).
- Module clients clear pending_command in `moduleHandleBlockedClients` before unblocking, since their reply is already handled by the module's callback (reply callback for VM_BlockClient, key-notification callback for VM_BlockClientOnKeys). The exception is module auth-in-progress clients, which keep pending_command = 1 because they need re-execution after authentication completes.