### PR TITLE
Test framework: avoid stale tmpdir reuse on PID collision

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -48,6 +48,7 @@ proc clean_persistence config {
     set aof_dirpath [format "%s/%s" $dir $aofdir]
     clean_aof_persistence $aof_dirpath
     catch {exec rm -rf $rdb}
+    catch {exec rm -f [format "%s/%s" $dir "nodes.conf"]}
 }
 
 # config is actually a srv

--- a/tests/support/tmpfile.tcl
+++ b/tests/support/tmpfile.tcl
@@ -4,7 +4,10 @@ file mkdir $::tmproot
 
 # returns a dirname unique to this process to write to
 proc tmpdir {basename} {
-    set dir [file join $::tmproot $basename.[pid].[incr ::tmpcounter]]
+    while 1 {
+        set dir [file join $::tmproot $basename.[pid].[incr ::tmpcounter]]
+        if {![file exists $dir]} break
+    }
     file mkdir $dir
     set _ $dir
 }


### PR DESCRIPTION
If the OS reuses a PID, the tmpdir name can collide with a leftover directory from a previous test run, causing servers to load stale config (e.g. nodes.conf). Fix by skipping existing directories in tmpdir allocation.

Also remove nodes.conf in clean_persistence, which was missing when removing files after a start_server block where other files were removed. Cleaning doesn't affect runs with `--dont-clean` though, so both fixes are useful.

----

This problem was seen in this CI job, where a fresh server loaded a stale nodes.conf which confused the cluster and caused the test to fail: https://github.com/valkey-io/valkey/actions/runs/27279021315/job/80567998236?pr=3961#step:6:7995