### PR TITLE
Limit multibulk args count and fix integer type truncations

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3181,6 +3181,9 @@ void handleParseError(client *c) {
     } else if (flags & READ_FLAGS_ERROR_UNBALANCED_QUOTES) {
         addReplyError(c, "Protocol error: unbalanced quotes in request");
         setProtocolError("unbalanced quotes in inline request", c);
+    } else if (flags & READ_FLAGS_ERROR_TOO_MANY_ARGS) {
+        addReplyError(c, "Protocol error: too many arguments");
+        setProtocolError("too many arguments", c);
     } else if (flags & READ_FLAGS_ERROR_INVALID_CRLF) {
         addReplyError(c, "Protocol error: invalid CRLF in request");
         setProtocolError("invalid CRLF in request", c);
@@ -3205,7 +3208,7 @@ int isParsingError(client *c) {
                             READ_FLAGS_ERROR_UNAUTHENTICATED_BULK_LEN | READ_FLAGS_ERROR_MBULK_INVALID_BULK_LEN |
                             READ_FLAGS_ERROR_BIG_BULK_COUNT | READ_FLAGS_ERROR_MBULK_UNEXPECTED_CHARACTER |
                             READ_FLAGS_ERROR_UNEXPECTED_INLINE_FROM_REPLICATED_CLIENT | READ_FLAGS_ERROR_UNBALANCED_QUOTES |
-                            READ_FLAGS_ERROR_INVALID_CRLF);
+                            READ_FLAGS_ERROR_TOO_MANY_ARGS | READ_FLAGS_ERROR_INVALID_CRLF);
 }
 
 /* This function is called after the query-buffer was parsed.
@@ -3651,7 +3654,9 @@ static int parseMultibulk(client *c,
         }
 
         /* Buffer should also contain \n */
-        if (newline - (c->querybuf + c->qb_pos) > (ssize_t)(sdslen(c->querybuf) - c->qb_pos - 2)) return 0;
+        size_t remaining = sdslen(c->querybuf) - c->qb_pos;
+        size_t line_len = newline - (c->querybuf + c->qb_pos);
+        if (line_len + 2 > remaining) return 0;
 
         /* Check that what follows \r is a real \n */
         if (unlikely(newline[1] != '\n')) {
@@ -3665,6 +3670,8 @@ static int parseMultibulk(client *c,
         ok = string2ll(c->querybuf + 1 + c->qb_pos, multibulklen_slen, &ll);
         if (!ok || ll > INT_MAX) {
             return READ_FLAGS_ERROR_INVALID_MULTIBULK_LEN;
+        } else if (ll > PROTO_MAX_MULTIBULK_LEN) {
+            return READ_FLAGS_ERROR_TOO_MANY_ARGS;
         } else if (ll > 10 && auth_required) {
             return READ_FLAGS_ERROR_UNAUTHENTICATED_MULTIBULK_LEN;
         }
@@ -3681,7 +3688,8 @@ static int parseMultibulk(client *c,
         /* Setup argv array */
         if (*argv) zfree(*argv);
         *argv_len = min(c->multibulklen, 1024);
-        *argv = zmalloc(sizeof(robj *) * *argv_len);
+        *argv = ztrymalloc(sizeof(robj *) * *argv_len);
+        if (!*argv) return READ_FLAGS_ERROR_TOO_MANY_ARGS;
         *argv_len_sum = 0;
 
         /* Per-slot network bytes-in calculation.
@@ -3731,7 +3739,9 @@ static int parseMultibulk(client *c,
             }
 
             /* Buffer should also contain \n */
-            if (newline - (c->querybuf + c->qb_pos) > (ssize_t)(sdslen(c->querybuf) - c->qb_pos - 2)) return 0;
+            size_t remaining = sdslen(c->querybuf) - c->qb_pos;
+            size_t line_len = newline - (c->querybuf + c->qb_pos);
+            if (line_len + 2 > remaining) return 0;
 
             if (c->querybuf[c->qb_pos] != '$') {
                 return READ_FLAGS_ERROR_MBULK_UNEXPECTED_CHARACTER;
@@ -3795,7 +3805,9 @@ static int parseMultibulk(client *c,
             if (*argc >= *argv_len) {
                 *argv_len = min(*argv_len < INT_MAX / 2 ? (*argv_len) * 2 : INT_MAX,
                                 *argc + c->multibulklen);
-                *argv = zrealloc(*argv, sizeof(robj *) * (*argv_len));
+                robj **newargv = ztryrealloc(*argv, sizeof(robj *) * (*argv_len));
+                if (!newargv) return READ_FLAGS_ERROR_TOO_MANY_ARGS;
+                *argv = newargv;
             }
 
             /* Check that what follows argv is a real \r\n */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -592,6 +592,11 @@ void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr) {
         }
     }
 
+    if (len > SIZE_MAX) {
+        rdbReportCorruptRDB("RDB string length %llu exceeds this platform's addressable size", len);
+        return NULL;
+    }
+
     if (plain || sds) {
         void *buf = plain ? ztrymalloc(len) : sdstrynewlen(SDS_NOINIT, len);
         if (!buf) {

--- a/src/sds.c
+++ b/src/sds.c
@@ -451,39 +451,46 @@ void *sdsAllocPtr(const_sds s) {
  * ... check for nread <= 0 and handle it ...
  * sdsIncrLen(s, nread);
  */
+static inline size_t sdsIncrLenAbs(ssize_t incr) {
+    return (size_t)(-(incr + 1)) + 1;
+}
+
 void sdsIncrLen(sds s, ssize_t incr) {
     size_t len;
     switch (sdsType(s)) {
     case SDS_TYPE_5: {
         unsigned char *fp = ((unsigned char *)s) - 1;
         unsigned char oldlen = SDS_TYPE_5_LEN(*fp);
-        assert((incr > 0 && oldlen + incr < 32) || (incr < 0 && oldlen >= (unsigned int)(-incr)));
+        assert((incr > 0 && oldlen + incr < 32) || (incr < 0 && oldlen >= sdsIncrLenAbs(incr)));
         *fp = SDS_TYPE_5 | ((oldlen + incr) << SDS_TYPE_BITS);
         len = oldlen + incr;
         break;
     }
     case SDS_TYPE_8: {
         SDS_HDR_VAR(8, s);
-        assert((incr >= 0 && sh->alloc - sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+        assert((incr >= 0 && sh->alloc - sh->len >= (size_t)incr) ||
+               (incr < 0 && sh->len >= sdsIncrLenAbs(incr)));
         len = (sh->len += incr);
         break;
     }
     case SDS_TYPE_16: {
         SDS_HDR_VAR(16, s);
-        assert((incr >= 0 && sh->alloc - sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+        assert((incr >= 0 && sh->alloc - sh->len >= (size_t)incr) ||
+               (incr < 0 && sh->len >= sdsIncrLenAbs(incr)));
         len = (sh->len += incr);
         break;
     }
     case SDS_TYPE_32: {
         SDS_HDR_VAR(32, s);
-        assert((incr >= 0 && sh->alloc - sh->len >= (unsigned int)incr) ||
-               (incr < 0 && sh->len >= (unsigned int)(-incr)));
+        assert((incr >= 0 && sh->alloc - sh->len >= (size_t)incr) ||
+               (incr < 0 && sh->len >= sdsIncrLenAbs(incr)));
         len = (sh->len += incr);
         break;
     }
     case SDS_TYPE_64: {
         SDS_HDR_VAR(64, s);
-        assert((incr >= 0 && sh->alloc - sh->len >= (uint64_t)incr) || (incr < 0 && sh->len >= (uint64_t)(-incr)));
+        assert((incr >= 0 && sh->alloc - sh->len >= (size_t)incr) ||
+               (incr < 0 && sh->len >= sdsIncrLenAbs(incr)));
         len = (sh->len += incr);
         break;
     }

--- a/src/server.h
+++ b/src/server.h
@@ -212,6 +212,7 @@ typedef enum {
 #define PROTO_REPLY_CHUNK_BYTES (16 * 1024) /* 16k output buffer */
 #define PROTO_INLINE_MAX_SIZE (1024 * 64)   /* Max size of inline reads */
 #define PROTO_MBULK_BIG_ARG (1024 * 32)
+#define PROTO_MAX_MULTIBULK_LEN (1024 * 1024)
 #define PROTO_RESIZE_THRESHOLD (1024 * 32)     /* Threshold for determining whether to resize query buffer */
 #define PROTO_REPLY_MIN_BYTES (1024)           /* the lower limit on reply buffer size */
 #define REDIS_AUTOSYNC_BYTES (1024 * 1024 * 4) /* Sync file every 4MB. */
@@ -2901,6 +2902,7 @@ void dictVanillaFree(void *val);
 #define READ_FLAGS_CROSSSLOT (1 << 20)
 #define READ_FLAGS_PREFETCHED (1 << 21)
 #define READ_FLAGS_ERROR_INVALID_CRLF (1 << 22)
+#define READ_FLAGS_ERROR_TOO_MANY_ARGS (1 << 23)
 
 /* Write flags for various write errors and states */
 #define WRITE_FLAGS_WRITE_ERROR (1 << 0)

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -34,6 +34,13 @@ start_server {tags {"protocol network"}} {
         assert_error "*invalid multibulk length*" {r read}
     }
 
+    test "Too many multibulk arguments" {
+        reconnect
+        r write "*1048577\r\n"
+        r flush
+        assert_error "*too many arguments*" {r read}
+    }
+
     test "Wrong multibulk payload header" {
         reconnect
         r write "*3\r\n\$3\r\nSET\r\n\$1\r\nx\r\nfooz\r\n"


### PR DESCRIPTION
Add PROTO_MAX_MULTIBULK_LEN (1M) to prevent OOM from large argv allocations. Use ztrymalloc/ztryrealloc so allocation failure returns a protocol error instead of crashing.

Replace fragile unsigned subtraction overflow cast with explicit size_t checks in parseMultibulk.

Add SIZE_MAX guard in rdbGenericLoadStringObject for 32-bit platforms.

Fix sdsIncrLen type truncation where ssize_t was cast to unsigned int, losing upper bits on 64-bit.