### PR TITLE
Add support for secondary certificates

### DIFF
--- a/.config/typos.toml
+++ b/.config/typos.toml
@@ -45,6 +45,11 @@ extend-ignore-re = [
     "DUMPed",
 ]
 
+[type.sh]
+extend-ignore-re = [
+    "passin", # gen-test-certs.sh
+]
+
 [type.c.extend-identifiers]
 advices = "advices"
 clen = "clen"

--- a/src/config.c
+++ b/src/config.c
@@ -3622,6 +3622,7 @@ standardConfig static_configs[] = {
     createStringConfig("tls-client-key-file-pass", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.client_key_file_pass, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-alt-cert-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.alt_cert_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-alt-key-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.alt_key_file, NULL, NULL, applyTlsCfg),
+    createStringConfig("tls-alt-key-file-pass", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.alt_key_file_pass, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-dh-params-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.dh_params_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ca-cert-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ca_cert_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ca-cert-dir", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ca_cert_dir, NULL, NULL, applyTlsCfg),

--- a/src/config.c
+++ b/src/config.c
@@ -3620,6 +3620,8 @@ standardConfig static_configs[] = {
     createStringConfig("tls-client-cert-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.client_cert_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-client-key-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.client_key_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-client-key-file-pass", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.client_key_file_pass, NULL, NULL, applyTlsCfg),
+    createStringConfig("tls-alt-cert-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.alt_cert_file, NULL, NULL, applyTlsCfg),
+    createStringConfig("tls-alt-key-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.alt_key_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-dh-params-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.dh_params_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ca-cert-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ca_cert_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ca-cert-dir", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ca_cert_dir, NULL, NULL, applyTlsCfg),

--- a/src/server.c
+++ b/src/server.c
@@ -2447,9 +2447,11 @@ void initServerConfig(void) {
     server.latency_tracking_info_percentiles[2] = 99.9; /* p999 */
 
     server.tls_server_cert_expire_time = 0;
+    server.tls_server_alt_cert_expire_time = 0;
     server.tls_client_cert_expire_time = 0;
     server.tls_ca_cert_expire_time = 0;
     server.tls_server_cert_serial = NULL;
+    server.tls_server_alt_cert_serial = NULL;
     server.tls_client_cert_serial = NULL;
     server.tls_ca_cert_serial = NULL;
 
@@ -6431,6 +6433,11 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             tls_server_seconds_remaining = server.tls_server_cert_expire_time - (long long)server.unixtime;
             if (tls_server_seconds_remaining < 0) tls_server_seconds_remaining = 0;
         }
+        long long tls_server_alt_seconds_remaining = 0;
+        if (server.tls_server_alt_cert_expire_time > 0) {
+            tls_server_alt_seconds_remaining = server.tls_server_alt_cert_expire_time - (long long)server.unixtime;
+            if (tls_server_alt_seconds_remaining < 0) tls_server_alt_seconds_remaining = 0;
+        }
         long long tls_client_seconds_remaining = 0;
         if (server.tls_client_cert_expire_time > 0) {
             tls_client_seconds_remaining = server.tls_client_cert_expire_time - (long long)server.unixtime;
@@ -6446,6 +6453,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             "# TLS\r\n" FMTARGS(
                 "tls_server_cert_serial:%s\r\n", server.tls_server_cert_serial ? server.tls_server_cert_serial : "none",
                 "tls_server_cert_expires_in_seconds:%lld\r\n", tls_server_seconds_remaining,
+                "tls_server_alt_cert_serial:%s\r\n", server.tls_server_alt_cert_serial ? server.tls_server_alt_cert_serial : "none",
+                "tls_server_alt_cert_expires_in_seconds:%lld\r\n", tls_server_alt_seconds_remaining,
                 "tls_client_cert_serial:%s\r\n", server.tls_client_cert_serial ? server.tls_client_cert_serial : "none",
                 "tls_client_cert_expires_in_seconds:%lld\r\n", tls_client_seconds_remaining,
                 "tls_ca_cert_serial:%s\r\n", server.tls_ca_cert_serial ? server.tls_ca_cert_serial : "none",

--- a/src/server.h
+++ b/src/server.h
@@ -1702,10 +1702,12 @@ struct malloc_stats {
 typedef struct serverTLSContextConfig {
     char *cert_file;            /* Server side and optionally client side cert file name */
     char *key_file;             /* Private key filename for cert_file */
-    char *key_file_pass;        /* Optional password for key_file */
+    char *key_file_pass;        /* Optional password for key_file AND alt_key_file */
     char *client_cert_file;     /* Certificate to use as a client; if none, use cert_file */
     char *client_key_file;      /* Private key filename for client_cert_file */
     char *client_key_file_pass; /* Optional password for client_key_file */
+    char *alt_cert_file;        /* Secondary server side cert file name */
+    char *alt_key_file;         /* Private key filename for alt_cert_file */
     int client_auth_user;       /* Field to be used for automatic TLS authentication based on client TLS certificate */
     char *dh_params_file;
     char *ca_cert_file;

--- a/src/server.h
+++ b/src/server.h
@@ -2424,9 +2424,11 @@ struct valkeyServer {
     int tls_auth_clients;
     serverTLSContextConfig tls_ctx_config;
     long long tls_server_cert_expire_time;
+    long long tls_server_alt_cert_expire_time;
     long long tls_client_cert_expire_time;
     long long tls_ca_cert_expire_time;
     sds tls_server_cert_serial;
+    sds tls_server_alt_cert_serial;
     sds tls_client_cert_serial;
     sds tls_ca_cert_serial;
     serverUnixContextConfig unix_ctx_config;

--- a/src/server.h
+++ b/src/server.h
@@ -1702,12 +1702,13 @@ struct malloc_stats {
 typedef struct serverTLSContextConfig {
     char *cert_file;            /* Server side and optionally client side cert file name */
     char *key_file;             /* Private key filename for cert_file */
-    char *key_file_pass;        /* Optional password for key_file AND alt_key_file */
+    char *key_file_pass;        /* Optional password for key_file */
     char *client_cert_file;     /* Certificate to use as a client; if none, use cert_file */
     char *client_key_file;      /* Private key filename for client_cert_file */
     char *client_key_file_pass; /* Optional password for client_key_file */
     char *alt_cert_file;        /* Secondary server side cert file name */
     char *alt_key_file;         /* Private key filename for alt_cert_file */
+    char *alt_key_file_pass;    /* Optional password for alt_key_file */
     int client_auth_user;       /* Field to be used for automatic TLS authentication based on client TLS certificate */
     char *dh_params_file;
     char *ca_cert_file;

--- a/src/tls.c
+++ b/src/tls.c
@@ -578,9 +578,11 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
 
     const char *alt_cert_file = client ? NULL : ctx_config->alt_cert_file;
     const char *alt_key_file = client ? NULL : ctx_config->alt_key_file;
+    const char *alt_key_file_pass = client ? NULL : ctx_config->alt_key_file_pass;
     char errbuf[256];
     SSL_CTX *ctx = NULL;
-    unsigned char* psig_data = NULL;
+    EVP_PKEY *primary_pkey = NULL;
+    EVP_PKEY *alt_pkey = NULL;
     ctx = SSL_CTX_new(SSLv23_method());
     if (!ctx) goto error;
 
@@ -621,11 +623,11 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
     }
 
     if (alt_cert_file) {
-        const ASN1_BIT_STRING *primary_signature;
-        X509_get0_signature(&primary_signature, NULL, SSL_CTX_get0_certificate(ctx));
-        const int psig_length = primary_signature->length;
-        psig_data = zmalloc(psig_length);
-        memcpy(psig_data, primary_signature->data, psig_length);
+        primary_pkey = X509_get_pubkey(SSL_CTX_get0_certificate(ctx));
+        if (!primary_pkey) {
+            serverLog(LL_WARNING, "Could not get public key from primary certificate");
+            goto error;
+        }
 
         if (SSL_CTX_use_certificate_chain_file(ctx, alt_cert_file) <= 0) {
             ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
@@ -638,28 +640,30 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
             goto error;
         }
 
-        const ASN1_BIT_STRING *alt_signature;
-        X509_get0_signature(&alt_signature, NULL, SSL_CTX_get0_certificate(ctx));
-        if (psig_length == alt_signature->length && memcmp(psig_data, alt_signature->data, psig_length) == 0) {
-            serverLog(LL_WARNING, "Primary and alternate certificates cannot be identical. Use two different ones with different algorithms");
+        alt_pkey = X509_get_pubkey(SSL_CTX_get0_certificate(ctx));
+        if (!alt_pkey) {
+            serverLog(LL_WARNING, "Could not get public key from alternate certificate");
+            goto error;
+        }
+
+        if (EVP_PKEY_base_id(primary_pkey) == EVP_PKEY_base_id(alt_pkey)) {
+            serverLog(LL_WARNING, "Primary and alternate certificates must use different key algorithms");
             goto error;
         }
     }
 
-    /* If the user tries to use a primary and alt cert of the same type, this will fail
-     * due to the first one being overwritten in the context, so it will attempt to load
-     * the first key for the second cert
-     */
     if (SSL_CTX_use_PrivateKey_file(ctx, key_file, SSL_FILETYPE_PEM) <= 0) {
         ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
         serverLog(LL_WARNING, "Failed to load private key: %s: %s", key_file, errbuf);
         goto error;
     }
-
-    if (alt_key_file && SSL_CTX_use_PrivateKey_file(ctx, alt_key_file, SSL_FILETYPE_PEM) <= 0) {
-        ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
-        serverLog(LL_WARNING, "Failed to load private key: %s: %s", alt_key_file, errbuf);
-        goto error;
+    if (alt_key_file) {
+        SSL_CTX_set_default_passwd_cb_userdata(ctx, (void *)alt_key_file_pass);
+        if (SSL_CTX_use_PrivateKey_file(ctx, alt_key_file, SSL_FILETYPE_PEM) <= 0) {
+            ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
+            serverLog(LL_WARNING, "Failed to load private key: %s: %s", alt_key_file, errbuf);
+            goto error;
+        }
     }
 
     if (ctx_config->ca_cert_file || ctx_config->ca_cert_dir) {
@@ -692,12 +696,14 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
     }
 #endif
 
-    zfree(psig_data);
+    EVP_PKEY_free(primary_pkey);
+    EVP_PKEY_free(alt_pkey);
     return ctx;
 
 error:
+    EVP_PKEY_free(primary_pkey);
+    EVP_PKEY_free(alt_pkey);
     if (ctx) SSL_CTX_free(ctx);
-    zfree(psig_data);
     return NULL;
 }
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -40,6 +40,7 @@
      ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
       (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
 
+#include <openssl/x509_vfy.h>
 #include <openssl/conf.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
@@ -56,7 +57,6 @@
 #include <arpa/inet.h>
 #include <dirent.h>
 #include <ctype.h>
-#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -564,9 +564,12 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
     const char *cert_file = client ? ctx_config->client_cert_file : ctx_config->cert_file;
     const char *key_file = client ? ctx_config->client_key_file : ctx_config->key_file;
     const char *key_file_pass = client ? ctx_config->client_key_file_pass : ctx_config->key_file_pass;
+
+    const char *alt_cert_file = client ? NULL : ctx_config->alt_cert_file;
+    const char *alt_key_file = client ? NULL : ctx_config->alt_key_file;
     char errbuf[256];
     SSL_CTX *ctx = NULL;
-
+    unsigned char* psig_data = NULL;
     ctx = SSL_CTX_new(SSLv23_method());
     if (!ctx) goto error;
 
@@ -606,9 +609,45 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
         goto error;
     }
 
+    if (alt_cert_file) {
+        const ASN1_BIT_STRING *primary_signature;
+        X509_get0_signature(&primary_signature, NULL, SSL_CTX_get0_certificate(ctx));
+        const int psig_length = primary_signature->length;
+        psig_data = zmalloc(psig_length);
+        memcpy(psig_data, primary_signature->data, psig_length);
+
+        if (SSL_CTX_use_certificate_chain_file(ctx, alt_cert_file) <= 0) {
+            ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
+            serverLog(LL_WARNING, "Failed to load certificate: %s: %s", alt_cert_file, errbuf);
+            goto error;
+        }
+
+        if (!isCertValid(SSL_CTX_get0_certificate(ctx))) {
+            serverLog(LL_WARNING, "Alternate server TLS certificate is invalid. Aborting TLS configuration.");
+            goto error;
+        }
+
+        const ASN1_BIT_STRING *alt_signature;
+        X509_get0_signature(&alt_signature, NULL, SSL_CTX_get0_certificate(ctx));
+        if (psig_length == alt_signature->length && memcmp(psig_data, alt_signature->data, psig_length) == 0) {
+            serverLog(LL_WARNING, "Primary and alternate certificates cannot be identical. Use two different ones with different algorithms");
+            goto error;
+        }
+    }
+
+    /* If the user tries to use a primary and alt cert of the same type, this will fail
+     * due to the first one being overwritten in the context, so it will attempt to load
+     * the first key for the second cert
+     */
     if (SSL_CTX_use_PrivateKey_file(ctx, key_file, SSL_FILETYPE_PEM) <= 0) {
         ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
         serverLog(LL_WARNING, "Failed to load private key: %s: %s", key_file, errbuf);
+        goto error;
+    }
+
+    if (alt_key_file && SSL_CTX_use_PrivateKey_file(ctx, alt_key_file, SSL_FILETYPE_PEM) <= 0) {
+        ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
+        serverLog(LL_WARNING, "Failed to load private key: %s: %s", alt_key_file, errbuf);
         goto error;
     }
 
@@ -642,10 +681,12 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
     }
 #endif
 
+    zfree(psig_data);
     return ctx;
 
 error:
     if (ctx) SSL_CTX_free(ctx);
+    zfree(psig_data);
     return NULL;
 }
 
@@ -666,6 +707,16 @@ static int tlsCreateContexts(serverTLSContextConfig *ctx_config, SSL_CTX **out_c
 
     if (!ctx_config->key_file) {
         serverLog(LL_WARNING, "No tls-key-file configured!");
+        goto error;
+    }
+
+    if (ctx_config->alt_cert_file && !ctx_config->alt_key_file) {
+        serverLog(LL_WARNING, "tls-alt-cert-file provided without a key");
+        goto error;
+    }
+
+    if (ctx_config->alt_key_file && !ctx_config->alt_cert_file) {
+        serverLog(LL_WARNING, "tls-alt-key-file provided without a certificate");
         goto error;
     }
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -399,9 +399,20 @@ static int tlsUpdateCertInfoFromDir(const char *path, long long *expiry, sds *se
 }
 
 static void tlsRefreshServerCertInfo(void) {
+    /* Cycle through both certificates to get the correct info for each */
     if (!(server.tls_port || server.tls_replication || server.tls_cluster) || !valkey_tls_ctx ||
+        SSL_CTX_set_current_cert(valkey_tls_ctx, SSL_CERT_SET_FIRST) != 1 ||
         tlsUpdateCertInfoFromCtx(valkey_tls_ctx, &server.tls_server_cert_expire_time, &server.tls_server_cert_serial) == C_ERR) {
         tlsClearCertInfo(&server.tls_server_cert_expire_time, &server.tls_server_cert_serial);
+    }
+    if (SSL_CTX_set_current_cert(valkey_tls_ctx, SSL_CERT_SET_NEXT) != 1 ||
+        tlsUpdateCertInfoFromCtx(valkey_tls_ctx, &server.tls_server_alt_cert_expire_time, &server.tls_server_alt_cert_serial) == C_ERR) {
+        tlsClearCertInfo(&server.tls_server_alt_cert_expire_time, &server.tls_server_alt_cert_serial);
+    }
+    if (SSL_CTX_set_current_cert(valkey_tls_ctx, SSL_CERT_SET_FIRST) != 1) {
+        serverLog(LL_WARNING, "Certificate unset during refresh, clearing all server certificate info");
+        tlsClearCertInfo(&server.tls_server_cert_expire_time, &server.tls_server_cert_serial);
+        tlsClearCertInfo(&server.tls_server_alt_cert_expire_time, &server.tls_server_alt_cert_serial);
     }
 }
 
@@ -832,6 +843,8 @@ error:
 typedef struct {
     unsigned char cert_fingerprint[EVP_MAX_MD_SIZE];
     unsigned int cert_fingerprint_len;
+    unsigned char alt_cert_fingerprint[EVP_MAX_MD_SIZE];
+    unsigned int alt_cert_fingerprint_len;
     unsigned char client_cert_fingerprint[EVP_MAX_MD_SIZE];
     unsigned int client_cert_fingerprint_len;
     unsigned char ca_cert_fingerprint[EVP_MAX_MD_SIZE];
@@ -889,6 +902,7 @@ static void captureMetadata(serverTLSContextConfig *ctx_config, tlsMaterialsMeta
 
     /* Certificate files: fingerprint-based detection */
     getCertFingerprint(ctx_config->cert_file, metadata->cert_fingerprint, &metadata->cert_fingerprint_len);
+    getCertFingerprint(ctx_config->alt_cert_file, metadata->alt_cert_fingerprint, &metadata->alt_cert_fingerprint_len);
     getCertFingerprint(ctx_config->client_cert_file, metadata->client_cert_fingerprint, &metadata->client_cert_fingerprint_len);
     getCertFingerprint(ctx_config->ca_cert_file, metadata->ca_cert_fingerprint, &metadata->ca_cert_fingerprint_len);
 
@@ -913,6 +927,11 @@ static int metadataChanged(const tlsMaterialsMetadata *old, const tlsMaterialsMe
     /* Check certificate fingerprints */
     if (old->cert_fingerprint_len != new->cert_fingerprint_len ||
         (new->cert_fingerprint_len > 0 && memcmp(old->cert_fingerprint, new->cert_fingerprint, new->cert_fingerprint_len) != 0)) {
+        return 1;
+    }
+
+    if (old->alt_cert_fingerprint_len != new->alt_cert_fingerprint_len ||
+        (new->alt_cert_fingerprint_len > 0 && memcmp(old->alt_cert_fingerprint, new->alt_cert_fingerprint, new->alt_cert_fingerprint_len) != 0)) {
         return 1;
     }
 
@@ -2124,6 +2143,7 @@ static void tlsClearCACertInfo(void) {
 
 static void tlsClearAllCertInfo(void) {
     tlsClearCertInfo(&server.tls_server_cert_expire_time, &server.tls_server_cert_serial);
+    tlsClearCertInfo(&server.tls_server_alt_cert_expire_time, &server.tls_server_alt_cert_serial);
     tlsClearCertInfo(&server.tls_client_cert_expire_time, &server.tls_client_cert_serial);
     tlsClearCACertInfo();
 }

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -127,6 +127,119 @@ start_server {tags {"tls"}} {
             }
         }
 
+        test {TLS: basic dual certificates support} {
+            # backup current certificates
+            set orig_server_crt [lindex [r config get tls-cert-file] 1]
+            set orig_server_key [lindex [r config get tls-key-file] 1]
+            set orig_server_alt_crt [lindex [r config get tls-alt-cert-file] 1]
+            set orig_server_alt_key [lindex [r config get tls-alt-key-file] 1]
+            set ca_file [lindex [r config get tls-ca-cert-file] 1]
+
+            set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+            set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
+            set valkey_pqc_crt [format "%s/tests/tls/valkey-mldsa.crt" [pwd]]
+            set valkey_pqc_key [format "%s/tests/tls/valkey-mldsa.key" [pwd]]
+            r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key
+            set s [valkey_client]
+            assert_equal "PONG" [$s PING]
+            $s close
+            # also test connecting with openssl without pqc ciphers support
+            set port [lindex [r config get tls-port] 1]
+            catch {exec /usr/bin/openssl s_client -connect localhost:$port -CAfile $valkey_crt -sigalgs "rsa_pss_pss_sha256:rsa_pss_rsae_sha256" < /dev/null} out
+            assert_match {*Peer signature type: rsa_pss_rsae_sha256*} $out
+
+            #cleanup
+            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
+        }
+
+        test {TLS: alt cert and key files must be provided together} {
+            # backup current certificates
+            set orig_server_crt [lindex [r config get tls-cert-file] 1]
+            set orig_server_key [lindex [r config get tls-key-file] 1]
+            set orig_server_alt_crt [lindex [r config get tls-alt-cert-file] 1]
+            set orig_server_alt_key [lindex [r config get tls-alt-key-file] 1]
+
+            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file "" tls-alt-key-file ""
+
+            catch {r CONFIG SET tls-alt-cert-file $orig_server_crt} e
+            assert_match {*related to argument 'tls-alt-cert-file'*} $e
+            catch {r CONFIG SET tls-alt-key-file $orig_server_key} e
+            assert_match {**related to argument 'tls-alt-key-file'*} $e
+
+            #cleanup
+            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
+        }
+
+        test {TLS: the same certificate twice not allowed} {
+            # backup current certificates
+            set orig_server_crt [lindex [r config get tls-cert-file] 1]
+            set orig_server_key [lindex [r config get tls-key-file] 1]
+            set orig_server_alt_crt [lindex [r config get tls-alt-cert-file] 1]
+            set orig_server_alt_key [lindex [r config get tls-alt-key-file] 1]
+
+            catch {r CONFIG SET tls-alt-cert-file $orig_server_crt tls-alt-key-file $orig_server_key} e
+            assert_match {*Unable to update TLS configuration*} $e
+
+            #cleanup
+            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
+        }
+
+        test {TLS: Two certificates of the same type not allowed} {
+            # backup current certificates
+            set orig_server_crt [lindex [r config get tls-cert-file] 1]
+            set orig_server_key [lindex [r config get tls-key-file] 1]
+            set orig_server_alt_crt [lindex [r config get tls-alt-cert-file] 1]
+            set orig_server_alt_key [lindex [r config get tls-alt-key-file] 1]
+
+            set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+            set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
+            set valkey_pqc_crt [format "%s/tests/tls/valkey-mldsa.crt" [pwd]]
+            set valkey_pqc_key [format "%s/tests/tls/valkey-mldsa.key" [pwd]]
+            set valkey_pw_crt [format "%s/tests/tls/valkey-pw.crt" [pwd]]
+            set valkey_pw_key [format "%s/tests/tls/valkey-pw.key" [pwd]]
+            set valkey_pqc_pw_crt [format "%s/tests/tls/valkey-mldsa-pw.crt" [pwd]]
+            set valkey_pqc_pw_key [format "%s/tests/tls/valkey-mldsa-pw.key" [pwd]]
+
+            r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key
+            set s [valkey_client]
+            assert_equal "PONG" [$s PING]
+            $s close
+            catch {r CONFIG SET tls-alt-cert-file $valkey_pqc_pw_crt tls-alt-key-file $valkey_pqc_pw_key tls-key-file-pass 1234} e
+            assert_match {*Unable to update TLS configuration*} $e
+            catch {r CONFIG SET tls-cert-file $valkey_pw_crt tls-key-file $valkey_pw_key tls-key-file-pass 1234} e
+            assert_match {*Unable to update TLS configuration*} $e
+
+            #cleanup
+            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key tls-key-file-pass ""
+        }
+
+        test {TLS: Dual certificates with passphrases} {
+            # backup current certificates
+            set orig_server_crt [lindex [r config get tls-cert-file] 1]
+            set orig_server_key [lindex [r config get tls-key-file] 1]
+            set orig_server_alt_crt [lindex [r config get tls-alt-cert-file] 1]
+            set orig_server_alt_key [lindex [r config get tls-alt-key-file] 1]
+
+            set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+            set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
+            set valkey_pqc_crt [format "%s/tests/tls/valkey-mldsa.crt" [pwd]]
+            set valkey_pqc_key [format "%s/tests/tls/valkey-mldsa.key" [pwd]]
+            set valkey_pw_crt [format "%s/tests/tls/valkey-pw.crt" [pwd]]
+            set valkey_pw_key [format "%s/tests/tls/valkey-pw.key" [pwd]]
+            set valkey_pqc_pw_crt [format "%s/tests/tls/valkey-mldsa-pw.crt" [pwd]]
+            set valkey_pqc_pw_key [format "%s/tests/tls/valkey-mldsa-pw.key" [pwd]]
+
+            r CONFIG SET tls-cert-file $valkey_pqc_pw_crt tls-key-file $valkey_pqc_pw_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key tls-key-file-pass 1234
+            set s [valkey_client]
+            assert_equal "PONG" [$s PING]
+            $s close
+            r CONFIG SET tls-cert-file $valkey_pqc_pw_crt tls-key-file $valkey_pqc_pw_key tls-alt-cert-file $valkey_pw_crt tls-alt-key-file $valkey_pw_key
+            r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_pw_crt tls-alt-key-file $valkey_pw_key
+
+            #cleanup
+            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key tls-key-file-pass ""
+        }
+
         test {TLS: switch between tcp and tls ports} {
             set srv_port [srv 0 port]
 

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -137,17 +137,17 @@ start_server {tags {"tls"}} {
 
             set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
             set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
-            set valkey_pqc_crt [format "%s/tests/tls/valkey-mldsa.crt" [pwd]]
-            set valkey_pqc_key [format "%s/tests/tls/valkey-mldsa.key" [pwd]]
+            set valkey_ec_crt [format "%s/tests/tls/valkey-ec.crt" [pwd]]
+            set valkey_ec_key [format "%s/tests/tls/valkey-ec.key" [pwd]]
             try {
-                r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key
+                r CONFIG SET tls-cert-file $valkey_ec_crt tls-key-file $valkey_ec_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key
                 set s [valkey_client]
                 assert_equal "PONG" [$s PING]
                 $s close
-                # also test connecting with openssl without pqc ciphers support
+                # also test connecting with openssl without ec ciphers support
                 set port [lindex [r config get tls-port] 1]
                 catch {exec openssl s_client -connect localhost:$port -CAfile $valkey_crt -sigalgs "rsa_pss_pss_sha256:rsa_pss_rsae_sha256" < /dev/null} out
-                assert_match {*Peer signature type: rsa_pss_rsae_sha256*} $out
+                assert_match {*Peer signature type: [rR][sS][aA][-_][pP][sS][sS]*} $out
             } finally {
                 #cleanup
                 r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
@@ -199,19 +199,19 @@ start_server {tags {"tls"}} {
 
             set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
             set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
-            set valkey_pqc_crt [format "%s/tests/tls/valkey-mldsa.crt" [pwd]]
-            set valkey_pqc_key [format "%s/tests/tls/valkey-mldsa.key" [pwd]]
+            set valkey_ec_crt [format "%s/tests/tls/valkey-ec.crt" [pwd]]
+            set valkey_ec_key [format "%s/tests/tls/valkey-ec.key" [pwd]]
             set valkey_pw_crt [format "%s/tests/tls/valkey-pw.crt" [pwd]]
             set valkey_pw_key [format "%s/tests/tls/valkey-pw.key" [pwd]]
-            set valkey_pqc_pw_crt [format "%s/tests/tls/valkey-mldsa-pw.crt" [pwd]]
-            set valkey_pqc_pw_key [format "%s/tests/tls/valkey-mldsa-pw.key" [pwd]]
+            set valkey_ec_pw_crt [format "%s/tests/tls/valkey-ec-pw.crt" [pwd]]
+            set valkey_ec_pw_key [format "%s/tests/tls/valkey-ec-pw.key" [pwd]]
 
             try {
-                r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key
+                r CONFIG SET tls-cert-file $valkey_ec_crt tls-key-file $valkey_ec_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key
                 set s [valkey_client]
                 assert_equal "PONG" [$s PING]
                 $s close
-                catch {r CONFIG SET tls-alt-cert-file $valkey_pqc_pw_crt tls-alt-key-file $valkey_pqc_pw_key tls-key-file-pass 1234} e
+                catch {r CONFIG SET tls-alt-cert-file $valkey_ec_pw_crt tls-alt-key-file $valkey_ec_pw_key tls-key-file-pass 1234} e
                 assert_match {*Unable to update TLS configuration*} $e
                 catch {r CONFIG SET tls-cert-file $valkey_pw_crt tls-key-file $valkey_pw_key tls-key-file-pass 1234} e
                 assert_match {*Unable to update TLS configuration*} $e
@@ -230,20 +230,20 @@ start_server {tags {"tls"}} {
 
             set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
             set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
-            set valkey_pqc_crt [format "%s/tests/tls/valkey-mldsa.crt" [pwd]]
-            set valkey_pqc_key [format "%s/tests/tls/valkey-mldsa.key" [pwd]]
+            set valkey_ec_crt [format "%s/tests/tls/valkey-ec.crt" [pwd]]
+            set valkey_ec_key [format "%s/tests/tls/valkey-ec.key" [pwd]]
             set valkey_pw_crt [format "%s/tests/tls/valkey-pw.crt" [pwd]]
             set valkey_pw_key [format "%s/tests/tls/valkey-pw.key" [pwd]]
-            set valkey_pqc_pw_crt [format "%s/tests/tls/valkey-mldsa-pw.crt" [pwd]]
-            set valkey_pqc_pw_key [format "%s/tests/tls/valkey-mldsa-pw.key" [pwd]]
+            set valkey_ec_pw_crt [format "%s/tests/tls/valkey-ec-pw.crt" [pwd]]
+            set valkey_ec_pw_key [format "%s/tests/tls/valkey-ec-pw.key" [pwd]]
 
             try {
-                r CONFIG SET tls-cert-file $valkey_pqc_pw_crt tls-key-file $valkey_pqc_pw_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key tls-key-file-pass asdf tls-alt-key-file-pass 1234
+                r CONFIG SET tls-cert-file $valkey_ec_pw_crt tls-key-file $valkey_ec_pw_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key tls-key-file-pass asdf tls-alt-key-file-pass 1234
                 set s [valkey_client]
                 assert_equal "PONG" [$s PING]
                 $s close
-                r CONFIG SET tls-cert-file $valkey_pqc_pw_crt tls-key-file $valkey_pqc_pw_key tls-alt-cert-file $valkey_pw_crt tls-alt-key-file $valkey_pw_key
-                r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_pw_crt tls-alt-key-file $valkey_pw_key
+                r CONFIG SET tls-cert-file $valkey_ec_pw_crt tls-key-file $valkey_ec_pw_key tls-alt-cert-file $valkey_pw_crt tls-alt-key-file $valkey_pw_key
+                r CONFIG SET tls-cert-file $valkey_ec_crt tls-key-file $valkey_ec_key tls-alt-cert-file $valkey_pw_crt tls-alt-key-file $valkey_pw_key
             } finally {
                 #cleanup
                 r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key tls-key-file-pass "" tls-alt-key-file-pass ""
@@ -402,8 +402,8 @@ start_server {tags {"tls"}} {
             set orig_server_key [lindex [r config get tls-key-file] 1]
             set orig_server_alt_crt [lindex [r config get tls-alt-cert-file] 1]
             set orig_server_alt_key [lindex [r config get tls-alt-key-file] 1]
-            set valkey_alt_crt [format "%s/tests/tls/valkey-mldsa.crt" [pwd]]
-            set valkey_alt_key [format "%s/tests/tls/valkey-mldsa.key" [pwd]]
+            set valkey_alt_crt [format "%s/tests/tls/valkey-ec.crt" [pwd]]
+            set valkey_alt_key [format "%s/tests/tls/valkey-ec.key" [pwd]]
             set orig_server_key_pass [lindex [r config get tls-alt-key-file-pass] 1]
 
             # Create temporary certificate files (copies of current ones)
@@ -462,8 +462,8 @@ start_server {tags {"tls"}} {
                 assert {$serial2 ne "none"}
                 assert {$serial1 ne $serial2}
 
-                set valkey_alt_crt [format "%s/tests/tls/valkey-mldsa-pw.crt" [pwd]]
-                set valkey_alt_key [format "%s/tests/tls/valkey-mldsa-pw.key" [pwd]]
+                set valkey_alt_crt [format "%s/tests/tls/valkey-ec-pw.crt" [pwd]]
+                set valkey_alt_key [format "%s/tests/tls/valkey-ec-pw.key" [pwd]]
                 file copy -force $valkey_alt_crt $temp_alt_crt
                 file copy -force $valkey_alt_key $temp_alt_key
 

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -139,17 +139,19 @@ start_server {tags {"tls"}} {
             set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
             set valkey_pqc_crt [format "%s/tests/tls/valkey-mldsa.crt" [pwd]]
             set valkey_pqc_key [format "%s/tests/tls/valkey-mldsa.key" [pwd]]
-            r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key
-            set s [valkey_client]
-            assert_equal "PONG" [$s PING]
-            $s close
-            # also test connecting with openssl without pqc ciphers support
-            set port [lindex [r config get tls-port] 1]
-            catch {exec /usr/bin/openssl s_client -connect localhost:$port -CAfile $valkey_crt -sigalgs "rsa_pss_pss_sha256:rsa_pss_rsae_sha256" < /dev/null} out
-            assert_match {*Peer signature type: rsa_pss_rsae_sha256*} $out
-
-            #cleanup
-            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
+            try {
+                r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key
+                set s [valkey_client]
+                assert_equal "PONG" [$s PING]
+                $s close
+                # also test connecting with openssl without pqc ciphers support
+                set port [lindex [r config get tls-port] 1]
+                catch {exec openssl s_client -connect localhost:$port -CAfile $valkey_crt -sigalgs "rsa_pss_pss_sha256:rsa_pss_rsae_sha256" < /dev/null} out
+                assert_match {*Peer signature type: rsa_pss_rsae_sha256*} $out
+            } finally {
+                #cleanup
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
+            }
         }
 
         test {TLS: alt cert and key files must be provided together} {
@@ -159,15 +161,17 @@ start_server {tags {"tls"}} {
             set orig_server_alt_crt [lindex [r config get tls-alt-cert-file] 1]
             set orig_server_alt_key [lindex [r config get tls-alt-key-file] 1]
 
-            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file "" tls-alt-key-file ""
+            try {
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file "" tls-alt-key-file ""
 
-            catch {r CONFIG SET tls-alt-cert-file $orig_server_crt} e
-            assert_match {*related to argument 'tls-alt-cert-file'*} $e
-            catch {r CONFIG SET tls-alt-key-file $orig_server_key} e
-            assert_match {**related to argument 'tls-alt-key-file'*} $e
-
-            #cleanup
-            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
+                catch {r CONFIG SET tls-alt-cert-file $orig_server_crt} e
+                assert_match {*related to argument 'tls-alt-cert-file'*} $e
+                catch {r CONFIG SET tls-alt-key-file $orig_server_key} e
+                assert_match {*related to argument 'tls-alt-key-file'*} $e
+            } finally {
+                #cleanup
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
+            }
         }
 
         test {TLS: the same certificate twice not allowed} {
@@ -177,11 +181,13 @@ start_server {tags {"tls"}} {
             set orig_server_alt_crt [lindex [r config get tls-alt-cert-file] 1]
             set orig_server_alt_key [lindex [r config get tls-alt-key-file] 1]
 
-            catch {r CONFIG SET tls-alt-cert-file $orig_server_crt tls-alt-key-file $orig_server_key} e
-            assert_match {*Unable to update TLS configuration*} $e
-
-            #cleanup
-            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
+            try {
+                catch {r CONFIG SET tls-alt-cert-file $orig_server_crt tls-alt-key-file $orig_server_key} e
+                assert_match {*Unable to update TLS configuration*} $e
+            } finally {
+                #cleanup
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
+            }
         }
 
         test {TLS: Two certificates of the same type not allowed} {
@@ -200,17 +206,19 @@ start_server {tags {"tls"}} {
             set valkey_pqc_pw_crt [format "%s/tests/tls/valkey-mldsa-pw.crt" [pwd]]
             set valkey_pqc_pw_key [format "%s/tests/tls/valkey-mldsa-pw.key" [pwd]]
 
-            r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key
-            set s [valkey_client]
-            assert_equal "PONG" [$s PING]
-            $s close
-            catch {r CONFIG SET tls-alt-cert-file $valkey_pqc_pw_crt tls-alt-key-file $valkey_pqc_pw_key tls-key-file-pass 1234} e
-            assert_match {*Unable to update TLS configuration*} $e
-            catch {r CONFIG SET tls-cert-file $valkey_pw_crt tls-key-file $valkey_pw_key tls-key-file-pass 1234} e
-            assert_match {*Unable to update TLS configuration*} $e
-
-            #cleanup
-            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key tls-key-file-pass ""
+            try {
+                r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key
+                set s [valkey_client]
+                assert_equal "PONG" [$s PING]
+                $s close
+                catch {r CONFIG SET tls-alt-cert-file $valkey_pqc_pw_crt tls-alt-key-file $valkey_pqc_pw_key tls-key-file-pass 1234} e
+                assert_match {*Unable to update TLS configuration*} $e
+                catch {r CONFIG SET tls-cert-file $valkey_pw_crt tls-key-file $valkey_pw_key tls-key-file-pass 1234} e
+                assert_match {*Unable to update TLS configuration*} $e
+            } finally {
+                #cleanup
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key tls-key-file-pass ""
+            }
         }
 
         test {TLS: Dual certificates with passphrases} {
@@ -229,15 +237,17 @@ start_server {tags {"tls"}} {
             set valkey_pqc_pw_crt [format "%s/tests/tls/valkey-mldsa-pw.crt" [pwd]]
             set valkey_pqc_pw_key [format "%s/tests/tls/valkey-mldsa-pw.key" [pwd]]
 
-            r CONFIG SET tls-cert-file $valkey_pqc_pw_crt tls-key-file $valkey_pqc_pw_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key tls-key-file-pass 1234
-            set s [valkey_client]
-            assert_equal "PONG" [$s PING]
-            $s close
-            r CONFIG SET tls-cert-file $valkey_pqc_pw_crt tls-key-file $valkey_pqc_pw_key tls-alt-cert-file $valkey_pw_crt tls-alt-key-file $valkey_pw_key
-            r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_pw_crt tls-alt-key-file $valkey_pw_key
-
-            #cleanup
-            r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key tls-key-file-pass ""
+            try {
+                r CONFIG SET tls-cert-file $valkey_pqc_pw_crt tls-key-file $valkey_pqc_pw_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key tls-key-file-pass 1234
+                set s [valkey_client]
+                assert_equal "PONG" [$s PING]
+                $s close
+                r CONFIG SET tls-cert-file $valkey_pqc_pw_crt tls-key-file $valkey_pqc_pw_key tls-alt-cert-file $valkey_pw_crt tls-alt-key-file $valkey_pw_key
+                r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_pw_crt tls-alt-key-file $valkey_pw_key
+            } finally {
+                #cleanup
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key tls-key-file-pass ""
+            }
         }
 
         test {TLS: switch between tcp and tls ports} {
@@ -390,17 +400,25 @@ start_server {tags {"tls"}} {
             # Get current certificate files
             set orig_server_crt [lindex [r config get tls-cert-file] 1]
             set orig_server_key [lindex [r config get tls-key-file] 1]
+            set orig_server_alt_crt [lindex [r config get tls-alt-cert-file] 1]
+            set orig_server_alt_key [lindex [r config get tls-alt-key-file] 1]
+            set valkey_alt_crt [format "%s/tests/tls/valkey-mldsa.crt" [pwd]]
+            set valkey_alt_key [format "%s/tests/tls/valkey-mldsa.key" [pwd]]
 
             # Create temporary certificate files (copies of current ones)
             set temp_crt "$orig_server_crt.temp"
             set temp_key "$orig_server_key.temp"
             file copy -force $orig_server_crt $temp_crt
             file copy -force $orig_server_key $temp_key
+            set temp_alt_crt "$valkey_alt_crt.temp"
+            set temp_alt_key "$valkey_alt_key.temp"
+            file copy -force $valkey_alt_crt $temp_alt_crt
+            file copy -force $valkey_alt_key $temp_alt_key
 
             # Ensure cleanup happens even if test fails
             try {
                 # Update server to use temporary certificate files
-                r CONFIG SET tls-cert-file $temp_crt tls-key-file $temp_key
+                r CONFIG SET tls-cert-file $temp_crt tls-key-file $temp_key tls-alt-cert-file $temp_alt_crt tls-alt-key-file $temp_alt_key
 
                 # Enable auto-reload with 1 second interval for faster testing
                 r CONFIG SET tls-auto-reload-interval 1
@@ -413,7 +431,11 @@ start_server {tags {"tls"}} {
                 if {![regexp {tls_server_cert_serial:([^\r\n]+)} $info1 -> serial1]} {
                     fail "INFO tls missing tls_server_cert_serial"
                 }
+                if {![regexp {tls_server_alt_cert_serial:([^\r\n]+)} $info1 -> alt_serial1]} {
+                    fail "INFO tls missing tls_server_alt_cert_serial"
+                }
                 assert {$serial1 ne "none"}
+                assert {$alt_serial1 ne "none"}
 
                 # Wait for at least one auto-reload cycle to complete
                 after 1100
@@ -439,6 +461,29 @@ start_server {tags {"tls"}} {
                 assert {$serial2 ne "none"}
                 assert {$serial1 ne $serial2}
 
+                set valkey_alt_crt [format "%s/tests/tls/valkey-mldsa-pw.crt" [pwd]]
+                set valkey_alt_key [format "%s/tests/tls/valkey-mldsa-pw.key" [pwd]]
+                file copy -force $valkey_alt_crt $temp_alt_crt
+                file copy -force $valkey_alt_key $temp_alt_key
+
+                # Wait for another auto-reload cycle to complete
+                after 2100
+
+                # Wait for reload to actually complete by checking server logs
+                # Use generous timeout for slow/busy CI systems
+                wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 150 100
+
+                # Verify connection still works after reload
+                set s [valkey_client]
+                assert_equal "PONG" [$s PING]
+                $s close
+                set info3 [r info tls]
+                if {![regexp {tls_server_alt_cert_serial:([^\r\n]+)} $info3 -> alt_serial2]} {
+                    fail "INFO tls missing tls_server_alt_cert_serial"
+                }
+                assert {$alt_serial2 ne "none"}
+                assert {$alt_serial1 ne $alt_serial2}
+
                 # Wait again to ensure filesystem timestamp will be different
                 # for the second modification and next reload cycle can detect it
                 after 1100
@@ -446,6 +491,8 @@ start_server {tags {"tls"}} {
                 # Restore original certificate content to temporary files
                 file copy -force $orig_server_crt $temp_crt
                 file copy -force $orig_server_key $temp_key
+                file copy -force $valkey_alt_crt $temp_alt_crt
+                file copy -force $valkey_alt_key $temp_alt_key
 
                 # Wait for second reload to complete
                 # Use generous timeout for slow/busy CI systems
@@ -457,13 +504,13 @@ start_server {tags {"tls"}} {
                 $s close
             } finally {
                 # Restore original configuration
-                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
 
                 # Disable auto-reload
                 r CONFIG SET tls-auto-reload-interval 0
 
                 # Clean up temporary files
-                file delete -force $temp_crt $temp_key
+                file delete -force $temp_crt $temp_key $temp_alt_crt $temp_alt_key
             }
         }
 

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -238,7 +238,7 @@ start_server {tags {"tls"}} {
             set valkey_pqc_pw_key [format "%s/tests/tls/valkey-mldsa-pw.key" [pwd]]
 
             try {
-                r CONFIG SET tls-cert-file $valkey_pqc_pw_crt tls-key-file $valkey_pqc_pw_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key tls-key-file-pass 1234
+                r CONFIG SET tls-cert-file $valkey_pqc_pw_crt tls-key-file $valkey_pqc_pw_key tls-alt-cert-file $valkey_crt tls-alt-key-file $valkey_key tls-key-file-pass asdf tls-alt-key-file-pass 1234
                 set s [valkey_client]
                 assert_equal "PONG" [$s PING]
                 $s close
@@ -246,7 +246,7 @@ start_server {tags {"tls"}} {
                 r CONFIG SET tls-cert-file $valkey_pqc_crt tls-key-file $valkey_pqc_key tls-alt-cert-file $valkey_pw_crt tls-alt-key-file $valkey_pw_key
             } finally {
                 #cleanup
-                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key tls-key-file-pass ""
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key tls-key-file-pass "" tls-alt-key-file-pass ""
             }
         }
 
@@ -404,6 +404,7 @@ start_server {tags {"tls"}} {
             set orig_server_alt_key [lindex [r config get tls-alt-key-file] 1]
             set valkey_alt_crt [format "%s/tests/tls/valkey-mldsa.crt" [pwd]]
             set valkey_alt_key [format "%s/tests/tls/valkey-mldsa.key" [pwd]]
+            set orig_server_key_pass [lindex [r config get tls-alt-key-file-pass] 1]
 
             # Create temporary certificate files (copies of current ones)
             set temp_crt "$orig_server_crt.temp"
@@ -418,7 +419,7 @@ start_server {tags {"tls"}} {
             # Ensure cleanup happens even if test fails
             try {
                 # Update server to use temporary certificate files
-                r CONFIG SET tls-cert-file $temp_crt tls-key-file $temp_key tls-alt-cert-file $temp_alt_crt tls-alt-key-file $temp_alt_key
+                r CONFIG SET tls-cert-file $temp_crt tls-key-file $temp_key tls-alt-cert-file $temp_alt_crt tls-alt-key-file $temp_alt_key tls-alt-key-file-pass "asdf"
 
                 # Enable auto-reload with 1 second interval for faster testing
                 r CONFIG SET tls-auto-reload-interval 1
@@ -504,7 +505,7 @@ start_server {tags {"tls"}} {
                 $s close
             } finally {
                 # Restore original configuration
-                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key tls-alt-key-file-pass $orig_server_key_pass
 
                 # Disable auto-reload
                 r CONFIG SET tls-auto-reload-interval 0

--- a/utils/gen-test-certs.sh
+++ b/utils/gen-test-certs.sh
@@ -8,7 +8,8 @@
 #   tests/tls/ca-notyet/                         Directory containing not-yet-valid CA certificate.
 #   tests/tls/ca-multi.crt                       CA bundle with multiple certs.
 #   tests/tls/ca-dir/                            CA directory with hashed links.
-#   tests/tls/valkey.{crt,key}                   A certificate with no key usage/policy restrictions.
+#   tests/tls/valkey{,-pw}.{crt,key}             A certificate with no key usage/policy restrictions. With and without a passphrase.
+#   tests/tls/valkey-mldsa{,-pw}.{crt,key}       A PQC certificate with no key usage/policy restrictions. With and without a passphrase.
 #   tests/tls/client.{crt,key}                   A certificate restricted for SSL client usage.
 #   tests/tls/client-{expired,notyet}.crt        Invalid certificates restricted for SSL client usage.
 #   tests/tls/server.{crt,key}                   A certificate restricted for SSL server usage.
@@ -28,7 +29,7 @@ generate_cert() {
     openssl req \
         -new -sha256 \
         -subj "/O=Valkey Test/CN=$cn" \
-        -key $keyfile | \
+        -key "$keyfile" | \
         openssl x509 \
             -req -sha256 \
             -CA tests/tls/ca.crt \
@@ -37,7 +38,7 @@ generate_cert() {
             -CAcreateserial \
             -days 365 \
             $opts \
-            -out $certfile
+            -out "$certfile"
 }
 
 mkdir -p tests/tls
@@ -67,6 +68,37 @@ _END_
 generate_cert server "Server-only" "-extfile tests/tls/openssl.cnf -extensions server_cert"
 generate_cert client "Client-only" "-extfile tests/tls/openssl.cnf -extensions client_cert"
 generate_cert valkey "Generic-cert" "-extfile tests/tls/openssl.cnf -extensions generic_cert"
+
+openssl req \
+    -x509 \
+    -newkey rsa:2048 \
+    -keyout tests/tls/valkey-pw.key \
+    -subj "/O=Valkey Test/CN=Generic-cert" \
+    -CA tests/tls/ca.crt \
+    -CAkey tests/tls/ca.key \
+    -days 365 \
+    -passout pass:1234 \
+    -out tests/tls/valkey-pw.crt
+openssl req \
+    -x509 \
+    -newkey mldsa65 \
+    -keyout tests/tls/valkey-mldsa.key \
+    -subj "/O=Valkey Test/CN=Generic-cert" \
+    -CA tests/tls/ca.crt \
+    -CAkey tests/tls/ca.key \
+    -days 365 \
+    -nodes \
+    -out tests/tls/valkey-mldsa.crt
+openssl req \
+    -x509 \
+    -newkey mldsa65 \
+    -keyout tests/tls/valkey-mldsa-pw.key \
+    -subj "/O=Valkey Test/CN=Generic-cert" \
+    -CA tests/tls/ca.crt \
+    -CAkey tests/tls/ca.key \
+    -days 365 \
+    -passout pass:1234 \
+    -out tests/tls/valkey-mldsa-pw.crt
 
 # A client certificate with the CN "Client-only\0attacker", which anything
 # reading the CN as a C string sees as "Client-only".

--- a/utils/gen-test-certs.sh
+++ b/utils/gen-test-certs.sh
@@ -97,7 +97,7 @@ openssl req \
     -CA tests/tls/ca.crt \
     -CAkey tests/tls/ca.key \
     -days 365 \
-    -passout pass:1234 \
+    -passout pass:asdf \
     -out tests/tls/valkey-mldsa-pw.crt
 
 # A client certificate with the CN "Client-only\0attacker", which anything

--- a/utils/gen-test-certs.sh
+++ b/utils/gen-test-certs.sh
@@ -20,7 +20,8 @@
 generate_cert() {
     local name=$1
     local cn="$2"
-    local opts="$3"
+    local reqopts="$3"
+    local opts="$4"
 
     local keyfile=tests/tls/${name}.key
     local certfile=tests/tls/${name}.crt
@@ -29,7 +30,8 @@ generate_cert() {
     openssl req \
         -new -sha256 \
         -subj "/O=Valkey Test/CN=$cn" \
-        -key "$keyfile" | \
+        -key "$keyfile" \
+        $reqopts | \
         openssl x509 \
             -req -sha256 \
             -CA tests/tls/ca.crt \
@@ -65,40 +67,17 @@ subjectAltName = URI:urn:valkey:user:first, URI:urn:valkey:user:second
 subjectAltName = IP:127.0.0.1, IP:::1, DNS:localhost
 _END_
 
-generate_cert server "Server-only" "-extfile tests/tls/openssl.cnf -extensions server_cert"
-generate_cert client "Client-only" "-extfile tests/tls/openssl.cnf -extensions client_cert"
-generate_cert valkey "Generic-cert" "-extfile tests/tls/openssl.cnf -extensions generic_cert"
+generate_cert server "Server-only" "" "-extfile tests/tls/openssl.cnf -extensions server_cert"
+generate_cert client "Client-only" "" "-extfile tests/tls/openssl.cnf -extensions client_cert"
+generate_cert valkey "Generic-cert" "" "-extfile tests/tls/openssl.cnf -extensions generic_cert"
 
-openssl req \
-    -x509 \
-    -newkey rsa:2048 \
-    -keyout tests/tls/valkey-pw.key \
-    -subj "/O=Valkey Test/CN=Generic-cert" \
-    -CA tests/tls/ca.crt \
-    -CAkey tests/tls/ca.key \
-    -days 365 \
-    -passout pass:1234 \
-    -out tests/tls/valkey-pw.crt
-openssl req \
-    -x509 \
-    -newkey mldsa65 \
-    -keyout tests/tls/valkey-mldsa.key \
-    -subj "/O=Valkey Test/CN=Generic-cert" \
-    -CA tests/tls/ca.crt \
-    -CAkey tests/tls/ca.key \
-    -days 365 \
-    -nodes \
-    -out tests/tls/valkey-mldsa.crt
-openssl req \
-    -x509 \
-    -newkey mldsa65 \
-    -keyout tests/tls/valkey-mldsa-pw.key \
-    -subj "/O=Valkey Test/CN=Generic-cert" \
-    -CA tests/tls/ca.crt \
-    -CAkey tests/tls/ca.key \
-    -days 365 \
-    -passout pass:asdf \
-    -out tests/tls/valkey-mldsa-pw.crt
+openssl genrsa -passout pass:1234 -aes256 -out tests/tls/valkey-pw.key 2048
+openssl ecparam -name prime256v1 -genkey -noout -out tests/tls/valkey-ec.key
+openssl ecparam -name prime256v1 -genkey | openssl ec -passout pass:asdf -aes256 -out tests/tls/valkey-ec-pw.key
+
+generate_cert valkey-pw "Generic-cert-passworded" "-passin pass:1234" "-extfile tests/tls/openssl.cnf -extensions generic_cert"
+generate_cert valkey-ec "EC-cert" "" "-extfile tests/tls/openssl.cnf -extensions generic_cert"
+generate_cert valkey-ec-pw "EC-cert-passworded" "-passin pass:asdf" "-extfile tests/tls/openssl.cnf -extensions generic_cert"
 
 # A client certificate with the CN "Client-only\0attacker", which anything
 # reading the CN as a C string sees as "Client-only".
@@ -106,7 +85,7 @@ openssl req \
 # The openssl CLI will not put a NUL in a name, so issue with a placeholder
 # byte, overwrite it with a NUL, and re-sign tbsCertificate. The signature is
 # the same length, so the DER layout is unchanged.
-generate_cert client-nul-cn "Client-only@attacker" "-extfile tests/tls/openssl.cnf -extensions client_cert"
+generate_cert client-nul-cn "Client-only@attacker" "" "-extfile tests/tls/openssl.cnf -extensions client_cert"
 python3 - tests/tls/client-nul-cn.crt tests/tls/ca.key 'Client-only@' <<'_PYEND_'
 import base64, re, subprocess, sys
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -209,7 +209,7 @@ tcp-keepalive 300
 # tls-port 6379
 
 # Configure a X.509 certificate and private key to use for authenticating the
-# server to connected clients, primaries or cluster peers.  These files should be
+# server to connected clients, primaries or cluster peers. These files should be
 # PEM formatted.
 #
 # tls-cert-file valkey.crt
@@ -219,6 +219,18 @@ tcp-keepalive 300
 # as well.
 #
 # tls-key-file-pass secret
+#
+# You may also set up a secondary certificate and private key that use a
+# different encryption algorithm in case a client, primary or cluster peer doesn't
+# support the algorithm the above defined certificate uses (e.g. a PQC one).
+# The ordering of the primary and secondary certificate does not matter as
+# the most secure one will be chosen automatically if supported on both the
+# client and server.
+# If the key file here also uses a passphrase, it must be the same as the one
+# defined above.
+#
+# tls-alt-cert-file valkey_rsa.crt
+# tls-alt-key-file valkey_rsa.key
 
 # Normally the server uses the same certificate for both server functions (accepting
 # connections) and client functions (replicating from a primary, establishing

--- a/valkey.conf
+++ b/valkey.conf
@@ -226,11 +226,10 @@ tcp-keepalive 300
 # The ordering of the primary and secondary certificate does not matter as
 # the most secure one will be chosen automatically if supported on both the
 # client and server.
-# If the key file here also uses a passphrase, it must be the same as the one
-# defined above.
 #
 # tls-alt-cert-file valkey_rsa.crt
 # tls-alt-key-file valkey_rsa.key
+# tls-alt-key-file-pass secret
 
 # Normally the server uses the same certificate for both server functions (accepting
 # connections) and client functions (replicating from a primary, establishing


### PR DESCRIPTION
New config options to enable using two certificates with different algorithm types at once.

    tls-alt-cert-file
    tls-alt-key-file
    tls-alt-key-file-pass

E.g. one can be a PQC mldsa certificate and another can be RSA for backwards compatibility with older clients that don't support PQC yet.

New INFO fields under the TLS section (matching existing `tls_server_cert_serial` and `tls_server_cert_expires_in_seconds`):

    tls_server_alt_cert_serial
    tls_server_alt_cert_expires_in_seconds



Resolves #3403 