### PR TITLE
Extend zmalloc_purge to also trim the libc main arena

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -821,7 +821,7 @@ void flushAllDataAndResetRDB(int flags) {
     /* jemalloc 5 doesn't release pages back to the OS when there's no traffic.
      * for large databases, flushdb blocks for long anyway, so a bit more won't
      * harm and this way the flush and purge will be synchronous. */
-    if (!(flags & EMPTYDB_ASYNC)) zmallocTrim();
+    if (!(flags & EMPTYDB_ASYNC)) zmalloc_purge();
 #endif
 }
 
@@ -846,7 +846,7 @@ void flushdbCommand(client *c) {
     /* jemalloc 5 doesn't release pages back to the OS when there's no traffic.
      * for large databases, flushdb blocks for long anyway, so a bit more won't
      * harm and this way the flush and purge will be synchronous. */
-    if (!(flags & EMPTYDB_ASYNC)) zmallocTrim();
+    if (!(flags & EMPTYDB_ASYNC)) zmalloc_purge();
 #endif
 }
 

--- a/src/db.c
+++ b/src/db.c
@@ -821,7 +821,7 @@ void flushAllDataAndResetRDB(int flags) {
     /* jemalloc 5 doesn't release pages back to the OS when there's no traffic.
      * for large databases, flushdb blocks for long anyway, so a bit more won't
      * harm and this way the flush and purge will be synchronous. */
-    if (!(flags & EMPTYDB_ASYNC)) jemalloc_purge();
+    if (!(flags & EMPTYDB_ASYNC)) zmallocTrim();
 #endif
 }
 
@@ -846,7 +846,7 @@ void flushdbCommand(client *c) {
     /* jemalloc 5 doesn't release pages back to the OS when there's no traffic.
      * for large databases, flushdb blocks for long anyway, so a bit more won't
      * harm and this way the flush and purge will be synchronous. */
-    if (!(flags & EMPTYDB_ASYNC)) jemalloc_purge();
+    if (!(flags & EMPTYDB_ASYNC)) zmallocTrim();
 #endif
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -1924,7 +1924,7 @@ void memoryCommand(client *c) {
         addReplyVerbatim(c, report, sdslen(report), "txt");
         sdsfree(report);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "purge") && c->argc == 2) {
-        if (zmallocTrim() == 0)
+        if (zmalloc_purge() == 0)
             addReply(c, shared.ok);
         else
             addReplyError(c, "Error purging dirty pages");

--- a/src/object.c
+++ b/src/object.c
@@ -1924,10 +1924,7 @@ void memoryCommand(client *c) {
         addReplyVerbatim(c, report, sdslen(report), "txt");
         sdsfree(report);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "purge") && c->argc == 2) {
-        /* jemalloc_purge() also calls zlibc_trim() to release free pages
-         * of the libc main arena back to the OS on glibc systems; see the
-         * comment above zlibc_trim() in zmalloc.c. */
-        if (jemalloc_purge() == 0)
+        if (zmallocTrim() == 0)
             addReply(c, shared.ok);
         else
             addReplyError(c, "Error purging dirty pages");

--- a/src/object.c
+++ b/src/object.c
@@ -1924,19 +1924,10 @@ void memoryCommand(client *c) {
         addReplyVerbatim(c, report, sdslen(report), "txt");
         sdsfree(report);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "purge") && c->argc == 2) {
-        int err = jemalloc_purge();
-        /* Also release free pages from the libc main arena back to the OS.
-         * When jemalloc is built with a prefix (the default for the bundled
-         * copy), libc-internal allocations made by glibc itself (for example
-         * from getaddrinfo(3), pthread internals, NSS or stdio) are served
-         * by libc malloc and live in the [heap] segment grown via sbrk(2).
-         * That memory is invisible to jemalloc and is rarely returned to the
-         * OS automatically, which can show up as a large rss_overhead and a
-         * high mem_fragmentation_ratio on long running instances. Calling
-         * malloc_trim(3) here lets the operator reclaim it on demand. The
-         * helper is a no-op on non-glibc builds. */
-        zlibc_trim();
-        if (err == 0)
+        /* jemalloc_purge() also calls zlibc_trim() to release free pages
+         * of the libc main arena back to the OS on glibc systems; see the
+         * comment above zlibc_trim() in zmalloc.c. */
+        if (jemalloc_purge() == 0)
             addReply(c, shared.ok);
         else
             addReplyError(c, "Error purging dirty pages");

--- a/src/object.c
+++ b/src/object.c
@@ -1609,7 +1609,9 @@ sds getMemoryDoctorReport(void) {
             s = sdscatprintf(
                 s, " * High process RSS overhead: This instance has non-allocator RSS memory overhead is greater than "
                    "1.1 (this means that the Resident Set Size of the Valkey process is much larger than the RSS the "
-                   "allocator holds). This problem may be due to Lua scripts or Modules.\n\n");
+                   "allocator holds). This problem may be due to Lua scripts, Modules, or, on glibc systems, memory "
+                   "retained in the libc main arena (the [heap] segment) by libc-internal allocations such as "
+                   "getaddrinfo(3), pthread internals or NSS. Try the MEMORY PURGE command to reclaim it.\n\n");
         }
         if (big_replica_buf) {
             s = sdscat(s,
@@ -1753,7 +1755,9 @@ void memoryCommand(client *c) {
             "MALLOC-STATS",
             "    Return internal statistics report from the memory allocator.",
             "PURGE",
-            "    Attempt to purge dirty pages for reclamation by the allocator.",
+            "    Attempt to purge dirty pages so they can be reclaimed by the allocator.",
+            "    On glibc systems this also releases free pages from the libc main arena",
+            "    (the process [heap] segment) back to the OS via malloc_trim(3).",
             "STATS",
             "    Return information about the memory usage of the server.",
             "USAGE <key> [SAMPLES <count>]",
@@ -1920,7 +1924,19 @@ void memoryCommand(client *c) {
         addReplyVerbatim(c, report, sdslen(report), "txt");
         sdsfree(report);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "purge") && c->argc == 2) {
-        if (jemalloc_purge() == 0)
+        int err = jemalloc_purge();
+        /* Also release free pages from the libc main arena back to the OS.
+         * When jemalloc is built with a prefix (the default for the bundled
+         * copy), libc-internal allocations made by glibc itself (for example
+         * from getaddrinfo(3), pthread internals, NSS or stdio) are served
+         * by libc malloc and live in the [heap] segment grown via sbrk(2).
+         * That memory is invisible to jemalloc and is rarely returned to the
+         * OS automatically, which can show up as a large rss_overhead and a
+         * high mem_fragmentation_ratio on long running instances. Calling
+         * malloc_trim(3) here lets the operator reclaim it on demand. The
+         * helper is a no-op on non-glibc builds. */
+        zlibc_trim();
+        if (err == 0)
             addReply(c, shared.ok);
         else
             addReplyError(c, "Error purging dirty pages");

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -831,7 +831,7 @@ void set_jemalloc_bg_thread(int enable) {
 
 #endif
 
-int zmallocTrim(void) {
+int zmalloc_purge(void) {
     int ret = 0;
 #if defined(USE_JEMALLOC)
     /* Return all unused (reserved) jemalloc pages to the OS. */
@@ -848,13 +848,10 @@ int zmallocTrim(void) {
     return ret;
 }
 
-/* Trim free pages of the libc main arena back to the OS via malloc_trim(3).
- *
- * Even when jemalloc is in use, libc-internal allocations - from
- * getaddrinfo(3), NSS lookups, pthread internals, stdio buffers or any
- * module that calls malloc() directly - are served by libc malloc and
- * live in the [heap] segment grown via sbrk(2). That memory is invisible
- * to jemalloc and is rarely returned to the OS automatically. */
+/* Release free pages of the libc main arena back to the OS via malloc_trim(3).
+ * Even with jemalloc, libc-internal allocations (getaddrinfo(3), NSS, pthread,
+ * stdio, or modules calling malloc() directly) live in the [heap] segment and
+ * are otherwise rarely returned to the OS. */
 void zlibc_trim(void) {
 #if defined(__GLIBC__) && !defined(USE_LIBC)
     malloc_trim(0);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -818,14 +818,18 @@ void set_jemalloc_bg_thread(int enable) {
 
 int jemalloc_purge(void) {
     /* return all unused (reserved) pages to the OS */
+    int ret = -1;
     char tmp[32];
     unsigned narenas = 0;
     size_t sz = sizeof(unsigned);
     if (!je_mallctl("arenas.narenas", &narenas, &sz, NULL, 0)) {
         snprintf(tmp, sizeof(tmp), "arena.%d.purge", narenas);
-        if (!je_mallctl(tmp, NULL, 0, NULL, 0)) return 0;
+        if (!je_mallctl(tmp, NULL, 0, NULL, 0)) ret = 0;
     }
-    return -1;
+    /* Also release free pages of the libc main arena back to the OS,
+     * see the comment above zlibc_trim() below. */
+    zlibc_trim();
+    return ret;
 }
 
 #else
@@ -842,12 +846,29 @@ void set_jemalloc_bg_thread(int enable) {
 }
 
 int jemalloc_purge(void) {
+    /* Even when jemalloc is not in use, callers ask the allocator to
+     * return memory to the OS. Trim the libc main arena where possible;
+     * zlibc_trim() is a no-op on non-glibc builds. */
+    zlibc_trim();
     return 0;
 }
 
 #endif
 
-/* This function provides us access to the libc malloc_trim(). */
+/* This function provides us access to the libc malloc_trim(3).
+ *
+ * When jemalloc is built with a prefix (the default for the bundled copy),
+ * libc-internal allocations made by glibc itself - for example from
+ * getaddrinfo(3), NSS lookups, pthread internals, stdio buffers or any
+ * module that calls malloc() directly - are served by libc malloc rather
+ * than jemalloc, and live in the libc main arena, growing the program
+ * break (the [heap] segment) via sbrk(2). That memory is invisible to
+ * jemalloc and is rarely returned to the OS automatically.
+ *
+ * jemalloc_purge() therefore also calls this helper so that whenever we
+ * ask the allocator to release memory - from MEMORY PURGE, FLUSHDB and
+ * FLUSHALL in their synchronous form - we also release free pages of
+ * the libc main arena back to the OS. */
 void zlibc_trim(void) {
 #if defined(__GLIBC__) && !defined(USE_LIBC)
     malloc_trim(0);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -816,22 +816,6 @@ void set_jemalloc_bg_thread(int enable) {
     je_mallctl("background_thread", NULL, 0, &val, 1);
 }
 
-int jemalloc_purge(void) {
-    /* return all unused (reserved) pages to the OS */
-    int ret = -1;
-    char tmp[32];
-    unsigned narenas = 0;
-    size_t sz = sizeof(unsigned);
-    if (!je_mallctl("arenas.narenas", &narenas, &sz, NULL, 0)) {
-        snprintf(tmp, sizeof(tmp), "arena.%d.purge", narenas);
-        if (!je_mallctl(tmp, NULL, 0, NULL, 0)) ret = 0;
-    }
-    /* Also release free pages of the libc main arena back to the OS,
-     * see the comment above zlibc_trim() below. */
-    zlibc_trim();
-    return ret;
-}
-
 #else
 
 int zmalloc_get_allocator_info(size_t *allocated, size_t *active, size_t *resident, size_t *retained, size_t *muzzy) {
@@ -845,30 +829,32 @@ void set_jemalloc_bg_thread(int enable) {
     ((void)(enable));
 }
 
-int jemalloc_purge(void) {
-    /* Even when jemalloc is not in use, callers ask the allocator to
-     * return memory to the OS. Trim the libc main arena where possible;
-     * zlibc_trim() is a no-op on non-glibc builds. */
-    zlibc_trim();
-    return 0;
-}
-
 #endif
 
-/* This function provides us access to the libc malloc_trim(3).
+int zmallocTrim(void) {
+    int ret = 0;
+#if defined(USE_JEMALLOC)
+    /* Return all unused (reserved) jemalloc pages to the OS. */
+    char tmp[32];
+    unsigned narenas = 0;
+    size_t sz = sizeof(unsigned);
+    ret = -1;
+    if (!je_mallctl("arenas.narenas", &narenas, &sz, NULL, 0)) {
+        snprintf(tmp, sizeof(tmp), "arena.%d.purge", narenas);
+        if (!je_mallctl(tmp, NULL, 0, NULL, 0)) ret = 0;
+    }
+#endif
+    zlibc_trim();
+    return ret;
+}
+
+/* Trim free pages of the libc main arena back to the OS via malloc_trim(3).
  *
- * When jemalloc is built with a prefix (the default for the bundled copy),
- * libc-internal allocations made by glibc itself - for example from
+ * Even when jemalloc is in use, libc-internal allocations - from
  * getaddrinfo(3), NSS lookups, pthread internals, stdio buffers or any
- * module that calls malloc() directly - are served by libc malloc rather
- * than jemalloc, and live in the libc main arena, growing the program
- * break (the [heap] segment) via sbrk(2). That memory is invisible to
- * jemalloc and is rarely returned to the OS automatically.
- *
- * jemalloc_purge() therefore also calls this helper so that whenever we
- * ask the allocator to release memory - from MEMORY PURGE, FLUSHDB and
- * FLUSHALL in their synchronous form - we also release free pages of
- * the libc main arena back to the OS. */
+ * module that calls malloc() directly - are served by libc malloc and
+ * live in the [heap] segment grown via sbrk(2). That memory is invisible
+ * to jemalloc and is rarely returned to the OS automatically. */
 void zlibc_trim(void) {
 #if defined(__GLIBC__) && !defined(USE_LIBC)
     malloc_trim(0);

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -135,7 +135,7 @@ void zmalloc_set_oom_handler(void (*oom_handler)(size_t));
 size_t zmalloc_get_rss(void);
 int zmalloc_get_allocator_info(size_t *allocated, size_t *active, size_t *resident, size_t *retained, size_t *muzzy);
 void set_jemalloc_bg_thread(int enable);
-int jemalloc_purge(void);
+int zmallocTrim(void);
 size_t zmalloc_get_private_dirty(long pid);
 size_t zmalloc_get_smap_bytes_by_field(char *field, long pid);
 size_t zmalloc_get_memory_size(void);

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -135,7 +135,7 @@ void zmalloc_set_oom_handler(void (*oom_handler)(size_t));
 size_t zmalloc_get_rss(void);
 int zmalloc_get_allocator_info(size_t *allocated, size_t *active, size_t *resident, size_t *retained, size_t *muzzy);
 void set_jemalloc_bg_thread(int enable);
-int zmallocTrim(void);
+int zmalloc_purge(void);
 size_t zmalloc_get_private_dirty(long pid);
 size_t zmalloc_get_smap_bytes_by_field(char *field, long pid);
 size_t zmalloc_get_memory_size(void);


### PR DESCRIPTION
## Summary

This PR makes `MEMORY PURGE` also release free pages from the libc main arena
(the process `[heap]` segment) back to the OS, in addition to purging
jemalloc dirty pages. It also extends the memory doctor diagnostic for high
process-RSS overhead and updates the `MEMORY HELP` text.

Fixes #3517.

## Why

When jemalloc is built with a prefix (the default for the bundled copy
shipped under `deps/jemalloc`, configured with
`--with-jemalloc-prefix=je_` in `deps/Makefile`), only Valkey's own
`zmalloc`/`zfree` calls reach jemalloc. Any allocation that goes through
plain `malloc(3)` — most notably libc-internal allocations made by glibc
itself, e.g. from `getaddrinfo(3)`, NSS lookups, pthread internals or
stdio — is served by libc malloc and lives in the main arena, growing the
program break (the `[heap]` segment) via `sbrk(2)`.

That memory is invisible to jemalloc, and glibc rarely returns it to the
OS automatically: `sbrk(2)` can only shrink the heap from the top, so a
single live allocation near the top of the heap is enough to pin a multi-
gigabyte segment. Over long uptimes the `[heap]` segment can grow to many
gigabytes while jemalloc itself reports a healthy footprint, which shows
up as a large `rss_overhead_bytes` and a high `mem_fragmentation_ratio` in
`INFO MEMORY`.

This is exactly what is reported in #3517 on a Valkey 8.1.6 cluster master
with ~41 days of uptime:

| Metric | Value |
| --- | --- |
| `used_memory` | 2.59 GiB |
| `used_memory_rss` | 9.43 GiB |
| `mem_fragmentation_ratio` | 3.64 |
| `allocator_frag_ratio` | 1.00 (jemalloc is healthy) |
| `allocator_resident` | 2.64 GiB |
| `rss_overhead_bytes` | 6.79 GiB |

The submitted `/proc/<pid>/smaps` shows a single `[heap]` mapping of
`Size: 7110580 kB` (~6.78 GiB), which exactly accounts for the
`rss_overhead`.

The codebase already had a `zlibc_trim()` helper that wraps
`malloc_trim(3)` — the standard glibc primitive for releasing free pages
of the main arena back to the OS — but the helper was only invoked from
the Lua engine after `lua_close` (see `src/modules/lua/engine_lua.c`).
`MEMORY PURGE` only called `jemalloc_purge()`, leaving operators on glibc
with no built-in way to reclaim the libc heap and confused by the fact
that PURGE did nothing for the symptom they were observing.

## What the change does

1. `MEMORY PURGE` now also calls `zlibc_trim()` after `jemalloc_purge()`.
   The two operations are independent, so the result code reported to the
   client is still driven by `jemalloc_purge()`.
2. The `MEMORY HELP` text for `PURGE` is updated to mention the libc main
   arena behavior on glibc.
3. The memory doctor `high_proc_rss` diagnostic, which currently only
   blames Lua scripts or modules, now also mentions libc-internal
   allocations as a possible cause on glibc and suggests `MEMORY PURGE`.

The helper is already a no-op on non-glibc builds (gated on `__GLIBC__`
and `!USE_LIBC` inside `zlibc_trim`), so this change has no effect on
macOS, FreeBSD or musl-based Linux.

## Verification

Built on Ubuntu 22.04 / glibc 2.35 / gcc 11.4. Ran the resulting
`valkey-server` under `strace -f -e trace=brk,madvise` to confirm that
`MEMORY PURGE` now drives `malloc_trim(3)`:

```
[heap] size before activity: 135168 bytes
[heap] size after libc-heap-touching activity: 135168 bytes
--- MEMORY PURGE ---
OK
[heap] size after PURGE: 114688 bytes

10287 brk(0x5bbba6d19000)               = 0x5bbba6d19000
10287 madvise(0x750f8085f000, 4096,  MADV_DONTNEED) = 0
10287 madvise(0x750f80888000, 12288, MADV_DONTNEED) = 0
10287 madvise(0x750f8094b000, 12288, MADV_DONTNEED) = 0
10287 madvise(0x750f8081d000, 8192,  MADV_DONTNEED) = 0
10287 madvise(0x750f80865000, 16384, MADV_DONTNEED) = 0
10287 madvise(0x750f80828000, 24576, MADV_DONTNEED) = 0
10287 madvise(0x750f80810000, 49152, MADV_DONTNEED) = 0
10287 brk(0x5bbba6d14000)               = 0x5bbba6d14000
```

The `madvise(MADV_DONTNEED)` calls release physical pages of free
chunks; the final `brk(<lower>)` lowers the program break — exactly
what the reporter needs to reclaim those 6.8 GiB on demand. Activity in
this reproducer was generated by issuing many `CLUSTER MEET` commands
against bogus hostnames, which calls `getaddrinfo(3)` and grows the
libc heap.

The `MEMORY HELP` and `MEMORY DOCTOR` outputs were also exercised
manually and look correct.

## Notes for reviewers

- This intentionally keeps the change minimal and on-demand. A periodic
  invocation from `serverCron` was considered, but `malloc_trim(0)`
  walks all glibc arenas and locks them briefly, so I'd rather not
  change default cron behavior in the same patch. Happy to add it as a
  follow-up (gated by a config option) if maintainers prefer.
- This should be safe to backport to 8.1.x and 8.0.x: it only adds a
  call that is a no-op on non-glibc and only does work when there are
  free pages to release.
- No new tests are added because the existing `tests/` suite does not
  cover `MEMORY PURGE` and a deterministic test for `malloc_trim`
  side effects would depend on libc-internal state. I am happy to add a
  smoke test that just exercises the new code path if requested.
