### PR TITLE
Reduce execution time for replica migration tests

### DIFF
--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -21,17 +21,15 @@ proc get_my_primary_peer {srv_idx} {
 
 proc test_migrated_replica {type} {
     test "Migrated replica reports zero repl offset and rank, and fails to win election - $type" {
-        # Write some data to primary 0, slot 1, make a small repl_offset.
-        for {set i 0} {$i < 1024} {incr i} {
-            R 0 incr key_991803
-        }
-        assert_equal {1024} [R 0 get key_991803]
+        # Write a key to primary 0, slot 1, make a small repl_offset.
+        set small_value [string repeat "x" 1024]
+        R 0 set key_991803 $small_value
+        assert_equal $small_value [R 0 get key_991803]
 
-        # Write some data to primary 3, slot 0, make a big repl_offset.
-        for {set i 0} {$i < 10240} {incr i} {
-            R 3 incr key_977613
-        }
-        assert_equal {10240} [R 3 get key_977613]
+        # Write a key to primary 3, slot 0, make a big repl_offset.
+        set large_value [string repeat "y" 10240]
+        R 3 set key_977613 $large_value
+        assert_equal $large_value [R 3 get key_977613]
 
         # 10s, make sure primary 0 will hang in the save.
         R 0 config set rdb-key-save-delay 100000000
@@ -106,11 +104,9 @@ proc test_migrated_replica {type} {
         R 3 readonly
         R 7 readonly
         wait_for_condition 1000 50 {
-            [catch {expr {
-                [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
-                [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
-                [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
-            }} result] == 0 && $result
+            [R 3 get key_991803] eq $small_value && [R 3 get key_977613] eq $large_value &&
+            [R 4 get key_991803] eq $small_value && [R 4 get key_977613] eq $large_value &&
+            [R 7 get key_991803] eq $small_value && [R 7 get key_977613] eq $large_value
         } else {
             catch {puts "R 3: [R 3 keys *]"}
             catch {puts "R 4: [R 4 keys *]"}
@@ -133,27 +129,25 @@ proc test_migrated_replica {type} {
     }
 } ;# proc
 
-start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999}} {
+start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999 shutdown-timeout 0}} {
     test_migrated_replica "shutdown"
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster
 
-start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999}} {
+start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999 shutdown-timeout 0}} {
     test_migrated_replica "sigstop"
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster
 
 proc test_nonempty_replica {type} {
     test "New non-empty replica reports zero repl offset and rank, and fails to win election - $type" {
-        # Write some data to primary 0, slot 1, make a small repl_offset.
-        for {set i 0} {$i < 1024} {incr i} {
-            R 0 incr key_991803
-        }
-        assert_equal {1024} [R 0 get key_991803]
+        # Write a key to primary 0, slot 1, make a small repl_offset.
+        set small_value [string repeat "x" 1024]
+        R 0 set key_991803 $small_value
+        assert_equal $small_value [R 0 get key_991803]
 
-        # Write some data to primary 3, slot 0, make a big repl_offset.
-        for {set i 0} {$i < 10240} {incr i} {
-            R 3 incr key_977613
-        }
-        assert_equal {10240} [R 3 get key_977613]
+        # Write a key to primary 3, slot 0, make a big repl_offset.
+        set large_value [string repeat "y" 10240]
+        R 3 set key_977613 $large_value
+        assert_equal $large_value [R 3 get key_977613]
 
         # 10s, make sure primary 0 will hang in the save.
         R 0 config set rdb-key-save-delay 100000000
@@ -205,10 +199,8 @@ proc test_nonempty_replica {type} {
         # Make sure the key exists and is consistent.
         R 7 readonly
         wait_for_condition 1000 50 {
-            [catch {expr {
-                [R 4 get key_991803] == 1024 &&
-                [R 7 get key_991803] == 1024
-            }} result] == 0 && $result
+            [R 4 get key_991803] eq $small_value &&
+            [R 7 get key_991803] eq $small_value
         } else {
             catch {puts "R 4: [R 4 get key_991803]"}
             catch {puts "R 7: [R 7 get key_991803]"}
@@ -228,27 +220,25 @@ proc test_nonempty_replica {type} {
     }
 } ;# proc
 
-start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999}} {
+start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999 shutdown-timeout 0}} {
     test_nonempty_replica "shutdown"
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster
 
-start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999}} {
+start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999 shutdown-timeout 0}} {
     test_nonempty_replica "sigstop"
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster
 
 proc test_sub_replica {type} {
     test "Sub-replica reports zero repl offset and rank, and fails to win election - $type" {
-        # Write some data to primary 0, slot 1, make a small repl_offset.
-        for {set i 0} {$i < 1024} {incr i} {
-            R 0 incr key_991803
-        }
-        assert_equal {1024} [R 0 get key_991803]
+        # Write a key to primary 0, slot 1, make a small repl_offset.
+        set small_value [string repeat "x" 1024]
+        R 0 set key_991803 $small_value
+        assert_equal $small_value [R 0 get key_991803]
 
-        # Write some data to primary 3, slot 0, make a big repl_offset.
-        for {set i 0} {$i < 10240} {incr i} {
-            R 3 incr key_977613
-        }
-        assert_equal {10240} [R 3 get key_977613]
+        # Write a key to primary 3, slot 0, make a big repl_offset.
+        set large_value [string repeat "y" 10240]
+        R 3 set key_977613 $large_value
+        assert_equal $large_value [R 3 get key_977613]
 
         R 3 config set cluster-replica-validity-factor 0
         R 7 config set cluster-replica-validity-factor 0
@@ -331,11 +321,9 @@ proc test_sub_replica {type} {
         R 3 readonly
         R 7 readonly
         wait_for_condition 1000 50 {
-            [catch {expr {
-                [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
-                [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
-                [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
-            }} result] == 0 && $result
+            [R 3 get key_991803] eq $small_value && [R 3 get key_977613] eq $large_value &&
+            [R 4 get key_991803] eq $small_value && [R 4 get key_977613] eq $large_value &&
+            [R 7 get key_991803] eq $small_value && [R 7 get key_977613] eq $large_value
         } else {
             catch {puts "R 3: [R 3 keys *]"}
             catch {puts "R 4: [R 4 keys *]"}
@@ -356,11 +344,11 @@ proc test_sub_replica {type} {
     }
 }
 
-start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999}} {
+start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999 shutdown-timeout 0}} {
     test_sub_replica "shutdown"
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster
 
-start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999}} {
+start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999 shutdown-timeout 0}} {
     test_sub_replica "sigstop"
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster
 


### PR DESCRIPTION
### Description
The test "Migrated replica reports zero repl offset and rank, and fails to win election - shutdown" takes upto 25s. This PR reduces it to ~4s while maintaining the same coverage.

This might end up closing #3992 as well

From https://github.com/valkey-io/valkey/actions/runs/27586402593/job/81557596685

```
[ok]: Migrated replica reports zero repl offset and rank, and fails to win election - shutdown (26545 ms)
```

After the fix
```
[ok]: Migrated replica reports zero repl offset and rank, and fails to win election - shutdown (4847 ms)
```

**Update** - Applied similar fix to other tests as well resulting

| Test | Before | After |
|------|--------|-------|
| Migrated replica - shutdown | ~25s | ~4s |
| Migrated replica - sigstop | ~4s | ~4s |
| Non-empty replica - shutdown | ~12.5s | ~1.5s |
| Non-empty replica - sigstop | ~3.5s | ~2.5s |
| Sub-replica - shutdown | ~13.5s | ~2s |
| Sub-replica - sigstop | ~3.5s | ~2s |


### Fix
- Replace ~10k individual INCR round-trips with single SET commands using large values.
- Set shutdown-timeout 0 before shutting down primary 0.