### PR TITLE
Fix build warnings with OpenSSL 4.0

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -466,6 +466,16 @@ static int tlsPasswordCallback(char *buf, int size, int rwflag, void *u) {
 /* Check a single X509 certificate validity */
 static bool isCertValid(X509 *cert) {
     if (!cert) return false;
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+    int error = 0;
+    if (X509_check_certificate_times(NULL, cert, &error) != 1) {
+        return false;
+    }
+    if (error > 0) {
+        serverLog(LL_WARNING, "X509_check_certificate_times() returned error %d", error);
+        return false;
+    }
+#else
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after = X509_get0_notAfter(cert);
     if (!not_before || !not_after) return false;
@@ -473,6 +483,7 @@ static bool isCertValid(X509 *cert) {
         X509_cmp_current_time(not_after) < 0) {
         return false;
     }
+#endif
     return true;
 }
 
@@ -1279,7 +1290,7 @@ static void updateSSLState(connection *conn_) {
 }
 
 static int getCertSubjectFieldByName(X509 *cert, const char *field, char *out, size_t outlen) {
-    if (!cert || !field || !out) return 0;
+    if (!cert || !field || !out || outlen == 0) return 0;
 
     int nid = -1;
 
@@ -1291,10 +1302,33 @@ static int getCertSubjectFieldByName(X509 *cert, const char *field, char *out, s
 
     if (nid == -1) return 0;
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    const X509_NAME *subject = X509_get_subject_name(cert);
+#else
     X509_NAME *subject = X509_get_subject_name(cert);
+#endif
     if (!subject) return 0;
 
-    return X509_NAME_get_text_by_NID(subject, nid, out, outlen) > 0;
+    /* X509_NAME_get_text_by_NID is deprecated in OpenSSL 4.0 */
+    int idx = X509_NAME_get_index_by_NID(subject, nid, -1);
+    if (idx < 0) return 0;
+
+    const X509_NAME_ENTRY *entry = X509_NAME_get_entry(subject, idx);
+    if (!entry) return 0;
+
+    const ASN1_STRING *data = X509_NAME_ENTRY_get_data(entry);
+    if (!data) return 0;
+
+    const unsigned char *str = ASN1_STRING_get0_data(data);
+    int len = ASN1_STRING_length(data);
+    if (!str || len <= 0) return 0;
+
+    /* Copy to output buffer, ensuring null termination */
+    size_t copy_len = (size_t)len < outlen - 1 ? (size_t)len : outlen - 1;
+    memcpy(out, str, copy_len);
+    out[copy_len] = '\0';
+
+    return 1;
 }
 
 /* Extract URI from Subject Alternative Name extension and return the first


### PR DESCRIPTION
Some functions are newly deprecated in OpenSSL 4.0, this commits works around those. More specifically:

- X509_cmp_current_time() in isCertValid() is no longer necessary as X509_check_certificate_times() compares the notBefore and notAfter on its own. Had to add a version check since this function is new in OpenSSL 4.0.

- Replace deprecated X509_NAME_get_text_by_NID. Not a perfect fix, because the new implementation still assumes that the name does not contain embedded null characters which may not be true, e.g., if the name is of type UniversalString or BMPString.

- Also fix constness of X509_get_subject_name return value.

The latter two fixes are taken from this Fedora patch: https://src.fedoraproject.org/rpms/valkey/c/1a9c8847172ef3fb116a1e2fdb3871692378adae?branch=rawhide

Closes #4012