### PR TITLE
AOF loading must not check ACL permissions

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1494,7 +1494,7 @@ struct client *createAOFClient(void) {
     c->id = CLIENT_ID_AOF; /* So modules can identify it's the AOF client. */
 
     /* The AOF client is not subject to ACL checks because all commands present
-       in the AOF file must be replayed. */
+     * in the AOF file must be replayed. */
     c->user = NULL;
 
     /*

--- a/src/aof.c
+++ b/src/aof.c
@@ -1493,6 +1493,10 @@ struct client *createAOFClient(void) {
 
     c->id = CLIENT_ID_AOF; /* So modules can identify it's the AOF client. */
 
+    /* The AOF client is not subject to ACL checks because all commands present
+       in the AOF file must be replayed. */
+    c->user = NULL;
+
     /*
      * The AOF client should never be blocked (unlike primary
      * replication connection).

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -404,6 +404,31 @@ tags {"aof external:skip logreqres:skip"} {
         }
     }
 
+    # A MULTI/EXEC block in the AOF must be replayed even when the default user
+    # is disabled. EXEC re-checks ACLs of the queued commands, but that check
+    # must not apply to the client used for loading the AOF, otherwise the
+    # transaction's writes are silently lost.
+    create_aof $aof_dirpath $aof_file {
+        append_to_aof [formatCommand set outside-tx 1]
+        append_to_aof [formatCommand multi]
+        append_to_aof [formatCommand set inside-tx-a 2]
+        append_to_aof [formatCommand set inside-tx-b 3]
+        append_to_aof [formatCommand exec]
+    }
+
+    set acl_config_lines {user {default off} user {someuser on nopass ~* &* +@all}}
+    start_server_aof_ex [list dir $server_path] [list wait_ready false config_lines $acl_config_lines] {
+        test {AOF with MULTI/EXEC is fully loaded when the default user is disabled} {
+            set c [valkey [srv host] [srv port] 0 $::tls]
+            $c auth someuser somepass
+            wait_done_loading $c
+            assert_equal 1 [$c get outside-tx]
+            assert_equal 2 [$c get inside-tx-a]
+            assert_equal 3 [$c get inside-tx-b]
+            $c close
+        }
+    }
+
     # The server could load AOF which has timestamp annotations inside
     create_aof $aof_dirpath $aof_file {
         append_to_aof "#TS:1628217470\r\n"


### PR DESCRIPTION
Permissions must not be checked when replaying commands from an AOF because all that matters is that the commands were allowed at the time they were originally performed. Checking permissions can result in silent data loss.

Fixes #3983