### PR TITLE
MONITOR TRACE: key-level access tracing with sampling

### DIFF
--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -26,6 +26,7 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/networking.c
     ${CMAKE_SOURCE_DIR}/src/util.c
     ${CMAKE_SOURCE_DIR}/src/object.c
+    ${CMAKE_SOURCE_DIR}/src/workload_trace.c
     ${CMAKE_SOURCE_DIR}/src/db.c
     ${CMAKE_SOURCE_DIR}/src/replication.c
     ${CMAKE_SOURCE_DIR}/src/rdb.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -534,6 +534,7 @@ ENGINE_SERVER_OBJ = \
     networking.o \
     notify.o \
     object.o \
+    workload_trace.o \
     pqsort.o \
     pubsub.o \
     quicklist.o \

--- a/src/commands.def
+++ b/src/commands.def
@@ -8381,6 +8381,50 @@ struct COMMAND_STRUCT MODULE_Subcommands[] = {
 #define MODULE_Keyspecs NULL
 #endif
 
+/********** MONITOR TRACE ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* MONITOR TRACE history */
+#define MONITOR_TRACE_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* MONITOR TRACE tips */
+#define MONITOR_TRACE_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* MONITOR TRACE key specs */
+#define MONITOR_TRACE_Keyspecs NULL
+#endif
+
+/* MONITOR TRACE negative_lookups argument table */
+struct COMMAND_ARG MONITOR_TRACE_negative_lookups_Subargs[] = {
+{MAKE_ARG("yes",ARG_TYPE_PURE_TOKEN,-1,"YES",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("no",ARG_TYPE_PURE_TOKEN,-1,"NO",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* MONITOR TRACE format argument table */
+struct COMMAND_ARG MONITOR_TRACE_format_Subargs[] = {
+{MAKE_ARG("resp",ARG_TYPE_PURE_TOKEN,-1,"RESP",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("csv",ARG_TYPE_PURE_TOKEN,-1,"CSV",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* MONITOR TRACE argument table */
+struct COMMAND_ARG MONITOR_TRACE_Args[] = {
+{MAKE_ARG("samples",ARG_TYPE_INTEGER,-1,"SAMPLES",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("negative-lookups",ARG_TYPE_ONEOF,-1,"NEGATIVE-LOOKUPS",NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=MONITOR_TRACE_negative_lookups_Subargs},
+{MAKE_ARG("format",ARG_TYPE_ONEOF,-1,"FORMAT",NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=MONITOR_TRACE_format_Subargs},
+{MAKE_ARG("rate",ARG_TYPE_DOUBLE,-1,"RATE",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("seed",ARG_TYPE_INTEGER,-1,"SEED",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
+};
+
+/* MONITOR command table */
+struct COMMAND_STRUCT MONITOR_Subcommands[] = {
+{MAKE_CMD("trace","Streams key-level access events for workload analysis.","O(1) to subscribe, then O(N) with the number of key accesses.","9.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,MONITOR_TRACE_History,0,MONITOR_TRACE_Tips,0,monitorCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,MONITOR_TRACE_Keyspecs,0,NULL,5),.args=MONITOR_TRACE_Args},
+{0}
+};
+
 /********** MONITOR ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -12033,7 +12077,7 @@ struct COMMAND_STRUCT serverCommandTable[] = {
 {MAKE_CMD("lolwut","Displays computer art and the server version.",NULL,"5.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,LOLWUT_History,0,LOLWUT_Tips,0,lolwutCommand,-1,CMD_READONLY|CMD_FAST,ACL_CATEGORY_FAST|ACL_CATEGORY_READ,NULL,LOLWUT_Keyspecs,0,NULL,1),.args=LOLWUT_Args},
 {MAKE_CMD("memory","A container for memory diagnostics commands.","Depends on subcommand.","4.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,MEMORY_History,0,MEMORY_Tips,0,NULL,-2,0,ACL_CATEGORY_SLOW,NULL,MEMORY_Keyspecs,0,NULL,0),.subcommands=MEMORY_Subcommands},
 {MAKE_CMD("module","A container for module commands.","Depends on subcommand.","4.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,MODULE_History,0,MODULE_Tips,0,NULL,-2,0,ACL_CATEGORY_SLOW,NULL,MODULE_Keyspecs,0,NULL,0),.subcommands=MODULE_Subcommands},
-{MAKE_CMD("monitor","Listens for all requests received by the server in real-time.",NULL,"1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,MONITOR_History,0,MONITOR_Tips,0,monitorCommand,1,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,MONITOR_Keyspecs,0,NULL,0)},
+{MAKE_CMD("monitor","A container for server monitoring commands.","Depends on subcommand.","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,MONITOR_History,0,MONITOR_Tips,0,monitorCommand,-1,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,MONITOR_Keyspecs,0,NULL,0),.subcommands=MONITOR_Subcommands},
 {MAKE_CMD("psync","An internal command used in replication.",NULL,"2.8.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,PSYNC_History,0,PSYNC_Tips,0,syncCommand,-3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NO_MULTI|CMD_NOSCRIPT,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,PSYNC_Keyspecs,0,NULL,2),.args=PSYNC_Args},
 {MAKE_CMD("replconf","An internal command for configuring the replication stream.","O(1)","3.0.0",CMD_DOC_SYSCMD,NULL,NULL,"server",COMMAND_GROUP_SERVER,REPLCONF_History,0,REPLCONF_Tips,0,replconfCommand,-1,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_ALLOW_BUSY,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,REPLCONF_Keyspecs,0,NULL,0)},
 {MAKE_CMD("replicaof","Configures a server as replica of another, or promotes it to a primary.","O(1)","5.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,REPLICAOF_History,0,REPLICAOF_Tips,0,replicaofCommand,3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,REPLICAOF_Keyspecs,0,NULL,1),.args=REPLICAOF_Args},

--- a/src/commands/monitor-trace.json
+++ b/src/commands/monitor-trace.json
@@ -1,0 +1,78 @@
+{
+    "TRACE": {
+        "summary": "Streams key-level access events for workload analysis.",
+        "complexity": "O(1) to subscribe, then O(N) with the number of key accesses.",
+        "group": "server",
+        "since": "9.0.0",
+        "arity": -2,
+        "container": "MONITOR",
+        "function": "monitorCommand",
+        "command_flags": [
+            "ADMIN",
+            "NOSCRIPT",
+            "LOADING",
+            "STALE"
+        ],
+        "acl_categories": [
+            "ADMIN",
+            "DANGEROUS",
+            "SLOW"
+        ],
+        "arguments": [
+            {
+                "name": "samples",
+                "token": "SAMPLES",
+                "type": "integer",
+                "optional": true
+            },
+            {
+                "name": "negative-lookups",
+                "token": "NEGATIVE-LOOKUPS",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "yes",
+                        "type": "pure-token",
+                        "token": "YES"
+                    },
+                    {
+                        "name": "no",
+                        "type": "pure-token",
+                        "token": "NO"
+                    }
+                ]
+            },
+            {
+                "name": "format",
+                "token": "FORMAT",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "resp",
+                        "type": "pure-token",
+                        "token": "RESP"
+                    },
+                    {
+                        "name": "csv",
+                        "type": "pure-token",
+                        "token": "CSV"
+                    }
+                ]
+            },
+            {
+                "name": "rate",
+                "token": "RATE",
+                "type": "double",
+                "optional": true
+            },
+            {
+                "name": "seed",
+                "token": "SEED",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/src/commands/monitor.json
+++ b/src/commands/monitor.json
@@ -1,9 +1,10 @@
 {
     "MONITOR": {
-        "summary": "Listens for all requests received by the server in real-time.",
+        "summary": "A container for server monitoring commands.",
+        "complexity": "Depends on subcommand.",
         "group": "server",
         "since": "1.0.0",
-        "arity": 1,
+        "arity": -1,
         "function": "monitorCommand",
         "command_flags": [
             "ADMIN",

--- a/src/db.c
+++ b/src/db.c
@@ -28,6 +28,7 @@
  */
 
 #include "server.h"
+#include "workload_trace.h"
 #include "cluster.h"
 #include "cluster_migrateslots.h"
 #include "latency.h"
@@ -120,6 +121,12 @@ robj *lookupKey(serverDb *db, robj *key, int flags) {
         if (!(flags & (LOOKUP_NONOTIFY | LOOKUP_WRITE))) notifyKeyspaceEvent(NOTIFY_KEY_MISS, "keymiss", key, db->id);
         if (!(flags & (LOOKUP_NOSTATS | LOOKUP_WRITE))) server.stat_keyspace_misses++;
         /* TODO: Use separate misses stats and notify event for WRITE */
+    }
+
+    /* Emit workload trace READ event for non-write lookups.
+     * Write-path lookups (LOOKUP_WRITE) get traced as WRITE events in setKey/dbAdd. */
+    if (workloadTraceActive() && !(flags & LOOKUP_WRITE)) {
+        workloadTraceEmitRead(db, key, val);
     }
 
     return val;
@@ -480,6 +487,11 @@ int dbGenericDeleteWithDictIndex(serverDb *db, robj *key, int async, int flags, 
         /* VM_StringDMA may call dbUnshareStringValue which may free val, so we
          * need to incr to retain val */
         incrRefCount(val);
+        /* Emit workload trace DELETE event before the object is freed.
+         * Skip expired keys — expiry is a server-side mechanism, not a workload event. */
+        if (workloadTraceActive() && !(flags & DB_FLAG_KEY_EXPIRED)) {
+            workloadTraceEmitDelete(db, key, val);
+        }
         /* Tells the module that the key has been unlinked from the database. */
         moduleNotifyKeyUnlink(key, val, db->id, flags);
         /* We want to try to unblock any module clients or clients using a blocking XREADGROUP */
@@ -755,6 +767,12 @@ long long dbTotalServerKeyCount(void) {
 void signalModifiedKey(client *c, serverDb *db, robj *key) {
     touchWatchedKey(db, key);
     trackingInvalidateKey(c, key, 1);
+    if (workloadTraceActive()) {
+        /* Extra lookup cost is acceptable: only paid when tracing is active,
+         * and avoids changing 77+ signalModifiedKey call sites. */
+        robj *val = dbFind(db, objectGetVal(key));
+        if (val) workloadTraceEmitWrite(db, key, val);
+    }
 }
 
 void signalFlushedDb(int dbid, int async) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -37,6 +37,7 @@
 #include "fpconv_dtoa.h"
 #include "fmtargs.h"
 #include "io_threads.h"
+#include "workload_trace.h"
 #include "module.h"
 #include "connection.h"
 #include "zmalloc.h"
@@ -353,6 +354,7 @@ client *createClient(connection *conn) {
     c->bstate = NULL;
     c->pubsub_data = NULL;
     c->module_data = NULL;
+    c->workload_tracer_config = NULL;
     c->mstate = NULL;
     c->woff = 0;
     c->peerid = NULL;
@@ -2081,6 +2083,10 @@ void clearClientConnectionState(client *c) {
     serverAssert(!(c->flag.replica || c->flag.primary || c->slot_migration_job));
 
     if (c->flag.tracking) disableTracking(c);
+
+    /* Clean up workload tracer subscription */
+    workloadTraceDetachClient(c);
+
     selectDb(c, 0);
 #ifdef LOG_REQ_RES
     c->resp = server.client_default_resp;
@@ -2193,6 +2199,9 @@ int freeClient(client *c) {
 
     freeClientBlockingState(c);
     freeClientPubSubData(c);
+
+    /* Clean up workload tracer subscription */
+    workloadTraceDetachClient(c);
 
     /* Free data structures. */
     releaseReplyReferences(c);

--- a/src/server.c
+++ b/src/server.c
@@ -48,6 +48,7 @@
 #include "fmtargs.h"
 #include "io_threads.h"
 #include "tls.h"
+#include "workload_trace.h"
 #include "sds.h"
 #include "module.h"
 #include "scripting_engine.h"
@@ -2952,6 +2953,7 @@ void initServer(void) {
     server.clients_to_close = listCreate();
     server.replicas = listCreate();
     server.monitors = listCreate();
+    workloadTraceInit();
     server.replicas_waiting_psync = raxNew();
     server.wait_before_rdb_client_free = DEFAULT_WAIT_BEFORE_RDB_CLIENT_FREE;
     server.clients_pending_write = listCreate();
@@ -3939,7 +3941,16 @@ void call(client *c, int flags) {
         }
     }
 
+    workloadTraceContext prev_trace_ctx;
+    bool trace_was_active = workloadTraceActive();
+    if (trace_was_active) {
+        prev_trace_ctx = workloadTraceSaveContext();
+        workloadTraceBeginCommand(c);
+    }
     c->cmd->proc(c);
+    if (trace_was_active) {
+        workloadTraceEndCommand(&prev_trace_ctx);
+    }
 
     if (c->flag.argv_borrowed && server.enable_debug_assert) {
         robj **argv = c->original_argv ? c->original_argv : c->argv;
@@ -4634,6 +4645,17 @@ int processCommand(client *c) {
                                       c->cmd->fullname);
         sdsmapchars(pubsub_err, "\r\n", "  ", 2);
         rejectCommandSds(c, pubsub_err, 1);
+        return C_OK;
+    }
+
+    /* Workload tracer clients are in streaming mode like MONITOR.
+     * Only allow PING, QUIT, and RESET. */
+    if (c->flag.workload_tracer && c->cmd->proc != pingCommand && c->cmd->proc != quitCommand &&
+        c->cmd->proc != resetCommand) {
+        rejectCommandSds(c,
+                         sdsnew("Can't execute commands while in MONITOR TRACE mode: "
+                                "only PING / QUIT / RESET are allowed"),
+                         1);
         return C_OK;
     }
 
@@ -6864,6 +6886,23 @@ void monitorCommand(client *c) {
          * A client that has CLIENT_DENY_BLOCKING flag on
          * expects a reply per command and so can't execute MONITOR. */
         addReplyError(c, "MONITOR isn't allowed for DENY BLOCKING client");
+        return;
+    }
+
+    /* MONITOR TRACE [SAMPLES n] [NEGATIVE-LOOKUPS yes|no] [FORMAT resp|csv] */
+    if (c->argc >= 2 && !strcasecmp(objectGetVal(c->argv[1]), "trace")) {
+        if (monitorTraceSetup(c, 2) == C_OK) {
+            workloadTracerConfig *cfg = c->workload_tracer_config;
+            if (cfg->sample_rate < 1.0) {
+                sds msg = sdscatprintf(sdsempty(),
+                                       "+OK sample_mode=key-hash rate=%.10g seed=%llu threshold=%llu\r\n",
+                                       cfg->sample_rate, (unsigned long long)cfg->sample_seed,
+                                       (unsigned long long)cfg->sample_threshold);
+                addReplySds(c, msg);
+            } else {
+                addReply(c, shared.ok);
+            }
+        }
         return;
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -1193,6 +1193,7 @@ typedef struct ClientFlags {
     uint64_t keyspace_notified : 1;        /* Indicates that a keyspace notification was triggered during the execution of the
                                               current command. */
     uint64_t argv_borrowed : 1;            /* The argv array and its elements are borrowed from the caller (VM_CallArgv) and must not be freed. */
+    uint64_t workload_tracer : 1;          /* This client is subscribed to MONITOR TRACE events. */
 } ClientFlags;
 /* Ensure ClientFlags never silently grows beyond two uint64_t words.
  * If this fires, move a flag to a separate field or widen the limit. */
@@ -1323,6 +1324,7 @@ typedef struct client {
     serverDb *db;                     /* Pointer to currently SELECTed DB. */
     /* Client state structs. */
     ClientPubSubData *pubsub_data;    /* Required for: pubsub commands and tracking. lazily initialized when first needed */
+    void *workload_tracer_config;     /* workloadTracerConfig* when flag.workload_tracer is set */
     ClientReplicationData *repl_data; /* Required for Replication operations. lazily initialized when first needed */
     ClientModuleData *module_data;    /* Required for Module operations. lazily initialized when first needed */
     multiState *mstate;               /* MULTI/EXEC state, lazily initialized when first needed */
@@ -1808,6 +1810,7 @@ struct valkeyServer {
     list *clients_to_close;                /* Clients to close asynchronously */
     list *clients_pending_write;           /* There is to write or install handler. */
     list *replicas, *monitors;             /* List of replicas and MONITORs */
+    list *workload_tracers;                /* List of MONITOR TRACE subscribers */
     rax *replicas_waiting_psync;           /* Radix tree for tracking replicas awaiting partial synchronization.
                                             * Key: RDB client ID
                                             * Value: RDB client object
@@ -4166,6 +4169,7 @@ int verifyDumpPayload(unsigned char *p, size_t len, uint16_t *rdbver_ptr);
 void dumpCommand(client *c);
 void objectCommand(client *c);
 void memoryCommand(client *c);
+size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid);
 void clientCommand(client *c);
 void clientHelpCommand(client *c);
 void clientIDCommand(client *c);

--- a/src/workload_trace.c
+++ b/src/workload_trace.c
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* workload_trace.c - MONITOR TRACE: key-level access tracing for workload analysis.
+ *
+ * Streams key-level access events (read, write, delete) to subscribed clients,
+ * enabling offline simulation of cache eviction policies and workload analysis.
+ *
+ * Architecture:
+ *   call()          -> workloadTraceBeginCommand/EndCommand (sets trace context)
+ *   lookupKey()     -> workloadTraceEmitRead  (key access)
+ *   setKey/dbAdd()  -> workloadTraceEmitWrite (key mutation)
+ *   dbDelete()      -> workloadTraceEmitDelete
+ */
+
+#include "workload_trace.h"
+
+/* File-scoped trace state (safe: command execution is single-threaded). */
+static workloadTraceContext trace_ctx = {0};
+static uint64_t trace_seq_counter = 0;
+
+/* Initialize the workload tracers list. Called once during server startup. */
+void workloadTraceInit(void) {
+    server.workload_tracers = listCreate();
+}
+
+/* Remove a client from the workload tracers list and free its config.
+ * Safe to call even if the client is not a tracer. */
+void workloadTraceDetachClient(client *c) {
+    if (!c->flag.workload_tracer) return;
+    listNode *ln = listSearchKey(server.workload_tracers, c);
+    if (ln) listDelNode(server.workload_tracers, ln);
+    zfree(c->workload_tracer_config);
+    c->workload_tracer_config = NULL;
+    c->flag.workload_tracer = 0;
+}
+
+/* --- Trace context management --- */
+
+/* Save the current command name and increment the sequence counter.
+ * Called from call() before command execution. No-op if no tracers active. */
+void workloadTraceBeginCommand(client *c) {
+    if (!workloadTraceActive()) return;
+    trace_ctx.cmd_name = c->cmd ? c->cmd->fullname : "unknown";
+    trace_ctx.seq = ++trace_seq_counter;
+}
+
+/* Restore the previous trace context. Called from call() after command execution.
+ * Supports nested command execution (modules, scripts).
+ * Preserves the current seq to maintain monotonicity across nested calls. */
+void workloadTraceEndCommand(workloadTraceContext *prev) {
+    uint64_t current_seq = trace_ctx.seq;
+    trace_ctx = *prev;
+    trace_ctx.seq = current_seq;
+}
+
+/* Capture the current trace context for later restoration. */
+workloadTraceContext workloadTraceSaveContext(void) {
+    return trace_ctx;
+}
+
+/* --- Size computation --- */
+
+/* Report the key entry allocation cost (zmalloc_size of the stored robj).
+ * When the value is embedded (EMBSTR/hasembval), this includes everything.
+ * When external (RAW), this is the robj + embedded key allocation only. */
+static size_t computeKeyBytes(robj *val) {
+    return zmalloc_size(val);
+}
+
+/* Report the value size. Returns 0 for embedded values (already in key_bytes).
+ * For external strings: sdsAllocSize of the separate SDS.
+ * For complex types: objectComputeSize minus the robj allocation when samples >= 0.
+ * samples=-1 means fast path (zmalloc_size only, no deep traversal).
+ * samples=0 means sample all (matches MEMORY USAGE SAMPLES 0 semantics). */
+static size_t computeValueBytes(robj *key, robj *val, int samples, int dbid) {
+    if (val == NULL) return 0;
+    if (val->hasembval) return 0; /* Value embedded in the robj allocation */
+    if (val->type == OBJ_STRING) {
+        if (val->encoding == OBJ_ENCODING_INT) return 0;
+        return sdsAllocSize(objectGetVal(val));
+    }
+    /* Complex types */
+    if (samples >= 0) {
+        size_t sample_size = (samples == 0) ? LLONG_MAX : (size_t)samples;
+        size_t total = objectComputeSize(key, val, sample_size, dbid);
+        size_t overhead = zmalloc_size(val);
+        return (total <= overhead) ? 0 : total - overhead;
+    }
+    /* samples=-1: fast path */
+    return zmalloc_size(objectGetVal(val));
+}
+
+/* --- Event formatting and emission --- */
+
+/* Return the string name for an access type constant. */
+static const char *accessTypeName(int access_type) {
+    switch (access_type) {
+    case WORKLOAD_ACCESS_READ: return "READ";
+    case WORKLOAD_ACCESS_WRITE: return "WRITE";
+    case WORKLOAD_ACCESS_DELETE: return "DELETE";
+    default: return "UNKNOWN";
+    }
+}
+
+/* Emit a trace event as a RESP array (10 elements, binary-safe keys). */
+static void emitEventResp(client *tracer, long long ts_us, uint64_t seq, int db_id, const char *cmd, robj *key, int access_type, int key_exists, const char *obj_type, size_t key_bytes, size_t value_bytes) {
+    /* RESP array with 10 elements */
+    addReplyArrayLen(tracer, 10);
+    addReplyLongLong(tracer, ts_us);                          /* ts_us */
+    addReplyLongLong(tracer, (long long)seq);                 /* seq */
+    addReplyLongLong(tracer, db_id);                          /* db */
+    addReplyBulkCString(tracer, cmd);                         /* cmd */
+    addReplyBulk(tracer, key);                                /* key (binary-safe) */
+    addReplyBulkCString(tracer, accessTypeName(access_type)); /* access_type */
+    addReplyLongLong(tracer, key_exists);                     /* key_exists */
+    addReplyBulkCString(tracer, obj_type);                    /* obj_type */
+    addReplyLongLong(tracer, (long long)key_bytes);           /* key_bytes */
+    if (key_exists) {
+        addReplyLongLong(tracer, (long long)value_bytes); /* value_bytes */
+    } else {
+        addReplyNull(tracer);
+    }
+}
+
+/* Emit a trace event as a RESP simple-string CSV line (RFC 4180 key quoting). */
+static void emitEventCsv(client *tracer, long long ts_us, uint64_t seq, int db_id, const char *cmd, robj *key, int access_type, int key_exists, const char *obj_type, size_t key_bytes, size_t value_bytes) {
+    sds line = sdscatprintf(sdsempty(), "+%lld,%llu,%d,%s,",
+                            ts_us, (unsigned long long)seq, db_id, cmd);
+    /* RFC 4180 CSV escaping: enclose in double-quotes, double any internal quotes.
+     * Also encode bytes outside printable ASCII as \xHH for binary safety. */
+    sds keystr = objectGetVal(key);
+    size_t keylen = sdslen(keystr);
+    line = sdscatlen(line, "\"", 1);
+    for (size_t i = 0; i < keylen; i++) {
+        unsigned char ch = keystr[i];
+        if (ch == '"') {
+            line = sdscatlen(line, "\"\"", 2);
+        } else if (ch < 32 || ch == 127 || ch > 127) {
+            /* Non-printable: hex escape for binary safety */
+            line = sdscatprintf(line, "\\x%02x", ch);
+        } else {
+            line = sdscatlen(line, &keystr[i], 1);
+        }
+    }
+    line = sdscatlen(line, "\"", 1);
+    line = sdscatprintf(line, ",%s,%d,%s,%zu,",
+                        accessTypeName(access_type), key_exists, obj_type, key_bytes);
+    if (key_exists) {
+        line = sdscatprintf(line, "%zu", value_bytes);
+    }
+    line = sdscatlen(line, "\r\n", 2);
+    addReplySds(tracer, line);
+}
+
+extern uint64_t siphash(const uint8_t *in, const size_t inlen, const uint8_t *k);
+
+/* Determine if a key should be traced based on hash-based sampling.
+ * Returns 1 if the key's SipHash is within the configured threshold. */
+static int keySampled(workloadTracerConfig *cfg, robj *key) {
+    if (cfg->sample_threshold == UINT64_MAX) return 1; /* rate=1.0 fast path */
+    if (cfg->sample_threshold == 0) return 0;          /* rate=0 fast path */
+    /* Keys from command argv are always SDS-encoded (never integer-encoded). */
+    serverAssert(key->encoding == OBJ_ENCODING_RAW || key->encoding == OBJ_ENCODING_EMBSTR);
+    sds keystr = objectGetVal(key);
+    uint64_t h = siphash((const uint8_t *)keystr, sdslen(keystr), cfg->sample_seed_bytes);
+    return h <= cfg->sample_threshold;
+}
+
+/* Core event emission: iterates all subscribed tracers, applies sampling and
+ * filtering, computes sizes, and emits in the configured format. */
+static void emitEvent(int access_type, serverDb *db, robj *key, robj *val) {
+    if (!workloadTraceActive()) return;
+    if (trace_ctx.cmd_name == NULL) return; /* No command context */
+
+    long long ts_us = ustime();
+    int key_exists = (val != NULL) ? 1 : 0;
+    const char *obj_type = "";
+    size_t key_bytes = 0;
+    size_t value_bytes = 0;
+
+    if (key_exists) {
+        obj_type = getObjectTypeName(val);
+    }
+
+    listIter li;
+    listNode *ln;
+    listRewind(server.workload_tracers, &li);
+    while ((ln = listNext(&li))) {
+        client *tracer = ln->value;
+        workloadTracerConfig *cfg = tracer->workload_tracer_config;
+        if (cfg == NULL) continue;
+
+        /* Key-hash sampling: deterministic per-key decision */
+        if (!keySampled(cfg, key)) continue;
+
+        /* Filter negative lookups if not requested */
+        if (!key_exists && access_type == WORKLOAD_ACCESS_READ && !cfg->negative_lookups) {
+            continue;
+        }
+
+        /* Compute sizes (once per unique sample config, but typically all tracers share config) */
+        if (key_exists) {
+            key_bytes = computeKeyBytes(val);
+            value_bytes = computeValueBytes(key, val, cfg->samples, db->id);
+        }
+
+        if (cfg->format == WORKLOAD_FORMAT_CSV) {
+            emitEventCsv(tracer, ts_us, trace_ctx.seq, db->id,
+                         trace_ctx.cmd_name, key, access_type, key_exists,
+                         obj_type, key_bytes, value_bytes);
+        } else {
+            emitEventResp(tracer, ts_us, trace_ctx.seq, db->id,
+                          trace_ctx.cmd_name, key, access_type, key_exists,
+                          obj_type, key_bytes, value_bytes);
+        }
+        updateClientMemUsageAndBucket(tracer);
+    }
+}
+
+/* --- Public event emitters --- */
+
+/* Emit a READ trace event. Called from lookupKey() for non-write lookups. */
+void workloadTraceEmitRead(serverDb *db, robj *key, robj *val) {
+    emitEvent(WORKLOAD_ACCESS_READ, db, key, val);
+}
+
+/* Emit a WRITE trace event. Called from signalModifiedKey(). */
+void workloadTraceEmitWrite(serverDb *db, robj *key, robj *val) {
+    emitEvent(WORKLOAD_ACCESS_WRITE, db, key, val);
+}
+
+/* Emit a DELETE trace event. Called from dbGenericDeleteWithDictIndex(). */
+void workloadTraceEmitDelete(serverDb *db, robj *key, robj *val) {
+    emitEvent(WORKLOAD_ACCESS_DELETE, db, key, val);
+}
+
+/* --- MONITOR TRACE setup (called from monitorCommand) --- */
+
+/* Parse TRACE options starting at argv[arg_start] and subscribe client.
+ * Returns C_OK on success, C_ERR if a reply was already sent. */
+int monitorTraceSetup(client *c, int arg_start) {
+    int samples = -1; /* -1 = fast path (no deep traversal), 0 = sample all, >0 = sample N */
+    int negative_lookups = 0;
+    int format = WORKLOAD_FORMAT_RESP;
+    double sample_rate = 1.0;
+    uint64_t sample_seed = 0; /* Default fixed seed */
+
+    for (int i = arg_start; i < c->argc; i++) {
+        if (!strcasecmp(objectGetVal(c->argv[i]), "samples") && i + 1 < c->argc) {
+            long long val;
+            if (getLongLongFromObjectOrReply(c, c->argv[i + 1], &val, NULL) != C_OK) return C_ERR;
+            if (val < 0 || val > INT_MAX) {
+                addReplyError(c, "SAMPLES must be >= 0 and <= 2147483647");
+                return C_ERR;
+            }
+            samples = (int)val;
+            i++;
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "negative-lookups") && i + 1 < c->argc) {
+            if (!strcasecmp(objectGetVal(c->argv[i + 1]), "yes")) {
+                negative_lookups = 1;
+            } else if (!strcasecmp(objectGetVal(c->argv[i + 1]), "no")) {
+                negative_lookups = 0;
+            } else {
+                addReplyError(c, "NEGATIVE-LOOKUPS must be yes or no");
+                return C_ERR;
+            }
+            i++;
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "format") && i + 1 < c->argc) {
+            if (!strcasecmp(objectGetVal(c->argv[i + 1]), "resp")) {
+                format = WORKLOAD_FORMAT_RESP;
+            } else if (!strcasecmp(objectGetVal(c->argv[i + 1]), "csv")) {
+                format = WORKLOAD_FORMAT_CSV;
+            } else {
+                addReplyError(c, "FORMAT must be resp or csv");
+                return C_ERR;
+            }
+            i++;
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "rate") && i + 1 < c->argc) {
+            double r;
+            if (getDoubleFromObjectOrReply(c, c->argv[i + 1], &r, "RATE must be a float") != C_OK)
+                return C_ERR;
+            if (r < 0.0 || r > 1.0) {
+                addReplyError(c, "RATE must be between 0 and 1");
+                return C_ERR;
+            }
+            sample_rate = r;
+            i++;
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "seed") && i + 1 < c->argc) {
+            long long s;
+            if (getLongLongFromObjectOrReply(c, c->argv[i + 1], &s, NULL) != C_OK) return C_ERR;
+            sample_seed = (uint64_t)s;
+            i++;
+        } else {
+            addReplyErrorObject(c, shared.syntaxerr);
+            return C_ERR;
+        }
+    }
+
+    /* Already tracing? Remove old subscription first. */
+    workloadTraceDetachClient(c);
+
+    /* Set up tracer config */
+    workloadTracerConfig *cfg = zmalloc(sizeof(workloadTracerConfig));
+    cfg->samples = samples;
+    cfg->negative_lookups = negative_lookups;
+    cfg->format = format;
+    cfg->sample_rate = sample_rate;
+    cfg->sample_seed = sample_seed;
+
+    /* Pre-compute threshold: rate * UINT64_MAX (avoid FP in hot path) */
+    if (sample_rate >= 1.0) {
+        cfg->sample_threshold = UINT64_MAX;
+    } else if (sample_rate <= 0.0) {
+        cfg->sample_threshold = 0;
+    } else {
+        cfg->sample_threshold = (uint64_t)(sample_rate * (double)UINT64_MAX);
+    }
+
+    /* Derive 16-byte siphash key from the 64-bit seed (endian-neutral) */
+    for (int b = 0; b < 8; b++) {
+        cfg->sample_seed_bytes[b] = (uint8_t)(sample_seed >> (b * 8));
+        cfg->sample_seed_bytes[b + 8] = cfg->sample_seed_bytes[b];
+    }
+
+    c->workload_tracer_config = cfg;
+    c->flag.workload_tracer = 1;
+    listAddNodeTail(server.workload_tracers, c);
+    return C_OK;
+}

--- a/src/workload_trace.h
+++ b/src/workload_trace.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __WORKLOAD_TRACE_H
+#define __WORKLOAD_TRACE_H
+
+#include "server.h"
+
+/* Access types for workload trace events */
+#define WORKLOAD_ACCESS_READ 0
+#define WORKLOAD_ACCESS_WRITE 1
+#define WORKLOAD_ACCESS_DELETE 2
+
+/* Format types */
+#define WORKLOAD_FORMAT_RESP 0
+#define WORKLOAD_FORMAT_CSV 1
+
+/* Per-client tracer config (set when MONITOR TRACE is issued) */
+typedef struct workloadTracerConfig {
+    int samples;                   /* -1=fast path, 0=sample all, >0=sample N (matches MEMORY USAGE) */
+    int negative_lookups;          /* Include READ events where key doesn't exist */
+    int format;                    /* WORKLOAD_FORMAT_RESP or WORKLOAD_FORMAT_CSV */
+    double sample_rate;            /* 0.0–1.0, fraction of keys to trace (1.0 = all) */
+    uint64_t sample_seed;          /* Seed for deterministic key-hash sampling */
+    uint64_t sample_threshold;     /* Pre-computed: sample_rate * UINT64_MAX */
+    uint8_t sample_seed_bytes[16]; /* siphash key derived from sample_seed */
+} workloadTracerConfig;
+
+/* Trace context set in call(), consumed by lookup/write/delete hooks */
+typedef struct workloadTraceContext {
+    const char *cmd_name; /* Current command name */
+    uint64_t seq;         /* Monotonic sequence ID */
+} workloadTraceContext;
+
+/* Initialize/cleanup */
+void workloadTraceInit(void);
+void workloadTraceDetachClient(client *c);
+
+/* MONITOR TRACE setup helper (called from monitorCommand) */
+int monitorTraceSetup(client *c, int arg_start);
+
+/* Trace context management (called from call()) */
+workloadTraceContext workloadTraceSaveContext(void);
+void workloadTraceBeginCommand(client *c);
+void workloadTraceEndCommand(workloadTraceContext *prev);
+
+/* Event emitters (called from db.c hot paths) */
+void workloadTraceEmitRead(serverDb *db, robj *key, robj *val);
+void workloadTraceEmitWrite(serverDb *db, robj *key, robj *val);
+void workloadTraceEmitDelete(serverDb *db, robj *key, robj *val);
+
+/* Fast-path check: are any tracers subscribed? */
+static inline int workloadTraceActive(void) {
+    return server.workload_tracers && listLength(server.workload_tracers) > 0;
+}
+
+#endif /* __WORKLOAD_TRACE_H */

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1191,6 +1191,398 @@ start_server {tags {"introspection"}} {
         $bc close
     }
 
+    test {MONITOR TRACE emits WRITE events in RESP format} {
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE
+        assert_match {*OK*} [$rd read]
+        r set tracekey traceval
+        set event [$rd read]
+        # RESP format: array of 10 elements
+        assert_equal [llength $event] 10
+        # Fields: ts_us, seq, db, cmd, key, access_type, key_exists, obj_type, key_bytes, value_bytes
+        assert_equal [lindex $event 4] {tracekey}
+        assert_equal [lindex $event 5] {WRITE}
+        assert_equal [lindex $event 6] 1
+        assert_equal [lindex $event 7] {string}
+        $rd close
+    }
+
+    test {MONITOR TRACE emits READ events} {
+        r set readkey readval
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE
+        assert_match {*OK*} [$rd read]
+        r get readkey
+        set event [$rd read]
+        assert_equal [lindex $event 4] {readkey}
+        assert_equal [lindex $event 5] {READ}
+        assert_equal [lindex $event 6] 1
+        $rd close
+    }
+
+    test {MONITOR TRACE emits DELETE events} {
+        r set delkey delval
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE
+        assert_match {*OK*} [$rd read]
+        r del delkey
+        set event [$rd read]
+        assert_equal [lindex $event 4] {delkey}
+        assert_equal [lindex $event 5] {DELETE}
+        $rd close
+    }
+
+    test {MONITOR TRACE CSV format escapes binary-unsafe keys} {
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE FORMAT csv
+        assert_match {*OK*} [$rd read]
+        # Key with quotes and commas that require RFC 4180 escaping
+        r set "key\"with,special" val
+        set line [$rd read]
+        # Quotes are doubled, commas are safe inside quotes
+        assert_match {*"key""with,special"*WRITE*} $line
+        # Key with non-printable byte (binary)
+        r set "bin\x01ary" val
+        set line [$rd read]
+        # Non-printable bytes are hex-escaped
+        assert_match {*"bin\\x01ary"*WRITE*} $line
+        $rd close
+    }
+
+    test {MONITOR TRACE RATE 0 suppresses all events} {
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE RATE 0 SEED 1
+        assert_match {*OK*} [$rd read]
+        r set ratekey rateval
+        r set ratekey2 rateval2
+        # With rate 0, no events should be emitted. Send a PING to verify
+        # the connection is alive and no events arrived before it.
+        after 100
+        $rd PING
+        set reply [$rd read]
+        assert_match {*PONG*} $reply
+        $rd close
+    }
+
+    test {MONITOR TRACE RATE 1 emits all events} {
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE RATE 1
+        assert_match {*OK*} [$rd read]
+        r set allkey allval
+        set event [$rd read]
+        assert_equal [lindex $event 4] {allkey}
+        assert_equal [lindex $event 5] {WRITE}
+        $rd close
+    }
+
+    test {MONITOR TRACE RATE with SEED is deterministic} {
+        # Run twice with the same RATE and SEED, verify identical key sets are sampled
+        set keys {aaa bbb ccc ddd eee fff ggg hhh iii jjj}
+        foreach attempt {1 2} {
+            set rd [valkey_deferring_client]
+            $rd MONITOR TRACE RATE 0.5 SEED 42
+            $rd read ;# Discard OK/status
+            foreach k $keys {
+                r set $k val
+            }
+            # Collect all emitted keys
+            set sampled($attempt) {}
+            foreach k $keys {
+                # Non-blocking read: try to get an event within a short window
+            }
+            # Read events until we get a PING response (sentinel for end of events)
+            after 50
+            $rd PING
+            while {1} {
+                set msg [$rd read]
+                if {$msg eq "PONG"} break
+                lappend sampled($attempt) [lindex $msg 4]
+            }
+            $rd close
+        }
+        # Both runs must produce the exact same sampled key set
+        assert_equal $sampled(1) $sampled(2)
+        # With RATE 0.5 SEED 42, the deterministic sampled set is:
+        assert_equal $sampled(1) {ddd eee fff ggg hhh iii jjj}
+    }
+
+    test {MONITOR TRACE NEGATIVE-LOOKUPS yes includes misses} {
+        r del noexist
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE NEGATIVE-LOOKUPS yes
+        assert_match {*OK*} [$rd read]
+        r get noexist
+        set event [$rd read]
+        assert_equal [lindex $event 4] {noexist}
+        assert_equal [lindex $event 5] {READ}
+        assert_equal [lindex $event 6] 0
+        $rd close
+    }
+
+    test {MONITOR TRACE NEGATIVE-LOOKUPS no excludes misses} {
+        r del noexist2
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE NEGATIVE-LOOKUPS no
+        assert_match {*OK*} [$rd read]
+        r get noexist2
+        # No event for the miss; verify by sending another command that does produce an event
+        r set existkey existval
+        set event [$rd read]
+        assert_equal [lindex $event 4] {existkey}
+        assert_equal [lindex $event 5] {WRITE}
+        $rd close
+    }
+
+    test {MONITOR TRACE reports non-zero key and value bytes} {
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE
+        assert_match {*OK*} [$rd read]
+        # Use a 500-byte value to guarantee RAW encoding (external SDS allocation)
+        r set sizekey [string repeat x 500]
+        set event [$rd read]
+        # key_bytes (index 8) = robj entry overhead, must be positive
+        assert {[lindex $event 8] > 0}
+        # value_bytes (index 9) = external value allocation, positive for RAW strings
+        assert {[lindex $event 9] > 0}
+        $rd close
+    }
+
+    test {MONITOR TRACE SAMPLES increases value_bytes for complex types} {
+        # Create a list large enough to use quicklist encoding (multiple nodes)
+        r del sizelist
+        for {set i 0} {$i < 1000} {incr i} {
+            r rpush sizelist "element:$i:padding-to-make-it-bigger"
+        }
+        # Measure with default (no SAMPLES = fast path, zmalloc_size only)
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE
+        assert_match {*OK*} [$rd read]
+        r rpush sizelist shallow
+        set event [$rd read]
+        set shallow_bytes [lindex $event 9]
+        $rd close
+
+        # Measure with SAMPLES 5 (deep objectComputeSize)
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE SAMPLES 5
+        assert_match {*OK*} [$rd read]
+        r rpush sizelist deep
+        set event [$rd read]
+        set deep_bytes [lindex $event 9]
+        $rd close
+
+        # Deep sizing should report more bytes than shallow for a list
+        assert {$deep_bytes > $shallow_bytes}
+    }
+
+    test {MONITOR TRACE client disconnect cleans up tracer list} {
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE
+        assert_match {*OK*} [$rd read]
+        $rd close
+        # After disconnect, SET should not crash
+        r set afterclose val
+        assert_equal [r get afterclose] {val}
+    }
+
+    test {MONITOR TRACE reports correct db for non-default database} {
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE
+        assert_match {*OK*} [$rd read]
+        r select 3
+        r set dbkey dbval
+        set event [$rd read]
+        # db field (index 2) should be 3
+        assert_equal [lindex $event 2] 3
+        r select 0
+        $rd close
+    }
+
+    test {MONITOR TRACE MOVE reports correct db for destination} {
+        r select 0
+        r set movekey moveval
+        r del movekey ;# clean up any prior state in db 5
+        r select 5
+        r del movekey
+        r select 0
+        r set movekey moveval
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE
+        assert_match {*OK*} [$rd read]
+        r move movekey 5
+        # Should see a DELETE on db 0 and a WRITE on db 5
+        set events {}
+        after 50
+        $rd PING
+        while {1} {
+            set msg [$rd read]
+            if {$msg eq "PONG"} break
+            lappend events $msg
+        }
+        # Find the DELETE event (source db 0)
+        set found_delete 0
+        set found_write 0
+        foreach ev $events {
+            if {[lindex $ev 4] eq "movekey" && [lindex $ev 5] eq "DELETE"} {
+                assert_equal [lindex $ev 2] 0
+                set found_delete 1
+            }
+            if {[lindex $ev 4] eq "movekey" && [lindex $ev 5] eq "WRITE"} {
+                assert_equal [lindex $ev 2] 5
+                set found_write 1
+            }
+        }
+        assert_equal $found_delete 1
+        assert_equal $found_write 1
+        $rd close
+    }
+
+    test {MONITOR TRACE reports correct value size per database} {
+        # Same key name in two DBs with different value sizes
+        r select 0
+        r set samekey "short"
+        r select 2
+        r set samekey [string repeat x 1000]
+        r select 0
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE
+        assert_match {*OK*} [$rd read]
+        # Read from db 0 (small value)
+        r get samekey
+        set ev0 [$rd read]
+        # Read from db 2 (large value)
+        r select 2
+        r get samekey
+        set ev2 [$rd read]
+        r select 0
+        $rd close
+        # db 0 value_bytes should be much smaller than db 2
+        set bytes0 [lindex $ev0 9]
+        set bytes2 [lindex $ev2 9]
+        assert {$bytes2 > $bytes0}
+        # Verify correct db ids
+        assert_equal [lindex $ev0 2] 0
+        assert_equal [lindex $ev2 2] 2
+    }
+
+    test {MONITOR TRACE key_bytes + value_bytes matches MEMORY USAGE for strings} {
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE SAMPLES 0
+        assert_match {*OK*} [$rd read]
+        # Embedded string (EMBSTR)
+        r set emb_key "small"
+        set event [$rd read]
+        set trace_total [expr {[lindex $event 8] + [lindex $event 9]}]
+        set mem [r memory usage emb_key samples 0]
+        assert_equal $trace_total $mem "embedded string mismatch"
+        # RAW string (large value)
+        r set raw_key [string repeat x 500]
+        set event [$rd read]
+        set trace_total [expr {[lindex $event 8] + [lindex $event 9]}]
+        set mem [r memory usage raw_key samples 0]
+        assert_equal $trace_total $mem "raw string mismatch"
+        $rd close
+    }
+
+    test {MONITOR TRACE key_bytes + value_bytes matches MEMORY USAGE for hash types} {
+        # Listpack hash (small)
+        r del myhash_lp
+        for {set i 0} {$i < 5} {incr i} {
+            r hset myhash_lp "field$i" "value$i"
+        }
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE SAMPLES 0
+        assert_match {*OK*} [$rd read]
+        r hget myhash_lp field0
+        set event [$rd read]
+        set trace_total [expr {[lindex $event 8] + [lindex $event 9]}]
+        set mem [r memory usage myhash_lp samples 0]
+        assert_equal $trace_total $mem "listpack hash mismatch"
+        $rd close
+
+        # Hashtable hash (large)
+        r del myhash_ht
+        for {set i 0} {$i < 200} {incr i} {
+            r hset myhash_ht "field_with_long_name_$i" [string repeat v 50]
+        }
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE SAMPLES 0
+        assert_match {*OK*} [$rd read]
+        r hget myhash_ht field_with_long_name_0
+        set event [$rd read]
+        set trace_total [expr {[lindex $event 8] + [lindex $event 9]}]
+        set mem [r memory usage myhash_ht samples 0]
+        assert_equal $trace_total $mem "hashtable hash mismatch"
+        $rd close
+    }
+
+    test {MONITOR TRACE key_bytes + value_bytes matches MEMORY USAGE for set} {
+        r del myset
+        for {set i 0} {$i < 200} {incr i} {
+            r sadd myset "member_$i"
+        }
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE SAMPLES 0
+        assert_match {*OK*} [$rd read]
+        r sismember myset member_0
+        set event [$rd read]
+        set trace_total [expr {[lindex $event 8] + [lindex $event 9]}]
+        set mem [r memory usage myset samples 0]
+        assert_equal $trace_total $mem "set mismatch"
+        $rd close
+    }
+
+    test {MONITOR TRACE key_bytes + value_bytes matches MEMORY USAGE for zset} {
+        r del myzset
+        for {set i 0} {$i < 200} {incr i} {
+            r zadd myzset $i "member_$i"
+        }
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE SAMPLES 0
+        assert_match {*OK*} [$rd read]
+        r zscore myzset member_0
+        set event [$rd read]
+        set trace_total [expr {[lindex $event 8] + [lindex $event 9]}]
+        set mem [r memory usage myzset samples 0]
+        assert_equal $trace_total $mem "zset mismatch"
+        $rd close
+    }
+
+    test {MONITOR TRACE key_bytes + value_bytes matches MEMORY USAGE for stream} {
+        r del mystream
+        for {set i 0} {$i < 50} {incr i} {
+            r xadd mystream "*" field value
+        }
+        set rd [valkey_deferring_client]
+        $rd MONITOR TRACE SAMPLES 0
+        assert_match {*OK*} [$rd read]
+        r xlen mystream
+        set event [$rd read]
+        set trace_total [expr {[lindex $event 8] + [lindex $event 9]}]
+        set mem [r memory usage mystream samples 0]
+        assert_equal $trace_total $mem "stream mismatch"
+        $rd close
+    }
+
+    test {MONITOR TRACE key_bytes + value_bytes matches MEMORY USAGE with various SAMPLES} {
+        # Create a large hash for meaningful sampling differences
+        r del sampled_hash
+        for {set i 0} {$i < 200} {incr i} {
+            r hset sampled_hash "field_$i" [string repeat v 30]
+        }
+        foreach samples_val {0 1 5 50} {
+            set rd [valkey_deferring_client]
+            $rd MONITOR TRACE SAMPLES $samples_val
+            assert_match {*OK*} [$rd read]
+            r hget sampled_hash field_0
+            set event [$rd read]
+            set trace_total [expr {[lindex $event 8] + [lindex $event 9]}]
+            set mem [r memory usage sampled_hash samples $samples_val]
+            assert_equal $trace_total $mem "SAMPLES $samples_val mismatch"
+            $rd close
+        }
+    }
+
     test {CLIENT GETNAME should return NIL if name is not assigned} {
         r client getname
     } {}


### PR DESCRIPTION
# MONITOR TRACE: Key-Level Workload Tracing for Valkey

## Summary

Adds `MONITOR TRACE` — a new subcommand that streams key-level access events (read, write, delete) to subscribed clients in real-time. Unlike `MONITOR` which captures full command text, `MONITOR TRACE` emits structured per-key records with metadata (timestamps, sizes, access type, object encoding), enabling offline simulation of cache eviction policies and workload characterization without replaying full command streams.

## Motivation

Cache tiering and eviction policy design requires understanding real workload access patterns — which keys are hot, how large they are, and what the read/write/delete ratio looks like. Existing tools (`MONITOR`, `SLOWLOG`, `INFO`) don't provide this. `MONITOR TRACE` fills the gap by producing a compact, structured trace suitable for feeding into simulators (e.g., MRC curve generators).

## Feature Design

### Command Syntax

```
MONITOR TRACE [SAMPLES <n>] [RATE <0.0-1.0>] [SEED <n>] [FORMAT CSV|RESP] [NEGATIVE-LOOKUPS YES|NO]
```
### Example
```
127.0.0.1:6379> monitor trace format csv
OK
1778474345309397,76,0,set,"key",WRITE,1,string,32,160
```
### Trace Record Fields (CSV format)

| Field | Description |
|-------|-------------|
| `ts_us` | Microsecond timestamp |
| `seq` | Monotonic sequence number |
| `db` | Database index |
| `cmd` | Command name |
| `key` | Key (RFC 4180 quoted, `\xHH` for non-printable bytes) |
| `access_type` | READ, WRITE, or DELETE |
| `key_exists` | Whether key existed at access time |
| `obj_type` | Object type (string, list, hash, etc.) |
| `key_bytes` | Key entry allocation size |
| `value_bytes` | Value allocation size (excludes embedded values) |

### Implementation Hooks

- **READ**: `lookupKey()` — emits on non-write lookups
- **WRITE**: `signalModifiedKey()` — universal mutation point, catches in-place mutations (HSET, LPUSH, etc.)
- **DELETE**: `dbGenericDeleteWithDictIndex()` — all deletion paths

### Key-Hash Sampling

When `RATE < 1.0`, uses SipHash on the key to deterministically select which keys to trace. This ensures all accesses to the same key are either traced or skipped (no aliasing with request patterns).

### Architecture

```
call()          → workloadTraceBeginCommand/EndCommand (sets trace context)
lookupKey()     → workloadTraceEmitRead
setKey/dbAdd()  → workloadTraceEmitWrite
dbDelete()      → workloadTraceEmitDelete
```

The trace context is thread-local (safe: Valkey is single-threaded for commands). A fast-path check (`workloadTraceActive()`) short-circuits when no tracers are subscribed — zero overhead in the common case.

## Benchmark Results

### Methodology

- **Instance**: r7g.4xlarge EC2 (single Valkey server, single-threaded, loopback)
- **Tool**: `memtier_benchmark` with `--rate-limiting` for controlled load
- **Pipeline**: P1 (no pipelining) — one command per round-trip, realistic for most clients
- **Core pinning**: Server on core 0, benchmark on cores 2-9, trace client on core 8
- **Clients**: 50 parallel clients, 4 threads
- **Pre-population**: 1M keys before each test
- **Duration**: 30 seconds per phase
- **Payload**: 256 bytes
- **Workload**: 1:1 SET:GET ratio

### Finding Saturation Point

With P1 (no pipelining) on loopback, the server saturates at **~175K ops/sec** regardless of client count (even 5 clients saturate a single core at sub-millisecond RTT). Used `memtier_benchmark --rate-limiting` to cap at exactly 50% for the half-load phases.

### Results (averaged over 3 runs)

**Saturated (server CPU-bound):**

| Metric | Baseline | + MONITOR TRACE | + MONITOR |
|--------|--------------------:|--------------------------:|--------------------:|
| **Total Ops/sec** | 172,595 | 158,564 | 152,191 |
| **TPS overhead** | — | **-8.1%** | **-11.8%** |
| **Avg latency** | 1.159 ms | 1.262 ms | 1.315 ms |
| **p50 latency** | 1.151 ms | 1.239 ms | 1.289 ms |
| **p99 latency** | 2.202 ms | 2.217 ms | 2.057 ms |
| **p99.9 latency** | 2.463 ms | 2.665 ms | 2.713 ms |

**Half rate (~85K ops/sec, rate-limited):**

| Metric | Baseline | + MONITOR TRACE | + MONITOR |
|--------|--------------------:|--------------------------:|--------------------:|
| **Total Ops/sec** | 84,596 | 84,595 | 84,595 |
| **TPS overhead** | — | **~0%** | **~0%** |
| **Avg latency** | 1.101 ms | 1.165 ms | 1.182 ms |
| **p50 latency** | 1.194 ms | 1.243 ms | 1.243 ms |
| **p99 latency** | 2.239 ms | 2.308 ms | 2.383 ms |
| **p99.9 latency** | 2.548 ms | 2.702 ms | 2.793 ms |
| **Avg latency overhead** | — | **+5.8%** | **+7.3%** |
| **p99.9 overhead** | — | **+6.0%** | **+9.6%** |

### Analysis

1. **MONITOR TRACE is ~30% lighter than MONITOR at saturation**: At full CPU load, MONITOR TRACE costs 8.1% throughput vs MONITOR's 11.8%. Both format output per-command, but MONITOR must serialize the entire command line (including large values) while MONITOR TRACE emits only compact key-level metadata.

2. **At half load (50% CPU)**: Both achieve zero throughput impact (rate-limited). MONITOR TRACE adds +5.8% average latency vs MONITOR's +7.3%. The tail (p99.9) shows a clearer gap: +6.0% for TRACE vs +9.6% for MONITOR.

3. **Zero overhead when inactive**: The `workloadTraceActive()` inline check short-circuits immediately when no trace clients are connected — no branch misprediction cost in the hot path.

4. **Pipelining amplification note**: Earlier tests with P16 pipelining showed ~43% overhead, but I believe this is misleading for the average use case. Pipelining batches 16 commands per event loop iteration, amplifying the per-command trace cost 16x within a single batch. Pipelining workloads should be aware that this will incur significantly more overhead when tracing.

## Files Changed

| File | Change |
|------|--------|
| `src/workload_trace.h` | New — trace API, config structs, inline fast-path check |
| `src/workload_trace.c` | New — trace emission, context management, size computation |
| `src/server.h` | Add `workload_tracers` list, client flag, config pointer |
| `src/server.c` | Init tracers list, call begin/end in `call()`, command gating for trace clients |
| `src/db.c` | Emit hooks in lookupKey, signalModifiedKey, dbDelete |
| `src/networking.c` | Init `workload_tracer_config`, detach tracer on client free/reset |
| `src/commands/monitor.json` | Convert MONITOR to container command |
| `src/commands/monitor-trace.json` | New — TRACE subcommand definition with arguments |
| `src/commands.def` | Regenerated — registers MONITOR TRACE subcommand |
| `cmake/Modules/SourceFiles.cmake` | Add `workload_trace.c` |
| `src/Makefile` | Add `workload_trace.o` |
| `tests/unit/introspection.tcl` | 16 new integration tests |

## Testing

16 integration tests in `tests/unit/introspection.tcl` covering:

- **Event emission**: READ, WRITE, DELETE events with correct fields
- **Output formats**: RESP (binary-safe bulk strings) and CSV (RFC 4180 quoting)
- **Sampling**: RATE 0 (suppresses all), RATE 1 (emits all), deterministic RATE+SEED (asserts exact sampled key set)
- **Filtering**: NEGATIVE-LOOKUPS yes/no for cache miss visibility
- **Size reporting**: Non-zero key/value bytes, SAMPLES effect on complex types
- **Lifecycle**: Client disconnect removes tracer from list
- **Multi-DB correctness**: Correct db field for non-default DB, MOVE emits DELETE on source + WRITE on destination, correct value sizes per DB
- **Size tests**: `key_bytes + value_bytes == MEMORY USAGE` verified for embedded strings, RAW strings, listpack hashes, hashtable hashes, sets, zsets, streams, and with SAMPLES 0/1/5/50