### PR TITLE
Raft Cluster: stability fixes

### DIFF
--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -2107,14 +2107,6 @@ static void clusterRaftDetectFailures(mstime_t now) {
         clusterNode *node = dictGetVal(de);
         if (node == myself) continue;
 
-        /* Disconnect outbound links with no AE_ACK for node_timeout/2.
-         * Detects half-open connections to frozen/dead peers so
-         * clusterConnectNodes can re-establish them. */
-        if (node->link && !(node->flags & CLUSTER_NODE_MEET) &&
-            now - RAFT_NODE(node)->last_ack_time > node_timeout / 2) {
-            freeClusterLink(node->link);
-        }
-
         if (nodeFailed(node)) {
             /* For failed nodes, drop stale links periodically so
              * clusterConnectNodes can establish a fresh connection.
@@ -2258,9 +2250,12 @@ static void clusterRaftCron(void) {
     clusterRaftState *rs = RAFT_STATE();
     mstime_t now = monotonicMs();
 
-    /* Disconnect dead outbound links where no data has been received on
-     * the current connection (HI never arrived). The peer's kernel
-     * accepted our SYN but the process is frozen. Applies to all roles. */
+    /* Disconnect dead outbound links after node_timeout/2. data_received tracks
+     * the last time we got data on our outbound link (HI, AE_ACK, votes).
+     * - All roles: no data received on the current connection (HI never
+     *   arrived). The peer's kernel accepted our SYN but the process is frozen.
+     * - Leader: no AE_ACK. last_ack_time is reset on election, giving peers
+     *   time to respond to the first AE. */
     {
         mstime_t stale = server.cluster_node_timeout / 2;
         dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
@@ -2269,7 +2264,8 @@ static void clusterRaftCron(void) {
             clusterNode *node = dictGetVal(de);
             if (node == myself || !node->link) continue;
             if (node->flags & CLUSTER_NODE_MEET) continue;
-            if (node->data_received < node->link->ctime && now - node->link->ctime > stale) {
+            if ((node->data_received < node->link->ctime && now - node->link->ctime > stale) ||
+                (rs->role == RAFT_ROLE_LEADER && now - RAFT_NODE(node)->last_ack_time > stale)) {
                 freeClusterLink(node->link);
             }
         }

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -102,6 +102,7 @@ enum raftEntryType {
     RAFT_ENTRY_NODE_INFO = 6,      /* IP, port, hostname, etc. */
     RAFT_ENTRY_NODE_FAIL = 7,      /* Node failure detected */
     RAFT_ENTRY_NODE_RECOVER = 8,   /* Node recovery detected */
+    RAFT_ENTRY_NOOP = 9,           /* No-op (leader term establishment) */
 };
 
 typedef struct {
@@ -788,6 +789,7 @@ static int raftEntryTypeByName(const char *name) {
     if (!strcasecmp(name, "NODE_INFO")) return RAFT_ENTRY_NODE_INFO;
     if (!strcasecmp(name, "NODE_FAIL")) return RAFT_ENTRY_NODE_FAIL;
     if (!strcasecmp(name, "NODE_RECOVER")) return RAFT_ENTRY_NODE_RECOVER;
+    if (!strcasecmp(name, "NOOP")) return RAFT_ENTRY_NOOP;
     return -1;
 }
 
@@ -801,6 +803,7 @@ static const char *raftEntryTypeName(uint8_t type) {
     case RAFT_ENTRY_NODE_INFO: return "NODE_INFO";
     case RAFT_ENTRY_NODE_FAIL: return "NODE_FAIL";
     case RAFT_ENTRY_NODE_RECOVER: return "NODE_RECOVER";
+    case RAFT_ENTRY_NOOP: return "NOOP";
     default: return "UNKNOWN";
     }
 }
@@ -1530,6 +1533,9 @@ static void raftLogApply(raftLogEntry *e) {
         serverLog(LL_NOTICE, "Applied NODE_INFO (index %llu).", (unsigned long long)e->index);
         break;
     }
+    case RAFT_ENTRY_NOOP:
+        /* No-op: nothing to apply. */
+        break;
     default:
         serverLog(LL_NOTICE, "Applied log entry type %d (index %llu).", e->type,
                   (unsigned long long)e->index);
@@ -1980,6 +1986,10 @@ static int clusterRaftProcessRequestVoteResponse(clusterLink *link, int argc, sd
                 }
             }
             dictReleaseIterator(di);
+            /* Append a no-op entry to commit prior-term entries (§5.4.2)
+             * and establish the new term in the log. */
+            uint64_t noop_idx = raftLogLastIndex() + 1;
+            raftLogAppend(raftLogCreate(rs->current_term, noop_idx, RAFT_ENTRY_NOOP, sdsempty()));
             /* Immediate heartbeat to assert leadership. */
             clusterRaftBroadcastAppendEntries();
         }
@@ -2974,8 +2984,8 @@ static void clusterRaftPersistNewLogEntries(uint64_t from) {
 
 
 static int clusterRaftParseLogLine(sds *argv, int argc) {
-    /* Format: log <crc64hex> <index> <term> <type> <data...> */
-    if (argc < 6) {
+    /* Format: log <crc64hex> <index> <term> <type> [<data...>] */
+    if (argc < 5) {
         serverLog(LL_WARNING, "Corrupt raft log line: too few fields (%d).", argc);
         return C_ERR;
     }
@@ -3008,9 +3018,9 @@ static int clusterRaftParseLogLine(sds *argv, int argc) {
     }
 
     /* Reconstruct data from remaining args (space-separated). */
-    sds data = sdsdup(argv[5]);
-    for (int i = 6; i < argc; i++) {
-        data = sdscatlen(data, " ", 1);
+    sds data = sdsempty();
+    for (int i = 5; i < argc; i++) {
+        if (i > 5) data = sdscatlen(data, " ", 1);
         data = sdscatsds(data, argv[i]);
     }
 

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -2746,7 +2746,8 @@ static int clusterRaftProcessMessage(struct clusterLink *link) {
         char *buf = link->rcvbuf + RAFT_HDR_SIZE;
         size_t buf_len = link->rcvbuf_len - RAFT_HDR_SIZE;
         char *nl = memchr(buf, '\n', buf_len);
-        if (nl && (size_t)(buf + buf_len - nl - 1) >= chan_len + msg_len) {
+        if (nl && chan_len + msg_len >= chan_len &&
+            (size_t)(buf + buf_len - nl - 1) >= chan_len + msg_len) {
             char *payload = nl + 1;
             robj *chan = createStringObject(payload, chan_len);
             robj *pmsg = createStringObject(payload + chan_len, msg_len);

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1635,7 +1635,12 @@ static int clusterRaftProcessAppendEntries(clusterLink *link, int argc, sds *arg
     /* Accept heartbeat. */
     if (rs->role != RAFT_ROLE_JOINER) rs->role = RAFT_ROLE_FOLLOWER;
     rs->last_heartbeat = monotonicMs();
-    memcpy(rs->leader, argv[1], CLUSTER_NAMELEN);
+    /* Detect leader change — retry pending proposals to the new leader. */
+    if (memcmp(rs->leader, argv[1], CLUSTER_NAMELEN) != 0) {
+        memcpy(rs->leader, argv[1], CLUSTER_NAMELEN);
+        if (listLength(rs->pending_proposals) > 0)
+            rs->todo_retry_proposals = 1;
+    }
 
     /* Log consistency check: verify prev_log_index/term match. */
     if (prev_log_index > 0 && raftLogTermAt(prev_log_index) != prev_log_term) {
@@ -1952,6 +1957,9 @@ static int clusterRaftProcessRequestVoteResponse(clusterLink *link, int argc, sd
             memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
             serverLog(LL_NOTICE, "Elected as Raft leader (term %llu, %d votes).",
                       (unsigned long long)rs->current_term, rs->votes_received);
+            /* Append any pending proposals locally now that we're leader. */
+            if (listLength(rs->pending_proposals) > 0)
+                rs->todo_retry_proposals = 1;
             /* Initialize nextIndex for each peer (Raft paper §5.3). */
             uint64_t last = raftLogLastIndex();
             dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
@@ -2027,6 +2035,8 @@ static void clusterRaftStartElection(void) {
         memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
         serverLog(LL_NOTICE, "Elected as Raft leader (term %llu, %d votes).",
                   (unsigned long long)rs->current_term, rs->votes_received);
+        if (listLength(rs->pending_proposals) > 0)
+            rs->todo_retry_proposals = 1;
     }
 }
 
@@ -2278,9 +2288,6 @@ static void clusterRaftCron(void) {
                 }
             }
         }
-
-        /* Retry proposals when leader link becomes available. */
-        clusterRaftRetryProposals(1);
 
         /* Periodically check if our NODE_INFO diverged from what was last
          * committed (e.g. a CONFIG SET succeeded but the proposal timed

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -2236,6 +2236,29 @@ static void clusterRaftCron(void) {
     clusterRaftState *rs = RAFT_STATE();
     mstime_t now = monotonicMs();
 
+    /* Disconnect dead outbound links. data_received tracks the last time
+     * we got data on our outbound link (HI, AE_ACK, votes).
+     * - No data ever received after node_timeout/2: HI never arrived,
+     *   the peer's kernel accepted our SYN but the process is frozen.
+     * - Leader: no AE_ACK for node_timeout/2. last_ack_time is reset on
+     *   election, giving peers time to respond to the first AE. */
+    {
+        mstime_t stale = server.cluster_node_timeout / 2;
+        dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
+        dictEntry *de;
+        while ((de = dictNext(di)) != NULL) {
+            clusterNode *node = dictGetVal(de);
+            if (node == myself || !node->link) continue;
+            if (node->flags & CLUSTER_NODE_MEET) continue;
+            if ((node->data_received == 0 && now - node->link->ctime > stale) ||
+                (rs->role == RAFT_ROLE_LEADER &&
+                 now - RAFT_NODE(node)->last_ack_time > stale)) {
+                freeClusterLink(node->link);
+            }
+        }
+        dictReleaseIterator(di);
+    }
+
     if (!server.debug_cluster_disable_reconnection) clusterConnectNodes();
 
     /* Joiner timeout: if we stepped down to join a cluster but never
@@ -2623,6 +2646,11 @@ static uint32_t clusterRaftValidateMessageHeader(char *header) {
 
 static int clusterRaftProcessMessage(struct clusterLink *link) {
     RAFT_STATE()->stats_bytes_received += link->rcvbuf_len;
+
+    /* Track data received on outbound links only. Each node manages its own
+     * outbound link; if it goes silent we must detect and reconnect. The
+     * inbound link is the peer's responsibility. */
+    if (link->node && !link->inbound) link->node->data_received = mstime();
 
     /* Parse the text payload after the binary header.
      * Split by \n first (AE messages have entry lines), then split

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1826,10 +1826,14 @@ static void clusterRaftSendPreVoteResponse(clusterLink *link, uint64_t term, int
 static int clusterRaftCanGrantVote(clusterRaftState *rs, uint64_t candidate_last_index, uint64_t candidate_last_term) {
     if (rs->role == RAFT_ROLE_JOINER) return 0;
 
-    /* Don't vote while we still consider a leader alive in this term. */
+    /* Deny vote if we recently heard from the leader (leader lease).
+     * Use the base node-timeout, not the randomized election timeout —
+     * the randomization is for staggering elections, not for lease duration. */
     mstime_t now = monotonicMs();
+    mstime_t lease = server.cluster_node_timeout;
+    if (lease < 1000) lease = 1000;
     if (rs->leader[0] != '\0' &&
-        now - rs->last_heartbeat < rs->election_timeout) {
+        now - rs->last_heartbeat < lease) {
         return 0;
     }
 

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1939,6 +1939,49 @@ static int clusterRaftProcessRequestVote(clusterLink *link, int argc, sds *argv)
     return 1;
 }
 
+/* Promote to leader after winning an election (quorum reached). */
+static void clusterRaftBecomeLeader(void) {
+    clusterRaftState *rs = RAFT_STATE();
+    char old_leader[CLUSTER_NAMELEN];
+    memcpy(old_leader, rs->leader, CLUSTER_NAMELEN);
+    rs->role = RAFT_ROLE_LEADER;
+    memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
+    serverLog(LL_NOTICE, "Elected as Raft leader (term %llu, %d votes).",
+              (unsigned long long)rs->current_term, rs->votes_received);
+
+    if (listLength(rs->pending_proposals) > 0)
+        rs->todo_retry_proposals = 1;
+
+    if (server.cluster->size <= 1) return;
+
+    /* Initialize nextIndex for each peer (Raft paper §5.3). */
+    uint64_t last = raftLogLastIndex();
+    dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
+    dictEntry *de;
+    while ((de = dictNext(di)) != NULL) {
+        clusterNode *peer = dictGetVal(de);
+        if (peer == myself) continue;
+        RAFT_NODE(peer)->next_index = last + 1;
+        RAFT_NODE(peer)->match_index = 0;
+        RAFT_NODE(peer)->pending_fail_change = 0;
+        /* For the old leader, backdate last_ack_time to when we last
+         * heard from it, so failure detection kicks in faster. This
+         * matters if the old leader is also a primary. */
+        if (memcmp(peer->name, old_leader, CLUSTER_NAMELEN) == 0) {
+            RAFT_NODE(peer)->last_ack_time = rs->last_heartbeat;
+        } else {
+            RAFT_NODE(peer)->last_ack_time = monotonicMs();
+        }
+    }
+    dictReleaseIterator(di);
+    /* Append a no-op entry to commit prior-term entries (§5.4.2)
+     * and establish the new term in the log. */
+    uint64_t noop_idx = raftLogLastIndex() + 1;
+    raftLogAppend(raftLogCreate(rs->current_term, noop_idx, RAFT_ENTRY_NOOP, sdsempty()));
+    /* Immediate heartbeat to assert leadership. */
+    clusterRaftBroadcastAppendEntries();
+}
+
 static int clusterRaftProcessRequestVoteResponse(clusterLink *link, int argc, sds *argv) {
     UNUSED(link);
     /* argv: VOTE <term> <granted> */
@@ -1957,41 +2000,7 @@ static int clusterRaftProcessRequestVoteResponse(clusterLink *link, int argc, sd
         rs->votes_received++;
         int quorum = clusterRaftQuorum();
         if (rs->votes_received >= quorum) {
-            char old_leader[CLUSTER_NAMELEN];
-            memcpy(old_leader, rs->leader, CLUSTER_NAMELEN);
-            rs->role = RAFT_ROLE_LEADER;
-            memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
-            serverLog(LL_NOTICE, "Elected as Raft leader (term %llu, %d votes).",
-                      (unsigned long long)rs->current_term, rs->votes_received);
-            /* Append any pending proposals locally now that we're leader. */
-            if (listLength(rs->pending_proposals) > 0)
-                rs->todo_retry_proposals = 1;
-            /* Initialize nextIndex for each peer (Raft paper §5.3). */
-            uint64_t last = raftLogLastIndex();
-            dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
-            dictEntry *de;
-            while ((de = dictNext(di)) != NULL) {
-                clusterNode *peer = dictGetVal(de);
-                if (peer == myself) continue;
-                RAFT_NODE(peer)->next_index = last + 1;
-                RAFT_NODE(peer)->match_index = 0;
-                RAFT_NODE(peer)->pending_fail_change = 0;
-                /* For the old leader, backdate last_ack_time to when we last
-                 * heard from it, so failure detection kicks in faster. This
-                 * matters if the old leader is also a primary. */
-                if (memcmp(peer->name, old_leader, CLUSTER_NAMELEN) == 0) {
-                    RAFT_NODE(peer)->last_ack_time = rs->last_heartbeat;
-                } else {
-                    RAFT_NODE(peer)->last_ack_time = monotonicMs();
-                }
-            }
-            dictReleaseIterator(di);
-            /* Append a no-op entry to commit prior-term entries (§5.4.2)
-             * and establish the new term in the log. */
-            uint64_t noop_idx = raftLogLastIndex() + 1;
-            raftLogAppend(raftLogCreate(rs->current_term, noop_idx, RAFT_ENTRY_NOOP, sdsempty()));
-            /* Immediate heartbeat to assert leadership. */
-            clusterRaftBroadcastAppendEntries();
+            clusterRaftBecomeLeader();
         }
     }
     return 1;
@@ -2041,12 +2050,7 @@ static void clusterRaftStartElection(void) {
     /* Single-node: already have quorum. */
     int quorum = clusterRaftQuorum();
     if (rs->votes_received >= quorum) {
-        rs->role = RAFT_ROLE_LEADER;
-        memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
-        serverLog(LL_NOTICE, "Elected as Raft leader (term %llu, %d votes).",
-                  (unsigned long long)rs->current_term, rs->votes_received);
-        if (listLength(rs->pending_proposals) > 0)
-            rs->todo_retry_proposals = 1;
+        clusterRaftBecomeLeader();
     }
 }
 
@@ -2102,6 +2106,14 @@ static void clusterRaftDetectFailures(mstime_t now) {
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
         if (node == myself) continue;
+
+        /* Disconnect outbound links with no AE_ACK for node_timeout/2.
+         * Detects half-open connections to frozen/dead peers so
+         * clusterConnectNodes can re-establish them. */
+        if (node->link && !(node->flags & CLUSTER_NODE_MEET) &&
+            now - RAFT_NODE(node)->last_ack_time > node_timeout / 2) {
+            freeClusterLink(node->link);
+        }
 
         if (nodeFailed(node)) {
             /* For failed nodes, drop stale links periodically so
@@ -2246,12 +2258,9 @@ static void clusterRaftCron(void) {
     clusterRaftState *rs = RAFT_STATE();
     mstime_t now = monotonicMs();
 
-    /* Disconnect dead outbound links. data_received tracks the last time
-     * we got data on our outbound link (HI, AE_ACK, votes).
-     * - No data ever received after node_timeout/2: HI never arrived,
-     *   the peer's kernel accepted our SYN but the process is frozen.
-     * - Leader: no AE_ACK for node_timeout/2. last_ack_time is reset on
-     *   election, giving peers time to respond to the first AE. */
+    /* Disconnect dead outbound links where no data has been received on
+     * the current connection (HI never arrived). The peer's kernel
+     * accepted our SYN but the process is frozen. Applies to all roles. */
     {
         mstime_t stale = server.cluster_node_timeout / 2;
         dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
@@ -2260,9 +2269,7 @@ static void clusterRaftCron(void) {
             clusterNode *node = dictGetVal(de);
             if (node == myself || !node->link) continue;
             if (node->flags & CLUSTER_NODE_MEET) continue;
-            if ((node->data_received == 0 && now - node->link->ctime > stale) ||
-                (rs->role == RAFT_ROLE_LEADER &&
-                 now - RAFT_NODE(node)->last_ack_time > stale)) {
+            if (node->data_received < node->link->ctime && now - node->link->ctime > stale) {
                 freeClusterLink(node->link);
             }
         }

--- a/tests/unit/cluster/cluster-raft-proto.tcl
+++ b/tests/unit/cluster/cluster-raft-proto.tcl
@@ -232,6 +232,52 @@ test "Raft proto: PRE_VOTE denied while leader lease is active" {
     }
 }
 
+test "Raft proto: PRE_VOTE granted after node-timeout even with randomized election timeout" {
+    # The leader lease uses the base node-timeout, not the randomized election
+    # timeout. If the lease used the randomized timeout (up to 2x node-timeout),
+    # a voter could incorrectly deny pre-votes from candidates that have
+    # legitimately detected a failed leader.
+    start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
+        set cport [expr {[srv 0 port] + 10000}]
+        set node_id [R 0 CLUSTER MYID]
+        set leader_id [string repeat "d" 40]
+        set leader_addr "127.0.0.1:9995@19995,,tls-port=0,shard-id=[string repeat e 40]"
+
+        # Connect as a fake peer and form a 2-node cluster via MEET.
+        set fd1 [raft_connect 127.0.0.1 $cport]
+        raft_send $fd1 "HELLO $leader_id $leader_addr"
+        set reply [raft_recv $fd1]
+        assert_match "HI *" $reply
+
+        # The real node is a singleton leader. MEET "cluster" makes it
+        # step down to joiner and reply ADD_ME.
+        raft_send $fd1 "MEET cluster"
+        set reply [raft_recv $fd1]
+        assert_match "ADD_ME*" $reply
+
+        # Send AE with NODE_JOIN entries for both nodes to form the cluster.
+        set node_addr "127.0.0.1:[srv 0 port]@$cport,,tls-port=0,shard-id=[string repeat a 40]"
+        set term 1
+        raft_send $fd1 "AE $leader_id $term 0 0 2 2\n1 NODE_JOIN $leader_id $leader_addr\n1 NODE_JOIN $node_id $node_addr"
+        set reply [raft_recv $fd1]
+        assert_match "AE_ACK *" $reply
+        assert_equal "follower" [CI 0 cluster_raft_role]
+        assert_equal $leader_id [CI 0 cluster_raft_leader]
+
+        # Leader goes silent. Wait just over node-timeout for lease to expire.
+        after 1100
+
+        # The old leader comes back as a candidate, sends PRE_VOTE_REQ.
+        # Its log is at least as up-to-date (same 2 entries at term 1).
+        set prevote_term [expr {$term + 1}]
+        raft_send $fd1 "PRE_VOTE_REQ $leader_id $prevote_term 2 1"
+        set reply [raft_recv $fd1]
+        assert_match "PRE_VOTE $prevote_term 1" $reply
+
+        close $fd1
+    }
+}
+
 test "Raft proto: PRE_VOTE granted when no leader lease is active" {
     start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
         set cport [expr {[srv 0 port] + 10000}]

--- a/tests/unit/cluster/cluster-shards.tcl
+++ b/tests/unit/cluster/cluster-shards.tcl
@@ -320,10 +320,7 @@ test "CLUSTER MYSHARDID reports same shard id after cluster restart" {
     for {set i 0} {$i < 8} {incr i} {
         assert_equal [dict get $node_ids $i] [R $i cluster myshardid]
     }
-} {} {cluster-raft:skip} ;# Skipped under raft: R8 stays running while R0-R7
-                          # restart, inflating its term with failed elections.
-                          # This disrupts leader election when others come back.
-                          # Needs pre-vote (Raft §9.6) to fix.
+}
 
 test "CLUSTER SHARDS id response validation" {
     # For each node in the cluster


### PR DESCRIPTION
A few independent small fixes to the Raft cluster implementation (the cluster-v2 feature branch).

I suggest reviewing these commit-by-commit.

1. Use base node-timeout for leader lease instead of randomized election timeout

   The leader lease (used to deny pre-votes while the leader is alive) was using the randomized election timeout (1x–2x node-timeout). A voter with a longer randomized
timeout could deny legitimate pre-votes from candidates that correctly detected a failed leader. Now uses the base node-timeout, ensuring consistent lease duration
across all nodes. Follow-up of #3931, @quanyeyang

2. Fix proposal retry flooding

   Pending proposals were unconditionally retried every 100ms in cron, flooding the leader with duplicate proposals. Replaced with targeted retry triggers: on leader change
(detected in AE handler), on reconnect to the same leader (HI handler), and on becoming leader. Reduces unnecessary network traffic and leader load.

3. Disconnect stale outbound links

   A node that was paused or killed could leave a half-open TCP connection that the peer kept sending to indefinitely. Added detection of dead outbound links: links that
never received HI (connection to a frozen peer) and leader links with no AE_ACK response. Disconnecting stale links allows clusterConnectNodes to re-establish working
connections promptly.

4. Fix size_t overflow in PUBLISH message bounds check

   A malicious or buggy peer could send PUBLISH with chan_len + msg_len values that overflow size_t, bypassing the buffer bounds check. Added an overflow guard to
prevent out-of-bounds memory access.

5. No-op entry after leader election

   A new leader appends a no-op entry in its own term immediately after winning election. This allows entries from prior terms (already replicated to a majority) to be
committed, since Raft requires a current-term entry to be committed before prior-term entries can be safely committed (§5.4.2). Without this, prior-term entries could
remain uncommitted indefinitely if no new proposals arrive.

@sushilpaneru1