### PR TITLE
Fix use after free

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -774,15 +774,18 @@ int verifyClusterNodeId(const char *name, int length) {
 }
 
 int isValidAuxChar(int c) {
-    /* Return true if the character is alphanumeric */
-    if (isalnum(c)) {
-        return 1;
-    }
+    unsigned char ch = (unsigned char)c;
 
-    /* List of invalid characters */
-    static const char *invalid_charset = "!#$%&()*+;<>?@[]^{|}~";
+    /* Reject control characters (0x00-0x1F) and DEL (0x7F). */
+    if (ch <= 0x1F || ch == 0x7F) return 0;
 
-    /* Return true if the character is NOT in the invalid charset */
+    /* Allow alphanumeric characters. */
+    if (isalnum(c)) return 1;
+
+    /* Reject characters that are format-significant in nodes.conf or could
+     * break parsing: delimiters, quotes, backslash, and other specials. */
+    static const char *invalid_charset = "!#$%&()*+,;<=>?@[]^{|}~\"'\\ ";
+
     return strchr(invalid_charset, c) == NULL;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2464,6 +2464,14 @@ static int isValidAnnouncedNodename(char *val, const char **err) {
     return 1;
 }
 
+static int isValidClusterAnnounceIp(char *val, const char **err) {
+    if (!(isValidAuxString(val, sdslen(val)))) {
+        *err = "cluster-announce-ip contained invalid character";
+        return 0;
+    }
+    return 1;
+}
+
 static int isValidAnnouncedHostname(char *val, const char **err) {
     if (strlen(val) >= NET_HOST_STR_LEN) {
         *err = "Hostnames must be less than " STRINGIFY(NET_HOST_STR_LEN) " characters";
@@ -3316,7 +3324,7 @@ standardConfig static_configs[] = {
     createStringConfig("pidfile", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.pidfile, NULL, NULL, NULL),
     createStringConfig("replica-announce-ip", "slave-announce-ip", MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.replica_announce_ip, NULL, NULL, NULL),
     createStringConfig("primaryuser", "masteruser", MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.primary_user, NULL, NULL, NULL),
-    createStringConfig("cluster-announce-ip", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_ip, NULL, NULL, updateClusterIp),
+    createStringConfig("cluster-announce-ip", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_ip, NULL, isValidClusterAnnounceIp, updateClusterIp),
     createStringConfig("cluster-announce-client-ipv4", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_client_ipv4, NULL, isValidIpV4, updateClusterClientIpV4),
     createStringConfig("cluster-announce-client-ipv6", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_client_ipv6, NULL, isValidIpV6, updateClusterClientIpV6),
     createStringConfig("cluster-config-file", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.cluster_configfile, "nodes.conf", isValidClusterConfigFile, NULL),

--- a/src/module.c
+++ b/src/module.c
@@ -9621,7 +9621,7 @@ void VM_RegisterClusterMessageReceiver(ValkeyModuleCtx *ctx,
                 if (prev)
                     prev->next = r->next;
                 else
-                    clusterReceivers[type]->next = r->next;
+                    clusterReceivers[type] = r->next;
                 zfree(r);
             }
             return;

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -4217,6 +4217,14 @@ void sentinelRoleCommand(client *c) {
     dictReleaseIterator(di);
 }
 
+static int containsControlChars(const char *s, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        unsigned char ch = (unsigned char)s[i];
+        if (ch <= 0x1F || ch == 0x7F) return 1;
+    }
+    return 0;
+}
+
 /* SENTINEL SET <primaryname> [<option> <value> ...] */
 void sentinelSetCommand(client *c) {
     sentinelValkeyInstance *ri;
@@ -4226,6 +4234,14 @@ void sentinelSetCommand(client *c) {
     int redacted;
 
     if ((ri = sentinelGetPrimaryByNameOrReplyError(c, c->argv[2])) == NULL) return;
+
+    for (j = 3; j < c->argc; j++) {
+        sds val = objectGetVal(c->argv[j]);
+        if (containsControlChars(val, sdslen(val))) {
+            addReplyError(c, "Invalid argument: control characters are not allowed in SENTINEL SET values");
+            return;
+        }
+    }
 
     /* Process option - value pairs. */
     for (j = 3; j < c->argc; j++) {

--- a/tests/sentinel/tests/03-runtime-reconf.tcl
+++ b/tests/sentinel/tests/03-runtime-reconf.tcl
@@ -198,3 +198,20 @@ test "Sentinel Set with other error situations" {
 
    assert_match "ERR Failed to save config file*" $err
 }
+
+test "SENTINEL SET rejects values containing control characters" {
+    # CRLF injection into auth-pass
+    assert_error "ERR Invalid argument*" {S 0 SENTINEL SET mymaster auth-pass "pass\r\nsentinel notification-script mymaster /tmp/evil.sh"}
+    # Newline in auth-user
+    assert_error "ERR Invalid argument*" {S 0 SENTINEL SET mymaster auth-user "user\ninjected"}
+    # Carriage return alone
+    assert_error "ERR Invalid argument*" {S 0 SENTINEL SET mymaster auth-pass "has\rcr"}
+    # Null byte
+    assert_error "ERR Invalid argument*" {S 0 SENTINEL SET mymaster auth-user "has\x00null"}
+    # Tab character (0x09)
+    assert_error "ERR Invalid argument*" {S 0 SENTINEL SET mymaster auth-pass "has\ttab"}
+    # DEL character (0x7F)
+    assert_error "ERR Invalid argument*" {S 0 SENTINEL SET mymaster auth-pass "has\x7F"}
+    # Control char in option name is also rejected
+    assert_error "ERR Invalid argument*" {S 0 SENTINEL SET mymaster "bad\noption" value}
+}

--- a/tests/unit/cluster/cluster-aux-field-validation.tcl
+++ b/tests/unit/cluster/cluster-aux-field-validation.tcl
@@ -1,0 +1,75 @@
+# Tests for cluster AUX field control-character and delimiter rejection.
+# Validates that isValidAuxChar rejects characters that could corrupt
+# nodes.conf or enable injection attacks.
+
+start_cluster 1 0 {tags {external:skip cluster}} {
+    test "cluster-announce-ip rejects control characters (newline)" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\n"
+        }
+    }
+
+    test "cluster-announce-ip rejects control characters (carriage return)" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\r"
+        }
+    }
+
+    test "cluster-announce-ip rejects control characters (null byte)" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\x00"
+        }
+    }
+
+    test "cluster-announce-ip rejects control characters (tab)" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\t"
+        }
+    }
+
+    test "cluster-announce-ip rejects space" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1 injected"
+        }
+    }
+
+    test "cluster-announce-ip rejects comma" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1,evil"
+        }
+    }
+
+    test "cluster-announce-ip rejects backslash" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\\evil"
+        }
+    }
+
+    test "cluster-announce-ip rejects double quote" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*invalid character*" {
+            R 0 CONFIG SET cluster-announce-ip "10.0.0.1\"evil"
+        }
+    }
+
+    test "cluster-announce-ip accepts valid IPv4" {
+        R 0 CONFIG SET cluster-announce-ip "192.168.1.100"
+        assert_equal "192.168.1.100" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
+    }
+
+    test "cluster-announce-ip accepts valid IPv6" {
+        R 0 CONFIG SET cluster-announce-ip "::1"
+        assert_equal "::1" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
+    }
+
+    test "cluster-announce-human-nodename rejects control characters" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-human-nodename*invalid character*" {
+            R 0 CONFIG SET cluster-announce-human-nodename "node\ninjected"
+        }
+    }
+
+    test "cluster-announce-human-nodename rejects space" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-human-nodename*invalid character*" {
+            R 0 CONFIG SET cluster-announce-human-nodename "node injected"
+        }
+    }
+}


### PR DESCRIPTION
  - **Fix use-after-free in VM_RegisterClusterMessageReceiver** 
  - **Fix SENTINEL SET Input validation**
  - **Fix cluster AUX-field control-character**

cc: @ranshid , @madolson 