### PR TITLE
draft implementation of randomized running-start scan cursor

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1310,7 +1310,12 @@ void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor
             if (o == NULL) {
                 cursor = kvstoreScan(c->db->keys, cursor, slot, final_slot, keysScanCallback, NULL, &data);
             } else {
-                cursor = hashtableScan(ht, cursor, hashtableScanCallback, &data);
+                /* Object scans use a randomized running-start scan so that
+                 * iteration begins at a random bucket position instead of
+                 * bucket zero, while preserving full-scan guarantees. The
+                 * returned cursor is opaque and carries the running start
+                 * position. */
+                cursor = hashtableScanRunningStart(ht, cursor, hashtableScanCallback, &data);
             }
         } while (cursor && maxiterations-- && data.sampled < opts->count);
     } else if (o->type == OBJ_SET) {

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2164,6 +2164,114 @@ size_t hashtableScanDefrag(hashtable *ht, size_t cursor, hashtableScanFunction f
     return cursor;
 }
 
+/* --- Randomized running-start scan --- */
+
+/* The running-start scan starts a new scan from a random bucket position instead
+ * of bucket zero, while preserving the full-scan guarantees of the underlying
+ * reverse-bit scan. The scan state is encoded in an opaque non-negative cursor
+ * with the following layout (most-significant bit first):
+ *
+ *   [0??????? ???????? ffffffff fffffffw cccccccc cccccccc cccccccc cccccccc]
+ *
+ *   0: bit 63 is always zero so the cursor fits in signed integer replies.
+ *   ?: 15-bit reserved for future use.
+ *   f: 15-bit random running start.
+ *   w: 1-bit wrapped flag, set after the scan reaches cursor zero after starting.
+ *   c: 32-bit internal hashtable scan cursor, masked by HASHTABLE_SCAN_CURSOR_MASK.
+ */
+#define HASHTABLE_SCAN_CURSOR_MASK 0xffffffffULL
+#define HASHTABLE_SCAN_WRAPPED_SHIFT 32
+#define HASHTABLE_SCAN_WRAPPED_FLAG (1ULL << HASHTABLE_SCAN_WRAPPED_SHIFT)
+#define HASHTABLE_SCAN_RSTART_SHIFT 33
+#define HASHTABLE_SCAN_RSTART_BITS 15
+#define HASHTABLE_SCAN_RSTART_MASK ((1ULL << HASHTABLE_SCAN_RSTART_BITS) - 1)
+
+/* Encode the running-start scan state into an opaque cursor. */
+static inline uint64_t encodeRunningStartCursor(unsigned running_start, int wrapped, size_t cursor) {
+    return (((uint64_t)running_start & HASHTABLE_SCAN_RSTART_MASK) << HASHTABLE_SCAN_RSTART_SHIFT) |
+           ((uint64_t)(wrapped != 0) << HASHTABLE_SCAN_WRAPPED_SHIFT) |
+           ((uint64_t)cursor & HASHTABLE_SCAN_CURSOR_MASK);
+}
+
+/* Decode an opaque running-start cursor into its components. */
+static inline void decodeRunningStartCursor(uint64_t opaque, unsigned *running_start, int *wrapped, size_t *cursor) {
+    *running_start = (opaque >> HASHTABLE_SCAN_RSTART_SHIFT) & HASHTABLE_SCAN_RSTART_MASK;
+    *wrapped = (opaque & HASHTABLE_SCAN_WRAPPED_FLAG) != 0;
+    *cursor = (size_t)(opaque & HASHTABLE_SCAN_CURSOR_MASK);
+}
+
+/* Scan-order (reverse-bit) position of the random running start fraction. */
+static inline size_t runningStartScanPosition(unsigned running_start) {
+    return ((size_t)(running_start & HASHTABLE_SCAN_RSTART_MASK)) << (CHAR_BIT * sizeof(size_t) - HASHTABLE_SCAN_RSTART_BITS);
+}
+
+/* Internal hashtable scan cursor corresponding to the random running start position. */
+static inline size_t runningStartToScanCursor(unsigned running_start) {
+    return rev(runningStartScanPosition(running_start)) & HASHTABLE_SCAN_CURSOR_MASK;
+}
+
+/* Like hashtableScanRunningStart, but when 'use_custom_start' is non-zero the fresh
+ * scan starts from 'custom_start' instead of a random position. Exposed (without
+ * a header prototype) for deterministic unit testing. */
+uint64_t hashtableScanRunningStartWithCustomStart(hashtable *ht, uint64_t cursor, hashtableScanFunction fn, void *privdata, int use_custom_start, unsigned custom_start) {
+    if (hashtableSize(ht) == 0) {
+        return 0;
+    }
+
+    unsigned running_start;
+    int wrapped;
+    size_t ht_cursor;
+    if (cursor == 0) {
+        /* Fresh scan: pick a random (or caller-provided) running start position. */
+        running_start = use_custom_start ? (custom_start & HASHTABLE_SCAN_RSTART_MASK) : (unsigned)(randomSizeT() & HASHTABLE_SCAN_RSTART_MASK);
+        wrapped = 0;
+        ht_cursor = runningStartToScanCursor(running_start);
+    } else {
+        decodeRunningStartCursor(cursor, &running_start, &wrapped, &ht_cursor);
+    }
+
+    /* Perform one step of the underlying reverse-bit scan. */
+    size_t next_ht_cursor = hashtableScan(ht, ht_cursor, fn, privdata);
+
+    /* The internal scan cursor must fit in the 32 bits reserved for it. */
+    assert((next_ht_cursor & ~(size_t)HASHTABLE_SCAN_CURSOR_MASK) == 0);
+
+    if (next_ht_cursor == 0) {
+        /* The underlying scan wrapped through zero. A second wrap (we had
+         * already wrapped once) means a full cycle has been scanned back to the
+         * start region. This is the termination safety net: it guarantees the
+         * scan ends even while a paused shrink rehash keeps the returned cursor
+         * at a coarser resolution than the start position, which would
+         * otherwise prevent the boundary check below from ever matching. */
+        if (wrapped) {
+            return 0;
+        }
+        wrapped = 1;
+    }
+
+    if (wrapped) {
+        if ((next_ht_cursor & HASHTABLE_SCAN_CURSOR_MASK) == (ht_cursor & HASHTABLE_SCAN_CURSOR_MASK)) {
+            return 0;
+        }
+        size_t mask = expToMask(ht->bucket_exp[0]) | expToMask(ht->bucket_exp[1]);
+        size_t start_pos = rev(runningStartToScanCursor(running_start) & mask);
+        size_t next_pos = rev(next_ht_cursor & mask);
+        if (next_pos >= start_pos) {
+            return 0;
+        }
+    }
+
+    return encodeRunningStartCursor(running_start, wrapped, next_ht_cursor);
+}
+
+/* Randomized running-start variant of hashtableScan for object scans. A fresh
+ * scan (cursor == 0) starts at a random bucket position and returns an opaque
+ * cursor encoding the scan state. The scan is complete when this function
+ * returns 0. */
+uint64_t hashtableScanRunningStart(hashtable *ht, uint64_t cursor, hashtableScanFunction fn, void *privdata) {
+    return hashtableScanRunningStartWithCustomStart(ht, cursor, fn, privdata, 0, 0);
+}
+
 /* --- Iterator --- */
 
 /* Initialize an iterator for a hashtable.

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -161,6 +161,7 @@ bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, voi
 /* Iteration & scan */
 size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, void *privdata);
 size_t hashtableScanDefrag(hashtable *ht, size_t cursor, hashtableScanFunction fn, void *privdata, void *(*defragfn)(void *), int flags);
+uint64_t hashtableScanRunningStart(hashtable *ht, uint64_t cursor, hashtableScanFunction fn, void *privdata);
 void hashtableInitIterator(hashtableIterator *iter, hashtable *ht, uint8_t flags);
 void hashtableRetargetIterator(hashtableIterator *iterator, hashtable *ht);
 void hashtableCleanupIterator(hashtableIterator *iter);

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -101,6 +101,8 @@ void hashtableDump(hashtable *ht);
 void hashtableHistogram(hashtable *ht);
 int hashtableLongestBucketChain(hashtable *ht);
 size_t nextCursor(size_t v, size_t mask);
+/* Deterministic running-start scan helper (not exposed in hashtable.h). */
+uint64_t hashtableScanRunningStartWithCustomStart(hashtable *ht, uint64_t cursor, hashtableScanFunction fn, void *privdata, int use_fixed, unsigned fixed_start);
 }
 
 class HashtableTest : public ::testing::Test {
@@ -618,6 +620,220 @@ TEST_F(HashtableTest, scan) {
         hashtableRelease(ht);
         free(data);
     }
+}
+
+/* Scans 'ht' to completion using the randomized running-start scan, recording
+ * per-entry emission counts (indexed by the small integer entry value) into
+ * 'seen'. When 'use_fixed' is non-zero the scan starts deterministically from
+ * 'fixed_start'. Returns the total number of emitted entries. */
+static long runningStartScanAll(hashtable *ht, long count, uint8_t *seen, int use_fixed, unsigned fixed_start) {
+    scandata *data = (scandata *)calloc(1, sizeof(scandata) + count);
+    long total = 0;
+    uint64_t cursor = 0;
+    long calls = 0;
+    long max_calls = (count + 16) * 100;
+    do {
+        data->count = 0;
+        if (use_fixed) {
+            cursor = hashtableScanRunningStartWithCustomStart(ht, cursor, scanfn, data, 1, fixed_start);
+        } else {
+            cursor = hashtableScanRunningStart(ht, cursor, scanfn, data);
+        }
+        total += data->count;
+    } while (cursor != 0 && ++calls < max_calls);
+    EXPECT_LT(calls, max_calls) << "running-start scan did not terminate";
+    for (long j = 0; j < count; j++) seen[j] = data->entry_seen[j];
+    free(data);
+    return total;
+}
+
+/* Populates 'ht' with the integers [0, count) and finishes any ongoing
+ * rehashing so the table is stable for deterministic exactly-once assertions. */
+static void populateStable(hashtable *ht, long count) {
+    for (long j = 0; j < count; j++) {
+        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
+    }
+    /* Adding the already-present entry 0 advances rehashing without resizing. */
+    while (hashtableIsRehashing(ht)) {
+        ASSERT_FALSE(hashtableAdd(ht, (void *)0));
+    }
+}
+
+TEST_F(HashtableTest, scan_running_start) {
+    long count = 2000;
+    int num_rounds = accurate ? 50 : 10;
+    hashtableType type = {};
+
+    for (int round = 0; round < num_rounds; round++) {
+        randomSeed();
+        hashtable *ht = hashtableCreate(&type);
+        populateStable(ht, count);
+
+        uint8_t *seen = (uint8_t *)calloc(count, 1);
+        long total = runningStartScanAll(ht, count, seen, 0, 0);
+
+        /* A stable table is visited exactly once per bucket, so every entry is
+         * emitted exactly once with no duplicates. */
+        ASSERT_EQ(total, count);
+        for (long j = 0; j < count; j++) {
+            ASSERT_EQ(seen[j], 1u) << "round=" << round << " j=" << j;
+        }
+        free(seen);
+        hashtableRelease(ht);
+    }
+}
+
+TEST_F(HashtableTest, scan_running_start_edge_starts) {
+    long count = 1000;
+    hashtableType type = {};
+    /* Zero, first nonzero and the maximum 15-bit fixed fraction. */
+    unsigned starts[] = {0u, 1u, 0x7fffu};
+
+    randomSeed();
+    for (unsigned s = 0; s < sizeof(starts) / sizeof(starts[0]); s++) {
+        hashtable *ht = hashtableCreate(&type);
+        populateStable(ht, count);
+
+        uint8_t *seen = (uint8_t *)calloc(count, 1);
+        long total = runningStartScanAll(ht, count, seen, 1, starts[s]);
+
+        ASSERT_EQ(total, count) << "start=" << starts[s];
+        for (long j = 0; j < count; j++) {
+            ASSERT_EQ(seen[j], 1u) << "start=" << starts[s] << " j=" << j;
+        }
+        free(seen);
+        hashtableRelease(ht);
+    }
+}
+
+TEST_F(HashtableTest, scan_running_start_one_bucket) {
+    hashtableType type = {};
+    /* Few enough entries to remain within a single bucket. */
+    long count = 3;
+    unsigned starts[] = {0u, 1u, 0x7fffu};
+
+    randomSeed();
+    for (unsigned s = 0; s < sizeof(starts) / sizeof(starts[0]); s++) {
+        hashtable *ht = hashtableCreate(&type);
+        for (long j = 0; j < count; j++) {
+            ASSERT_TRUE(hashtableAdd(ht, (void *)j));
+        }
+        ASSERT_FALSE(hashtableIsRehashing(ht));
+        ASSERT_EQ(hashtableBuckets(ht), 1u);
+
+        uint8_t *seen = (uint8_t *)calloc(count, 1);
+        long total = runningStartScanAll(ht, count, seen, 1, starts[s]);
+
+        /* A single-bucket table must terminate without re-emitting the bucket. */
+        ASSERT_EQ(total, count) << "start=" << starts[s];
+        for (long j = 0; j < count; j++) {
+            ASSERT_EQ(seen[j], 1u) << "start=" << starts[s] << " j=" << j;
+        }
+        free(seen);
+        hashtableRelease(ht);
+    }
+}
+
+TEST_F(HashtableTest, scan_running_start_post_wrap) {
+    hashtableType type = {};
+    long count = 500;
+
+    randomSeed();
+    hashtable *ht = hashtableCreate(&type);
+    populateStable(ht, count);
+
+    /* Sweep fixed starts across the whole 15-bit range. Each scan wraps through
+     * zero and must terminate before re-emitting the start bucket, so every
+     * entry is still emitted exactly once. */
+    for (unsigned f = 0; f < 0x8000u; f += 0x800u) {
+        uint8_t *seen = (uint8_t *)calloc(count, 1);
+        long total = runningStartScanAll(ht, count, seen, 1, f);
+        ASSERT_EQ(total, count) << "f=" << f;
+        for (long j = 0; j < count; j++) {
+            ASSERT_EQ(seen[j], 1u) << "f=" << f << " j=" << j;
+        }
+        free(seen);
+    }
+    hashtableRelease(ht);
+}
+
+TEST_F(HashtableTest, scan_running_start_expand) {
+    hashtableType type = {};
+    long count = 1000;
+    long total_keys = count * 10;
+
+    randomSeed();
+    hashtable *ht = hashtableCreate(&type);
+    populateStable(ht, count);
+
+    scandata *data = (scandata *)calloc(1, sizeof(scandata) + total_keys);
+    uint64_t cursor = 0;
+    int added = 0;
+    long calls = 0;
+    long max_calls = total_keys * 100;
+    do {
+        cursor = hashtableScanRunningStart(ht, cursor, scanfn, data);
+        if (!added && cursor != 0) {
+            /* Force expansion (and rehashing) in the middle of the scan. */
+            for (long j = count; j < total_keys; j++) {
+                ASSERT_TRUE(hashtableAdd(ht, (void *)j));
+            }
+            added = 1;
+        }
+    } while (cursor != 0 && ++calls < max_calls);
+    ASSERT_LT(calls, max_calls);
+
+    /* Entries present for the entire scan must be emitted at least once (and at
+     * most twice per the scan guarantees). */
+    for (long j = 0; j < count; j++) {
+        ASSERT_GE(data->entry_seen[j], 1u) << "j=" << j;
+        ASSERT_LE(data->entry_seen[j], 2u) << "j=" << j;
+    }
+    free(data);
+    hashtableRelease(ht);
+}
+
+TEST_F(HashtableTest, scan_running_start_shrink) {
+    hashtableType type = {};
+    long count = 2000;
+    long keep = 16;
+
+    randomSeed();
+    hashtable *ht = hashtableCreate(&type);
+    populateStable(ht, count);
+    size_t buckets_before = hashtableBuckets(ht);
+
+    scandata *data = (scandata *)calloc(1, sizeof(scandata) + count);
+    uint64_t cursor = 0;
+    int deleted = 0;
+    long calls = 0;
+    long hard_cap = (long)buckets_before * 100;
+    do {
+        cursor = hashtableScanRunningStart(ht, cursor, scanfn, data);
+        if (!deleted && cursor != 0) {
+            /* Delete most entries to trigger shrink rehashing mid-scan. */
+            for (long j = keep; j < count; j++) {
+                hashtableDelete(ht, (void *)j);
+            }
+            deleted = 1;
+        }
+    } while (cursor != 0 && ++calls < hard_cap);
+    ASSERT_LT(calls, hard_cap) << "running-start scan did not terminate after shrink";
+
+    size_t buckets_after = hashtableBuckets(ht);
+
+    /* Each call advances the underlying cursor by one bucket. A correct scan does
+     * at most one pass over the large table plus one over the shrunk table; an
+     * unnecessary full second pass would roughly double this. */
+    ASSERT_LE((size_t)calls, buckets_before + buckets_after + 64)
+        << "shrink triggered an unnecessary full second pass";
+
+    /* Entries kept for the whole scan must be emitted at least once. */
+    for (long j = 0; j < keep; j++) {
+        ASSERT_GE(data->entry_seen[j], 1u) << "j=" << j;
+    }
+    free(data);
+    hashtableRelease(ht);
 }
 
 /* Helper types for mock hash entry tests */

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -459,6 +459,113 @@ proc test_scan {type} {
         set keys [lsort -unique $keys]
         assert_equal 100 [llength $keys]
     }
+
+    test "{$type} running-start object scans return exact items without duplicates" {
+        set count 500
+
+        # Force hashtable/skiplist encodings regardless of the configured
+        # listpack limits.
+        set saved_hash [lindex [r config get hash-max-listpack-entries] 1]
+        set saved_set [lindex [r config get set-max-listpack-entries] 1]
+        set saved_zset [lindex [r config get zset-max-listpack-entries] 1]
+        r config set hash-max-listpack-entries 16
+        r config set set-max-listpack-entries 16
+        r config set zset-max-listpack-entries 16
+
+        # String members force the set into hashtable encoding (not intset or
+        # listpack).
+        r del rset
+        for {set j 0} {$j < $count} {incr j} { r sadd rset "m:$j" }
+        assert_encoding hashtable rset
+
+        # Above the listpack limit forces hashtable encoding.
+        r del rhash
+        for {set j 0} {$j < $count} {incr j} { r hset rhash "f:$j" $j }
+        assert_encoding hashtable rhash
+
+        # Above the listpack limit forces skiplist encoding.
+        r del rzset
+        for {set j 0} {$j < $count} {incr j} { r zadd rzset $j "z:$j" }
+        assert_encoding skiplist rzset
+
+        # Finish any incremental rehashing so a stable table is scanned without
+        # duplicates (reads advance rehashing when the resize policy is ALLOW).
+        for {set j 0} {$j < $count} {incr j} {
+            r sismember rset "m:$j"
+            r hget rhash "f:$j"
+            r zscore rzset "z:$j"
+        }
+
+        # Each running-start scan begins at a random bucket position, so repeat
+        # several rounds to exercise different start positions.
+        for {set round 0} {$round < 10} {incr round} {
+            # SSCAN: every member exactly once.
+            set cur 0; set items {}
+            while 1 {
+                set res [r sscan rset $cur]
+                set cur [lindex $res 0]
+                lappend items {*}[lindex $res 1]
+                if {$cur == 0} break
+            }
+            assert_equal $count [llength $items]
+            assert_equal $count [llength [lsort -unique $items]]
+
+            # HSCAN: every field/value pair exactly once.
+            set cur 0; set pairs {}
+            while 1 {
+                set res [r hscan rhash $cur]
+                set cur [lindex $res 0]
+                lappend pairs {*}[lindex $res 1]
+                if {$cur == 0} break
+            }
+            assert_equal [expr {$count * 2}] [llength $pairs]
+            set hkeys {}
+            foreach {k v} $pairs {
+                assert_equal $v [string range $k 2 end]
+                lappend hkeys $k
+            }
+            assert_equal $count [llength [lsort -unique $hkeys]]
+
+            # HSCAN NOVALUES: every field exactly once.
+            set cur 0; set hkeys2 {}
+            while 1 {
+                set res [r hscan rhash $cur novalues]
+                set cur [lindex $res 0]
+                lappend hkeys2 {*}[lindex $res 1]
+                if {$cur == 0} break
+            }
+            assert_equal $count [llength $hkeys2]
+            assert_equal $count [llength [lsort -unique $hkeys2]]
+
+            # ZSCAN: every member/score pair exactly once.
+            set cur 0; set zpairs {}
+            while 1 {
+                set res [r zscan rzset $cur]
+                set cur [lindex $res 0]
+                lappend zpairs {*}[lindex $res 1]
+                if {$cur == 0} break
+            }
+            assert_equal [expr {$count * 2}] [llength $zpairs]
+            set zmembers {}
+            foreach {m s} $zpairs { lappend zmembers $m }
+            assert_equal $count [llength [lsort -unique $zmembers]]
+
+            # ZSCAN NOSCORES: every member exactly once.
+            set cur 0; set zmembers2 {}
+            while 1 {
+                set res [r zscan rzset $cur noscores]
+                set cur [lindex $res 0]
+                lappend zmembers2 {*}[lindex $res 1]
+                if {$cur == 0} break
+            }
+            assert_equal $count [llength $zmembers2]
+            assert_equal $count [llength [lsort -unique $zmembers2]]
+        }
+
+        r config set hash-max-listpack-entries $saved_hash
+        r config set set-max-listpack-entries $saved_set
+        r config set zset-max-listpack-entries $saved_zset
+    }
 }
 
 start_server {tags {"scan network standalone"}} {


### PR DESCRIPTION
Fixes #3955 by randomizing the starting bucket for hashtable-backed object scans (`SSCAN`, `HSCAN`, and `ZSCAN`) while preserving the existing cursor-based full-scan guarantees.

Object scans currently always start from bucket zero when the client passes cursor `0`. Workloads that repeatedly start a scan, delete the first returned batch, stop early, and then refill the object can create a stable scan-order bias: buckets near the end of the scan order keep accumulating entries. Since `COUNT` is only a hint and a single bucket chain is emitted as one unit, this can make `SSCAN ... COUNT 1` return thousands of elements.

This change removes the deterministic “bucket zero is always the start” behavior for hashtable-backed object scans. Each fresh object scan starts from a randomized running-start position, and the returned opaque cursor carries enough state to finish the scan from that same logical start point.

## What Changed

- Added `hashtableScanRunningStart()` as a wrapper around the existing hashtable scan primitive.
- Route hashtable-backed `SSCAN`, `HSCAN`, and skiplist-backed `ZSCAN` through the running-start scan path.
- Keep keyspace `SCAN` / `CLUSTERSCAN` unchanged for now.
- Keep compact encodings such as listpack/intset unchanged; they still return the full object in one call.
- Encode running-start state in the returned cursor:
  ```
  [0??????? ???????? ffffffff fffffffw cccccccc cccccccc cccccccc cccccccc]
  0: bit 63 is always zero so the cursor fits in signed integer replies.
  ?: 15-bit reserved for future use.
  f: 15-bit random running start.
  w: 1-bit wrapped flag, set after the scan reaches cursor zero after starting.
  c: 32-bit internal hashtable scan cursor, masked by HASHTABLE_SCAN_CURSOR_MASK.
  ```
- Added test coverage for hashtable-backed `SSCAN`, `HSCAN`, `HSCAN NOVALUES`, `ZSCAN`, and `ZSCAN NOSCORES`.

## Implementation Notes

The randomized start is fixed for the lifetime of a scan and encoded into the cursor. This is important because choosing a new random bucket on every call would break cursor semantics and could skip stable entries. A fresh scan picks the start; continuation calls decode and reuse it.

The running-start logic does not change the underlying hashtable scan algorithm. It still uses the existing reverse-bit cursor order and preserves the existing scan guarantees. The wrapper only changes where an object scan begins and when it is considered complete.

The post-wrap termination check compares positions in scan-order space:

```c
rev(cursor & mask) >= rev(start & mask)
```

This is intentionally an inequality, not equality. After the scan wraps through zero, it should stop as soon as the next cursor reaches or passes the original start boundary in reverse-bit scan order. This avoids doing an extra cycle over the start range.

The >= also handles table shrink correctly. After a shrink, multiple old bucket positions can fold into one new bucket position. If termination required an exact equality match, the scan could miss the precise original boundary and overshoot into another pass. The inequality catches the first folded position that is at or past the start boundary.

The lower-32-bit “next cursor equals current cursor” check is a no-progress guard. If the underlying scan cannot advance at the cursor precision retained in the opaque cursor, the wrapper terminates instead of returning a cursor that would repeat the same scan step.

## Compatibility

Cursor values remain opaque to clients. Clients that continue using server-returned cursors keep the same command flow and reply shape. This change does not make COUNT a hard limit; it reduces the deterministic accumulation pattern that can make pathological bucket chains appear at the same point in repeated partial scans.