### PR TITLE
Add futex-based blocking when main thread waits for IO poll results

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3385,6 +3385,7 @@ standardConfig static_configs[] = {
     createIntConfig("cluster-databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.config_databases_cluster, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort),                                               /* TCP port. */
     createIntConfig("io-threads", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1, IO_THREADS_MAX_NUM, server.io_threads_num, 1, INTEGER_CONFIG, NULL, updateIOThreads), /* Single threaded by default */
+    createIntConfig("io-poll-block-threshold", NULL, MODIFIABLE_CONFIG, 0, 1000, server.io_poll_block_threshold, 8, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("min-io-threads-avoid-copy-reply", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.min_io_threads_copy_avoid, 7, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("min-string-size-avoid-copy-reply", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.min_string_size_copy_avoid, 16384, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("min-string-size-avoid-copy-reply-threaded", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.min_string_size_copy_avoid_threaded, 65536, INTEGER_CONFIG, NULL, NULL),

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -7,6 +7,10 @@
 #include "io_threads.h"
 #include "queues.h"
 #include <sys/resource.h>
+#ifdef __linux__
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#endif
 
 #define IO_MPSC_QUEUE_SIZE 16384
 #define IO_SPMC_QUEUE_SIZE 4096
@@ -237,6 +241,13 @@ void ioThreadPoll(aeEventLoop *el) {
     int num_events = aePoll(el, &tvp);
     server.io_ae_fired_events = num_events;
     atomic_store_explicit(&server.io_poll_state, AE_IO_STATE_DONE, memory_order_release);
+
+#ifdef __linux__
+    /* Wake main thread via futex only if it's actually waiting. */
+    if (atomic_load_explicit(&server.io_poll_waiting, memory_order_acquire)) {
+        syscall(SYS_futex, &server.io_poll_state, FUTEX_WAKE_PRIVATE, 1, NULL, NULL, 0);
+    }
+#endif
 }
 
 static void flushPendingIOResponses(int blocking) {
@@ -484,6 +495,7 @@ void initIOThreads(int prev_threads_num) {
         server.active_io_threads_num = 1; /* We start with threads not active. */
         server.io_poll_state = AE_IO_STATE_NONE;
         server.io_ae_fired_events = 0;
+        atomic_init(&server.io_poll_waiting, 0);
         spmcInit(&io_shared_inbox, IO_SPMC_QUEUE_SIZE);
         mpscInit(&io_shared_outbox, IO_MPSC_QUEUE_SIZE);
         io_jobs_submitted = 0;
@@ -703,6 +715,21 @@ static int getIOThreadPollResults(aeEventLoop *eventLoop) {
     io_state = atomic_load_explicit(&server.io_poll_state, memory_order_acquire);
     if (io_state == AE_IO_STATE_POLL) {
         /* IO thread is still processing poll events. */
+#ifdef __linux__
+        /* Decide whether to spin or block based on pending response count. */
+        int pending = getPendingIOResponsesCount();
+        if (pending < server.io_poll_block_threshold) {
+            /* Low pending count - block on futex to save CPU. */
+            atomic_store_explicit(&server.io_poll_waiting, 1, memory_order_release);
+            struct timespec ts = {0, 20000}; /* 20µs timeout */
+            syscall(SYS_futex, &server.io_poll_state, FUTEX_WAIT_PRIVATE, AE_IO_STATE_POLL, &ts, NULL, 0);
+            atomic_store_explicit(&server.io_poll_waiting, 0, memory_order_release);
+            server.stat_io_poll_blocked++;
+        } else {
+            /* High pending count - spin to minimize latency. */
+            server.stat_io_poll_spinning++;
+        }
+#endif
         return 0;
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -2828,6 +2828,8 @@ void resetServerStats(void) {
     server.stat_io_freed_objects = 0;
     server.stat_io_accept_offloaded = 0;
     server.stat_poll_processed_by_io_threads = 0;
+    server.stat_io_poll_blocked = 0;
+    server.stat_io_poll_spinning = 0;
     server.stat_total_writes_processed = 0;
     server.stat_client_qbuf_limit_disconnections = 0;
     server.stat_client_outbuf_limit_disconnections = 0;
@@ -6542,6 +6544,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "io_threaded_freed_objects:%lld\r\n", server.stat_io_freed_objects,
                 "io_threaded_accept_processed:%lld\r\n", server.stat_io_accept_offloaded,
                 "io_threaded_poll_processed:%lld\r\n", server.stat_poll_processed_by_io_threads,
+                "io_poll_blocked_count:%lld\r\n", server.stat_io_poll_blocked,
+                "io_poll_spinning_count:%lld\r\n", server.stat_io_poll_spinning,
                 "io_threaded_total_prefetch_batches:%lld\r\n", server.stat_total_prefetch_batches,
                 "io_threaded_total_prefetch_entries:%lld\r\n", server.stat_total_prefetch_entries,
                 "client_query_buffer_limit_disconnections:%lld\r\n", server.stat_client_qbuf_limit_disconnections,

--- a/src/server.h
+++ b/src/server.h
@@ -1757,8 +1757,12 @@ struct valkeyServer {
     hashtable *orig_commands;                         /* Command table before command renaming. */
     sds command_response_cache[RESP_CACHE_INDEX_MAX]; /* Cached COMMAND response: [0]=RESP2, [1]=RESP3 */
     aeEventLoop *el;
-    _Atomic(AeIoState) io_poll_state;    /* Indicates the state of the IO polling. */
+    _Atomic(AeIoState) io_poll_state;    /* Indicates the state of the IO polling. Also used as futex. */
     int io_ae_fired_events;              /* Number of poll events received by the IO thread. */
+    _Atomic(int) io_poll_waiting;        /* 1 if main thread is blocked on futex. */
+    long long stat_io_poll_blocked;      /* Times main thread blocked on futex (low pending). */
+    long long stat_io_poll_spinning;     /* Times main thread chose to spin (high pending). */
+    int io_poll_block_threshold;         /* Pending count threshold for blocking vs spinning. */
     rax *errors;                         /* Errors table */
     volatile sig_atomic_t shutdown_asap; /* Shutdown ordered by signal handler. */
     mstime_t shutdown_mstime;            /* Timestamp to limit graceful shutdown. */


### PR DESCRIPTION
## Summary

Fixes #4001

When IO threads are enabled and the main thread waits for poll results from an IO thread, it currently busy-spins, consuming ~80- 100% CPU even at low throughput. This PR uses Linux futex to efficiently block the main thread when there's little work pending, while preserving the low-latency spinning behavior at high throughput.

**Key changes:**
- Use `io_poll_state` as the futex variable (no extra synchronization needed)
- Add `io_poll_waiting` flag to skip `FUTEX_WAKE` syscall when main thread is spinning
- Block on futex with 20µs timeout when pending IO responses < threshold
- Add configurable `io-poll-block-threshold` (default 8) for tuning
- Add INFO stats: `io_poll_blocked_count`, `io_poll_spinning_count`
- Wrapped in `#ifdef __linux__` for cross-platform compatibility

## Benchmark Results - Pipeline 1

### Test Configuration
| Parameter | Value |
|-----------|-------|
| Workload | 80% GET, 20% SET (parallel) |
| IO Threads | 8 |
| Clients | 400 per benchmark (800 total) |
| Pipeline | 1 (no pipelining) |
| Value Size | 512 bytes |
| Keys | 3M |
| Duration | 30 seconds per TPS level |

### CPU Usage (Main Thread)

<img width="1380" height="762" alt="image" src="https://github.com/user-attachments/assets/16b1a277-2746-4841-8c40-bc318d0f9463" />


| Target TPS | Baseline CPU | Futex CPU | CPU Saved |
|------------|--------------|-----------|-----------|
| 100K | 69.6% | 57.3% | **+12.3%** |
| 200K | 88.4% | 67.0% | **+21.4%** |
| 300K | 95.1% | 72.2% | **+22.9%** |
| 400K | 98.2% | 77.3% | **+20.9%** |
| 500K | 98.8% | 82.2% | **+16.6%** |
| 600K | 99.5% | 86.9% | **+12.6%** |
| 700K | 99.8% | 89.4% | **+10.4%** |
| 800K | 100.0% | 93.3% | **+6.7%** |
| 900K | 100.0% | 98.2% | **+1.8%** |
| 1M | 100.0% | 100.0% | 0.0% |

###  Latency
<img width="1428" height="462" alt="image" src="https://github.com/user-attachments/assets/9d769c33-b5d7-41c9-8e86-2c6fe6c44803" />

### P50 Latency (ms)

| Target TPS | Baseline | Futex |
|------------|----------|-------|
| 100K | 0.335 | 0.343 |
| 300K | 0.343 | 0.343 |
| 500K | 0.351 | 0.343 |
| 700K | 0.359 | 0.367 |
| 1M | 0.471 | 0.455 |

### P99 Latency (ms)

| Target TPS | Baseline | Futex |
|------------|----------|-------|
| 100K | 0.623 | 0.615 |
| 300K | 2.839 | 2.407 |
| 500K | 3.903 | 3.623 |
| 700K | 3.559 | 3.655 |
| 1M | 3.591 | 3.615 |

### Throughput

No regression - both baseline and futex achieve ~1M TPS maximum.

## Benchmark Results - Pipeline 10

### Test Configuration
| Parameter | Value |
|-----------|-------|
| Workload | 80% GET, 20% SET (parallel) |
| IO Threads | 9 |
| Clients | 400 per benchmark (800 total) |
| Pipeline | 10 |
| Value Size | 512 bytes |
| Keys | 3M |
| Duration | 30 seconds per TPS level |

### CPU Usage (Main Thread)

<img width="1385" height="730" alt="image" src="https://github.com/user-attachments/assets/566f1394-1f4d-43dc-a151-84c0ae3507cd" />

| Target TPS | Baseline CPU | Futex CPU | CPU Saved |
|------------|--------------|-----------|-----------|
| 400K | 63.5% | 58.3% | **+5.2%** |
| 500K | 77.0% | 60.7% | **+16.3%** |
| 600K | 84.4% | 65.2% | **+19.2%** |
| 700K | 89.3% | 69.7% | **+19.6%** |
| 800K | 92.3% | 74.4% | **+17.9%** |
| 900K | 95.1% | 78.3% | **+16.8%** |
| 1M | 98.4% | 81.8% | **+16.6%** |
| 1.1M | 99.6% | 86.2% | **+13.4%** |
| 1.2M | 99.9% | 89.9% | **+10.0%** |
| 1.3M | 100.0% | 92.3% | **+7.7%** |
| 1.4M | 102.8% | 98.2% | **+4.6%** |

### Latency 

<img width="1399" height="434" alt="image" src="https://github.com/user-attachments/assets/65606c18-23ea-4e23-ac57-6c213ea3e465" />


### P50 Latency (ms)

| Target TPS | Baseline | Futex |
|------------|----------|-------|
| 500K | 0.351 | 0.359 |
| 700K | 0.359 | 0.359 |
| 1M | 0.367 | 0.391 |
| 1.2M | 0.415 | 0.423 |
| 1.4M | 3.683 | 3.639 |

### P99 Latency (ms)

| Target TPS | Baseline | Futex |
|------------|----------|-------|
| 500K | 0.659 | 0.655 |
| 700K | 0.675 | 0.639 |
| 1M | 8.451 | 7.647 |
| 1.2M | 9.427 | 8.303 |
| 1.4M | 10.559 | 9.247 |

### Throughput

No regression - No regression - both baseline and futex achieve 1.6M TPS

### Notes

- All tests were executed 3 times and results are reproducible. P99 is a bit noisy ~10% noise. we may want to run it several more times,

## How It Works

1. When `getIOThreadPollResults()` finds the IO thread still polling (`AE_IO_STATE_POLL`):
   - If pending IO responses < threshold (default 8): block on futex with 20µs timeout
   - Otherwise: spin (existing behavior for latency-sensitive high-TPS scenarios)

2. When the IO thread completes polling in `IOThreadPoll()`:
   - Sets state to `AE_IO_STATE_DONE`
   - Only calls `FUTEX_WAKE` if `io_poll_waiting` flag is set (avoids syscall overhead at high TPS)

