### PR TITLE
Optimize ZSET score updates with equal-score neighbors

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -249,6 +249,32 @@ static int zslCompareNodes(const zskiplistNode *a, const zskiplistNode *b) {
     return sdscmp(zslGetNodeElement(a), zslGetNodeElement(b));
 }
 
+/* Compares node and score/ele; defines zset ordering. Return value:
+ *     positive if node comes after score/ele.
+ *     negative if node comes before score/ele.
+ *     0 if node's score and ele are both equal to score/ele. */
+static int zslCompareNodeWithScoreElement(const zskiplistNode *node, double score, const_sds ele) {
+    if (node == NULL) return 1;
+
+    if (node->score > score) return 1;
+    if (node->score < score) return -1;
+
+    return sdscmp(zslGetNodeElement(node), ele);
+}
+
+/* Returns true if node would still be strictly between its level-0 neighbors
+ * after changing its score. The sorted-set order is (score, element), so equal
+ * scores still need the lexicographic tie-breaker. */
+static int zslNodeCanKeepPosition(zskiplistNode *node, double newscore) {
+    sds ele = zslGetNodeElement(node);
+    zskiplistNode *prev = node->backward;
+    zskiplistNode *next = node->level[0].forward;
+
+    if (prev != NULL && zslCompareNodeWithScoreElement(prev, newscore, ele) >= 0) return 0;
+    if (next != NULL && zslCompareNodeWithScoreElement(next, newscore, ele) <= 0) return 0;
+    return 1;
+}
+
 /* Insert a node in the skiplist. Assumes the element does not already exist in
  * the skiplist (up to the caller to enforce that). The skiplist takes ownership
  * of the passed node. */
@@ -366,8 +392,7 @@ static zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double
     /* If the node, after the score update, would be still exactly
      * at the same position, we can just update the score without
      * actually removing and re-inserting the element in the skiplist. */
-    if ((node->backward == NULL || node->backward->score < newscore) &&
-        (node->level[0].forward == NULL || node->level[0].forward->score > newscore)) {
+    if (zslNodeCanKeepPosition(node, newscore)) {
         node->score = newscore;
         return NULL;
     }

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -127,6 +127,30 @@ start_server {tags {"zset"}} {
             assert_equal {y x z} [r zrange ztmp 0 -1]
         }
 
+        test "ZSET score update with equal-score neighbor - $encoding" {
+            r del ztmp
+            r zadd ztmp 1 a 2 b 3 c
+            r zadd ztmp 3 b
+            assert_equal {a b c} [r zrange ztmp 0 -1]
+            assert_equal {a 1 b 3 c 3} [r zrange ztmp 0 -1 withscores]
+
+            r zadd ztmp 1 b
+            assert_equal {a b c} [r zrange ztmp 0 -1]
+            assert_equal {a 1 b 1 c 3} [r zrange ztmp 0 -1 withscores]
+
+            r del ztmp
+            r zadd ztmp 1 a 2 c 3 b
+            r zadd ztmp 3 c
+            assert_equal {a b c} [r zrange ztmp 0 -1]
+            assert_equal {a 1 b 3 c 3} [r zrange ztmp 0 -1 withscores]
+
+            r del ztmp
+            r zadd ztmp 1 b 2 a 3 c
+            r zadd ztmp 1 a
+            assert_equal {a b c} [r zrange ztmp 0 -1]
+            assert_equal {a 1 b 1 c 3} [r zrange ztmp 0 -1 withscores]
+        }
+
         test "ZSET element can't be set to NaN with ZADD - $encoding" {
             assert_error "*not*float*" {r zadd myzset nan abc}
         }


### PR DESCRIPTION

## Issue

`zslUpdateScore()` only checked neighboring scores when deciding whether a skiplist node could keep its current position after a score update. Since sorted set ordering is `(score, element)`, updates that create equal-score adjacency can still keep the node correctly ordered by the lexicographic tie-breaker, but Valkey would unnecessarily remove and reinsert the node.

## Change

Add a helper to compare a skiplist node against a `(score, element)` pair, and use it from `zslNodeCanKeepPosition()` so `zslUpdateScore()` can update in place when the node remains correctly ordered between its neighbors.

Add ZSET coverage for equal-score neighbor score updates in both listpack and skiplist encodings.
