### PR TITLE
fix json.mset first win, revert #2365

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -7537,7 +7537,7 @@ int VM_ModuleTypeSetValue(ValkeyModuleKey *key, moduleType *mt, void *value) {
     if (!(key->mode & VALKEYMODULE_WRITE) || key->iter) return VALKEYMODULE_ERR;
     VM_DeleteKey(key);
     robj *o = createModuleObject(mt, value);
-    setKey(key->ctx->client, key->db, key->key, &o, SETKEY_NO_SIGNAL | SETKEY_DOESNT_EXIST);
+    setKey(key->ctx->client, key->db, key->key, &o, SETKEY_NO_SIGNAL);
     key->value = o;
     return VALKEYMODULE_OK;
 }


### PR DESCRIPTION
Revert the `SETKEY_DOESNT_EXIST` optimization in `VM_ModuleTypeSetValue()` introduced by #2365, which causes a "first win" bug when a module operates on the same key multiple times within a single command.

For example, with [valkey-json](https://github.com/valkey-io/valkey-json):

```
127.0.0.1:6379> JSON.MSET mykey . '{"v":1}' mykey . '{"v":2}'
OK
127.0.0.1:6379> JSON.GET mykey
{"v":1}
```

Expected result is `{"v":2}` (last write wins), but got `{"v":1}` (first write wins).

The same `SETKEY_DOESNT_EXIST` optimization was applied to `VM_StringSet()` and `VM_StringTruncate()` in the same PR. They are susceptible to the same bug if any module opens multiple handles to the same string key within one command. While I'm not currently aware of a specific module triggering this for string operations.

I'd recommend reverting those two as well for safety. Happy to include them in this PR if reviewers agree.
