### PR TITLE
fix: improve Makefile robustness by accomodating file paths with spaces

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -258,6 +258,9 @@ endif
 # Include paths to dependencies
 FINAL_CFLAGS+= -I../deps/libvalkey/include -I../deps/linenoise -I../deps/hdr_histogram -I../deps/fpconv -I../deps/fast_float
 
+get_cwd = $(subst $() $(),\ ,$(shell pwd))
+current_dir = $(call get_cwd)
+
 # Lua scripting engine module
 ifeq ($(BUILD_LUA),no)
 	LUA_MODULE_NAME=
@@ -269,7 +272,6 @@ else ifeq ($(BUILD_LUA),module)
 	LUA_MODULE=$(LUA_MODULE_NAME)
 	LUA_MODULE_INSTALL=install-lua-module
 
-	current_dir = $(shell pwd)
 	FINAL_CFLAGS+=-DLUA_ENABLED -DLUA_LIB=libvalkeylua.so -DSTATIC_LUA=0
 	ifeq ($(uname_S),Darwin)
 		FINAL_LDFLAGS+= -Wl,-rpath,$(PREFIX)/lib
@@ -281,7 +283,6 @@ else
 	# The default: building Lua as a static module.
 	LUA_MODULE_NAME=modules/lua/libvalkeylua.a
 	LUA_MODULE=$(LUA_MODULE_NAME)
-	current_dir = $(shell pwd)
 	FINAL_CFLAGS+=-DLUA_ENABLED -DSTATIC_LUA=1
 	ifeq ($(uname_S),Darwin)
 		LUA_LDFLAGS=-Wl,-export_dynamic -Wl,-force_load,$(current_dir)/modules/lua/libvalkeylua.a ../deps/lua/src/liblua.a
@@ -687,8 +688,8 @@ persist-settings: distclean
 	echo LDFLAGS=$(LDFLAGS) >> .make-settings
 	echo SERVER_CFLAGS=$(SERVER_CFLAGS) >> .make-settings
 	echo SERVER_LDFLAGS=$(SERVER_LDFLAGS) >> .make-settings
-	echo PREV_FINAL_CFLAGS=$(FINAL_CFLAGS) >> .make-settings
-	echo PREV_FINAL_LDFLAGS=$(FINAL_LDFLAGS) >> .make-settings
+	echo 'PREV_FINAL_CFLAGS=$(FINAL_CFLAGS)' >> .make-settings
+	echo 'PREV_FINAL_LDFLAGS=$(FINAL_LDFLAGS)' >> .make-settings
 	echo ENGINE_SERVER_OBJ=$(ENGINE_SERVER_OBJ) >> .make-settings
 	-(cd ../deps && $(MAKE) $(DEPENDENCY_TARGETS))
 


### PR DESCRIPTION
Makefile fails to build when the full file path to valkey contains a directory with a space somewhere in between.

Suppose valkey is present at: `/user/Downloads/Coding\ Projects/valkey`
current Makefile would fail and return "`Projects/valkey/src/xyz.c`" is not present and the build would simply fail.

Fix: 
replace `$(current_dir)` with `"$(current_dir)"`

---
P.S:
This is my first contribution to valkey, let me know if I've missed anything from the contribution / development guidelines. Thanks!