### PR TITLE
Support VALKEYMODULE_REPLY_AGAIN in VM_UnblockClient Reply cb

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -8907,6 +8907,7 @@ int VM_UnblockClient(ValkeyModuleBlockedClient *bc, void *privdata) {
         errno = EINVAL;
         return VALKEYMODULE_ERR;
     }
+    if (bc->unblocked) return VALKEYMODULE_OK;
     if (bc->blocked_on_keys) {
         /* In theory the user should always pass the timeout handler as an
          * argument, but better to be safe than sorry. */
@@ -8914,7 +8915,6 @@ int VM_UnblockClient(ValkeyModuleBlockedClient *bc, void *privdata) {
             errno = ENOTSUP;
             return VALKEYMODULE_ERR;
         }
-        if (bc->unblocked) return VALKEYMODULE_OK;
         if (bc->client) moduleBlockedClientTimedOut(bc->client, 1);
     }
     moduleUnblockClientByHandle(bc, privdata);

--- a/src/module.c
+++ b/src/module.c
@@ -8997,12 +8997,15 @@ void moduleHandleBlockedClients(void) {
 
         /* If reply callback returned VALKEYMODULE_REPLY_AGAIN, keep the client
          * blocked. The module must not have written any reply before returning
-         * this value. The module will call UnblockClient again later. */
+         * this value. The module will call UnblockClient again later.
+         * The module must handle timeout/disconnect by calling UnblockClient
+         * from those callbacks (standard blocked client contract). */
         if (reply_ret == VALKEYMODULE_REPLY_AGAIN) {
             moduleReleaseTempClient(bc->reply_client);
             moduleReleaseTempClient(bc->thread_safe_ctx_client);
             bc->reply_client = moduleAllocTempClient();
             bc->thread_safe_ctx_client = moduleAllocTempClient();
+            if (c) bc->reply_client->resp = c->resp;
             bc->unblocked = 0;
             pthread_mutex_lock(&moduleUnblockedClientsMutex);
             continue;

--- a/src/module.c
+++ b/src/module.c
@@ -8980,6 +8980,7 @@ void moduleHandleBlockedClients(void) {
          * the key was signaled as ready. */
         long long prev_error_replies = server.stat_total_error_replies;
         uint64_t reply_us = 0;
+        int reply_ret = VALKEYMODULE_OK;
         if (c && !bc->blocked_on_keys && bc->reply_callback) {
             ValkeyModuleCtx ctx;
             moduleCreateContext(&ctx, bc->module, VALKEYMODULE_CTX_BLOCKED_REPLY);
@@ -8989,9 +8990,22 @@ void moduleHandleBlockedClients(void) {
             ctx.blocked_client = bc;
             monotime replyTimer;
             elapsedStart(&replyTimer);
-            bc->reply_callback(&ctx, (void **)c->argv, c->argc);
+            reply_ret = bc->reply_callback(&ctx, (void **)c->argv, c->argc);
             reply_us = elapsedUs(replyTimer);
             moduleFreeContext(&ctx);
+        }
+
+        /* If reply callback returned VALKEYMODULE_REPLY_AGAIN, keep the client
+         * blocked. The module must not have written any reply before returning
+         * this value. The module will call UnblockClient again later. */
+        if (reply_ret == VALKEYMODULE_REPLY_AGAIN) {
+            moduleReleaseTempClient(bc->reply_client);
+            moduleReleaseTempClient(bc->thread_safe_ctx_client);
+            bc->reply_client = moduleAllocTempClient();
+            bc->thread_safe_ctx_client = moduleAllocTempClient();
+            bc->unblocked = 0;
+            pthread_mutex_lock(&moduleUnblockedClientsMutex);
+            continue;
         }
         /* Hold onto the blocked client if module auth is in progress. The reply callback is invoked
          * when the client is reprocessed. */

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -50,6 +50,9 @@ typedef long long ustime_t;
 #define VALKEYMODULE_OK 0
 #define VALKEYMODULE_ERR 1
 
+/* Return from reply callback to keep client blocked (re-block). */
+#define VALKEYMODULE_REPLY_AGAIN 2
+
 /* Module Based Authentication status return values. */
 #define VALKEYMODULE_AUTH_HANDLED 0
 #define VALKEYMODULE_AUTH_NOT_HANDLED 1

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -1024,7 +1024,6 @@ int unblock_by_timer(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
 
 static int reblock_reply_count = 0;
 static volatile int reblock_disconnect_called = 0;
-static volatile int reblock_free_called = 0;
 
 /* Reply callback that re-blocks twice, then replies on the third call. */
 int reblock_reply(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
@@ -1043,7 +1042,6 @@ int reblock_reply(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
 void reblock_free(ValkeyModuleCtx *ctx, void *privdata) {
     UNUSED(ctx);
     UNUSED(privdata);
-    reblock_free_called++;
 }
 
 void reblock_disconnect(ValkeyModuleCtx *ctx, ValkeyModuleBlockedClient *bc) {
@@ -1055,11 +1053,12 @@ void reblock_disconnect(ValkeyModuleCtx *ctx, ValkeyModuleBlockedClient *bc) {
 static ValkeyModuleBlockedClient *reblock_bc = NULL;
 
 void reblock_timer_cb(ValkeyModuleCtx *ctx, void *data) {
-    UNUSED(ctx);
     UNUSED(data);
-    /* Each timer fire triggers one UnblockClient. The reply callback
-     * returns REPLY_AGAIN for the first two, then replies on the third. */
     ValkeyModule_UnblockClient(reblock_bc, NULL);
+    /* If not done yet, schedule the next unblock from this timer */
+    if (reblock_reply_count < 2) {
+        ValkeyModule_CreateTimer(ctx, 10, reblock_timer_cb, NULL);
+    }
 }
 
 /* Command: reblock.test — blocks, re-blocks twice, replies on third unblock */
@@ -1068,48 +1067,49 @@ int reblock_test_cmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
     UNUSED(argc);
     reblock_reply_count = 0;
     reblock_bc = ValkeyModule_BlockClient(ctx, reblock_reply, NULL, reblock_free, 5000);
-    /* Schedule 3 timer callbacks at 10ms intervals */
     ValkeyModule_CreateTimer(ctx, 10, reblock_timer_cb, NULL);
-    ValkeyModule_CreateTimer(ctx, 30, reblock_timer_cb, NULL);
-    ValkeyModule_CreateTimer(ctx, 50, reblock_timer_cb, NULL);
     return VALKEYMODULE_OK;
 }
 
-/* Reply callback that always re-blocks (to test timeout while re-blocked) */
+/* Reply callback that always re-blocks (to test timeout while re-blocked).
+ * Called exactly once — the initial UnblockClient triggers it, then the client
+ * stays re-blocked until timeout fires. */
+static int reblock_timeout_reply_count = 0;
+
 int reblock_timeout_reply(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     UNUSED(ctx);
     UNUSED(argv);
     UNUSED(argc);
+    reblock_timeout_reply_count++;
+    assert(reblock_timeout_reply_count == 1);
     return VALKEYMODULE_REPLY_AGAIN;
 }
 
 int reblock_timeout_cb(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     UNUSED(argv);
     UNUSED(argc);
+    ValkeyModuleBlockedClient *bc = ValkeyModule_GetBlockedClientHandle(ctx);
     ValkeyModule_ReplyWithSimpleString(ctx, "Timed out while re-blocked");
+    ValkeyModule_UnblockClient(bc, NULL);
     return VALKEYMODULE_OK;
 }
 
 static ValkeyModuleBlockedClient *reblock_timeout_bc = NULL;
 
-void reblock_timeout_timer_cb(ValkeyModuleCtx *ctx, void *data) {
-    UNUSED(ctx);
-    UNUSED(data);
-    ValkeyModule_UnblockClient(reblock_timeout_bc, NULL);
-}
-
 /* Command: reblock.timeout — blocks, re-blocks forever, should timeout */
 int reblock_timeout_cmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     UNUSED(argv);
     UNUSED(argc);
+    reblock_timeout_reply_count = 0;
     reblock_timeout_bc = ValkeyModule_BlockClient(ctx, reblock_timeout_reply, reblock_timeout_cb, reblock_free, 500);
     /* Unblock once to trigger the reply callback (which returns REPLY_AGAIN).
      * After that, timeout at 500ms should fire. */
-    ValkeyModule_CreateTimer(ctx, 10, reblock_timeout_timer_cb, NULL);
+    ValkeyModule_UnblockClient(reblock_timeout_bc, NULL);
     return VALKEYMODULE_OK;
 }
 
-/* Reply callback that always re-blocks (for disconnect test) */
+/* Reply callback that re-blocks until disconnect (reply cb is never called
+ * after disconnect since c == NULL, so this always returns REPLY_AGAIN) */
 int reblock_disconnect_reply(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     UNUSED(ctx);
     UNUSED(argv);
@@ -1123,7 +1123,6 @@ int reblock_disconnect_cmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int 
     UNUSED(argv);
     UNUSED(argc);
     reblock_disconnect_called = 0;
-    reblock_free_called = 0;
     ValkeyModuleBlockedClient *bc = ValkeyModule_BlockClient(ctx, reblock_disconnect_reply, NULL, reblock_free, 0);
     ValkeyModule_SetDisconnectCallback(bc, reblock_disconnect);
     /* Unblock once to trigger reply callback which returns REPLY_AGAIN */
@@ -1136,14 +1135,6 @@ int reblock_get_disconnect_called(ValkeyModuleCtx *ctx, ValkeyModuleString **arg
     UNUSED(argv);
     UNUSED(argc);
     ValkeyModule_ReplyWithLongLong(ctx, reblock_disconnect_called);
-    return VALKEYMODULE_OK;
-}
-
-/* Command: reblock.get_free_called — returns free callback count */
-int reblock_get_free_called(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
-    UNUSED(argv);
-    UNUSED(argc);
-    ValkeyModule_ReplyWithLongLong(ctx, reblock_free_called);
     return VALKEYMODULE_OK;
 }
 
@@ -1251,9 +1242,6 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
         return VALKEYMODULE_ERR;
 
     if (ValkeyModule_CreateCommand(ctx, "reblock.get_disconnect_called", reblock_get_disconnect_called, "", 0, 0, 0) == VALKEYMODULE_ERR)
-        return VALKEYMODULE_ERR;
-
-    if (ValkeyModule_CreateCommand(ctx, "reblock.get_free_called", reblock_get_free_called, "", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
     return VALKEYMODULE_OK;

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -1125,7 +1125,7 @@ int reblock_disconnect_cmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int 
     reblock_disconnect_called = 0;
     ValkeyModuleBlockedClient *bc = ValkeyModule_BlockClient(ctx, reblock_disconnect_reply, NULL, reblock_free, 0);
     ValkeyModule_SetDisconnectCallback(bc, reblock_disconnect);
-    /* Unblock once to trigger reply callback which returns REPLY_AGAIN */
+    /* Unblock once to trigger reply callback which then returns REPLY_AGAIN */
     ValkeyModule_UnblockClient(bc, NULL);
     return VALKEYMODULE_OK;
 }

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -1020,6 +1020,133 @@ int unblock_by_timer(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
     return VALKEYMODULE_OK;
 }
 
+/* --- REPLY_AGAIN (re-block) tests --- */
+
+static int reblock_reply_count = 0;
+static volatile int reblock_disconnect_called = 0;
+static volatile int reblock_free_called = 0;
+
+/* Reply callback that re-blocks twice, then replies on the third call. */
+int reblock_reply(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    reblock_reply_count++;
+    if (reblock_reply_count < 3) {
+        /* Re-block: don't write any reply */
+        return VALKEYMODULE_REPLY_AGAIN;
+    }
+    /* Third time: actually reply */
+    ValkeyModule_ReplyWithLongLong(ctx, reblock_reply_count);
+    return VALKEYMODULE_OK;
+}
+
+void reblock_free(ValkeyModuleCtx *ctx, void *privdata) {
+    UNUSED(ctx);
+    UNUSED(privdata);
+    reblock_free_called++;
+}
+
+void reblock_disconnect(ValkeyModuleCtx *ctx, ValkeyModuleBlockedClient *bc) {
+    UNUSED(ctx);
+    reblock_disconnect_called++;
+    ValkeyModule_UnblockClient(bc, NULL);
+}
+
+static ValkeyModuleBlockedClient *reblock_bc = NULL;
+
+void reblock_timer_cb(ValkeyModuleCtx *ctx, void *data) {
+    UNUSED(ctx);
+    UNUSED(data);
+    /* Each timer fire triggers one UnblockClient. The reply callback
+     * returns REPLY_AGAIN for the first two, then replies on the third. */
+    ValkeyModule_UnblockClient(reblock_bc, NULL);
+}
+
+/* Command: reblock.test — blocks, re-blocks twice, replies on third unblock */
+int reblock_test_cmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    reblock_reply_count = 0;
+    reblock_bc = ValkeyModule_BlockClient(ctx, reblock_reply, NULL, reblock_free, 5000);
+    /* Schedule 3 timer callbacks at 10ms intervals */
+    ValkeyModule_CreateTimer(ctx, 10, reblock_timer_cb, NULL);
+    ValkeyModule_CreateTimer(ctx, 30, reblock_timer_cb, NULL);
+    ValkeyModule_CreateTimer(ctx, 50, reblock_timer_cb, NULL);
+    return VALKEYMODULE_OK;
+}
+
+/* Reply callback that always re-blocks (to test timeout while re-blocked) */
+int reblock_timeout_reply(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(ctx);
+    UNUSED(argv);
+    UNUSED(argc);
+    return VALKEYMODULE_REPLY_AGAIN;
+}
+
+int reblock_timeout_cb(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    ValkeyModule_ReplyWithSimpleString(ctx, "Timed out while re-blocked");
+    return VALKEYMODULE_OK;
+}
+
+static ValkeyModuleBlockedClient *reblock_timeout_bc = NULL;
+
+void reblock_timeout_timer_cb(ValkeyModuleCtx *ctx, void *data) {
+    UNUSED(ctx);
+    UNUSED(data);
+    ValkeyModule_UnblockClient(reblock_timeout_bc, NULL);
+}
+
+/* Command: reblock.timeout — blocks, re-blocks forever, should timeout */
+int reblock_timeout_cmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    reblock_timeout_bc = ValkeyModule_BlockClient(ctx, reblock_timeout_reply, reblock_timeout_cb, reblock_free, 500);
+    /* Unblock once to trigger the reply callback (which returns REPLY_AGAIN).
+     * After that, timeout at 500ms should fire. */
+    ValkeyModule_CreateTimer(ctx, 10, reblock_timeout_timer_cb, NULL);
+    return VALKEYMODULE_OK;
+}
+
+/* Reply callback that always re-blocks (for disconnect test) */
+int reblock_disconnect_reply(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(ctx);
+    UNUSED(argv);
+    UNUSED(argc);
+    return VALKEYMODULE_REPLY_AGAIN;
+}
+
+/* Command: reblock.disconnect — blocks, re-blocks, waits for disconnect.
+ * Use reblock.get_disconnect_called to verify disconnect callback fired. */
+int reblock_disconnect_cmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    reblock_disconnect_called = 0;
+    reblock_free_called = 0;
+    ValkeyModuleBlockedClient *bc = ValkeyModule_BlockClient(ctx, reblock_disconnect_reply, NULL, reblock_free, 0);
+    ValkeyModule_SetDisconnectCallback(bc, reblock_disconnect);
+    /* Unblock once to trigger reply callback which returns REPLY_AGAIN */
+    ValkeyModule_UnblockClient(bc, NULL);
+    return VALKEYMODULE_OK;
+}
+
+/* Command: reblock.get_disconnect_called — returns disconnect callback count */
+int reblock_get_disconnect_called(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    ValkeyModule_ReplyWithLongLong(ctx, reblock_disconnect_called);
+    return VALKEYMODULE_OK;
+}
+
+/* Command: reblock.get_free_called — returns free callback count */
+int reblock_get_free_called(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    ValkeyModule_ReplyWithLongLong(ctx, reblock_free_called);
+    return VALKEYMODULE_OK;
+}
+
 int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     VALKEYMODULE_NOT_USED(argv);
     VALKEYMODULE_NOT_USED(argc);
@@ -1112,6 +1239,21 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
         return VALKEYMODULE_ERR;
 
     if (ValkeyModule_CreateCommand(ctx, "unblock_by_timer", unblock_by_timer, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "reblock.test", reblock_test_cmd, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "reblock.timeout", reblock_timeout_cmd, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "reblock.disconnect", reblock_disconnect_cmd, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "reblock.get_disconnect_called", reblock_get_disconnect_called, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "reblock.get_free_called", reblock_get_free_called, "", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
     return VALKEYMODULE_OK;

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -296,7 +296,65 @@ foreach call_type {nested normal} {
         # when the client is unlock, we will get the OK reply from timer.
         assert_match "OK" [r unblock_by_timer 100 100]
     }
-    
+
+    test {REPLY_AGAIN re-blocks and eventually replies} {
+        # reblock.test: blocks, reply callback returns REPLY_AGAIN twice,
+        # then replies with the call count (3) on the third unblock.
+        set result [r reblock.test]
+        assert_equal 3 $result
+    }
+
+    test {REPLY_AGAIN with timeout fires timeout callback} {
+        # reblock.timeout: reply callback always returns REPLY_AGAIN,
+        # timeout is 500ms, should get timeout response.
+        set result [r reblock.timeout]
+        assert_match "*Timed out*" $result
+    }
+
+    test {REPLY_AGAIN disconnect fires disconnect callback} {
+        # Start reblock.disconnect on a separate client, then kill that client.
+        set rd [valkey_deferring_client]
+        $rd reblock.disconnect
+        after 100
+        # Get the client id
+        set clients [r client list]
+        set target_id ""
+        foreach line [split $clients "\n"] {
+            if {[string match "*cmd=reblock.disconnect*" $line]} {
+                regexp {id=(\d+)} $line -> target_id
+            }
+        }
+        # Kill the client
+        if {$target_id ne ""} {
+            r client kill id $target_id
+        }
+        after 200
+        # Verify disconnect callback was called
+        assert_equal 1 [r reblock.get_disconnect_called]
+        $rd close
+    }
+
+    test {REPLY_AGAIN CLIENT UNBLOCK triggers timeout callback} {
+        # Block a client with reblock that always returns REPLY_AGAIN
+        # then use CLIENT UNBLOCK to abort it — should trigger timeout cb
+        set rd [valkey_deferring_client]
+        $rd reblock.timeout
+        after 100
+        set clients [r client list]
+        set target_id ""
+        foreach line [split $clients "\n"] {
+            if {[string match "*cmd=reblock.timeout*" $line]} {
+                regexp {id=(\d+)} $line -> target_id
+            }
+        }
+        if {$target_id ne ""} {
+            r client unblock $target_id timeout
+        }
+        set result [$rd read]
+        assert_match "*Timed out*" $result
+        $rd close
+    }
+
     test "Unload the module - blockedclient" {
         assert_equal {OK} [r module unload blockedclient]
     }

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -312,44 +312,25 @@ foreach call_type {nested normal} {
     }
 
     test {REPLY_AGAIN disconnect fires disconnect callback} {
-        # Start reblock.disconnect on a separate client, then kill that client.
         set rd [valkey_deferring_client]
+        $rd client id
+        set client_id [$rd read]
         $rd reblock.disconnect
-        after 100
-        # Get the client id
-        set clients [r client list]
-        set target_id ""
-        foreach line [split $clients "\n"] {
-            if {[string match "*cmd=reblock.disconnect*" $line]} {
-                regexp {id=(\d+)} $line -> target_id
-            }
+        assert_equal 1 [r client kill id $client_id]
+        wait_for_condition 50 20 {
+            [r reblock.get_disconnect_called] eq 1
+        } else {
+            fail "Failed waiting for disconnect callback"
         }
-        # Kill the client
-        if {$target_id ne ""} {
-            r client kill id $target_id
-        }
-        after 200
-        # Verify disconnect callback was called
-        assert_equal 1 [r reblock.get_disconnect_called]
         $rd close
     }
 
     test {REPLY_AGAIN CLIENT UNBLOCK triggers timeout callback} {
-        # Block a client with reblock that always returns REPLY_AGAIN
-        # then use CLIENT UNBLOCK to abort it — should trigger timeout cb
         set rd [valkey_deferring_client]
+        $rd client id
+        set client_id [$rd read]
         $rd reblock.timeout
-        after 100
-        set clients [r client list]
-        set target_id ""
-        foreach line [split $clients "\n"] {
-            if {[string match "*cmd=reblock.timeout*" $line]} {
-                regexp {id=(\d+)} $line -> target_id
-            }
-        }
-        if {$target_id ne ""} {
-            r client unblock $target_id timeout
-        }
+        assert_equal 1 [r client unblock $client_id timeout]
         set result [$rd read]
         assert_match "*Timed out*" $result
         $rd close


### PR DESCRIPTION


Today, a module that blocks a client cannot keep it blocked after the reply callback is invoked. The core always unblocks the client and frees the blocked client handle after the reply callback returns. This forces modules that need to do main-thread work after unblock (like valkey-search's content resolution) to use `EventLoopAddOneShot` to schedule that work, adding an extra event loop iteration of latency per operation.

The fix adds a new return value `VALKEYMODULE_REPLY_AGAIN` (value 2). When the reply callback returns this, the core keeps the client blocked with its privdata intact. The module calls `UnblockClient` again later to re-trigger the reply callback. This is not a breaking change — the reply callback already returns `int` and existing modules return 0 or 1.

I am leaning towards this over a separate `VM_ReblockClient()` API (or new blocking framework) because the blocked client already has all necessary state (privdata, callbacks, timeout). No new state machine or lifecycle management needed — just a signal that says "I'm not done yet."

Tested with valkey-search (10k docs, `FT.SEARCH "common" LIMIT 0 10`). Both before and after include the valkeysearch PausePoint + DecrementRefCount fixes from PR 1037.

    Scenario: 1 TEXT field × 25 bytes (minimal content)
    Clients | Before (req/s) | After (req/s) | Improvement
    1       | 1,372          | 1,385         | +1%
    10      | 9,174          | 9,615         | +5%
    50      | 24,390         | 25,641        | +5%

    Scenario: 5 TEXT fields × 1KB each (typical content workload)
    Clients | Before (req/s) | After (req/s) | Improvement
    1       | 588            | 1,036         | +76%
    50      | 12,048         | 17,422        | +45%
    200     | 11,429         | 12,136        | +6%
    500     | 11,062         | 13,193        | +19%

The fix helps most when content resolution involves real work (multiple fields, larger data). With trivial content (1 small field), the event loop hop is negligible. With 5 fields × 1KB, the scheduling overhead becomes a significant fraction of per-query latency — especially at low concurrency where each query pays the full round-trip cost.

Prior to the fix, main thread is mostly idle between `EventLoopAddOneShot` callbacks — the scheduling hop is the bottleneck at low concurrency.


After the fix, Main thread does content fetch + reply inline in the reply callback. No scheduling hop.

Tests added to `tests/modules/blockedclient.c`:
- `reblock.test` — re-blocks twice, replies on third unblock
- `reblock.timeout` — re-blocks forever, verifies timeout callback fires
- `reblock.disconnect` — re-blocks, client killed, verifies disconnect callback fires
- `CLIENT UNBLOCK` on re-blocked client — verifies abort triggers timeout callback


