### PR TITLE
Skip NOT_KEY commands in client tracking

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -229,8 +229,7 @@ void trackingRememberKeys(client *tracking, client *executing) {
 
     getKeysResult result;
     initGetKeysResult(&result);
-    int numkeys =
-        getKeysFromCommandWithSpecs(executing->cmd, executing->argv, executing->argc, GET_KEYSPEC_DEFAULT, &result);
+    int numkeys = getKeysFromCommandWithSpecs(executing->cmd, executing->argv, executing->argc, GET_KEYSPEC_DEFAULT, &result);
     if (!numkeys) {
         getKeysFreeResult(&result);
         return;

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -229,7 +229,8 @@ void trackingRememberKeys(client *tracking, client *executing) {
 
     getKeysResult result;
     initGetKeysResult(&result);
-    int numkeys = getKeysFromCommand(executing->cmd, executing->argv, executing->argc, &result);
+    int numkeys =
+        getKeysFromCommandWithSpecs(executing->cmd, executing->argv, executing->argc, GET_KEYSPEC_DEFAULT, &result);
     if (!numkeys) {
         getKeysFreeResult(&result);
         return;

--- a/tests/unit/cluster/clusterscan.tcl
+++ b/tests/unit/cluster/clusterscan.tcl
@@ -40,6 +40,16 @@ start_cluster 1 0 {tags {external:skip cluster}} {
         assert_error "*unknown type name*" {R 0 clusterscan 0 TYPE notatype}
     }
 
+    test "CLUSTERSCAN cursor is not tracked by client tracking" {
+        R 0 client tracking on
+        assert_equal 0 [s 0 tracking_total_keys]
+
+        R 0 clusterscan "0-{06S}-0"
+        assert_equal 0 [s 0 tracking_total_keys]
+
+        R 0 client tracking off
+    }
+
     test "CLUSTERSCAN with SLOT restricts to single slot" {
         # When SLOT X is provided, clusterscan should only iterate on slot X
         # and return "0" when exhausted and not advance to slot X+1.


### PR DESCRIPTION
While reviewing #3675 I found a pre-existing `NOT_KEY` inconsistency in client tracking.

`CLUSTERSCAN` is skipped by `COMMAND GETKEYS/ACL` through the key spec path, but tracking still uses `getKeysFromCommand()`. Updated to use `getKeysFromCommandWithSpecs`

```
raghav$ printf 'client tracking on\ninfo stats\nclusterscan 0-{06S}-0\ninfo stats\n'   | /tmp/valkey-unstable-single/src/valkey-cli -p 7001 --raw   | grep -E '^(OK|tracking_total_keys:|0$)'
OK
tracking_total_keys:2
0
tracking_total_keys:2
````

This affects today `CLUSTERSCAN` because it is RO, `SPUBLISH/SSUBSCRIBE/SUNSUBSCRIBE` using `NOT_KEY` are not RO.