### PR TITLE
Run test-unit target on macos in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,8 @@ jobs:
           export AR=/opt/homebrew/opt/llvm/bin/llvm-ar
           export RANLIB=/opt/homebrew/opt/llvm/bin/llvm-ranlib
           make -j3 all-with-unit-tests SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes LIBBACKTRACE_PREFIX=/usr/local
+      - name: unit tests
+        run: make test-unit
 
   build-32bit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Output from GH actions run https://github.com/valkey-io/valkey/actions/runs/27131566431/job/80073523675 : 
```
/bin/sh: llc: command not found
Error: File 'wrapped/acl_temp.o' does not exist.
/bin/sh: llvm-objcopy: command not found
/bin/sh: llc: command not found
Error: File 'wrapped/adlist_temp.o' does not exist.
/bin/sh: llvm-objcopy: command not found
/bin/sh: llc: command not found
...
Error: File 'wrapped/vector_temp.o' does not exist.
/bin/sh: llvm-objcopy: command not found
...
make[3]: `libvalkey.a' is up to date.
/bin/sh: llc: command not found
Error: File 'wrapped/acl_temp.o' does not exist.
/bin/sh: llvm-objcopy: command not found
/bin/sh: llc: command not found
Error: File 'wrapped/adlist_temp.o' does not exist.
...
[279/279] QuicklistTest.quicklistComprassionPlainNode (2454 ms)
All UNIT TESTS PASSED!
```