### PR TITLE
Increase max proctitle length from 255 to 1024

### DIFF
--- a/src/setproctitle.c
+++ b/src/setproctitle.c
@@ -269,7 +269,7 @@ error:
 
 
 #ifndef SPT_MAXTITLE
-#define SPT_MAXTITLE 255
+#define SPT_MAXTITLE 1024
 #endif
 
 void setproctitle(const char *fmt, ...) {


### PR DESCRIPTION
255 is too short if valkey-server is being run from a long path, especially if many fields are included such as in the "Process title set as expected" test in `unit/other.tcl`, where the max length for the cmdline is 1024, so having the same number in both makes sense.

Closes #3832.