### PR TITLE
Make VM_CallArgv() API public

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3637,7 +3637,6 @@ int VM_ReplyWithCallReply(ValkeyModuleCtx *ctx, ValkeyModuleCallReply *reply) {
  * `proto` must point to a valid, complete RESP-encoded reply of length
  * `proto_len`.  Returns VALKEYMODULE_OK.  If there is no client context
  * (script, timer, etc.) the call is a no-op and returns VALKEYMODULE_OK. */
-// NON-PUBLIC API: remove this line when making this API public.
 int VM_ReplyRaw(ValkeyModuleCtx *ctx, const char *proto, size_t proto_len) {
     client *c = moduleGetReplyClient(ctx);
     if (c == NULL) return VALKEYMODULE_OK;
@@ -6282,7 +6281,6 @@ int VM_CallReplyPromiseAbort(ValkeyModuleCallReply *reply, void **private_data) 
  * Note: as with VM_CallReplyPromiseAbort, if the underlying blocking command
  * belongs to a module that does not honour disconnect callbacks, the abort may
  * succeed internally without the command actually stopping. */
-// NON-PUBLIC API: remove this line when making this API public.
 int VM_CallArgvAbort(ValkeyModuleCallArgvBlockedHandle *handle) {
     ValkeyModuleAsyncRMCallPromise *promise = handle;
     serverAssert(promise->from_call_argv);
@@ -7045,7 +7043,6 @@ cleanup:
  * * ENOSPC: Write or deny-oom command is not allowed
  * * ESPIPE: Command not allowed on script mode
  */
-// NON-PUBLIC API: remove this line when making this API public.
 int VM_CallArgv(ValkeyModuleCtx *ctx,
                 ValkeyModuleString **argv,
                 int argc,
@@ -15129,6 +15126,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ReplyWithNull);
     REGISTER_API(ReplyWithBool);
     REGISTER_API(ReplyWithCallReply);
+    REGISTER_API(ReplyRaw);
     REGISTER_API(ReplyWithDouble);
     REGISTER_API(ReplyWithBigNumber);
     REGISTER_API(ReplyWithLongDouble);
@@ -15152,6 +15150,8 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(StringToLongDouble);
     REGISTER_API(StringToStreamID);
     REGISTER_API(Call);
+    REGISTER_API(CallArgv);
+    REGISTER_API(CallArgvAbort);
     REGISTER_API(CallReplyProto);
     REGISTER_API(FreeCallReply);
     REGISTER_API(CallReplyInteger);

--- a/src/modules/lua/script_lua.c
+++ b/src/modules/lua/script_lua.c
@@ -45,12 +45,6 @@
 #include <errno.h>
 #include <time.h>
 
-/* Forward declarations of module API functions not publicly exposed */
-extern int VM_CallArgv(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc, int flags, const ValkeyModuleReplyHandlers *resp_handlers, void *reply_ctx);
-extern int VM_ReplyRaw(ValkeyModuleCtx *ctx, const char *proto, size_t proto_len);
-#define ValkeyModule_CallArgv VM_CallArgv
-#define ValkeyModule_ReplyRaw VM_ReplyRaw
-
 #define LUA_CMD_OBJCACHE_SIZE 32
 #define LUA_CMD_OBJCACHE_MAX_LEN 64
 

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1617,6 +1617,13 @@ VALKEYMODULE_API ValkeyModuleCallReply *(*ValkeyModule_Call)(ValkeyModuleCtx *ct
                                                              const char *cmdname,
                                                              const char *fmt,
                                                              ...)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CallArgv)(ValkeyModuleCtx *ctx,
+                                              ValkeyModuleString **argv,
+                                              int argc,
+                                              int flags,
+                                              const ValkeyModuleReplyHandlers *reply_handlers,
+                                              void *reply_ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CallArgvAbort)(ValkeyModuleCallArgvBlockedHandle *handle) VALKEYMODULE_ATTR;
 VALKEYMODULE_API const char *(*ValkeyModule_CallReplyProto)(ValkeyModuleCallReply *reply, size_t *len)VALKEYMODULE_ATTR;
 VALKEYMODULE_API void (*ValkeyModule_FreeCallReply)(ValkeyModuleCallReply *reply) VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_CallReplyType)(ValkeyModuleCallReply *reply) VALKEYMODULE_ATTR;
@@ -1705,6 +1712,9 @@ VALKEYMODULE_API int (*ValkeyModule_ReplyWithBigNumber)(ValkeyModuleCtx *ctx,
                                                         size_t len) VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_ReplyWithCallReply)(ValkeyModuleCtx *ctx,
                                                         ValkeyModuleCallReply *reply) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyRaw)(ValkeyModuleCtx *ctx,
+                                              const char *proto,
+                                              size_t proto_len) VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_StringToLongLong)(const ValkeyModuleString *str, long long *ll) VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_StringToULongLong)(const ValkeyModuleString *str,
                                                        unsigned long long *ull) VALKEYMODULE_ATTR;
@@ -2368,6 +2378,7 @@ static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, in
     VALKEYMODULE_GET_API(ReplyWithNull);
     VALKEYMODULE_GET_API(ReplyWithBool);
     VALKEYMODULE_GET_API(ReplyWithCallReply);
+    VALKEYMODULE_GET_API(ReplyRaw);
     VALKEYMODULE_GET_API(ReplyWithDouble);
     VALKEYMODULE_GET_API(ReplyWithBigNumber);
     VALKEYMODULE_GET_API(ReplyWithLongDouble);
@@ -2391,6 +2402,8 @@ static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, in
     VALKEYMODULE_GET_API(StringToLongDouble);
     VALKEYMODULE_GET_API(StringToStreamID);
     VALKEYMODULE_GET_API(Call);
+    VALKEYMODULE_GET_API(CallArgv);
+    VALKEYMODULE_GET_API(CallArgvAbort);
     VALKEYMODULE_GET_API(CallReplyProto);
     VALKEYMODULE_GET_API(FreeCallReply);
     VALKEYMODULE_GET_API(CallReplyInteger);

--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -34,12 +34,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-/* Forward declarations of module API functions not publicly exposed */
-extern int VM_CallArgv(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc, int flags, const ValkeyModuleReplyHandlers *resp_handlers, void *reply_ctx);
-extern int VM_ReplyRaw(ValkeyModuleCtx *ctx, const char *proto, size_t proto_len);
-#define ValkeyModule_CallArgv VM_CallArgv
-#define ValkeyModule_ReplyRaw VM_ReplyRaw
-
 /* --------------------------------- Helpers -------------------------------- */
 
 /* Return true if the reply and the C null term string matches. */

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -12,14 +12,6 @@
 
 #define UNUSED(V) ((void) V)
 
-/* Forward declarations of module API functions not publicly exposed */
-extern int VM_CallArgv(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc, int flags, const ValkeyModuleReplyHandlers *resp_handlers, void *reply_ctx);
-extern int VM_CallArgvAbort(ValkeyModuleCallArgvBlockedHandle *handle);
-extern int VM_ReplyRaw(ValkeyModuleCtx *ctx, const char *proto, size_t proto_len);
-#define ValkeyModule_CallArgv VM_CallArgv
-#define ValkeyModule_CallArgvAbort VM_CallArgvAbort
-#define ValkeyModule_ReplyRaw VM_ReplyRaw
-
 /* used to test processing events during slow bg operation */
 static volatile int g_slow_bg_operation = 0;
 static volatile int g_is_in_slow_bg_operation = 0;

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -8,12 +8,6 @@
 
 #define UNUSED(x) (void)(x)
 
-/* Forward declarations of module API functions not publicly exposed */
-extern int VM_CallArgv(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc, int flags, const ValkeyModuleReplyHandlers *resp_handlers, void *reply_ctx);
-extern int VM_ReplyRaw(ValkeyModuleCtx *ctx, const char *proto, size_t proto_len);
-#define ValkeyModule_CallArgv VM_CallArgv
-#define ValkeyModule_ReplyRaw VM_ReplyRaw
-
 static int n_events = 0;
 
 static int KeySpace_NotificationModuleKeyMissExpired(ValkeyModuleCtx *ctx, int type, const char *event, ValkeyModuleString *key) {

--- a/tests/modules/usercall.c
+++ b/tests/modules/usercall.c
@@ -4,12 +4,6 @@
 
 #define UNUSED(V) ((void) V)
 
-/* Forward declarations of module API functions not publicly exposed */
-extern int VM_CallArgv(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc, int flags, const ValkeyModuleReplyHandlers *resp_handlers, void *reply_ctx);
-extern int VM_ReplyRaw(ValkeyModuleCtx *ctx, const char *proto, size_t proto_len);
-#define ValkeyModule_CallArgv VM_CallArgv
-#define ValkeyModule_ReplyRaw VM_ReplyRaw
-
 ValkeyModuleUser *user = NULL;
 
 int call_without_user(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {


### PR DESCRIPTION
Previously in https://github.com/valkey-io/valkey/pull/3122 it was decided not to make this API public in 9.1 version, making it public for next version so other Lua modules would be able to use less overhead API (e.g. LuaJIT https://github.com/valkey-io/valkey-luajit and later Lua 5.5 module)