### PR TITLE
acl: Escape special characters during ACL rule serialization

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -175,17 +175,18 @@ typedef struct {
      * matching is used, the field is just set to NULL to avoid allocating
      * USER_COMMAND_BITS_COUNT pointers. */
     sds **allowed_firstargs;
-    list *patterns;    /* A list of allowed key patterns. If this field is NULL
-                          the user cannot mention any key in a command, unless
-                          the flag ALLKEYS is set in the user. */
-    list *channels;    /* A list of allowed Pub/Sub channel patterns. If this
-                          field is NULL the user cannot mention any channel in a
-                          `PUBLISH` or [P][UNSUBSCRIBE] command, unless the flag
-                          ALLCHANNELS is set in the user. */
-    sds command_rules; /* A string representation of the ordered categories and commands, this
-                        * is used to regenerate the original ACL string for display. */
-    intset *dbs;       /* Set of allowed database ids. If set is NULL or empty the user
-                        * cannot access any database, unless the flag ALLDBS is set. */
+    list *patterns;      /* A list of allowed key patterns. If this field is NULL
+                            the user cannot mention any key in a command, unless
+                            the flag ALLKEYS is set in the user. */
+    list *channels;      /* A list of allowed Pub/Sub channel patterns. If this
+                            field is NULL the user cannot mention any channel in a
+                            `PUBLISH` or [P][UNSUBSCRIBE] command, unless the flag
+                            ALLCHANNELS is set in the user. */
+    list *command_rules; /* A list of unescaped SDS strings representing the ordered
+                          * categories and commands. This is used to regenerate the
+                          * original ACL string for display and modification. */
+    intset *dbs;         /* Set of allowed database ids. If set is NULL or empty the user
+                          * cannot access any database, unless the flag ALLDBS is set. */
 } aclSelector;
 
 static void ACLResetFirstArgsForCommand(aclSelector *selector, unsigned long id);
@@ -372,7 +373,7 @@ static aclSelector *ACLCreateSelector(int flags) {
     selector->channels = listCreate();
     selector->dbs = intsetNew();
     selector->allowed_firstargs = NULL;
-    selector->command_rules = sdsempty();
+    selector->command_rules = listCreate();
 
     listSetMatchMethod(selector->patterns, ACLListMatchKeyPattern);
     listSetFreeMethod(selector->patterns, ACLListFreeKeyPattern);
@@ -380,6 +381,9 @@ static aclSelector *ACLCreateSelector(int flags) {
     listSetMatchMethod(selector->channels, ACLListMatchSds);
     listSetFreeMethod(selector->channels, sdsfreeVoid);
     listSetDupMethod(selector->channels, ACLListDupSds);
+    listSetFreeMethod(selector->command_rules, sdsfreeVoid);
+    listSetMatchMethod(selector->command_rules, ACLListMatchSds);
+    listSetDupMethod(selector->command_rules, ACLListDupSds);
     memset(selector->allowed_commands, 0, sizeof(selector->allowed_commands));
 
     return selector;
@@ -390,7 +394,7 @@ static void ACLFreeSelector(aclSelector *selector) {
     listRelease(selector->patterns);
     listRelease(selector->channels);
     intsetFree(selector->dbs);
-    sdsfree(selector->command_rules);
+    listRelease(selector->command_rules);
     ACLResetFirstArgs(selector);
     zfree(selector);
 }
@@ -402,7 +406,7 @@ static aclSelector *ACLCopySelector(aclSelector *src) {
     dst->patterns = listDup(src->patterns);
     dst->channels = listDup(src->channels);
     dst->dbs = intsetDup(src->dbs);
-    dst->command_rules = sdsdup(src->command_rules);
+    dst->command_rules = listDup(src->command_rules);
     memcpy(dst->allowed_commands, src->allowed_commands, sizeof(dst->allowed_commands));
     dst->allowed_firstargs = NULL;
     /* Copy the allowed first-args array of array of SDS strings. */
@@ -597,45 +601,22 @@ static void ACLSetSelectorCommandBit(aclSelector *selector, unsigned long id, in
  * verbatim, but also remove subcommand rules if we are adding or removing the
  * entire command. */
 static void ACLSelectorRemoveCommandRule(aclSelector *selector, sds new_rule) {
-    int argc = 0;
-    /* command_rules is stored as an escaped string in memory to handle
-     * rules with spaces (like deprecated first-arg rules). We use
-     * sdssplitargs to parse it correctly. */
-    sds *argv = sdssplitargs(selector->command_rules, &argc);
-    if (!argv) return;
-
-    sds updated_rules = sdsempty();
+    listIter li;
+    listNode *ln;
+    listRewind(selector->command_rules, &li);
     size_t new_len = sdslen(new_rule);
 
-    for (int i = 0; i < argc; i++) {
-        sds rule = argv[i];
-        if (sdslen(rule) == 0) continue;
-
-        /* The first character of the rule is +/-, which we don't need to compare. */
+    while ((ln = listNext(&li))) {
+        sds rule = listNodeValue(ln);
         char *existing_rule = rule + 1;
         size_t existing_len = sdslen(rule) - 1;
 
-        /* Exact match or the rule we are comparing is a subcommand denoted by '|' */
         if (!memcmp(existing_rule, new_rule, min(existing_len, new_len))) {
             if ((existing_len == new_len) || (existing_len > new_len && (existing_rule[new_len]) == '|')) {
-                /* Found a match. Don't add this to the updated_rules. */
-                continue;
+                listDelNode(selector->command_rules, ln);
             }
         }
-
-        /* Not a match. Add the rule back to the new updated_rules */
-        if (sdslen(updated_rules)) updated_rules = sdscat(updated_rules, " ");
-
-        /* Some edge cases could result in a command needing escaping:
-         * 1. (deprecated) First argument rules (e.g. "+get|my key")
-         * 2. Module commands could register characters needing escape, like
-         *    double quotes (e.g. "+my_command\""). */
-        updated_rules = sdscatreprifneeded(updated_rules, rule, sdslen(rule));
     }
-
-    sdsfree(selector->command_rules);
-    selector->command_rules = updated_rules;
-    sdsfreesplitres(argv, argc);
 }
 
 /* This function is responsible for updating the command_rules struct so that relative ordering of
@@ -649,15 +630,8 @@ static void ACLUpdateCommandRules(aclSelector *selector, const char *rule, int a
     sds rule_to_add = sdsempty();
     rule_to_add = sdscatfmt(rule_to_add, allow ? "+%S" : "-%S", new_rule);
 
-    if (sdslen(selector->command_rules)) selector->command_rules = sdscat(selector->command_rules, " ");
+    listAddNodeTail(selector->command_rules, rule_to_add);
 
-    /* Command rules are stored escaped in memory in selector->command_rules.
-     * This ensures that they are unambiguously separable by sdssplitargs
-     * during modification (e.g. in ACLSelectorRemoveCommandRule), even if
-     * they contain spaces (like in deprecated first-arg rules). */
-    selector->command_rules = sdscatreprifneeded(selector->command_rules, rule_to_add, sdslen(rule_to_add));
-
-    sdsfree(rule_to_add);
     sdsfree(new_rule);
 }
 
@@ -715,9 +689,6 @@ void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void) {
         listRewind(u->selectors, &li);
         while ((ln = listNext(&li))) {
             aclSelector *selector = (aclSelector *)listNodeValue(ln);
-            int argc = 0;
-            sds *argv = sdssplitargs(selector->command_rules, &argc);
-            serverAssert(argv != NULL);
             /* Checking selector's permissions for all commands to start with a clean state. */
             if (ACLSelectorCanExecuteFutureCommands(selector)) {
                 int res = ACLSetSelector(selector, "+@all", -1);
@@ -728,11 +699,14 @@ void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void) {
             }
 
             /* Apply all of the commands and categories to this selector. */
-            for (int i = 0; i < argc; i++) {
-                int res = ACLSetSelector(selector, argv[i], sdslen(argv[i]));
+            listIter sli;
+            listNode *sln;
+            listRewind(selector->command_rules, &sli);
+            while ((sln = listNext(&sli))) {
+                sds rule = listNodeValue(sln);
+                int res = ACLSetSelector(selector, rule, sdslen(rule));
                 serverAssert(res == C_OK);
             }
-            sdsfreesplitres(argv, argc);
         }
     }
     raxStop(&ri);
@@ -764,14 +738,13 @@ int ACLModuleHasCommandRules(const struct ValkeyModule *module, sds *rule_out) {
         listRewind(u->selectors, &li);
         while ((ln = listNext(&li)) != NULL) {
             aclSelector *selector = listNodeValue(ln);
-            if (sdslen(selector->command_rules) == 0) continue;
+            if (listLength(selector->command_rules) == 0) continue;
 
-            int argc = 0;
-            sds *argv = sdssplitargs(selector->command_rules, &argc);
-            if (!argv) continue;
-
-            for (int i = 0; i < argc; i++) {
-                sds rule = argv[i];
+            listIter sli;
+            listNode *sln;
+            listRewind(selector->command_rules, &sli);
+            while ((sln = listNext(&sli))) {
+                sds rule = listNodeValue(sln);
                 if (rule[0] != '+' && rule[0] != '-') continue;
                 if (rule[1] == '@') continue;
 
@@ -789,11 +762,9 @@ int ACLModuleHasCommandRules(const struct ValkeyModule *module, sds *rule_out) {
                 if (moduleFromCommand(cmd) != module) continue;
 
                 if (rule_out) *rule_out = sdsdup(rule);
-                sdsfreesplitres(argv, argc);
                 raxStop(&ri);
                 return 1;
             }
-            sdsfreesplitres(argv, argc);
         }
     }
     raxStop(&ri);
@@ -828,19 +799,20 @@ static sds ACLDescribeSelectorCommandRules(aclSelector *selector) {
         ACLSetSelector(fake_selector, "-@all", -1);
     }
 
-    /* Apply all of the commands and categories to the fake selector. */
-    int argc = 0;
-    sds *argv = sdssplitargs(selector->command_rules, &argc);
-    serverAssert(argv != NULL);
-
-    for (int i = 0; i < argc; i++) {
-        int res = ACLSetSelector(fake_selector, argv[i], -1);
+    /* Apply all of the commands and categories to the fake selector and build rules string. */
+    listIter li;
+    listNode *ln;
+    listRewind(selector->command_rules, &li);
+    while ((ln = listNext(&li))) {
+        sds rule = listNodeValue(ln);
+        /* Apply to fake selector */
+        int res = ACLSetSelector(fake_selector, rule, -1);
         serverAssert(res == C_OK);
+
+        /* Append to rules string, quoting if needed */
+        rules = sdscatreprifneeded(rules, rule, sdslen(rule));
+        rules = sdscatlen(rules, " ", 1);
     }
-    if (sdslen(selector->command_rules)) {
-        rules = sdscatfmt(rules, "%S ", selector->command_rules);
-    }
-    sdsfreesplitres(argv, argc);
 
     /* Trim the final useless space. */
     sdsrange(rules, 0, -2);
@@ -1219,12 +1191,12 @@ static int ACLSetSelector(aclSelector *selector, const char *op, size_t oplen) {
     } else if (!strcasecmp(op, "allcommands") || !strcasecmp(op, "+@all")) {
         memset(selector->allowed_commands, 255, sizeof(selector->allowed_commands));
         selector->flags |= SELECTOR_FLAG_ALLCOMMANDS;
-        sdsclear(selector->command_rules);
+        listEmpty(selector->command_rules);
         ACLResetFirstArgs(selector);
     } else if (!strcasecmp(op, "nocommands") || !strcasecmp(op, "-@all")) {
         memset(selector->allowed_commands, 0, sizeof(selector->allowed_commands));
         selector->flags &= ~SELECTOR_FLAG_ALLCOMMANDS;
-        sdsclear(selector->command_rules);
+        listEmpty(selector->command_rules);
         ACLResetFirstArgs(selector);
     } else if (op[0] == '~' || op[0] == '%') {
         if (selector->flags & SELECTOR_FLAG_ALLKEYS) {

--- a/src/acl.c
+++ b/src/acl.c
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "sds.h"
 #include "server.h"
 #include "sha256.h"
 #include "module.h"
@@ -336,6 +337,16 @@ static void *ACLListDupKeyPattern(void *item) {
     return ACLKeyPatternCreate(sdsdup(old->pattern), old->flags);
 }
 
+/* Append the string with quotes if it needs representation, otherwise append
+ * it raw. */
+static sds sdscatreprifneeded(sds base, const char *s, size_t len) {
+    if (sdsneedsrepr(s)) {
+        return sdscatrepr(base, s, len);
+    } else {
+        return sdscatlen(base, s, len);
+    }
+}
+
 /* Append the string representation of a key pattern onto the
  * provided base string. */
 static sds sdsCatPatternString(sds base, keyPattern *pat) {
@@ -586,47 +597,45 @@ static void ACLSetSelectorCommandBit(aclSelector *selector, unsigned long id, in
  * verbatim, but also remove subcommand rules if we are adding or removing the
  * entire command. */
 static void ACLSelectorRemoveCommandRule(aclSelector *selector, sds new_rule) {
+    int argc = 0;
+    /* command_rules is stored as an escaped string in memory to handle
+     * rules with spaces (like deprecated first-arg rules). We use
+     * sdssplitargs to parse it correctly. */
+    sds *argv = sdssplitargs(selector->command_rules, &argc);
+    if (!argv) return;
+
+    sds updated_rules = sdsempty();
     size_t new_len = sdslen(new_rule);
-    char *existing_rule = selector->command_rules;
 
-    /* Loop over the existing rules, trying to find a rule that "matches"
-     * the new rule. If we find a match, then remove the command from the string by
-     * copying the later rules over it. */
-    while (existing_rule[0]) {
+    for (int i = 0; i < argc; i++) {
+        sds rule = argv[i];
+        if (sdslen(rule) == 0) continue;
+
         /* The first character of the rule is +/-, which we don't need to compare. */
-        char *copy_position = existing_rule;
-        existing_rule += 1;
-
-        /* Assume a trailing space after a command is part of the command, like '+get ', so trim it
-         * as well if the command is removed. */
-        char *rule_end = strchr(existing_rule, ' ');
-        if (!rule_end) {
-            /* This is the last rule, so move it to the end of the string. */
-            rule_end = existing_rule + strlen(existing_rule);
-
-            /* This approach can leave a trailing space if the last rule is removed,
-             * but only if it's not the first rule, so handle that case. */
-            if (copy_position != selector->command_rules) copy_position -= 1;
-        }
-        char *copy_end = rule_end;
-        if (*copy_end == ' ') copy_end++;
+        char *existing_rule = rule + 1;
+        size_t existing_len = sdslen(rule) - 1;
 
         /* Exact match or the rule we are comparing is a subcommand denoted by '|' */
-        size_t existing_len = rule_end - existing_rule;
         if (!memcmp(existing_rule, new_rule, min(existing_len, new_len))) {
             if ((existing_len == new_len) || (existing_len > new_len && (existing_rule[new_len]) == '|')) {
-                /* Copy the remaining rules starting at the next rule to replace the rule to be
-                 * deleted, including the terminating NULL character. */
-                memmove(copy_position, copy_end, strlen(copy_end) + 1);
-                existing_rule = copy_position;
+                /* Found a match. Don't add this to the updated_rules. */
                 continue;
             }
         }
-        existing_rule = copy_end;
+
+        /* Not a match. Add the rule back to the new updated_rules */
+        if (sdslen(updated_rules)) updated_rules = sdscat(updated_rules, " ");
+
+        /* Some edge cases could result in a command needing escaping:
+         * 1. (deprecated) First argument rules (e.g. "+get|my key")
+         * 2. Module commands could register characters needing escape, like
+         *    double quotes (e.g. "+my_command\""). */
+        updated_rules = sdscatreprifneeded(updated_rules, rule, sdslen(rule));
     }
 
-    /* There is now extra padding at the end of the rules, so clean that up. */
-    sdsupdatelen(selector->command_rules);
+    sdsfree(selector->command_rules);
+    selector->command_rules = updated_rules;
+    sdsfreesplitres(argv, argc);
 }
 
 /* This function is responsible for updating the command_rules struct so that relative ordering of
@@ -636,8 +645,19 @@ static void ACLUpdateCommandRules(aclSelector *selector, const char *rule, int a
     sdstolower(new_rule);
 
     ACLSelectorRemoveCommandRule(selector, new_rule);
+
+    sds rule_to_add = sdsempty();
+    rule_to_add = sdscatfmt(rule_to_add, allow ? "+%S" : "-%S", new_rule);
+
     if (sdslen(selector->command_rules)) selector->command_rules = sdscat(selector->command_rules, " ");
-    selector->command_rules = sdscatfmt(selector->command_rules, allow ? "+%S" : "-%S", new_rule);
+
+    /* Command rules are stored escaped in memory in selector->command_rules.
+     * This ensures that they are unambiguously separable by sdssplitargs
+     * during modification (e.g. in ACLSelectorRemoveCommandRule), even if
+     * they contain spaces (like in deprecated first-arg rules). */
+    selector->command_rules = sdscatreprifneeded(selector->command_rules, rule_to_add, sdslen(rule_to_add));
+
+    sdsfree(rule_to_add);
     sdsfree(new_rule);
 }
 
@@ -848,8 +868,18 @@ static sds ACLDescribeSelector(aclSelector *selector) {
         listRewind(selector->patterns, &li);
         while ((ln = listNext(&li))) {
             keyPattern *thispat = (keyPattern *)listNodeValue(ln);
-            res = sdsCatPatternString(res, thispat);
+            sds rule = sdsempty();
+            rule = sdsCatPatternString(rule, thispat);
+            /* We only need to quote individual key patterns if they are on the
+             * root selector. Non-root selectors are quoted as a whole in
+             * ACLDescribeUser. */
+            if ((selector->flags & SELECTOR_FLAG_ROOT) && sdsneedsrepr(rule)) {
+                res = sdscatrepr(res, rule, sdslen(rule));
+            } else {
+                res = sdscatsds(res, rule);
+            }
             res = sdscatlen(res, " ", 1);
+            sdsfree(rule);
         }
     }
 
@@ -861,9 +891,19 @@ static sds ACLDescribeSelector(aclSelector *selector) {
         listRewind(selector->channels, &li);
         while ((ln = listNext(&li))) {
             sds thispat = listNodeValue(ln);
-            res = sdscatlen(res, "&", 1);
-            res = sdscatsds(res, thispat);
+            sds rule = sdsempty();
+            rule = sdscatlen(rule, "&", 1);
+            rule = sdscatsds(rule, thispat);
+            /* We only need to quote individual channel patterns if they are on
+             * the root selector. Non-root selectors are quoted as a whole in
+             * ACLDescribeUser. */
+            if ((selector->flags & SELECTOR_FLAG_ROOT) && sdsneedsrepr(rule)) {
+                res = sdscatrepr(res, rule, sdslen(rule));
+            } else {
+                res = sdscatsds(res, rule);
+            }
             res = sdscatlen(res, " ", 1);
+            sdsfree(rule);
         }
     }
 
@@ -934,7 +974,14 @@ robj *ACLDescribeUser(user *u) {
         if (selector->flags & SELECTOR_FLAG_ROOT) {
             res = sdscatfmt(res, "%s", default_perm);
         } else {
-            res = sdscatfmt(res, " (%s)", default_perm);
+            res = sdscatlen(res, " ", 1);
+            sds selector_str = sdsempty();
+            selector_str = sdscatfmt(selector_str, "(%s)", default_perm);
+
+            /* If needed, wrap selectors as a whole in one pair of quotes and
+             * escape any special characters within them. */
+            res = sdscatreprifneeded(res, selector_str, sdslen(selector_str));
+            sdsfree(selector_str);
         }
         sdsfree(default_perm);
     }
@@ -2480,6 +2527,23 @@ static int ACLLoadConfiguredUsers(void) {
     return C_OK;
 }
 
+/* Return 1 if the line needs to be parsed with sdssplitargs instead of
+ * sdssplitlen. */
+static int ACLLineNeedsQuotedParser(const char *s) {
+    int i = 0;
+    while (s[i]) {
+        if (s[i] == '"') {
+            /* A quote is at the start of a token if it's the first character
+             * or if it's preceded by a space or tab. */
+            if (i == 0 || s[i - 1] == ' ' || s[i - 1] == '\t') {
+                return 1;
+            }
+        }
+        i++;
+    }
+    return 0;
+}
+
 /* This function loads the ACL from the specified filename: every line
  * is validated and should be either empty or in the format used to specify
  * users in the valkey.conf or in the ACL file, that is:
@@ -2541,8 +2605,27 @@ static sds ACLLoadFromFile(const char *filename) {
         /* Skip blank lines */
         if (lines[i][0] == '\0') continue;
 
-        /* Split into arguments */
-        argv = sdssplitlen(lines[i], sdslen(lines[i]), " ", 1, &argc);
+        /* Old ACL file formats did not escape characters like quotes,
+         * which can lead to parsing failures during upgrade if we unconditionally
+         * use sdssplitargs (which assumes quotes are used to escape an argument).
+         *
+         * E.g.
+         * - Old Format: user testuser on -@all (~my"key"name +get)
+         * - New Format: user testuser on -@all "(~my\"key\"name +get)"
+         *
+         * Passing old format to sdssplitargs would incorrectly return the tokens:
+         *
+         * ["user", "testuser", "on", "-@all", "(~mykeyname", "+get)"]
+         *
+         * And remove the double quotes from the key name. In the new format, quotes
+         * are used to escape characters, so sdssplitargs would correctly return:
+         *
+         * ["user", "testuser", "on", "-@all", "(~my\"key\"name +get)"] */
+        if (ACLLineNeedsQuotedParser(lines[i])) {
+            argv = sdssplitargs(lines[i], &argc);
+        } else {
+            argv = sdssplitlen(lines[i], sdslen(lines[i]), " ", 1, &argc);
+        }
         if (argv == NULL) {
             errors = sdscatprintf(errors, "%s:%d: unbalanced quotes in acl line. ", server.acl_filename, linenum);
             continue;
@@ -2585,6 +2668,12 @@ static sds ACLLoadFromFile(const char *filename) {
          * be cleanly applied to the user. If any option fails
          * to apply, the other values won't be applied since
          * all the pending changes will get dropped. */
+
+        /* In the old ACL file format, selectors were not wrapped in quotes.
+         * To figure out where selectors begin and end, we used a naive merging
+         * approach that attempted to match tokens starting with "(" with
+         * tokens ending with ")". For backwards compatibility, we continue to
+         * attempt this merge, although the new format doesn't need to do it. */
         int merged_argc;
         sds *acl_args = ACLMergeSelectorArguments(argv + 2, argc - 2, &merged_argc, NULL);
         if (!acl_args) {
@@ -2707,7 +2796,10 @@ static int ACLSaveToFile(const char *filename) {
         user *u = ri.data;
         /* Return information in the configuration file format. */
         sds user = sdsnew("user ");
-        user = sdscatsds(user, u->name);
+
+        /* Users may contain special characters that need escaping (e.g. my"user
+         * is valid). */
+        user = sdscatreprifneeded(user, u->name, sdslen(u->name));
         user = sdscatlen(user, " ", 1);
         robj *descr = ACLDescribeUser(u);
         user = sdscatsds(user, objectGetVal(descr));
@@ -3225,7 +3317,11 @@ void aclCommand(client *c) {
             } else {
                 /* Return information in the configuration file format. */
                 sds config = sdsnew("user ");
-                config = sdscatsds(config, u->name);
+
+                /* Users may contain special characters that need escaping (e.g.
+                 * my"user is valid). */
+                config = sdscatreprifneeded(config, u->name, sdslen(u->name));
+
                 config = sdscatlen(config, " ", 1);
                 robj *descr = ACLDescribeUser(u);
                 config = sdscatsds(config, objectGetVal(descr));

--- a/src/acl.c
+++ b/src/acl.c
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "sds.h"
 #include "server.h"
+#include "sds.h"
 #include "sha256.h"
 #include "module.h"
 #include "intset.h"
@@ -676,7 +676,7 @@ static void ACLSetSelectorCommandBitsForCategory(hashtable *commands, aclSelecto
 }
 
 /* This function is responsible for recomputing the command bits for all selectors of the existing users.
- * It uses the 'command_rules', a string representation of the ordered categories and commands,
+ * It uses the 'command_rules', a list of the ordered categories and commands,
  * to recompute the command bits. */
 void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void) {
     raxIterator ri;
@@ -689,6 +689,10 @@ void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void) {
         listRewind(u->selectors, &li);
         while ((ln = listNext(&li))) {
             aclSelector *selector = (aclSelector *)listNodeValue(ln);
+            /* Duplicate the rules list before resetting the selector, as
+             * ACLSetSelector will clear selector->command_rules. */
+            list *rules_copy = listDup(selector->command_rules);
+ 
             /* Checking selector's permissions for all commands to start with a clean state. */
             if (ACLSelectorCanExecuteFutureCommands(selector)) {
                 int res = ACLSetSelector(selector, "+@all", -1);
@@ -698,15 +702,16 @@ void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void) {
                 serverAssert(res == C_OK);
             }
 
-            /* Apply all of the commands and categories to this selector. */
+            /* Apply all of the commands and categories to this selector from the copy. */
             listIter sli;
             listNode *sln;
-            listRewind(selector->command_rules, &sli);
+            listRewind(rules_copy, &sli);
             while ((sln = listNext(&sli))) {
                 sds rule = listNodeValue(sln);
                 int res = ACLSetSelector(selector, rule, sdslen(rule));
                 serverAssert(res == C_OK);
             }
+            listRelease(rules_copy);
         }
     }
     raxStop(&ri);

--- a/src/acl.c
+++ b/src/acl.c
@@ -692,7 +692,7 @@ void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void) {
             /* Duplicate the rules list before resetting the selector, as
              * ACLSetSelector will clear selector->command_rules. */
             list *rules_copy = listDup(selector->command_rules);
- 
+
             /* Checking selector's permissions for all commands to start with a clean state. */
             if (ACLSelectorCanExecuteFutureCommands(selector)) {
                 int res = ACLSetSelector(selector, "+@all", -1);

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1493,16 +1493,16 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
                 } else {
                     assert_equal [dict get $acl $field] $expected_val
                 }
-            
-            # Verify with LIST for specific cases to ensure quoting in serialization
-            if {$username eq "keyquoter"} {
-                set acl_list [r ACL LIST]
-                assert_match {*"~key\\\"name"*} $acl_list
-            }
-            if {$username eq "chanquoter"} {
-                set acl_list [r ACL LIST]
-                assert_match {*"&chan\\\"name"*} $acl_list
-            }
+
+                # Verify with LIST for specific cases to ensure quoting in serialization
+                if {$username eq "keyquoter"} {
+                    set acl_list [r ACL LIST]
+                    assert_match {*"~key\\\"name"*} $acl_list
+                }
+                if {$username eq "chanquoter"} {
+                    set acl_list [r ACL LIST]
+                    assert_match {*"&chan\\\"name"*} $acl_list
+                }
             }
             
             # Clean up user for next iteration

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -621,6 +621,29 @@ start_server {tags {"acl external:skip"}} {
         assert_equal "-@all +config" [dict get [r ACL getuser adv-test] commands]
     }
 
+    test {ACL serialization - Remove Quoted Rule} {
+        r ACL SETUSER panic-user-quote "+get|text\""
+        set acl [r ACL GETUSER panic-user-quote]
+        set cmdstr [dict get $acl commands]
+        assert_match {*+get|text\\\"*} $cmdstr
+
+        # First, check that unrelated rule preserves the quoted rule.
+        r ACL SETUSER panic-user-quote "+set"
+        set acl [r ACL GETUSER panic-user-quote]
+        set cmdstr [dict get $acl commands]
+        assert_match {*+get|text\\\"*} $cmdstr
+        assert_match {*+set*} $cmdstr
+
+        # Now add +get to remove the specific first-arg rule
+        r ACL SETUSER panic-user-quote "+get"
+        set acl [r ACL GETUSER panic-user-quote]
+        set cmdstr [dict get $acl commands]
+        assert {![string match {*+get|text\\\"*} $cmdstr]}
+        assert_match {*+get*} $cmdstr
+        assert_match {*+set*} $cmdstr
+        r ACL DELUSER panic-user-quote
+    }
+
     test "ACL CAT with illegal arguments" {
         assert_error {*Unknown category 'NON_EXISTS'} {r ACL CAT NON_EXISTS}
         assert_error {*unknown subcommand or wrong number of arguments for 'CAT'*} {r ACL CAT NON_EXISTS NON_EXISTS2}
@@ -1421,3 +1444,146 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
         }
     }
 }
+
+set cases {
+    {"quoter" "+get|text\"" {commands "-@all \"+get|text\\\"\""}}
+    {"tester" "(~key) +get)" {selectors {{keys "~key)" commands "-@all +get"}}}}
+    {"test\"user" "+get" {commands "-@all +get"}}
+    {"keyquoter" "~key\"name" {keys "~key\"name"}}
+    {"chanquoter" "&chan\"name" {channels "&chan\"name"}}
+}
+
+set server_path [tmpdir "server.acl.roundtrip"]
+set acl_file [file join $server_path "user.acl"]
+
+set fp [open $acl_file w]
+puts $fp "user default on nopass ~* \&* +@all"
+close $fp
+
+start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags [list "external:skip"]] {
+    foreach case $cases {
+        lassign $case username rules expected_fields
+        
+        test "ACL serialization - Round Trip - $username" {
+            # Set user
+            r ACL SETUSER $username on nopass $rules
+            
+            # Save
+            r ACL SAVE
+            
+            # Load
+            r ACL LOAD
+            
+            # Verify with GETUSER
+            set acl [r ACL GETUSER $username]
+            
+            # Check expected fields
+            foreach {field expected_val} $expected_fields {
+                if {$field eq "selectors"} {
+                    set selectors [dict get $acl selectors]
+                    set expected_selectors $expected_val
+                    assert_equal [llength $selectors] [llength $expected_selectors]
+                    for {set i 0} {$i < [llength $selectors]} {incr i} {
+                        set s [lindex $selectors $i]
+                        set es [lindex $expected_selectors $i]
+                        foreach {f v} $es {
+                            assert_equal [dict get $s $f] $v
+                        }
+                    }
+                } else {
+                    assert_equal [dict get $acl $field] $expected_val
+                }
+            
+            # Verify with LIST for specific cases to ensure quoting in serialization
+            if {$username eq "keyquoter"} {
+                set acl_list [r ACL LIST]
+                assert_match {*"~key\\\"name"*} $acl_list
+            }
+            if {$username eq "chanquoter"} {
+                set acl_list [r ACL LIST]
+                assert_match {*"&chan\\\"name"*} $acl_list
+            }
+            }
+            
+            # Clean up user for next iteration
+            r ACL DELUSER $username
+        }
+    }
+}
+
+set old_cases {
+    {"unquoted_selector" "user tester on nopass -@all (~key resetchannels -@all +get)" "tester" {selectors {{keys "~key" commands "-@all +get"}}}}
+    {"unquoted_username" "user test\"user on nopass +@all" "test\"user" {commands "+@all"}}
+    {"unquoted_key" "user tester on nopass ~key\"name" "tester" {keys "~key\"name"}}
+}
+
+set server_path [tmpdir "server.acl.upgrade"]
+set acl_file [file join $server_path "user.acl"]
+
+set fp [open $acl_file w]
+puts $fp "user default on nopass ~* \&* +@all"
+close $fp
+
+start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags [list "external:skip"]] {
+    foreach case $old_cases {
+        lassign $case name file_line username expected_fields
+        
+        test "ACL LOAD - Upgrade Scenario - $name" {
+            # Write old format to file
+            set fp [open $acl_file w]
+            puts $fp "user default on nopass ~* \&* +@all"
+            puts $fp $file_line
+            close $fp
+            
+            # Load it
+            r ACL LOAD
+            
+            # Verify LOAD worked via GETUSER
+            set acl [r ACL GETUSER $username]
+            foreach {field expected_val} $expected_fields {
+                if {$field eq "selectors"} {
+                    set selectors [dict get $acl selectors]
+                    set expected_selectors $expected_val
+                    for {set i 0} {$i < [llength $selectors]} {incr i} {
+                        set s [lindex $selectors $i]
+                        set es [lindex $expected_selectors $i]
+                        foreach {f v} $es {
+                            assert_equal [dict get $s $f] $v
+                        }
+                    }
+                } else {
+                    assert_equal [dict get $acl $field] $expected_val
+                }
+            }
+            
+            # Save (should upgrade to new format with quotes)
+            r ACL SAVE
+            
+            # Load again
+            r ACL LOAD
+            
+            # Verify semantics still preserved
+            set acl [r ACL GETUSER $username]
+            foreach {field expected_val} $expected_fields {
+                if {$field eq "selectors"} {
+                    set selectors [dict get $acl selectors]
+                    set expected_selectors $expected_val
+                    for {set i 0} {$i < [llength $selectors]} {incr i} {
+                        set s [lindex $selectors $i]
+                        set es [lindex $expected_selectors $i]
+                        foreach {f v} $es {
+                            assert_equal [dict get $s $f] $v
+                        }
+                    }
+                } else {
+                    assert_equal [dict get $acl $field] $expected_val
+                }
+            }
+            
+            # Clean up user for next iteration
+            r ACL DELUSER $username
+        }
+    }
+}
+
+


### PR DESCRIPTION
This PR fixes several critical bugs in ACL serialization and deserialization regarding command rules, selectors, and usernames containing special characters (like spaces, quotes, and parentheses).

### Problem

1. **Unquoted Parentheses**: A selector containing a rule with a parenthesis, like `(~key) +get)`, was serialized without quotes. On reload, `ACL LOAD` used a simple space-splitter (`sdssplitlen`) and a simple paren-merging logic (`ACLMergeSelectorArguments`) that got confused if a rule _inside_ the selector contained a parenthesis (like `~key)`), leading to loading failures.
2. **Unescaped Command Rules**: Command rules containing quotes (e.g., from module commands or deprecated first-arg rules like `+get|text"`) were not escaped on save, leading to assertion failures or loading failures.
3. **No support for quote-escaping in ACL LOAD**: `ACLLoadFromFile` used `sdssplitlen` (splitting strictly by spaces), which could not handle quoted arguments, preventing simple fixes. This is different than the behavior of ACL SETUSER and prevents control planes from working around the problems above by directly editing the ACL file.

### Solution

1. Root selector serialization: All ACL tokens that may contain special characters (i.e. users, command rules, key patterns, channel patterns) are checked for special characters (using `sdsneedsrepr`) and escaped and wrapped, if needed, during `ACL LIST` and `ACL SAVE`.
2. Non-root selectors serialization:  All non-root selectors are wrapped in quotes and escaped if they contain special characters. Space counts as a special character, meaning most non-root selectors are now wrapped in quotes during serialization.
3. In memory representation: the `aclSelector->command_rules` suffered from the ["stringly typed" anti-pattern](https://wiki.c2.com/?StringlyTyped). The in memory representation were rules separated by spaces. To properly support things like keys/command-arguments with spaces in them, it would have needed to be stored escaped in memory. To simplify this, we store it as a list of rules now, also simplifying things like rule removal.

### Backwards comaptibility

- Updated `ACLLoadFromFile` to use a static heuristic `ACLLineNeedsQuotedParser`.
- If it detects a token starting with `"` (indicating new quoted format), it uses `sdssplitargs` to parse it correctly respecting quotes and escapes.
- Otherwise, it falls back to the legacy `sdssplitlen` to maintain backward compatibility with old unquoted files (preserving the fix Antirez made in https://github.com/redis/redis/issues/7329).

### Forwards compatibility

- ACL files are **NOT** forwards compatible (e.g. `alldbs` is added by default starting in 9.1).
- Therefore, forwards compatibility is not attempted.

#### Clients

- Important note: `ACL LIST` output and ACL file format is changing to properly escape in the ambiguous scenarios. These situations were not working as expected before, and in some cases caused crashes on serialization, so I think changing the format is reasonable for 10.0 

### Serialized Output Comparison

With this fix, rules and selectors containing special characters are properly quoted when saved (e.g., via `ACL SAVE` or `ACL LIST`).

| Case                    | Command to Set                                      | What It Should Do                                       | Old Serialization (Broken)                          | New Serialization (Fixed)                             |
| :---------------------- | :-------------------------------------------------- | :------------------------------------------------------ | :-------------------------------------------------- | :---------------------------------------------------- |
| **Selector with Paren** | `ACL SETUSER tester on nopass -@all "(~key) +get)"` | Grant access to `GET` on keys matching `~key)` | `user tester on ... (~key) resetchannels ... +get)` | `user tester on ... "(~key) resetchannels ... +get)"` |
| **Command with Quote**  | `ACL SETUSER quoter on nopass "+get\|text\""`   | Grant access to command `get text"` (first-arg rule)    | `=== ASSERTION FAILED ===`                          | `user quoter on ... "+get\|text\""`               |
| **Username with Quote** | `ACL SETUSER "test\"user" on nopass +@all`          | Create user named `test"user`                           | `user test"user on ...`                             | `user "test\"user" on ...`                            |
| **Key with Quote**      | `ACL SETUSER keyquoter on nopass "~key\"name"`      | Grant access to key `key"name`                          | `user keyquoter on ... ~key"name`                   | `user keyquoter on ... "~key\"name"`                  |
| **Channel with Quote**  | `ACL SETUSER chanquoter on nopass "&chan\"name"`    | Grant access to channel `chan"name`                     | `user chanquoter on ... &chan"name`                 | `user chanquoter on ... "&chan\"name"`                |

### Tradeoffs/discussion points

1. Storing the command rules as a list will mean `ACL LIST` and `ACL SAVE` take a few more CPU cycles and involves more small memory allocations during the command execution. I still believe it is worth it since this is much less prone to bugs and will be easier to maintain. Alternatively, we can keep it a string and store the rules escaped in memory, at the cost of complexity.
2. In `ACL LOAD` - we do a O(n) pass to check if we should split with the quoted parser or the simple space parser. It also is a heuristic that adds some complexity. An alternative could have been to version the ACL rules in the file (e.g. `user default on ver:2 ...`). I chose the easier option for now, but curious what others think.
3. Escaping non-root selectors: I chose to do it for all non-root selectors, which I think is more readable. But we could limit this further by only escaping non-root selectors if some token ends in `)` (this is the scenario that `ACLMergeSelectorArguments` fails in).