### PR TITLE
Fix zrangebyscore empty exclusive bound

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -3436,6 +3436,7 @@ void genericZpopCommand(client *c,
 sds lpGetObject(unsigned char *sptr);
 int zslValueGteMin(double value, zrangespec *spec);
 int zslValueLteMax(double value, zrangespec *spec);
+int zslParseRange(robj *min, robj *max, zrangespec *spec);
 void zsetFreeLexRange(zlexrangespec *spec);
 int zsetParseLexRange(robj *min, robj *max, zlexrangespec *spec);
 unsigned char *zzlFirstInLexRange(unsigned char *zl, zlexrangespec *range);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -620,7 +620,7 @@ zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank) {
 }
 
 /* Populate the rangespec according to the objects min and max. */
-static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
+int zslParseRange(robj *min, robj *max, zrangespec *spec) {
     char *eptr;
     spec->minex = spec->maxex = 0;
 
@@ -634,10 +634,12 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
         char *s = objectGetVal(min);
         size_t len = sdslen(s);
         if (s[0] == '(') {
+            if (len == 1) return C_ERR;
             spec->min = valkey_strtod_n(s + 1, len - 1, &eptr);
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
             spec->minex = 1;
         } else {
+            if (len == 0) return C_ERR;
             spec->min = valkey_strtod_n(s, len, &eptr);
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
         }
@@ -648,10 +650,12 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
         char *s = objectGetVal(max);
         size_t len = sdslen(s);
         if (s[0] == '(') {
+            if (len == 1) return C_ERR;
             spec->max = valkey_strtod_n(s + 1, len - 1, &eptr);
             if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
             spec->maxex = 1;
         } else {
+            if (len == 0) return C_ERR;
             spec->max = valkey_strtod_n(s, len, &eptr);
             if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
         }

--- a/src/unit/test_t_zset.cpp
+++ b/src/unit/test_t_zset.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+
+#include <cstring>
+
+extern "C" {
+#include "server.h"
+}
+
+class ZsetRangeTest : public ::testing::Test {
+};
+
+static void assertScoreRangeParseFails(const char *min, const char *max) {
+    robj *minobj = createStringObject(min, strlen(min));
+    robj *maxobj = createStringObject(max, strlen(max));
+    zrangespec range;
+
+    EXPECT_EQ(zslParseRange(minobj, maxobj, &range), C_ERR) << "min=" << min << " max=" << max;
+
+    decrRefCount(minobj);
+    decrRefCount(maxobj);
+}
+
+static void assertScoreRangeParseSucceeds(const char *min, const char *max, double expected_min, double expected_max, int expected_minex, int expected_maxex) {
+    robj *minobj = createStringObject(min, strlen(min));
+    robj *maxobj = createStringObject(max, strlen(max));
+    zrangespec range;
+
+    ASSERT_EQ(zslParseRange(minobj, maxobj, &range), C_OK) << "min=" << min << " max=" << max;
+    EXPECT_DOUBLE_EQ(range.min, expected_min);
+    EXPECT_DOUBLE_EQ(range.max, expected_max);
+    EXPECT_EQ(range.minex, expected_minex);
+    EXPECT_EQ(range.maxex, expected_maxex);
+
+    decrRefCount(minobj);
+    decrRefCount(maxobj);
+}
+
+TEST_F(ZsetRangeTest, ParseRangeRejectsEmptyScoreBounds) {
+    assertScoreRangeParseFails("", "1");
+    assertScoreRangeParseFails("1", "");
+}
+
+TEST_F(ZsetRangeTest, ParseRangeRejectsBareExclusiveScoreBounds) {
+    assertScoreRangeParseFails("(", "1");
+    assertScoreRangeParseFails("1", "(");
+}
+
+TEST_F(ZsetRangeTest, ParseRangeAcceptsValidInclusiveAndExclusiveBounds) {
+    assertScoreRangeParseSucceeds("0", "1", 0.0, 1.0, 0, 0);
+    assertScoreRangeParseSucceeds("(0", "(1", 0.0, 1.0, 1, 1);
+}

--- a/src/unit/test_t_zset.cpp
+++ b/src/unit/test_t_zset.cpp
@@ -20,7 +20,9 @@ static void assertScoreRangeParseFails(const char *min, const char *max) {
     robj *maxobj = createStringObject(max, strlen(max));
     zrangespec range;
 
-    EXPECT_EQ(zslParseRange(minobj, maxobj, &range), C_ERR) << "min=" << min << " max=" << max;
+    char err_msg[256];
+    snprintf(err_msg, sizeof(err_msg), "min=%s max=%s", min, max);
+    EXPECT_EQ(zslParseRange(minobj, maxobj, &range), C_ERR) << err_msg;
 
     decrRefCount(minobj);
     decrRefCount(maxobj);
@@ -31,7 +33,9 @@ static void assertScoreRangeParseSucceeds(const char *min, const char *max, doub
     robj *maxobj = createStringObject(max, strlen(max));
     zrangespec range;
 
-    ASSERT_EQ(zslParseRange(minobj, maxobj, &range), C_OK) << "min=" << min << " max=" << max;
+    char err_msg[256];
+    snprintf(err_msg, sizeof(err_msg), "min=%s max=%s", min, max);
+    ASSERT_EQ(zslParseRange(minobj, maxobj, &range), C_OK) << err_msg;
     EXPECT_DOUBLE_EQ(range.min, expected_min);
     EXPECT_DOUBLE_EQ(range.max, expected_max);
     EXPECT_EQ(range.minex, expected_minex);
@@ -44,14 +48,25 @@ static void assertScoreRangeParseSucceeds(const char *min, const char *max, doub
 TEST_F(ZsetRangeTest, ParseRangeRejectsEmptyScoreBounds) {
     assertScoreRangeParseFails("", "1");
     assertScoreRangeParseFails("1", "");
+    assertScoreRangeParseFails("1.0abc", "1");
+    assertScoreRangeParseFails("1", "1.0abc");
+    assertScoreRangeParseFails("(1.0abc", "1");
+    assertScoreRangeParseFails("1", "(1.0abc");
 }
 
 TEST_F(ZsetRangeTest, ParseRangeRejectsBareExclusiveScoreBounds) {
     assertScoreRangeParseFails("(", "1");
     assertScoreRangeParseFails("1", "(");
+    assertScoreRangeParseFails("(nan", "1");
+    assertScoreRangeParseFails("1", "(nan");
 }
 
 TEST_F(ZsetRangeTest, ParseRangeAcceptsValidInclusiveAndExclusiveBounds) {
     assertScoreRangeParseSucceeds("0", "1", 0.0, 1.0, 0, 0);
     assertScoreRangeParseSucceeds("(0", "(1", 0.0, 1.0, 1, 1);
+}
+
+TEST_F(ZsetRangeTest, ParseRangeAcceptsInfinityBounds) {
+    assertScoreRangeParseSucceeds("-inf", "+inf", -HUGE_VAL, HUGE_VAL, 0, 0);
+    assertScoreRangeParseSucceeds("(-inf", "(+inf", -HUGE_VAL, HUGE_VAL, 1, 1);
 }


### PR DESCRIPTION
## Background

`ZRANGEBYSCORE` and related sorted set commands currently accept invalid score range bounds such as an empty string (`""`) or a bare exclusive marker (`(`). These inputs should be rejected as invalid floating-point values, but they are silently parsed as `0`.

The issue happens in `zslParseRange()`: the exclusive-bound path strips the leading `(` and then calls `valkey_strtod_n()` on the remaining string without checking whether anything is left. Similarly, the plain-bound path does not reject zero-length input before conversion. Since `valkey_strtod_n()` returns `0.0` for zero-length input, invalid bounds can be treated as valid score `0`.

## Changes

This patch adds explicit length validation in `zslParseRange()`:

- Reject empty plain score bounds before calling `valkey_strtod_n()`.
- Reject bare `(` exclusive score bounds before parsing the numeric part.
- Return `C_ERR` in both cases so callers report the existing `not a float` error.

Regression tests were added for the affected command paths:

- `ZRANGEBYSCORE`
- `ZREVRANGEBYSCORE`
- `ZCOUNT`
- `ZRANGE ... BYSCORE`
- `ZRANGESTORE ... BYSCORE`

## Example

Before this change, commands such as the following could be accepted and interpreted as using score `0`:

```
ZRANGEBYSCORE zset ( 1
ZRANGEBYSCORE zset "" 1
ZRANGEBYSCORE zset 1 ""
ZRANGESTORE dst src ( 1 BYSCORE
```
After this change, these inputs are rejected with the expected not a float error.

