### PR TITLE
Fix deadlock in pipelined ingestion when command spans TCP packet boundary

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -154,7 +154,8 @@ static int parseMultibulk(client *c,
                           robj ***argv,
                           int *argv_len,
                           size_t *argv_len_sum,
-                          unsigned long long *net_input_bytes_curr_cmd);
+                          unsigned long long *net_input_bytes_curr_cmd,
+                          int allow_trim);
 
 int ProcessingEventsWhileBlocked = 0; /* See processEventsWhileBlocked(). */
 _Thread_local sds thread_shared_qb = NULL;
@@ -3556,7 +3557,7 @@ static void setProtocolError(const char *errstr, client *c) {
  * to be '*'. Otherwise for inline commands parseInlineBuffer() is called. */
 void parseMultibulkBuffer(client *c) {
     int flag = parseMultibulk(c, &c->argc, &c->argv, &c->argv_len,
-                              &c->argv_len_sum, &c->net_input_bytes_curr_cmd);
+                              &c->argv_len_sum, &c->net_input_bytes_curr_cmd, 1);
     c->read_flags |= flag;
 
     if (c->read_flags & READ_FLAGS_AUTH_REQUIRED) {
@@ -3592,8 +3593,22 @@ void parseMultibulkBuffer(client *c) {
         }
         parsedCommand *p = &queue->cmds[queue->len++];
         memset(p, 0, sizeof(*p));
+        size_t qb_pos_before = c->qb_pos;
         flag = parseMultibulk(c, &p->argc, &p->argv, &p->argv_len,
-                              &p->argv_len_sum, &p->input_bytes);
+                              &p->argv_len_sum, &p->input_bytes, 0);
+        if (!(flag & READ_FLAGS_PARSING_COMPLETED)) {
+            /* Parsing incomplete — the command spans a packet boundary.
+             * Free partially parsed args, remove from queue, and reset
+             * parse state so the command is re-parsed when data arrives. */
+            for (int j = 0; j < p->argc; j++) decrRefCount(p->argv[j]);
+            zfree(p->argv);
+            queue->len--;
+            c->qb_pos = qb_pos_before;
+            c->multibulklen = 0;
+            c->bulklen = -1;
+            c->reqtype = 0;
+            break;
+        }
         p->read_flags = flag;
         p->slot = -1;
     }
@@ -3618,7 +3633,8 @@ static int parseMultibulk(client *c,
                           robj ***argv,
                           int *argv_len,
                           size_t *argv_len_sum,
-                          unsigned long long *net_input_bytes_curr_cmd) {
+                          unsigned long long *net_input_bytes_curr_cmd,
+                          int allow_trim) {
     char *newline = NULL;
     int ok;
     long long ll;
@@ -3739,7 +3755,7 @@ static int parseMultibulk(client *c,
             }
 
             c->qb_pos = newline - c->querybuf + 2;
-            if (!(is_replicated) && ll >= PROTO_MBULK_BIG_ARG) {
+            if (!(is_replicated) && allow_trim && ll >= PROTO_MBULK_BIG_ARG) {
                 /* When the client is not a replicated client (because replicated
                  * client's querybuf can only be trimmed after data applied
                  * and sent to replicas).


### PR DESCRIPTION
## Summary
  
Fixes a deadlock in `parseMultibulkBuffer()` where a partially parsed pipelined command left in `cmd_queue` causes `processInputBuffer` to permanently stall the client when used with blocking modules (e.g. valkey-search).

  Fixes: https://github.com/valkey-io/valkey-search/issues/992

  ## Root Cause

 The pre-parse loop in `parseMultibulkBuffer()` pushes a `parsedCommand` entry onto `cmd_queue` **before** calling `parseMultibulk()`. If the last command in the buffer is incomplete (spans a TCP packet boundary), the partial entry remains in the queue without `READ_FLAGS_PARSING_COMPLETED`.

 With blocking modules that process one command at a time (block/unblock cycles), `processInputBuffer` eventually pops this partial entry via `consumeCommandQueue`.
`handleParseResults` returns `PARSE_NEEDMORE` and the loop breaks — no command is executed, no reply is sent, and no re-parse is attempted even though the remaining data may already be in `querybuf`. The client and server deadlock permanently.

  ## Fix

  When `parseMultibulk` returns incomplete for a queued command:

  1. Free any partially parsed args (`decrRefCount` each + `zfree` the argv array)
  2. Remove the entry from the queue (`queue->len--`)
  3. Roll back `c->qb_pos` to before the command started
  4. Reset `c->multibulklen`, `c->bulklen`, and `c->reqtype` to a clean state

  The command will be re-parsed from scratch when more data arrives and `processInputBuffer` is called again via `readQueryFromClient` or `processUnblockedClients`.

  Additionally, pass `allow_trim=0` to `parseMultibulk` for queued commands to prevent the big-arg `sdsrange` optimization from modifying `c->querybuf` — this ensures the `qb_pos` rollback is always valid.