### PR TITLE
Clear import-source connection flag on RESET

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2087,6 +2087,7 @@ void clearClientConnectionState(client *c) {
     c->flag.reply_skip_next = 0;
     c->flag.no_touch = 0;
     c->flag.no_evict = 0;
+    c->flag.import_source = 0;
 }
 
 /* Free the client structure and all the data associated with it.

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -977,6 +977,49 @@ start_server {tags {"expire"}} {
         }
     }
 
+    test {RESET clears the import-source flag} {
+        r config set import-mode yes
+        assert_equal [r client import-source on] {OK}
+        assert_match {*flags=I*} [r client list id [r client id]]
+
+        # RESET must make the connection resemble a fresh client, which
+        # includes dropping the import-source privilege.
+        r reset
+        assert_match {*flags=N*} [r client list id [r client id]]
+
+        r config set import-mode no
+    } {OK} {needs:reset}
+
+    test {RESET drops import-source expiration semantics} {
+        r flushall
+        r config set import-mode yes
+
+        r set foo1 1 PX 1
+        after 10
+
+        # While import-source is on, the expired key is visible.
+        assert_equal [r client import-source on] {OK}
+        assert_match {*flags=I*} [r client list id [r client id]]
+        assert_equal [r ttl foo1] {0}
+        assert_equal [r get foo1] {1}
+
+        # After RESET the connection must lose import-source semantics, so the
+        # logically-expired key looks missing again, exactly like a fresh client.
+        r reset
+        assert_match {*flags=N*} [r client list id [r client id]]
+        assert_equal [r get foo1] {}
+        assert_equal [r ttl foo1] {-2}
+
+        r config set import-mode no
+
+        # Verify all keys have expired (cleanup, mirrors the import-source tests).
+        wait_for_condition 40 100 {
+            [r dbsize] eq 0
+        } else {
+            fail "Keys did not actively expire."
+        }
+    } {} {needs:reset}
+
     test {replicaKeysWithExpire memory leak verification and cleanup} {
         # This test verifies the memory leak issue and cleanup mechanism for replicaKeysWithExpire
         


### PR DESCRIPTION
## Problem

`clearClientConnectionState()` resets the per-connection flags (tracking, db, auth, transactions, pub/sub, name, no-touch, no-evict) but leaves `c->flag.import_source` set. 

That flag is only toggled by `CLIENT IMPORT-SOURCE ON|OFF`. When set it makes the connection treat logically expired keys as live (see `objectIsExpired()` / `keyIsExpiredWithDictIndex()` in `db.c` and the `POLICY_IGNORE_EXPIRE` path in `expire.c`).

`RESET` is `NO_AUTH` and is commonly issued by connection pools before handing a socket to another user. Because the flag survives RESET, a pooled connection that was placed in import mode keeps import-mode expiration semantics for whoever reuses it, reading expired data a fresh connection would see as missing.

## Fix

Clear `c->flag.import_source` alongside the other flags in `clearClientConnectionState()` so RESET returns the connection to normal expiration semantics.

A bare `AUTH` (without a preceding RESET) still does not clear the flag, since `AUTH` does not route through `clearClientConnectionState()`. The pooling pattern that exposes this always issues RESET before reuse, so it is covered; clearing on the auth path as well would be a reasonable follow-up.

## Testing

Added regression tests in `tests/unit/expire.tcl`: after `CLIENT IMPORT-SOURCE ON` then `RESET`, `CLIENT LIST` reports `flags=N`, and a logically expired key reads back nil with TTL `-2`. 

I verified both fail on pre-fix code (the flag stays `I`) and pass after the fix.