### PR TITLE
fix: Prevent EXISTS from incrementing keyspace hit/miss stats

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -901,7 +901,7 @@ void existsCommand(client *c) {
     int j;
 
     for (j = 1; j < c->argc; j++) {
-        if (lookupKeyReadWithFlags(c->db, c->argv[j], LOOKUP_NOTOUCH)) count++;
+        if (lookupKeyReadWithFlags(c->db, c->argv[j], LOOKUP_NOTOUCH | LOOKUP_NOSTATS)) count++;
     }
     addReplyLongLong(c, count);
 }

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -67,6 +67,21 @@ start_server {tags {"keyspace"}} {
         append res [r exists newkey]
     } {10}
 
+    test {EXISTS does not update keyspace hits or misses} {
+        r set existskey value
+        set info [r info stats]
+        set hits_before [getInfoProperty $info keyspace_hits]
+        set misses_before [getInfoProperty $info keyspace_misses]
+        r exists existskey
+        r exists nonexistingkey
+        set info [r info stats]
+        set hits_after [getInfoProperty $info keyspace_hits]
+        set misses_after [getInfoProperty $info keyspace_misses]
+        assert_equal $hits_before $hits_after
+        assert_equal $misses_before $misses_after
+        r del existskey
+    }
+
     test {Zero length value in key. SET/GET/EXISTS} {
         r set emptykey {}
         set res [r get emptykey]


### PR DESCRIPTION
Add LOOKUP_NOSTATS flag to lookupKeyReadWithFlags in existsCommand so that EXISTS does not affect keyspace_hits or keyspace_misses counters. These stats are meant for cache hit/miss tracking and EXISTS is a key existence check, not a cache access.