### PR TITLE
conf: document chown(2) requirement for unixsocketgroup

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -163,6 +163,11 @@ tcp-backlog 511
 # incoming connections. There is no default, so the server will not listen
 # on a unix socket when not specified.
 #
+# Setting `unixsocketgroup` changes the group of the socket via chown(2).
+# If the server runs under a sandbox that filters syscalls (for example,
+# a systemd unit with `SystemCallFilter` restricting `@resources`),
+# `chown` must be explicitly allowed or the server will fail to start.
+#
 # unixsocket /run/valkey.sock
 # unixsocketgroup wheel
 # unixsocketperm 700


### PR DESCRIPTION
## Summary

`unixsocketgroup` uses `chown(2)` to set the socket's group. When that
syscall is filtered out by a sandbox, the server is killed with `SIGSYS`
before the chown error path runs, so the user sees only
`Main process exited, code=killed, status=31/SYS` with no useful log line.

This is exactly what packagers and operators are hitting on Debian, where
the shipped systemd unit applies
`SystemCallFilter=@system-service` followed by
`SystemCallFilter=~ @privileged @resources` -- the second line removes
`chown` from the allowlist, so `unixsocketgroup` causes the server to
crash at startup. See #3457 for the full investigation.

This PR documents the requirement next to the option in `valkey.conf`,
so operators and packagers can avoid the trap. No code changes.

A separate enhancement -- installing a `SIGSYS` handler that logs a
helpful diagnostic before the process dies, as discussed in
[#3457](https://github.com/valkey-io/valkey/issues/3457#issuecomment-2802543253)
-- is intentionally out of scope for this PR.

Refs #3457