### PR TITLE
DRAFT: Fix copy-avoidance throughput regression by deferring reply size tracking to IO thread

### DIFF
--- a/src/commandlog.c
+++ b/src/commandlog.c
@@ -168,7 +168,71 @@ void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd) {
 
     commandlogPushEntryIfNeeded(c, argv, argc, duration, COMMANDLOG_TYPE_SLOW);
     commandlogPushEntryIfNeeded(c, argv, argc, net_input_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REQUEST);
-    commandlogPushEntryIfNeeded(c, argv, argc, net_output_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REPLY);
+
+    /* Deferred large-reply check for copy-avoidance replies.
+     *
+     * Problem: with copy avoidance, the reply buffer holds a reference to the
+     * value object (BULK_STR_REF) rather than a copy. The IO thread resolves
+     * the actual byte count when writing to the socket (trackBufReferences).
+     * At this point in command processing, argv is available but reply size is
+     * not. By the time postWriteToClient fires (reply size known), argv has
+     * been freed by resetClient/freeClientArgv.
+     *
+     * Solution: for small-argc commands (argc <= CMDLOG_INLINE_ARGV_MAX, covering
+     * GET and GETRANGE), stash argv object refs (incrRefCount, no string copies)
+     * into a per-client inline array. After the IO thread writes and postWriteToClient
+     * confirms all replies are flushed, check io_reply_len_cmdlog against the
+     * threshold and log with the stashed argv for full command attribution.
+     *
+     * For large-argc commands (MGET, etc.), skip the deferred path entirely — the
+     * values are cache-hot from the multi-key lookup anyway, so the immediate check
+     * (which may undercount copy-avoidance bytes) is acceptable.
+     *
+     * Cost: 2 refcount increments + 2 pointer stores per copy-avoidance command
+     * (zero allocation for argc <= CMDLOG_INLINE_ARGV_MAX). */
+    if (c->flag.buf_encoded && server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold >= 0 &&
+        argc <= CMDLOG_INLINE_ARGV_MAX) {
+        /* Release any previous stash that wasn't consumed yet (pipelining edge case:
+         * multiple copy-avoidance commands before a single write completion). The
+         * last command's stash will be checked at write completion with the combined
+         * byte count — this is acceptable since large-reply detection cares about
+         * total reply size, and with pipelining the responses are written together. */
+        if (c->cmdlog_argc > 0) {
+            for (int j = 0; j < c->cmdlog_argc; j++)
+                decrRefCount(c->cmdlog_argv[j]);
+        }
+        /* Stash current argv with incrRefCount into inline array (no allocation). */
+        c->cmdlog_argv = c->cmdlog_argv_inline;
+        for (int j = 0; j < argc; j++) {
+            c->cmdlog_argv[j] = argv[j];
+            incrRefCount(argv[j]);
+        }
+        c->cmdlog_argc = argc;
+    } else {
+        /* For commands with argc > CMDLOG_INLINE_ARGV_MAX (e.g., MGET with many keys),
+         * we skip the deferred stash to avoid per-command zmalloc overhead. Use the
+         * immediately-known net_output_bytes_curr_cmd for the check. For copy-avoidance
+         * replies this may undercount (BULK_STR_REF bytes tracked by IO thread aren't
+         * included yet), but multi-key commands with all values exceeding the large-reply
+         * threshold are rare in practice, and the values are cache-hot anyway. */
+        commandlogPushEntryIfNeeded(c, argv, argc, net_output_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REPLY);
+    }
+}
+
+/* Check deferred large-reply commandlog entry after IO thread has written the
+ * copy-avoidance reply. Called from postWriteToClient() on the main thread once
+ * all pending replies are flushed. Uses the stashed argv refs from
+ * commandlogPushCurrentCommand() for full command attribution. */
+void commandlogCheckDeferredLargeReply(client *c) {
+    if (c->cmdlog_argc == 0) return;
+
+    size_t io_bytes = atomic_load_explicit(&c->io_reply_len_cmdlog, memory_order_relaxed);
+    commandlogPushEntryIfNeeded(c, c->cmdlog_argv, c->cmdlog_argc,
+                                (long long)io_bytes, COMMANDLOG_TYPE_LARGE_REPLY);
+    for (int j = 0; j < c->cmdlog_argc; j++)
+        decrRefCount(c->cmdlog_argv[j]);
+    c->cmdlog_argv = NULL;
+    c->cmdlog_argc = 0;
 }
 
 /* The SLOWLOG command. Implements all the subcommands needed to handle the

--- a/src/commandlog.c
+++ b/src/commandlog.c
@@ -178,36 +178,44 @@ void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd) {
      * not. By the time postWriteToClient fires (reply size known), argv has
      * been freed by resetClient/freeClientArgv.
      *
-     * Solution: for small-argc commands (argc <= CMDLOG_INLINE_ARGV_MAX, covering
-     * GET and GETRANGE), stash argv object refs (incrRefCount, no string copies)
-     * into a per-client inline array. After the IO thread writes and postWriteToClient
-     * confirms all replies are flushed, check io_reply_len_cmdlog against the
-     * threshold and log with the stashed argv for full command attribution.
+     * Solution: stash argv refs for the FIRST command in a pipeline batch and
+     * defer its check to postWriteToClient. For subsequent pipelined commands,
+     * fall back to immediate sdslen (which is cheap — values are cache-hot from
+     * sequential processing). This avoids the cold cache miss that only affects
+     * the first GET in isolation, while preserving per-command commandlog entries
+     * for pipelined workloads.
      *
-     * For large-argc commands (MGET, etc.), skip the deferred path entirely — the
-     * values are cache-hot from the multi-key lookup anyway, so the immediate check
-     * (which may undercount copy-avoidance bytes) is acceptable.
+     * For large-argc commands (MGET, etc.), skip the deferred path entirely.
      *
-     * Cost: 2 refcount increments + 2 pointer stores per copy-avoidance command
-     * (zero allocation for argc <= CMDLOG_INLINE_ARGV_MAX). */
+     * Cost: 2 refcount increments + 2 pointer stores for the first command only
+     * (zero allocation, inline array). */
     if (c->flag.buf_encoded && server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold >= 0 &&
         argc <= CMDLOG_INLINE_ARGV_MAX) {
-        /* Release any previous stash that wasn't consumed yet (pipelining edge case:
-         * multiple copy-avoidance commands before a single write completion). The
-         * last command's stash will be checked at write completion with the combined
-         * byte count — this is acceptable since large-reply detection cares about
-         * total reply size, and with pipelining the responses are written together. */
         if (c->cmdlog_argc > 0) {
+            /* Pipelining: a previous command's stash hasn't been consumed yet.
+             * Log it now with whatever bytes have been tracked so far (may be 0
+             * if the IO thread hasn't run yet — accepted as under-report for the
+             * first command). Then do the immediate check for this command since
+             * addReplyBulk computed net_output_bytes_curr_cmd for it (values are
+             * cache-hot from sequential pipeline processing). */
+            size_t io_bytes = atomic_load_explicit(&c->io_reply_len_cmdlog, memory_order_relaxed);
+            commandlogPushEntryIfNeeded(c, c->cmdlog_argv, c->cmdlog_argc,
+                                        (long long)io_bytes, COMMANDLOG_TYPE_LARGE_REPLY);
             for (int j = 0; j < c->cmdlog_argc; j++)
                 decrRefCount(c->cmdlog_argv[j]);
+            c->cmdlog_argc = 0;
+            /* Check this command immediately — net_output_bytes_curr_cmd was
+             * populated by addReplyBulk since it detected pipelining (cmdlog_argc > 0). */
+            commandlogPushEntryIfNeeded(c, argv, argc, net_output_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REPLY);
+        } else {
+            /* First (or only) command — stash argv for deferred check. */
+            c->cmdlog_argv = c->cmdlog_argv_inline;
+            for (int j = 0; j < argc; j++) {
+                c->cmdlog_argv[j] = argv[j];
+                incrRefCount(argv[j]);
+            }
+            c->cmdlog_argc = argc;
         }
-        /* Stash current argv with incrRefCount into inline array (no allocation). */
-        c->cmdlog_argv = c->cmdlog_argv_inline;
-        for (int j = 0; j < argc; j++) {
-            c->cmdlog_argv[j] = argv[j];
-            incrRefCount(argv[j]);
-        }
-        c->cmdlog_argc = argc;
     } else {
         /* For commands with argc > CMDLOG_INLINE_ARGV_MAX (e.g., MGET with many keys),
          * we skip the deferred stash to avoid per-command zmalloc overhead. Use the

--- a/src/commandlog.c
+++ b/src/commandlog.c
@@ -143,6 +143,8 @@ static void commandlogGetReply(client *c, int type, long count) {
     }
 }
 
+static void commandlogEnqueueDeferred(client *c, robj **argv, int argc, size_t plain_bytes);
+
 /* Log the last command a client executed into the commandlog. */
 void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd) {
     /* Some commands may contain sensitive data that should not be available in the commandlog.
@@ -169,80 +171,96 @@ void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd) {
     commandlogPushEntryIfNeeded(c, argv, argc, duration, COMMANDLOG_TYPE_SLOW);
     commandlogPushEntryIfNeeded(c, argv, argc, net_input_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REQUEST);
 
-    /* Deferred large-reply check for copy-avoidance replies.
+    /* Large-reply check.
      *
-     * Problem: with copy avoidance, the reply buffer holds a reference to the
-     * value object (BULK_STR_REF) rather than a copy. The IO thread resolves
-     * the actual byte count when writing to the socket (trackBufReferences).
-     * At this point in command processing, argv is available but reply size is
-     * not. By the time postWriteToClient fires (reply size known), argv has
-     * been freed by resetClient/freeClientArgv.
+     * With copy avoidance the reply buffer holds a reference to the value object
+     * (BULK_STR_REF) instead of a copy, so the exact reply size is only known
+     * once the IO thread writes it (trackBufReferences). At this point argv is
+     * available but the size is not; by the time the reply is flushed, argv has
+     * been freed. To avoid dereferencing the value's sds header on the main
+     * thread (a guaranteed cache miss — the original regression), we stash argv
+     * refs into a per-command FIFO and defer the threshold check until the reply
+     * bytes have been attributed at buffer-release time.
      *
-     * Solution: stash argv refs for the FIRST command in a pipeline batch and
-     * defer its check to postWriteToClient. For subsequent pipelined commands,
-     * fall back to immediate sdslen (which is cheap — values are cache-hot from
-     * sequential processing). This avoids the cold cache miss that only affects
-     * the first GET in isolation, while preserving per-command commandlog entries
-     * for pipelined workloads.
-     *
-     * For large-argc commands (MGET, etc.), skip the deferred path entirely.
-     *
-     * Cost: 2 refcount increments + 2 pointer stores for the first command only
-     * (zero allocation, inline array). */
-    if (c->flag.buf_encoded && server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold >= 0 &&
-        argc <= CMDLOG_INLINE_ARGV_MAX) {
-        if (c->cmdlog_argc > 0) {
-            /* Pipelining: a previous command's stash hasn't been consumed yet.
-             * Log it now with whatever bytes have been tracked so far (may be 0
-             * if the IO thread hasn't run yet — accepted as under-report for the
-             * first command). Then do the immediate check for this command since
-             * addReplyBulk computed net_output_bytes_curr_cmd for it (values are
-             * cache-hot from sequential pipeline processing). */
-            size_t io_bytes = atomic_load_explicit(&c->io_reply_len_cmdlog, memory_order_relaxed);
-            commandlogPushEntryIfNeeded(c, c->cmdlog_argv, c->cmdlog_argc,
-                                        (long long)io_bytes, COMMANDLOG_TYPE_LARGE_REPLY);
-            for (int j = 0; j < c->cmdlog_argc; j++)
-                decrRefCount(c->cmdlog_argv[j]);
-            c->cmdlog_argc = 0;
-            /* Check this command immediately — net_output_bytes_curr_cmd was
-             * populated by addReplyBulk since it detected pipelining (cmdlog_argc > 0). */
-            commandlogPushEntryIfNeeded(c, argv, argc, net_output_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REPLY);
-        } else {
-            /* First (or only) command — stash argv for deferred check. */
-            c->cmdlog_argv = c->cmdlog_argv_inline;
-            for (int j = 0; j < argc; j++) {
-                c->cmdlog_argv[j] = argv[j];
-                incrRefCount(argv[j]);
-            }
-            c->cmdlog_argc = argc;
-        }
+     * Non-copy-avoidance replies already have their size tracked synchronously
+     * in net_output_bytes_curr_cmd, so they are checked immediately as before. */
+    if (c->flag.buf_encoded && server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold >= 0) {
+        commandlogEnqueueDeferred(c, argv, argc, net_output_bytes_curr_cmd);
     } else {
-        /* For commands with argc > CMDLOG_INLINE_ARGV_MAX (e.g., MGET with many keys),
-         * we skip the deferred stash to avoid per-command zmalloc overhead. Use the
-         * immediately-known net_output_bytes_curr_cmd for the check. For copy-avoidance
-         * replies this may undercount (BULK_STR_REF bytes tracked by IO thread aren't
-         * included yet), but multi-key commands with all values exceeding the large-reply
-         * threshold are rare in practice, and the values are cache-hot anyway. */
         commandlogPushEntryIfNeeded(c, argv, argc, net_output_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REPLY);
     }
 }
 
-/* Check deferred large-reply commandlog entry after IO thread has written the
- * copy-avoidance reply. Called from postWriteToClient() on the main thread once
- * all pending replies are flushed. Uses the stashed argv refs from
- * commandlogPushCurrentCommand() for full command attribution. */
-void commandlogCheckDeferredLargeReply(client *c) {
-    if (c->cmdlog_argc == 0) return;
+/* Stash a copy-avoidance command's argv (and the plain-reply bytes already
+ * counted on the main thread) into the per-client deferred FIFO. The exact
+ * reply size is filled in later at buffer-release time. The FIFO is lazily
+ * allocated and grown geometrically, then reused for the client's lifetime. */
+static void commandlogEnqueueDeferred(client *c, robj **argv, int argc, size_t plain_bytes) {
+    if (c->cmdlog_deferred_len == c->cmdlog_deferred_cap) {
+        int newcap = c->cmdlog_deferred_cap ? c->cmdlog_deferred_cap * 2 : 8;
+        c->cmdlog_deferred = zrealloc(c->cmdlog_deferred, (size_t)newcap * sizeof(cmdlogDeferredReply));
+        c->cmdlog_deferred_cap = newcap;
+    }
 
-    size_t io_bytes = atomic_load_explicit(&c->io_reply_len_cmdlog, memory_order_relaxed);
-    commandlogPushEntryIfNeeded(c, c->cmdlog_argv, c->cmdlog_argc,
-                                (long long)io_bytes, COMMANDLOG_TYPE_LARGE_REPLY);
-    for (int j = 0; j < c->cmdlog_argc; j++)
-        decrRefCount(c->cmdlog_argv[j]);
-    c->cmdlog_argv = NULL;
-    c->cmdlog_argc = 0;
+    cmdlogDeferredReply *e = &c->cmdlog_deferred[c->cmdlog_deferred_len++];
+    if (argc <= CMDLOG_INLINE_ARGV_MAX) {
+        e->argv = e->argv_inline;
+    } else {
+        e->argv = zmalloc((size_t)argc * sizeof(robj *));
+    }
+    for (int j = 0; j < argc; j++) {
+        e->argv[j] = argv[j];
+        incrRefCount(argv[j]);
+    }
+    e->argc = argc;
+    e->plain_bytes = plain_bytes;
+    e->bulk_bytes = 0;
+
+    /* The next command's first BULK_STR_REF header starts a new command. */
+    c->cmdlog_bulk_boundary = 1;
 }
 
+/* Attribute one BULK_STR_REF header's exact reply size (as computed by the IO
+ * thread) to the correct deferred command. Called in buffer order from
+ * releaseBufReferences() on the main thread; a cmd_start header advances to the
+ * next queued command. */
+void commandlogAccumulateDeferredBytes(client *c, size_t reply_len, int cmd_start) {
+    if (cmd_start) c->cmdlog_deferred_cursor++;
+    if (c->cmdlog_deferred_cursor < 0 || c->cmdlog_deferred_cursor >= c->cmdlog_deferred_len) return;
+    c->cmdlog_deferred[c->cmdlog_deferred_cursor].bulk_bytes += reply_len;
+}
+
+/* Run the deferred large-reply threshold checks once all of a client's replies
+ * have been flushed and their exact sizes attributed. Called from
+ * postWriteToClient() on the main thread. */
+void commandlogFinalizeDeferred(client *c) {
+    for (int i = 0; i < c->cmdlog_deferred_len; i++) {
+        cmdlogDeferredReply *e = &c->cmdlog_deferred[i];
+        long long total = (long long)(e->plain_bytes + e->bulk_bytes);
+        commandlogPushEntryIfNeeded(c, e->argv, e->argc, total, COMMANDLOG_TYPE_LARGE_REPLY);
+        for (int j = 0; j < e->argc; j++) decrRefCount(e->argv[j]);
+        if (e->argv != e->argv_inline) zfree(e->argv);
+    }
+    c->cmdlog_deferred_len = 0;
+    c->cmdlog_deferred_cursor = -1;
+    /* Ready the boundary marker for the next command's first reply. */
+    c->cmdlog_bulk_boundary = 1;
+}
+
+/* Release any queued deferred entries without logging (e.g. on client free).
+ * Frees stashed argv refs and the FIFO backing array. */
+void commandlogFreeDeferred(client *c) {
+    for (int i = 0; i < c->cmdlog_deferred_len; i++) {
+        cmdlogDeferredReply *e = &c->cmdlog_deferred[i];
+        for (int j = 0; j < e->argc; j++) decrRefCount(e->argv[j]);
+        if (e->argv != e->argv_inline) zfree(e->argv);
+    }
+    zfree(c->cmdlog_deferred);
+    c->cmdlog_deferred = NULL;
+    c->cmdlog_deferred_len = 0;
+    c->cmdlog_deferred_cap = 0;
+    c->cmdlog_deferred_cursor = -1;
+}
 /* The SLOWLOG command. Implements all the subcommands needed to handle the
  * slow log. */
 void slowlogCommand(client *c) {

--- a/src/commandlog.c
+++ b/src/commandlog.c
@@ -203,13 +203,16 @@ static void commandlogEnqueueDeferred(client *c, robj **argv, int argc, size_t p
     }
 
     cmdlogDeferredReply *e = &c->cmdlog_deferred[c->cmdlog_deferred_len++];
+    robj **dst;
     if (argc <= CMDLOG_INLINE_ARGV_MAX) {
-        e->argv = e->argv_inline;
+        e->argv_heap = NULL;
+        dst = e->argv_inline;
     } else {
-        e->argv = zmalloc((size_t)argc * sizeof(robj *));
+        e->argv_heap = zmalloc((size_t)argc * sizeof(robj *));
+        dst = e->argv_heap;
     }
     for (int j = 0; j < argc; j++) {
-        e->argv[j] = argv[j];
+        dst[j] = argv[j];
         incrRefCount(argv[j]);
     }
     e->argc = argc;
@@ -236,10 +239,11 @@ void commandlogAccumulateDeferredBytes(client *c, size_t reply_len, int cmd_star
 void commandlogFinalizeDeferred(client *c) {
     for (int i = 0; i < c->cmdlog_deferred_len; i++) {
         cmdlogDeferredReply *e = &c->cmdlog_deferred[i];
+        robj **argv = e->argv_heap ? e->argv_heap : e->argv_inline;
         long long total = (long long)(e->plain_bytes + e->bulk_bytes);
-        commandlogPushEntryIfNeeded(c, e->argv, e->argc, total, COMMANDLOG_TYPE_LARGE_REPLY);
-        for (int j = 0; j < e->argc; j++) decrRefCount(e->argv[j]);
-        if (e->argv != e->argv_inline) zfree(e->argv);
+        commandlogPushEntryIfNeeded(c, argv, e->argc, total, COMMANDLOG_TYPE_LARGE_REPLY);
+        for (int j = 0; j < e->argc; j++) decrRefCount(argv[j]);
+        if (e->argv_heap) zfree(e->argv_heap);
     }
     c->cmdlog_deferred_len = 0;
     c->cmdlog_deferred_cursor = -1;
@@ -252,8 +256,9 @@ void commandlogFinalizeDeferred(client *c) {
 void commandlogFreeDeferred(client *c) {
     for (int i = 0; i < c->cmdlog_deferred_len; i++) {
         cmdlogDeferredReply *e = &c->cmdlog_deferred[i];
-        for (int j = 0; j < e->argc; j++) decrRefCount(e->argv[j]);
-        if (e->argv != e->argv_inline) zfree(e->argv);
+        robj **argv = e->argv_heap ? e->argv_heap : e->argv_inline;
+        for (int j = 0; j < e->argc; j++) decrRefCount(argv[j]);
+        if (e->argv_heap) zfree(e->argv_heap);
     }
     zfree(c->cmdlog_deferred);
     c->cmdlog_deferred = NULL;

--- a/src/networking.c
+++ b/src/networking.c
@@ -119,7 +119,9 @@ typedef struct __attribute__((__packed__)) payloadHeader {
     int16_t slot;             /* to report network-bytes-out for BULK_STR_REF chunks */
     uint8_t payload_type : 1; /* one of payloadType */
     uint8_t track_bytes : 1;  /* 1 if net bytes tracking was enabled when reply was added */
-    uint8_t reserved : 6;     /* reserved */
+    uint8_t cmd_start : 1;    /* 1 if this BULK_STR_REF header is the first of a command's reply
+                               * (used to attribute deferred commandlog reply bytes per command) */
+    uint8_t reserved : 5;     /* reserved */
     /* tracked_for_cob is placed after the bitfield byte so it is byte aligned.
      * _Atomic(uint8_t) has alignment 1, this is safe inside __packed__
      * because the compiler will not insert padding before it */
@@ -371,9 +373,11 @@ client *createClient(connection *conn) {
     c->net_output_bytes = 0;
     c->net_output_bytes_curr_cmd = 0;
     c->io_tracked_reply_len = 0;
-    c->io_reply_len_cmdlog = 0;
-    c->cmdlog_argv = NULL;
-    c->cmdlog_argc = 0;
+    c->cmdlog_deferred = NULL;
+    c->cmdlog_deferred_len = 0;
+    c->cmdlog_deferred_cap = 0;
+    c->cmdlog_deferred_cursor = -1;
+    c->cmdlog_bulk_boundary = 1;
     c->commands_processed = 0;
     c->io_last_reply_block = NULL;
     c->io_last_bufpos = 0;
@@ -582,6 +586,7 @@ static size_t upsertPayloadHeader(char *buf,
     (*last_header)->reply_len = 0;
     (*last_header)->track_bytes = track_bytes;
     (*last_header)->tracked_for_cob = 0;
+    (*last_header)->cmd_start = 0;
     (*last_header)->reserved = 0;
 
     *bufpos += sizeof(payloadHeader);
@@ -611,7 +616,17 @@ static size_t _addReplyPayloadToBuffer(client *c, const void *payload, size_t le
          * main thread. For PLAIN_REPLY, track in main thread as before. */
         int track_bytes = (payload_type != BULK_STR_REF &&
                            server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
+        /* Mark the first BULK_STR_REF header of a command so its reply bytes can
+         * be attributed per-command at release time. Force a fresh header (no
+         * coalescing) so a command boundary never shares a header. */
+        int mark_cmd_start = (payload_type == BULK_STR_REF && c->cmdlog_bulk_boundary &&
+                              server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold >= 0);
+        if (mark_cmd_start) c->last_header = NULL;
         reply_len = upsertPayloadHeader(c->buf, &c->bufpos, &c->last_header, payload_type, len, c->slot, track_bytes, available);
+        if (mark_cmd_start && reply_len) {
+            c->last_header->cmd_start = 1;
+            c->cmdlog_bulk_boundary = 0;
+        }
     }
     if (!reply_len) return 0;
 
@@ -663,7 +678,14 @@ static void _addReplyPayloadToList(client *c, list *reply_list, const char *payl
         if (tail->flag.buf_encoded) {
             int track_bytes = (payload_type != BULK_STR_REF &&
                                server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
+            int mark_cmd_start = (payload_type == BULK_STR_REF && c->cmdlog_bulk_boundary &&
+                                  server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold >= 0);
+            if (mark_cmd_start) tail->last_header = NULL;
             copy = upsertPayloadHeader(tail->buf, &tail->used, &tail->last_header, payload_type, len, c->slot, track_bytes, avail);
+            if (mark_cmd_start && copy) {
+                tail->last_header->cmd_start = 1;
+                c->cmdlog_bulk_boundary = 0;
+            }
         } else if (encoded) {
             /* If encoded buffer is required but tail is unencoded then pretend nothing can be added to it
              * and, as consequence, cause addition of a new tail */
@@ -693,7 +715,13 @@ static void _addReplyPayloadToList(client *c, list *reply_list, const char *payl
         if (tail->flag.buf_encoded) {
             int track_bytes = (payload_type != BULK_STR_REF &&
                                server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
+            int mark_cmd_start = (payload_type == BULK_STR_REF && c->cmdlog_bulk_boundary &&
+                                  server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold >= 0);
             upsertPayloadHeader(tail->buf, &tail->used, &tail->last_header, payload_type, len, c->slot, track_bytes, tail->size);
+            if (mark_cmd_start && tail->last_header) {
+                tail->last_header->cmd_start = 1;
+                c->cmdlog_bulk_boundary = 0;
+            }
         }
         memcpy(tail->buf + tail->used, payload, len);
         tail->used += len;
@@ -1481,20 +1509,12 @@ static int tryAvoidBulkStrCopyToReply(client *c, robj *obj) {
 /* Add an Object as a bulk reply */
 void addReplyBulk(client *c, robj *obj) {
     if (tryAvoidBulkStrCopyToReply(c, obj) == C_OK) {
-        /* When a previous command's argv is already stashed for deferred commandlog
-         * (pipelining), compute reply size here so this command can be logged
-         * immediately in commandlogPushCurrentCommand. The sdslen is cheap here
-         * because pipelined values are cache-hot from sequential processing.
-         *
-         * When no stash is pending (first/only command), skip sdslen entirely —
-         * the IO thread handles byte tracking via trackBufReferences. */
-        if (c->cmdlog_argc > 0 &&
-            server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold >= 0) {
-            serverAssert(obj->encoding == OBJ_ENCODING_RAW);
-            size_t str_len = sdslen(objectGetVal(obj));
-            uint32_t num_len = digits10(str_len);
-            c->net_output_bytes_curr_cmd += (num_len + 3) + str_len + 2;
-        }
+        /* Copy avoidance: the value bytes are never read on the main thread.
+         * The IO thread computes the exact reply size in trackBufReferences,
+         * which is later attributed per-command for the deferred commandlog
+         * large-reply check (see commandlog.c). Deliberately no sdslen() here —
+         * dereferencing the value's sds header would be a guaranteed L2/L3 cache
+         * miss on the hot path, which is exactly the regression being fixed. */
         return;
     }
     addReplyBulkLen(c, obj);
@@ -2195,10 +2215,7 @@ int freeClient(client *c) {
 
     freeClientArgv(c);
     freeClientOriginalArgv(c);
-    if (c->cmdlog_argc > 0) {
-        for (int j = 0; j < c->cmdlog_argc; j++)
-            decrRefCount(c->cmdlog_argv[j]);
-    }
+    commandlogFreeDeferred(c);
     discardCommandQueue(c);
     if (c->deferred_reply_errors) listRelease(c->deferred_reply_errors);
     c->deferred_reply_errors = NULL;
@@ -2911,7 +2928,6 @@ static void trackBufReferences(char *buf, size_t bufpos, client *c) {
                  * headers after write boundary */
                 header->reply_len = total_reply_len;
                 atomic_fetch_add_explicit(&c->io_tracked_reply_len, total_reply_len, memory_order_relaxed);
-                atomic_fetch_add_explicit(&c->io_reply_len_cmdlog, total_reply_len, memory_order_relaxed);
             }
         }
 
@@ -2928,6 +2944,13 @@ static void releaseBufReferences(char *buf, size_t bufpos, client *c) {
         ptr += sizeof(payloadHeader);
 
         if (header->payload_type == BULK_STR_REF) {
+            /* Attribute this reply's exact size (computed by the IO thread) to the
+             * command that produced it, for the deferred commandlog large-reply
+             * check. Headers are walked in command order; a cmd_start header marks
+             * the start of the next command's reply. */
+            if (c && c->cmdlog_deferred_len > 0)
+                commandlogAccumulateDeferredBytes(c, header->reply_len, header->cmd_start);
+
             /* Decrement tracked reply size only if it was previously tracked.
              * Use atomic exchange to ensure we only decrement once. */
             if (c && atomic_exchange_explicit(&header->tracked_for_cob, 0, memory_order_acq_rel)) {
@@ -3053,12 +3076,10 @@ int postWriteToClient(client *c) {
     }
     if (!clientHasPendingReplies(c)) {
         resetLastWrittenBuf(c);
-        /* All replies written — check deferred commandlog large-reply entry now
-         * that the IO thread has computed exact reply sizes. */
-        commandlogCheckDeferredLargeReply(c);
-        /* Reset IO-tracked cmdlog bytes regardless of whether a stash was pending,
-         * to avoid stale accumulation across unrelated commands. */
-        atomic_store_explicit(&c->io_reply_len_cmdlog, 0, memory_order_relaxed);
+        /* All replies flushed — the IO thread has computed exact reply sizes and
+         * releaseBufReferences has attributed them per command. Run the deferred
+         * commandlog large-reply checks now, then clear the FIFO. */
+        commandlogFinalizeDeferred(c);
         if (connHasWriteHandler(c->conn)) {
             connSetWriteHandler(c->conn, NULL);
         }

--- a/src/networking.c
+++ b/src/networking.c
@@ -371,6 +371,9 @@ client *createClient(connection *conn) {
     c->net_output_bytes = 0;
     c->net_output_bytes_curr_cmd = 0;
     c->io_tracked_reply_len = 0;
+    c->io_reply_len_cmdlog = 0;
+    c->cmdlog_argv = NULL;
+    c->cmdlog_argc = 0;
     c->commands_processed = 0;
     c->io_last_reply_block = NULL;
     c->io_last_bufpos = 0;
@@ -603,7 +606,11 @@ static size_t _addReplyPayloadToBuffer(client *c, const void *payload, size_t le
     size_t available = c->buf_usable_size - c->bufpos;
     size_t reply_len = min(available, len);
     if (c->flag.buf_encoded) {
-        int track_bytes = (server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
+        /* For BULK_STR_REF, always delegate byte tracking to the IO thread
+         * (trackBufReferences) to avoid expensive sdslen() cache misses in the
+         * main thread. For PLAIN_REPLY, track in main thread as before. */
+        int track_bytes = (payload_type != BULK_STR_REF &&
+                           server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
         reply_len = upsertPayloadHeader(c->buf, &c->bufpos, &c->last_header, payload_type, len, c->slot, track_bytes, available);
     }
     if (!reply_len) return 0;
@@ -654,7 +661,8 @@ static void _addReplyPayloadToList(client *c, list *reply_list, const char *payl
         size_t copy = avail >= len ? len : avail;
 
         if (tail->flag.buf_encoded) {
-            int track_bytes = (server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
+            int track_bytes = (payload_type != BULK_STR_REF &&
+                               server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
             copy = upsertPayloadHeader(tail->buf, &tail->used, &tail->last_header, payload_type, len, c->slot, track_bytes, avail);
         } else if (encoded) {
             /* If encoded buffer is required but tail is unencoded then pretend nothing can be added to it
@@ -683,7 +691,8 @@ static void _addReplyPayloadToList(client *c, list *reply_list, const char *payl
         tail->flag.buf_encoded = encoded;
         tail->last_header = NULL;
         if (tail->flag.buf_encoded) {
-            int track_bytes = (server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
+            int track_bytes = (payload_type != BULK_STR_REF &&
+                               server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
             upsertPayloadHeader(tail->buf, &tail->used, &tail->last_header, payload_type, len, c->slot, track_bytes, tail->size);
         }
         memcpy(tail->buf + tail->used, payload, len);
@@ -1472,17 +1481,11 @@ static int tryAvoidBulkStrCopyToReply(client *c, robj *obj) {
 /* Add an Object as a bulk reply */
 void addReplyBulk(client *c, robj *obj) {
     if (tryAvoidBulkStrCopyToReply(c, obj) == C_OK) {
-        /* If copy avoidance allowed, then we explicitly maintain net_output_bytes_curr_cmd.
-         * We determine per-reply if tracking is enabled by checking the config in the main thread. */
-        if (server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1) {
-            serverAssert(obj->encoding == OBJ_ENCODING_RAW);
-            size_t str_len = sdslen(objectGetVal(obj));
-            uint32_t num_len = digits10(str_len);
-            /* RESP encodes bulk strings as $<length>\r\n<data>\r\n */
-            c->net_output_bytes_curr_cmd += (num_len + 3); /* $<length>\r\n */
-            c->net_output_bytes_curr_cmd += str_len;       /* <data> */
-            c->net_output_bytes_curr_cmd += 2;             /* \r\n */
-        }
+        /* Reply size tracking for copy-avoidance replies is handled by the IO
+         * thread in trackBufReferences(), which already computes sdslen() when
+         * writing to the socket. The commandlog check in commandlogPushCurrentCommand()
+         * reads io_tracked_reply_len to account for these bytes. This avoids an
+         * expensive cache-missing sdslen() call here in the main thread hot path. */
         return;
     }
     addReplyBulkLen(c, obj);
@@ -2183,6 +2186,10 @@ int freeClient(client *c) {
 
     freeClientArgv(c);
     freeClientOriginalArgv(c);
+    if (c->cmdlog_argc > 0) {
+        for (int j = 0; j < c->cmdlog_argc; j++)
+            decrRefCount(c->cmdlog_argv[j]);
+    }
     discardCommandQueue(c);
     if (c->deferred_reply_errors) listRelease(c->deferred_reply_errors);
     c->deferred_reply_errors = NULL;
@@ -2895,6 +2902,7 @@ static void trackBufReferences(char *buf, size_t bufpos, client *c) {
                  * headers after write boundary */
                 header->reply_len = total_reply_len;
                 atomic_fetch_add_explicit(&c->io_tracked_reply_len, total_reply_len, memory_order_relaxed);
+                atomic_fetch_add_explicit(&c->io_reply_len_cmdlog, total_reply_len, memory_order_relaxed);
             }
         }
 
@@ -3036,6 +3044,12 @@ int postWriteToClient(client *c) {
     }
     if (!clientHasPendingReplies(c)) {
         resetLastWrittenBuf(c);
+        /* All replies written — check deferred commandlog large-reply entry now
+         * that the IO thread has computed exact reply sizes. */
+        commandlogCheckDeferredLargeReply(c);
+        /* Reset IO-tracked cmdlog bytes regardless of whether a stash was pending,
+         * to avoid stale accumulation across unrelated commands. */
+        atomic_store_explicit(&c->io_reply_len_cmdlog, 0, memory_order_relaxed);
         if (connHasWriteHandler(c->conn)) {
             connSetWriteHandler(c->conn, NULL);
         }

--- a/src/networking.c
+++ b/src/networking.c
@@ -1481,11 +1481,20 @@ static int tryAvoidBulkStrCopyToReply(client *c, robj *obj) {
 /* Add an Object as a bulk reply */
 void addReplyBulk(client *c, robj *obj) {
     if (tryAvoidBulkStrCopyToReply(c, obj) == C_OK) {
-        /* Reply size tracking for copy-avoidance replies is handled by the IO
-         * thread in trackBufReferences(), which already computes sdslen() when
-         * writing to the socket. The commandlog check in commandlogPushCurrentCommand()
-         * reads io_tracked_reply_len to account for these bytes. This avoids an
-         * expensive cache-missing sdslen() call here in the main thread hot path. */
+        /* When a previous command's argv is already stashed for deferred commandlog
+         * (pipelining), compute reply size here so this command can be logged
+         * immediately in commandlogPushCurrentCommand. The sdslen is cheap here
+         * because pipelined values are cache-hot from sequential processing.
+         *
+         * When no stash is pending (first/only command), skip sdslen entirely —
+         * the IO thread handles byte tracking via trackBufReferences. */
+        if (c->cmdlog_argc > 0 &&
+            server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold >= 0) {
+            serverAssert(obj->encoding == OBJ_ENCODING_RAW);
+            size_t str_len = sdslen(objectGetVal(obj));
+            uint32_t num_len = digits10(str_len);
+            c->net_output_bytes_curr_cmd += (num_len + 3) + str_len + 2;
+        }
         return;
     }
     addReplyBulkLen(c, obj);

--- a/src/server.h
+++ b/src/server.h
@@ -1305,7 +1305,10 @@ typedef struct slotMigrationJob slotMigrationJob;
  * payloadHeader->reply_len, then compared against the large-reply threshold. */
 typedef struct cmdlogDeferredReply {
     robj *argv_inline[CMDLOG_INLINE_ARGV_MAX]; /* Inline argv stash for small argc (no allocation). */
-    robj **argv;                               /* Points to argv_inline, or heap-allocated for large argc. */
+    robj **argv_heap;                          /* Heap-allocated argv array when argc > CMDLOG_INLINE_ARGV_MAX, else NULL.
+                                                * Never store a pointer to argv_inline here: the entry lives in a
+                                                * reallocatable array, so the active argv is computed from the current
+                                                * entry address (argv_heap ? argv_heap : argv_inline). */
     int argc;                                  /* Number of stashed args. */
     size_t plain_bytes;                        /* PLAIN_REPLY bytes for this command, counted on the main thread. */
     size_t bulk_bytes;                         /* BULK_STR_REF bytes for this command, accumulated at release time. */

--- a/src/server.h
+++ b/src/server.h
@@ -1368,6 +1368,15 @@ typedef struct client {
     unsigned long long commands_processed;        /* Total count of commands this client executed. */
     unsigned long long net_output_bytes_curr_cmd; /* Total network output bytes sent to this client, by the current command. */
     _Atomic(size_t) io_tracked_reply_len;         /* Total size of BULK_STR_REF replies tracked by I/O threads. */
+    _Atomic(size_t) io_reply_len_cmdlog;          /* Monotonic accumulator for deferred commandlog large-reply check. */
+    /* Inline stash for deferred commandlog large-reply check with copy avoidance.
+     * When a command uses copy avoidance, we stash argv refs (incrRefCount) here
+     * so postWriteToClient can log the full command after the IO thread computes
+     * exact reply size. Avoids zmalloc in the hot path. */
+#define CMDLOG_INLINE_ARGV_MAX 4                  /* Covers GET (argc=2), GETRANGE (argc=3), MGET single-key (argc=2) */
+    robj *cmdlog_argv_inline[CMDLOG_INLINE_ARGV_MAX]; /* Inline stash for small argc */
+    robj **cmdlog_argv;                           /* Points to cmdlog_argv_inline or heap-allocated for large argc */
+    int cmdlog_argc;                              /* Number of stashed args (0 = no pending check) */
     size_t buf_peak;                              /* Peak used size of buffer in last 5 sec interval. */
     int nwritten;                                 /* Number of bytes of the last write. */
     int nread;                                    /* Number of bytes of the last read. */
@@ -3480,6 +3489,7 @@ void preventCommandPropagation(client *c);
 void preventCommandAOF(client *c);
 void preventCommandReplication(client *c);
 void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd);
+void commandlogCheckDeferredLargeReply(client *c);
 void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int64_t duration_hist);
 int prepareForShutdown(client *c, int flags);
 void replyToClientsBlockedOnShutdown(void);

--- a/src/server.h
+++ b/src/server.h
@@ -1295,6 +1295,22 @@ typedef struct LastWrittenBuf {
 /* Forward declaration of slotMigrationJob */
 typedef struct slotMigrationJob slotMigrationJob;
 
+/* Covers GET (argc=2), GETRANGE (argc=3), SUBSTR (argc=4). Larger-argc commands
+ * (e.g. MGET with many keys) fall back to a heap-allocated argv copy. */
+#define CMDLOG_INLINE_ARGV_MAX 4
+
+/* One deferred commandlog large-reply check, queued while a copy-avoidance
+ * command's reply size is still unknown on the main thread. The exact reply
+ * size is filled in later (at buffer-release time) from the IO-thread-computed
+ * payloadHeader->reply_len, then compared against the large-reply threshold. */
+typedef struct cmdlogDeferredReply {
+    robj *argv_inline[CMDLOG_INLINE_ARGV_MAX]; /* Inline argv stash for small argc (no allocation). */
+    robj **argv;                               /* Points to argv_inline, or heap-allocated for large argc. */
+    int argc;                                  /* Number of stashed args. */
+    size_t plain_bytes;                        /* PLAIN_REPLY bytes for this command, counted on the main thread. */
+    size_t bulk_bytes;                         /* BULK_STR_REF bytes for this command, accumulated at release time. */
+} cmdlogDeferredReply;
+
 typedef struct client {
     /* Basic client information and connection. */
     uint64_t id; /* Client incremental unique ID. */
@@ -1368,20 +1384,24 @@ typedef struct client {
     unsigned long long commands_processed;        /* Total count of commands this client executed. */
     unsigned long long net_output_bytes_curr_cmd; /* Total network output bytes sent to this client, by the current command. */
     _Atomic(size_t) io_tracked_reply_len;         /* Total size of BULK_STR_REF replies tracked by I/O threads. */
-    _Atomic(size_t) io_reply_len_cmdlog;          /* Monotonic accumulator for deferred commandlog large-reply check. */
-    /* Inline stash for deferred commandlog large-reply check with copy avoidance.
-     * When a command uses copy avoidance, we stash argv refs (incrRefCount) here
-     * so postWriteToClient can log the full command after the IO thread computes
-     * exact reply size. Avoids zmalloc in the hot path. */
-#define CMDLOG_INLINE_ARGV_MAX 4                  /* Covers GET (argc=2), GETRANGE (argc=3), MGET single-key (argc=2) */
-    robj *cmdlog_argv_inline[CMDLOG_INLINE_ARGV_MAX]; /* Inline stash for small argc */
-    robj **cmdlog_argv;                           /* Points to cmdlog_argv_inline or heap-allocated for large argc */
-    int cmdlog_argc;                              /* Number of stashed args (0 = no pending check) */
-    size_t buf_peak;                              /* Peak used size of buffer in last 5 sec interval. */
-    int nwritten;                                 /* Number of bytes of the last write. */
-    int nread;                                    /* Number of bytes of the last read. */
-    int read_flags;                               /* Client Read flags - used to communicate the client read state. */
-    int slot;                                     /* The slot the client is executing against. Set to -1 if no slot is being used */
+    /* Deferred commandlog large-reply state for copy-avoidance replies.
+     * With copy avoidance the reply size isn't known on the main thread at
+     * command time, and argv is freed before the IO thread writes. We stash a
+     * per-command FIFO of argv refs here; each command's exact reply size is
+     * attributed at buffer-release time (from payloadHeader->reply_len) and the
+     * threshold check + logging happens once all replies are flushed. The FIFO
+     * is lazily allocated and reused for the client's lifetime; when
+     * commandlog-reply-larger-than is -1 (disabled) it is never touched. */
+    cmdlogDeferredReply *cmdlog_deferred; /* FIFO of pending checks (NULL until first use). */
+    int cmdlog_deferred_len;              /* Number of queued entries. */
+    int cmdlog_deferred_cap;              /* Allocated capacity of the FIFO. */
+    int cmdlog_deferred_cursor;           /* Entry currently receiving bytes during release (-1 = none yet). */
+    int cmdlog_bulk_boundary;             /* 1 = next BULK_STR_REF header begins a new command. */
+    size_t buf_peak;                      /* Peak used size of buffer in last 5 sec interval. */
+    int nwritten;                         /* Number of bytes of the last write. */
+    int nread;                            /* Number of bytes of the last read. */
+    int read_flags;                       /* Client Read flags - used to communicate the client read state. */
+    int slot;                             /* The slot the client is executing against. Set to -1 if no slot is being used */
     listNode *mem_usage_bucket_node;
     clientMemUsageBucket *mem_usage_bucket;
     /* In updateClientMemoryUsage() we track the memory usage of
@@ -3489,7 +3509,9 @@ void preventCommandPropagation(client *c);
 void preventCommandAOF(client *c);
 void preventCommandReplication(client *c);
 void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd);
-void commandlogCheckDeferredLargeReply(client *c);
+void commandlogAccumulateDeferredBytes(client *c, size_t reply_len, int cmd_start);
+void commandlogFinalizeDeferred(client *c);
+void commandlogFreeDeferred(client *c);
 void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int64_t duration_hist);
 int prepareForShutdown(client *c, int flags);
 void replyToClientsBlockedOnShutdown(void);

--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -518,6 +518,33 @@ start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overr
         r del small big
     }
 
+    test {COMMANDLOG large-reply - deep pipeline grows FIFO past initial capacity} {
+        r config set min-string-size-avoid-copy-reply 1
+        r config set commandlog-reply-larger-than 1024
+        r commandlog reset large-reply
+
+        # 20 distinct large values, pipelined in one batch. This forces the
+        # deferred FIFO to grow past its initial capacity (8) via realloc, which
+        # previously left dangling argv pointers into the moved array and crashed
+        # at finalize. All 20 must be logged with their exact per-command sizes.
+        set n 20
+        set rd [valkey_deferring_client]
+        for {set i 0} {$i < $n} {incr i} {
+            r set dpkey$i [string repeat X 2048]
+        }
+        for {set i 0} {$i < $n} {incr i} { $rd get dpkey$i }
+        for {set i 0} {$i < $n} {incr i} { $rd read }
+        $rd close
+        after 150
+
+        assert_equal [r commandlog len large-reply] $n
+        foreach e [r commandlog get -1 large-reply] {
+            assert_equal [lindex $e 2] 2057
+        }
+
+        for {set i 0} {$i < $n} {incr i} { r del dpkey$i }
+    }
+
     test {COMMANDLOG large-reply - client disconnect releases stashed refs} {
         r config set min-string-size-avoid-copy-reply 1
         r config set commandlog-reply-larger-than 1024

--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -453,7 +453,7 @@ start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overr
         r config set commandlog-reply-larger-than 1024
         r commandlog reset large-reply
 
-        # Create two large values
+        # Create two large values (both individually exceed 1024 threshold)
         set val1 [string repeat D 2048]
         set val2 [string repeat E 3072]
         r set key1 $val1
@@ -468,14 +468,21 @@ start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overr
         $rd close
         after 100
 
-        # At least one large-reply entry should be logged
+        # Both commands should be logged (not just the last one)
         set len [r commandlog len large-reply]
-        assert_morethan $len 0
+        assert_morethan_equal $len 2
 
-        # The logged entry should have full argv (not empty or truncated)
-        set e [lindex [r commandlog get -1 large-reply] 0]
-        # argv should be "get key1" or "get key2"
-        assert_match {get key*} [lindex $e 3]
+        # Verify both keys appear in the commandlog entries
+        set entries [r commandlog get -1 large-reply]
+        set found_key1 0
+        set found_key2 0
+        foreach e $entries {
+            set cmd [lindex $e 3]
+            if {[string match "*key1*" $cmd]} { set found_key1 1 }
+            if {[string match "*key2*" $cmd]} { set found_key2 1 }
+        }
+        assert_equal $found_key1 1
+        assert_equal $found_key2 1
 
         r del key1 key2
     }

--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -409,3 +409,94 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
         r del testkey
     }
 }
+
+start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overrides {io-threads 4 commandlog-execution-slower-than 1000000 commandlog-request-larger-than 1048576 commandlog-reply-larger-than 1024}} {
+    test {COMMANDLOG large-reply - deferred check with io-threads and copy avoidance} {
+        r config set min-string-size-avoid-copy-reply 1
+
+        set value [string repeat B 2048]
+        r set testkey $value
+        r commandlog reset large-reply
+
+        r get testkey
+        # Wait for IO thread write completion + postWriteToClient deferred check
+        after 100
+        assert_equal [r commandlog len large-reply] 1
+        set e [lindex [r commandlog get -1 large-reply] 0]
+        # Full argv preserved via inline stash
+        assert_equal [lindex $e 3] {get testkey}
+        # Exact byte count: $2048\r\n<data>\r\n = 2057
+        assert_equal [lindex $e 2] 2057
+
+        r del testkey
+    }
+
+    test {COMMANDLOG large-reply - threshold -1 skips stash entirely with io-threads} {
+        r config set min-string-size-avoid-copy-reply 1
+        r config set commandlog-reply-larger-than -1
+        r commandlog reset large-reply
+
+        set value [string repeat C 4096]
+        r set testkey $value
+
+        r get testkey
+        after 100
+        # Nothing logged when disabled
+        assert_equal [r commandlog len large-reply] 0
+
+        r config set commandlog-reply-larger-than 1024
+        r del testkey
+    }
+
+    test {COMMANDLOG large-reply - pipelined commands with copy avoidance} {
+        r config set min-string-size-avoid-copy-reply 1
+        r config set commandlog-reply-larger-than 1024
+        r commandlog reset large-reply
+
+        # Create two large values
+        set val1 [string repeat D 2048]
+        set val2 [string repeat E 3072]
+        r set key1 $val1
+        r set key2 $val2
+
+        # Pipeline two GETs — both use copy avoidance
+        set rd [valkey_deferring_client]
+        $rd get key1
+        $rd get key2
+        $rd read
+        $rd read
+        $rd close
+        after 100
+
+        # At least one large-reply entry should be logged
+        set len [r commandlog len large-reply]
+        assert_morethan $len 0
+
+        # The logged entry should have full argv (not empty or truncated)
+        set e [lindex [r commandlog get -1 large-reply] 0]
+        # argv should be "get key1" or "get key2"
+        assert_match {get key*} [lindex $e 3]
+
+        r del key1 key2
+    }
+
+    test {COMMANDLOG large-reply - client disconnect releases stashed refs} {
+        r config set min-string-size-avoid-copy-reply 1
+        r config set commandlog-reply-larger-than 1024
+
+        set value [string repeat F 2048]
+        r set testkey $value
+
+        # Connect, trigger copy avoidance GET, then disconnect immediately
+        set rd [valkey_deferring_client]
+        $rd get testkey
+        $rd close
+        after 100
+
+        # Server should not crash (stashed refs freed in freeClient).
+        # Verify server is still responsive.
+        assert_equal [r ping] PONG
+
+        r del testkey
+    }
+}

--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -468,23 +468,54 @@ start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overr
         $rd close
         after 100
 
-        # Both commands should be logged (not just the last one)
-        set len [r commandlog len large-reply]
-        assert_morethan_equal $len 2
-
-        # Verify both keys appear in the commandlog entries
+        # Exactly two entries, each attributed to its own command with the
+        # exact per-command reply size (not summed, not under-reported).
+        # RESP bulk size = len + digits10(len) + 5 (for $<len>\r\n...\r\n).
+        assert_equal [r commandlog len large-reply] 2
         set entries [r commandlog get -1 large-reply]
-        set found_key1 0
-        set found_key2 0
+        array set bytes {}
         foreach e $entries {
             set cmd [lindex $e 3]
-            if {[string match "*key1*" $cmd]} { set found_key1 1 }
-            if {[string match "*key2*" $cmd]} { set found_key2 1 }
+            set key [lindex $cmd 1]
+            set bytes($key) [lindex $e 2]
         }
-        assert_equal $found_key1 1
-        assert_equal $found_key2 1
+        assert_equal $bytes(key1) 2057
+        assert_equal $bytes(key2) 3081
 
         r del key1 key2
+    }
+
+    test {COMMANDLOG large-reply - pipeline mixes above/below threshold correctly} {
+        r config set min-string-size-avoid-copy-reply 1
+        r config set commandlog-reply-larger-than 1024
+        r commandlog reset large-reply
+
+        # smallval uses copy avoidance (>= min-string-size-avoid-copy-reply) but
+        # its reply is BELOW the 1024 large-reply threshold; bigval is ABOVE it.
+        set smallval [string repeat S 100]
+        set bigval [string repeat L 2048]
+        r set small $smallval
+        r set big $bigval
+
+        # Pipeline small, big, small — only 'big' should be logged. This catches
+        # both the old "sum multiple commands together" bug (which would push a
+        # small reply over threshold) and the "under-report first command" bug.
+        set rd [valkey_deferring_client]
+        $rd get small
+        $rd get big
+        $rd get small
+        $rd read
+        $rd read
+        $rd read
+        $rd close
+        after 100
+
+        assert_equal [r commandlog len large-reply] 1
+        set e [lindex [r commandlog get -1 large-reply] 0]
+        assert_equal [lindex $e 3] {get big}
+        assert_equal [lindex $e 2] 2057
+
+        r del small big
     }
 
     test {COMMANDLOG large-reply - client disconnect releases stashed refs} {


### PR DESCRIPTION
## Problem

PR #2652 introduced a 14–17% throughput regression on ARM (Graviton 3) and 8% on Intel (Sapphire Rapids) for GET workloads using copy avoidance with io-threads.

Root cause: `sdslen(obj->ptr)` in `addReplyBulk()` dereferences a random heap pointer on every reply for `net_output_bytes_curr_cmd` tracking. With copy avoidance, this value hasn't been touched since the client stored it — guaranteed L2/L3 cache miss at ~80ns each, consuming 15% of main-thread cycles at 2M rps.

`perf diff` confirms: `addReplyBulk` went from 1% → 14.8% (ARM) / 8.95% (Intel) of main-thread cycles.

## Fix

The IO thread already computes `sdslen` when writing to the socket (`trackBufReferences`) — the cache miss is unavoidable there. This PR eliminates the redundant main-thread access with a two-phase deferred commandlog check:

1. **Remove `sdslen`/`digits10` from main thread** — set `track_bytes=0` for `BULK_STR_REF` payloads, delegating byte counting to the IO thread.

2. **Stash argv refs at command time** — when copy avoidance is active and `commandlog-reply-larger-than >= 0`, `incrRefCount` the argv into a per-client inline array (`CMDLOG_INLINE_ARGV_MAX=4`, zero allocation for GET/GETRANGE). Skip the large-reply check since reply size is unknown.

3. **Accumulate bytes in IO thread** — new `io_reply_len_cmdlog` atomic counter alongside existing `io_tracked_reply_len`.

4. **Check threshold at write completion** — `postWriteToClient` calls `commandlogCheckDeferredLargeReply()` once all replies are flushed, logging with the stashed argv for full command attribution, then releases the refs.

## Results

ARM Graviton 3, 128B GET, io-threads=7, P=10, 3M random keys, 5 reps:

| Build | Throughput | IPC | Backend Stalls | Δ |
|-------|-----------|-----|----------------|---|
| Pre-regression (`29d3244`) | 2,179,643 rps | 3.93 | 43% | — |
| Current HEAD (`d0ffbabb0`) | 1,874,527 rps | 1.56 | 60% | **−14.0%** |
| This PR (`1e21e024`) | 2,194,660 rps | 2.42 | 41% | **+17.1%** |

Full recovery (+0.7% above pre-regression). CV improved from 0.73% → 0.21%.

## Design

The fundamental timing problem: with copy avoidance, argv is available at command time but reply size isn't known until the IO thread writes. By write completion time, argv has been freed by `resetClient`.

Solution: bridge the gap with lightweight ref-counted stash. Cost per copy-avoidance command on main thread:
- 2× `incrRefCount` (plain integer increment, L1 hit — robj was just accessed during parsing)
- 2× pointer store into inline array (no heap allocation)
- 2× `decrRefCount` in `postWriteToClient`

When `commandlog-reply-larger-than = -1` (disabled), the stash path is never entered — zero overhead.

## Trade-offs

- **40 bytes per client struct** (4 inline robj* slots + argc + atomic counter) — always allocated regardless of copy-avoidance usage. Negligible at any realistic connection count.
- **Commandlog timestamp** is at write-completion rather than command-completion (typically one event loop iteration later).
- **Pipelining**: if multiple copy-avoidance commands pipeline before a write completion, only the last command's argv is logged with the combined byte count.

Fixes the regression from #2652. Supersedes #3646 (commandlog can stay enabled by default).
