### PR TITLE
Optimize HMGET, SMISMEMBER and ZMSCORE with batched hashtable lookup

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1912,6 +1912,11 @@ bool hashtableIncrementalFindStep(hashtableIncrementalFindState *state) {
                 /* It's a match. */
                 data->state = HASHTABLE_FOUND;
                 return false;
+            if (compareKeys(ht, data->key, elem_key)) {
+                /* It's a match. */
+                data->state = validateElementIfNeeded(ht, entry) ?
+                    HASHTABLE_FOUND : HASHTABLE_NOT_FOUND;
+                return false;
             }
             /* No match. Look for next candidate entry in the bucket. */
             data->pos++;

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1908,14 +1908,9 @@ bool hashtableIncrementalFindStep(hashtableIncrementalFindState *state) {
             hashtable *ht = data->hashtable;
             void *entry = data->bucket->entries[data->pos];
             const void *elem_key = entryGetKey(ht, entry);
-            if (compareKeys(ht, data->key, elem_key) && validateElementIfNeeded(ht, entry)) {
-                /* It's a match. */
-                data->state = HASHTABLE_FOUND;
-                return false;
             if (compareKeys(ht, data->key, elem_key)) {
                 /* It's a match. */
-                data->state = validateElementIfNeeded(ht, entry) ?
-                    HASHTABLE_FOUND : HASHTABLE_NOT_FOUND;
+                data->state = validateElementIfNeeded(ht, entry) ? HASHTABLE_FOUND : HASHTABLE_NOT_FOUND;
                 return false;
             }
             /* No match. Look for next candidate entry in the bucket. */

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1908,7 +1908,7 @@ bool hashtableIncrementalFindStep(hashtableIncrementalFindState *state) {
             hashtable *ht = data->hashtable;
             void *entry = data->bucket->entries[data->pos];
             const void *elem_key = entryGetKey(ht, entry);
-            if (compareKeys(ht, data->key, elem_key)) {
+            if (compareKeys(ht, data->key, elem_key) && validateElementIfNeeded(ht, entry)) {
                 /* It's a match. */
                 data->state = HASHTABLE_FOUND;
                 return false;
@@ -1987,6 +1987,39 @@ bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, voi
     } else {
         assert(data->state == HASHTABLE_NOT_FOUND);
         return false;
+    }
+}
+
+#define HASHTABLE_FIND_BATCH_SIZE 16
+
+/* Provides batch lookup. Compared with serial single-key lookups, it can improve
+ * performance by parallelizing memory accesses. */
+void hashtableFindBatch(hashtable *ht, hashtableFindBatchItem *items, size_t count) {
+    if (count == 0) return;
+
+    rehashStepOnReadIfNeeded(ht);
+
+    hashtableIncrementalFindState states[HASHTABLE_FIND_BATCH_SIZE];
+    for (size_t base = 0; base < count; base += HASHTABLE_FIND_BATCH_SIZE) {
+        size_t batch = count - base;
+        if (batch > HASHTABLE_FIND_BATCH_SIZE) batch = HASHTABLE_FIND_BATCH_SIZE;
+
+        for (size_t i = 0; i < batch; i++) {
+            hashtableIncrementalFindInit(&states[i], ht, items[base + i].key);
+        }
+
+        size_t incomplete;
+        do {
+            incomplete = 0;
+            for (size_t i = 0; i < batch; i++) {
+                incomplete += hashtableIncrementalFindStep(&states[i]);
+            }
+        } while (incomplete != 0);
+
+        for (size_t i = 0; i < batch; i++) {
+            items[base + i].entry = NULL;
+            items[base + i].found = hashtableIncrementalFindGetResult(&states[i], &items[base + i].entry);
+        }
     }
 }
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1990,37 +1990,35 @@ bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, voi
     }
 }
 
-#define HASHTABLE_FIND_BATCH_SIZE 16
-
 /* Provides batch lookup. Compared with serial single-key lookups, it can improve
- * performance by parallelizing memory accesses. */
-void hashtableFindBatch(hashtable *ht, hashtableFindBatchItem *items, size_t count) {
-    if (count == 0) return;
+ * performance by parallelizing memory accesses. Each bit in the returned bitmap
+ * indicates whether the key at the same index was found. */
+uint32_t hashtableFindBatch(hashtable *ht, int numkeys, const void **keys, void **found_entries) {
+    assert(numkeys >= 0 && numkeys <= HASHTABLE_FIND_BATCH_MAX_SIZE);
+    if (numkeys == 0) return 0;
 
     rehashStepOnReadIfNeeded(ht);
 
-    hashtableIncrementalFindState states[HASHTABLE_FIND_BATCH_SIZE];
-    for (size_t base = 0; base < count; base += HASHTABLE_FIND_BATCH_SIZE) {
-        size_t batch = count - base;
-        if (batch > HASHTABLE_FIND_BATCH_SIZE) batch = HASHTABLE_FIND_BATCH_SIZE;
+    hashtableIncrementalFindState states[numkeys];
+    for (int i = 0; i < numkeys; i++) {
+        hashtableIncrementalFindInit(&states[i], ht, keys[i]);
+    }
 
-        for (size_t i = 0; i < batch; i++) {
-            hashtableIncrementalFindInit(&states[i], ht, items[base + i].key);
+    size_t incomplete;
+    do {
+        incomplete = 0;
+        for (int i = 0; i < numkeys; i++) {
+            incomplete += hashtableIncrementalFindStep(&states[i]);
         }
+    } while (incomplete != 0);
 
-        size_t incomplete;
-        do {
-            incomplete = 0;
-            for (size_t i = 0; i < batch; i++) {
-                incomplete += hashtableIncrementalFindStep(&states[i]);
-            }
-        } while (incomplete != 0);
-
-        for (size_t i = 0; i < batch; i++) {
-            items[base + i].entry = NULL;
-            items[base + i].found = hashtableIncrementalFindGetResult(&states[i], &items[base + i].entry);
+    uint32_t result = 0;
+    for (int i = 0; i < numkeys; i++) {
+        if (hashtableIncrementalFindGetResult(&states[i], &found_entries[i])) {
+            result |= (uint32_t)1 << i;
         }
     }
+    return result;
 }
 
 /* --- Scan --- */

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -163,7 +163,7 @@ bool hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void
 void hashtableIncrementalFindInit(hashtableIncrementalFindState *state, hashtable *ht, const void *key);
 bool hashtableIncrementalFindStep(hashtableIncrementalFindState *state);
 bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, void **found);
-void hashtableFindBatch(hashtable *ht, hashtableFindBatchItem *items, size_t count);
+uint32_t hashtableFindBatch(hashtable *ht, int numkeys, const void **keys, void **found_entries);
 
 /* Iteration & scan */
 size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, void *privdata);

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -91,6 +91,12 @@ typedef enum {
 
 typedef void (*hashtableScanFunction)(void *privdata, void *entry);
 
+typedef struct {
+    const void *key;
+    void *entry;
+    bool found;
+} hashtableFindBatchItem;
+
 /* Constants */
 #define HASHTABLE_BUCKET_SIZE 64 /* bytes, the most common cache line size */
 
@@ -157,6 +163,7 @@ bool hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void
 void hashtableIncrementalFindInit(hashtableIncrementalFindState *state, hashtable *ht, const void *key);
 bool hashtableIncrementalFindStep(hashtableIncrementalFindState *state);
 bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, void **found);
+void hashtableFindBatch(hashtable *ht, hashtableFindBatchItem *items, size_t count);
 
 /* Iteration & scan */
 size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, void *privdata);

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -92,7 +92,7 @@ typedef enum {
 typedef void (*hashtableScanFunction)(void *privdata, void *entry);
 
 /* Constants */
-#define HASHTABLE_BUCKET_SIZE 64 /* bytes, the most common cache line size */
+#define HASHTABLE_BUCKET_SIZE 64         /* bytes, the most common cache line size */
 #define HASHTABLE_FIND_BATCH_MAX_SIZE 32 /* Limited by the result bitmap size. */
 
 /* Scan flags */

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -91,14 +91,9 @@ typedef enum {
 
 typedef void (*hashtableScanFunction)(void *privdata, void *entry);
 
-typedef struct {
-    const void *key;
-    void *entry;
-    bool found;
-} hashtableFindBatchItem;
-
 /* Constants */
 #define HASHTABLE_BUCKET_SIZE 64 /* bytes, the most common cache line size */
+#define HASHTABLE_FIND_BATCH_MAX_SIZE 32 /* Limited by the result bitmap size. */
 
 /* Scan flags */
 #define HASHTABLE_SCAN_EMIT_REF (1 << 0)
@@ -150,6 +145,7 @@ void hashtableSetCanAbortShrink(bool can_abort);
 
 /* Entries */
 bool hashtableFind(hashtable *ht, const void *key, void **found);
+uint32_t hashtableFindBatch(hashtable *ht, int numkeys, const void **keys, void **found_entries);
 void **hashtableFindRef(hashtable *ht, const void *key);
 bool hashtableAdd(hashtable *ht, void *entry);
 bool hashtableAddOrFind(hashtable *ht, void *entry, void **existing);
@@ -163,7 +159,6 @@ bool hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void
 void hashtableIncrementalFindInit(hashtableIncrementalFindState *state, hashtable *ht, const void *key);
 bool hashtableIncrementalFindStep(hashtableIncrementalFindState *state);
 bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, void **found);
-uint32_t hashtableFindBatch(hashtable *ht, int numkeys, const void **keys, void **found_entries);
 
 /* Iteration & scan */
 size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, void *privdata);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1096,6 +1096,61 @@ static void addHashFieldToReply(client *c, robj *o, sds field) {
     }
 }
 
+#define HMGET_FIND_BATCH_SIZE 16
+
+static void addHashEntryToReply(client *c, void *hash_entry) {
+    if (hash_entry == NULL) {
+        addReplyNull(c);
+        return;
+    }
+
+    size_t len = 0;
+    char *value = entryGetValue(hash_entry, &len);
+    serverAssert(value != NULL);
+    addReplyBulkCBuffer(c, value, len);
+}
+
+static void hmgetReplyWithHashtable(client *c, hashtable *ht, robj **fields, size_t count) {
+    hashtableFindBatchItem items[HMGET_FIND_BATCH_SIZE];
+    while (count) {
+        size_t batch = count > HMGET_FIND_BATCH_SIZE ? HMGET_FIND_BATCH_SIZE : count;
+
+        for (size_t i = 0; i < batch; i++) {
+            items[i].key = objectGetVal(fields[i]);
+        }
+
+        hashtableFindBatch(ht, items, batch);
+
+        for (size_t i = 0; i < batch; i++) {
+            addHashEntryToReply(c, items[i].found ? items[i].entry : NULL);
+        }
+
+        fields += batch;
+        count -= batch;
+    }
+}
+
+static void hmgetReply(client *c, robj *o, robj **fields, size_t count) {
+    addReplyArrayLen(c, count);
+
+    if (o == NULL) {
+        for (size_t i = 0; i < count; i++) {
+            addReplyNull(c);
+        }
+        return;
+    }
+
+    /* Prefer hashtable batch lookup to improve performance. */
+    if (o->encoding == OBJ_ENCODING_HASHTABLE && count > 1) {
+        hmgetReplyWithHashtable(c, objectGetVal(o), fields, count);
+        return;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        addHashFieldToReply(c, o, objectGetVal(fields[i]));
+    }
+}
+
 void hgetCommand(client *c) {
     robj *o;
 
@@ -1105,7 +1160,6 @@ void hgetCommand(client *c) {
 
 void hmgetCommand(client *c) {
     robj *o;
-    int i;
 
     /* Don't abort when the key cannot be found. Non-existing keys are empty
      * hashes, where HMGET should respond with a series of null bulks. */
@@ -1113,13 +1167,7 @@ void hmgetCommand(client *c) {
 
     if (checkType(c, o, OBJ_HASH)) return;
 
-    addReplyArrayLen(c, c->argc - 2);
-    for (i = 2; i < c->argc; i++) {
-        addHashFieldToReply(c, o, objectGetVal(c->argv[i]));
-    }
-    if (o && hashTypeLength(o) == 0) {
-        dbDelete(c->db, c->argv[1]);
-    }
+    hmgetReply(c, o, c->argv + 2, c->argc - 2);
 }
 
 void hdelCommand(client *c) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1100,7 +1100,7 @@ static void addHashFieldToReply(client *c, robj *o, sds field) {
 static_assert(HMGET_FIND_BATCH_SIZE <= HASHTABLE_FIND_BATCH_MAX_SIZE,
               "HMGET batch size exceeds hashtable batch lookup limit");
 
-static void addHashEntryToReply(client *c, void *hash_entry) {
+static void addHashEntryToReply(client *c, const entry *hash_entry) {
     if (hash_entry == NULL) {
         addReplyNull(c);
         return;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1097,6 +1097,8 @@ static void addHashFieldToReply(client *c, robj *o, sds field) {
 }
 
 #define HMGET_FIND_BATCH_SIZE 16
+static_assert(HMGET_FIND_BATCH_SIZE <= HASHTABLE_FIND_BATCH_MAX_SIZE,
+              "HMGET batch size exceeds hashtable batch lookup limit");
 
 static void addHashEntryToReply(client *c, void *hash_entry) {
     if (hash_entry == NULL) {
@@ -1111,43 +1113,23 @@ static void addHashEntryToReply(client *c, void *hash_entry) {
 }
 
 static void hmgetReplyWithHashtable(client *c, hashtable *ht, robj **fields, size_t count) {
-    hashtableFindBatchItem items[HMGET_FIND_BATCH_SIZE];
+    const void *keys[HMGET_FIND_BATCH_SIZE];
+    void *found_entries[HMGET_FIND_BATCH_SIZE];
     while (count) {
         size_t batch = count > HMGET_FIND_BATCH_SIZE ? HMGET_FIND_BATCH_SIZE : count;
 
         for (size_t i = 0; i < batch; i++) {
-            items[i].key = objectGetVal(fields[i]);
+            keys[i] = objectGetVal(fields[i]);
         }
 
-        hashtableFindBatch(ht, items, batch);
+        uint32_t result = hashtableFindBatch(ht, (int)batch, keys, found_entries);
 
         for (size_t i = 0; i < batch; i++) {
-            addHashEntryToReply(c, items[i].found ? items[i].entry : NULL);
+            addHashEntryToReply(c, (result >> i) & 1 ? found_entries[i] : NULL);
         }
 
         fields += batch;
         count -= batch;
-    }
-}
-
-static void hmgetReply(client *c, robj *o, robj **fields, size_t count) {
-    addReplyArrayLen(c, count);
-
-    if (o == NULL) {
-        for (size_t i = 0; i < count; i++) {
-            addReplyNull(c);
-        }
-        return;
-    }
-
-    /* Prefer hashtable batch lookup to improve performance. */
-    if (o->encoding == OBJ_ENCODING_HASHTABLE && count > 1) {
-        hmgetReplyWithHashtable(c, objectGetVal(o), fields, count);
-        return;
-    }
-
-    for (size_t i = 0; i < count; i++) {
-        addHashFieldToReply(c, o, objectGetVal(fields[i]));
     }
 }
 
@@ -1160,6 +1142,7 @@ void hgetCommand(client *c) {
 
 void hmgetCommand(client *c) {
     robj *o;
+    size_t count = c->argc - 2;
 
     /* Don't abort when the key cannot be found. Non-existing keys are empty
      * hashes, where HMGET should respond with a series of null bulks. */
@@ -1167,7 +1150,24 @@ void hmgetCommand(client *c) {
 
     if (checkType(c, o, OBJ_HASH)) return;
 
-    hmgetReply(c, o, c->argv + 2, c->argc - 2);
+    addReplyArrayLen(c, count);
+
+    if (o == NULL) {
+        for (size_t i = 0; i < count; i++) {
+            addReplyNull(c);
+        }
+        return;
+    }
+
+    /* Prefer hashtable batch lookup to improve performance. */
+    if (o->encoding == OBJ_ENCODING_HASHTABLE && count > 1) {
+        hmgetReplyWithHashtable(c, objectGetVal(o), c->argv + 2, count);
+        return;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        addHashFieldToReply(c, o, objectGetVal(c->argv[i + 2]));
+    }
 }
 
 void hdelCommand(client *c) {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -700,34 +700,70 @@ void smoveCommand(client *c) {
     addReply(c, shared.cone);
 }
 
+#define SMISMEMBER_FIND_BATCH_SIZE 16
+
+static void sismemberReply(client *c, robj *set, robj *member) {
+    addReply(c, setTypeIsMember(set, objectGetVal(member)) ? shared.cone : shared.czero);
+}
+
+static void smismemberReplyWithHashtable(client *c, hashtable *ht, robj **members, size_t count) {
+    hashtableFindBatchItem items[SMISMEMBER_FIND_BATCH_SIZE];
+    while (count) {
+        size_t batch = count > SMISMEMBER_FIND_BATCH_SIZE ? SMISMEMBER_FIND_BATCH_SIZE : count;
+
+        for (size_t i = 0; i < batch; i++) {
+            items[i].key = objectGetVal(members[i]);
+        }
+
+        hashtableFindBatch(ht, items, batch);
+
+        for (size_t i = 0; i < batch; i++) {
+            addReply(c, items[i].found ? shared.cone : shared.czero);
+        }
+
+        members += batch;
+        count -= batch;
+    }
+}
+
+static void smismemberReply(client *c, robj *set, robj **members, size_t count) {
+    addReplyArrayLen(c, count);
+
+    /* Prefer hashtable batch lookup to improve performance. */
+    if (set->encoding == OBJ_ENCODING_HASHTABLE && count > 1) {
+        smismemberReplyWithHashtable(c, objectGetVal(set), members, count);
+        return;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        sismemberReply(c, set, members[i]);
+    }
+}
+
 void sismemberCommand(client *c) {
     robj *set;
 
     if ((set = lookupKeyReadOrReply(c, c->argv[1], shared.czero)) == NULL || checkType(c, set, OBJ_SET)) return;
 
-    if (setTypeIsMember(set, objectGetVal(c->argv[2])))
-        addReply(c, shared.cone);
-    else
-        addReply(c, shared.czero);
+    sismemberReply(c, set, c->argv[2]);
 }
 
 void smismemberCommand(client *c) {
     robj *set;
-    int j;
 
     /* Don't abort when the key cannot be found. Non-existing keys are empty
      * sets, where SMISMEMBER should respond with a series of zeros. */
     set = lookupKeyRead(c->db, c->argv[1]);
-    if (set && checkType(c, set, OBJ_SET)) return;
-
-    addReplyArrayLen(c, c->argc - 2);
-
-    for (j = 2; j < c->argc; j++) {
-        if (set && setTypeIsMember(set, objectGetVal(c->argv[j])))
-            addReply(c, shared.cone);
-        else
+    if (set == NULL) {
+        addReplyArrayLen(c, c->argc - 2);
+        for (int j = 2; j < c->argc; j++) {
             addReply(c, shared.czero);
+        }
+        return;
     }
+    if (checkType(c, set, OBJ_SET)) return;
+
+    smismemberReply(c, set, c->argv + 2, c->argc - 2);
 }
 
 void scardCommand(client *c) {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -701,42 +701,31 @@ void smoveCommand(client *c) {
 }
 
 #define SMISMEMBER_FIND_BATCH_SIZE 16
+static_assert(SMISMEMBER_FIND_BATCH_SIZE <= HASHTABLE_FIND_BATCH_MAX_SIZE,
+              "SMISMEMBER batch size exceeds hashtable batch lookup limit");
 
 static void sismemberReply(client *c, robj *set, robj *member) {
     addReply(c, setTypeIsMember(set, objectGetVal(member)) ? shared.cone : shared.czero);
 }
 
 static void smismemberReplyWithHashtable(client *c, hashtable *ht, robj **members, size_t count) {
-    hashtableFindBatchItem items[SMISMEMBER_FIND_BATCH_SIZE];
+    const void *keys[SMISMEMBER_FIND_BATCH_SIZE];
+    void *found_entries[SMISMEMBER_FIND_BATCH_SIZE];
     while (count) {
         size_t batch = count > SMISMEMBER_FIND_BATCH_SIZE ? SMISMEMBER_FIND_BATCH_SIZE : count;
 
         for (size_t i = 0; i < batch; i++) {
-            items[i].key = objectGetVal(members[i]);
+            keys[i] = objectGetVal(members[i]);
         }
 
-        hashtableFindBatch(ht, items, batch);
+        uint32_t result = hashtableFindBatch(ht, (int)batch, keys, found_entries);
 
         for (size_t i = 0; i < batch; i++) {
-            addReply(c, items[i].found ? shared.cone : shared.czero);
+            addReply(c, (result >> i) & 1 ? shared.cone : shared.czero);
         }
 
         members += batch;
         count -= batch;
-    }
-}
-
-static void smismemberReply(client *c, robj *set, robj **members, size_t count) {
-    addReplyArrayLen(c, count);
-
-    /* Prefer hashtable batch lookup to improve performance. */
-    if (set->encoding == OBJ_ENCODING_HASHTABLE && count > 1) {
-        smismemberReplyWithHashtable(c, objectGetVal(set), members, count);
-        return;
-    }
-
-    for (size_t i = 0; i < count; i++) {
-        sismemberReply(c, set, members[i]);
     }
 }
 
@@ -763,7 +752,18 @@ void smismemberCommand(client *c) {
     }
     if (checkType(c, set, OBJ_SET)) return;
 
-    smismemberReply(c, set, c->argv + 2, c->argc - 2);
+    size_t count = c->argc - 2;
+    addReplyArrayLen(c, count);
+
+    /* Prefer hashtable batch lookup to improve performance. */
+    if (set->encoding == OBJ_ENCODING_HASHTABLE && count > 1) {
+        smismemberReplyWithHashtable(c, objectGetVal(set), c->argv + 2, count);
+        return;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        sismemberReply(c, set, c->argv[i + 2]);
+    }
 }
 
 void scardCommand(client *c) {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3118,36 +3118,82 @@ void zcardCommand(client *c) {
     addReplyLongLong(c, zsetLength(zobj));
 }
 
-void zscoreCommand(client *c) {
-    robj *key = c->argv[1];
-    robj *zobj;
+static void zscoreReply(client *c, robj *zobj, robj *member) {
     double score;
 
-    if ((zobj = lookupKeyReadOrReply(c, key, shared.null[c->resp])) == NULL || checkType(c, zobj, OBJ_ZSET)) return;
-
-    if (zsetScore(zobj, objectGetVal(c->argv[2]), &score) == C_ERR) {
+    if (zsetScore(zobj, objectGetVal(member), &score) == C_ERR) {
         addReplyNull(c);
     } else {
         addReplyDouble(c, score);
     }
 }
 
+void zscoreCommand(client *c) {
+    robj *key = c->argv[1];
+    robj *zobj;
+
+    if ((zobj = lookupKeyReadOrReply(c, key, shared.null[c->resp])) == NULL || checkType(c, zobj, OBJ_ZSET)) return;
+
+    zscoreReply(c, zobj, c->argv[2]);
+}
+
+#define ZMSCORE_FIND_BATCH_SIZE 16
+
+static void zmscoreReplyWithHashtable(client *c, hashtable *ht, robj **members, size_t count) {
+    hashtableFindBatchItem items[ZMSCORE_FIND_BATCH_SIZE];
+    while (count) {
+        size_t batch = count > ZMSCORE_FIND_BATCH_SIZE ? ZMSCORE_FIND_BATCH_SIZE : count;
+
+        for (size_t i = 0; i < batch; i++) {
+            items[i].key = objectGetVal(members[i]);
+        }
+
+        hashtableFindBatch(ht, items, batch);
+
+        for (size_t i = 0; i < batch; i++) {
+            if (items[i].found) {
+                zskiplistNode *node = items[i].entry;
+                addReplyDouble(c, node->score);
+            } else {
+                addReplyNull(c);
+            }
+        }
+
+        members += batch;
+        count -= batch;
+    }
+}
+
+static void zmscoreReply(client *c, robj *zobj, robj **members, size_t count) {
+    addReplyArrayLen(c, count);
+
+    /* Prefer hashtable batch lookup to improve performance. */
+    if (zobj->encoding == OBJ_ENCODING_SKIPLIST && count > 1) {
+        zset *zs = objectGetVal(zobj);
+        zmscoreReplyWithHashtable(c, zs->ht, members, count);
+        return;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        zscoreReply(c, zobj, members[i]);
+    }
+}
+
 void zmscoreCommand(client *c) {
     robj *key = c->argv[1];
     robj *zobj;
-    double score;
+
     zobj = lookupKeyRead(c->db, key);
+    if (zobj == NULL) {
+        addReplyArrayLen(c, c->argc - 2);
+        for (int j = 2; j < c->argc; j++) {
+            addReplyNull(c);
+        }
+        return;
+    }
     if (checkType(c, zobj, OBJ_ZSET)) return;
 
-    addReplyArrayLen(c, c->argc - 2);
-    for (int j = 2; j < c->argc; j++) {
-        /* Treat a missing set the same way as an empty set */
-        if (zobj == NULL || zsetScore(zobj, objectGetVal(c->argv[j]), &score) == C_ERR) {
-            addReplyNull(c);
-        } else {
-            addReplyDouble(c, score);
-        }
-    }
+    zmscoreReply(c, zobj, c->argv + 2, c->argc - 2);
 }
 
 void zrankGenericCommand(client *c, int reverse) {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3148,16 +3148,25 @@ static void zmscoreReplyWithHashtable(client *c, hashtable *ht, robj **members, 
     while (count) {
         size_t batch = count > ZMSCORE_FIND_BATCH_SIZE ? ZMSCORE_FIND_BATCH_SIZE : count;
 
+        /* The same SDS may appear more than once, so only mark it once. */
         for (size_t i = 0; i < batch; i++) {
-            keys[i] = objectGetVal(members[i]);
+            sds member = objectGetVal(members[i]);
+            if (!zsetIsLookupKey(member)) zsetMarkLookupKey(member);
+            keys[i] = member;
         }
 
         uint32_t result = hashtableFindBatch(ht, (int)batch, keys, found_entries);
 
+        /* Unmark each SDS once; later duplicates are already unmarked. */
+        for (size_t i = 0; i < batch; i++) {
+            sds member = objectGetVal(members[i]);
+            if (zsetIsLookupKey(member)) zsetUnmarkLookupKey(member);
+        }
+
         for (size_t i = 0; i < batch; i++) {
             if ((result >> i) & 1) {
-                zskiplistNode *node = found_entries[i];
-                addReplyDouble(c, node->score);
+                OrderedIndexItem *node = found_entries[i];
+                addReplyDouble(c, orderedIndexItemGetScore(node));
             } else {
                 addReplyNull(c);
             }
@@ -3186,7 +3195,7 @@ void zmscoreCommand(client *c) {
     addReplyArrayLen(c, count);
 
     /* Prefer hashtable batch lookup to improve performance. */
-    if (zobj->encoding == OBJ_ENCODING_SKIPLIST && count > 1) {
+    if (zobj->encoding == OBJ_ENCODING_BTREE && count > 1) {
         zset *zs = objectGetVal(zobj);
         zmscoreReplyWithHashtable(c, zs->ht, c->argv + 2, count);
         return;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3118,6 +3118,7 @@ void zcardCommand(client *c) {
     addReplyLongLong(c, zsetLength(zobj));
 }
 
+/* Adds the member's score as a reply to the client. */
 static void zscoreReply(client *c, robj *zobj, robj *member) {
     double score;
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3139,21 +3139,24 @@ void zscoreCommand(client *c) {
 }
 
 #define ZMSCORE_FIND_BATCH_SIZE 16
+static_assert(ZMSCORE_FIND_BATCH_SIZE <= HASHTABLE_FIND_BATCH_MAX_SIZE,
+              "ZMSCORE batch size exceeds hashtable batch lookup limit");
 
 static void zmscoreReplyWithHashtable(client *c, hashtable *ht, robj **members, size_t count) {
-    hashtableFindBatchItem items[ZMSCORE_FIND_BATCH_SIZE];
+    const void *keys[ZMSCORE_FIND_BATCH_SIZE];
+    void *found_entries[ZMSCORE_FIND_BATCH_SIZE];
     while (count) {
         size_t batch = count > ZMSCORE_FIND_BATCH_SIZE ? ZMSCORE_FIND_BATCH_SIZE : count;
 
         for (size_t i = 0; i < batch; i++) {
-            items[i].key = objectGetVal(members[i]);
+            keys[i] = objectGetVal(members[i]);
         }
 
-        hashtableFindBatch(ht, items, batch);
+        uint32_t result = hashtableFindBatch(ht, (int)batch, keys, found_entries);
 
         for (size_t i = 0; i < batch; i++) {
-            if (items[i].found) {
-                zskiplistNode *node = items[i].entry;
+            if ((result >> i) & 1) {
+                zskiplistNode *node = found_entries[i];
                 addReplyDouble(c, node->score);
             } else {
                 addReplyNull(c);
@@ -3162,21 +3165,6 @@ static void zmscoreReplyWithHashtable(client *c, hashtable *ht, robj **members, 
 
         members += batch;
         count -= batch;
-    }
-}
-
-static void zmscoreReply(client *c, robj *zobj, robj **members, size_t count) {
-    addReplyArrayLen(c, count);
-
-    /* Prefer hashtable batch lookup to improve performance. */
-    if (zobj->encoding == OBJ_ENCODING_SKIPLIST && count > 1) {
-        zset *zs = objectGetVal(zobj);
-        zmscoreReplyWithHashtable(c, zs->ht, members, count);
-        return;
-    }
-
-    for (size_t i = 0; i < count; i++) {
-        zscoreReply(c, zobj, members[i]);
     }
 }
 
@@ -3194,7 +3182,19 @@ void zmscoreCommand(client *c) {
     }
     if (checkType(c, zobj, OBJ_ZSET)) return;
 
-    zmscoreReply(c, zobj, c->argv + 2, c->argc - 2);
+    size_t count = c->argc - 2;
+    addReplyArrayLen(c, count);
+
+    /* Prefer hashtable batch lookup to improve performance. */
+    if (zobj->encoding == OBJ_ENCODING_SKIPLIST && count > 1) {
+        zset *zs = objectGetVal(zobj);
+        zmscoreReplyWithHashtable(c, zs->ht, c->argv + 2, count);
+        return;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        zscoreReply(c, zobj, c->argv[i + 2]);
+    }
 }
 
 void zrankGenericCommand(client *c, int reverse) {

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1728,6 +1728,24 @@ start_server {tags {"hashexpire"}} {
         r DEBUG SET-ACTIVE-EXPIRE 1
     } {OK} {needs:debug}
 
+    set original_max [lindex [r config get hash-max-listpack-entries] 1]
+    r config set hash-max-listpack-entries 0
+    test {HMGET batch lookup skips expired hash fields} {
+        r DEBUG SET-ACTIVE-EXPIRE 0
+
+        r del hmgetbatchhfetest
+        r hset hmgetbatchhfetest alive value expired stale
+        assert_encoding hashtable hmgetbatchhfetest
+        assert_equal {1} [r hpexpire hmgetbatchhfetest 1 fields 1 expired]
+        after 2
+
+        assert_equal {value {} {}} [r hmget hmgetbatchhfetest alive expired missing]
+        assert_equal {} [r hget hmgetbatchhfetest expired]
+
+        r DEBUG SET-ACTIVE-EXPIRE 1
+    } {OK} {needs:debug}
+    r config set hash-max-listpack-entries $original_max
+
     test {HGETALL skips expired fields} {
         r FLUSHALL
         r DEBUG SET-ACTIVE-EXPIRE 0

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -426,6 +426,24 @@ start_server {tags {"hash"}} {
         r config set hash-max-listpack-entries $original_max
     }
 
+    test {HMGET batch lookup skips expired hash fields} {
+        set original_max [lindex [r config get hash-max-listpack-entries] 1]
+        r config set hash-max-listpack-entries 0
+        r DEBUG SET-ACTIVE-EXPIRE 0
+
+        r del hmgetbatchhfetest
+        r hset hmgetbatchhfetest alive value expired stale
+        assert_encoding hashtable hmgetbatchhfetest
+        assert_equal {1} [r hpexpire hmgetbatchhfetest 1 fields 1 expired]
+        after 2
+
+        assert_equal {value {} {}} [r hmget hmgetbatchhfetest alive expired missing]
+        assert_equal {} [r hget hmgetbatchhfetest expired]
+
+        r DEBUG SET-ACTIVE-EXPIRE 1
+        r config set hash-max-listpack-entries $original_max
+    } {OK} {needs:debug}
+
     test {HKEYS - small hash} {
         lsort [r hkeys smallhash]
     } [lsort [array names smallhash *]]

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -402,6 +402,30 @@ start_server {tags {"hash"}} {
         set _ $err
     } {}
 
+    test {HMGET uses hashtable batch lookup} {
+        set original_max [lindex [r config get hash-max-listpack-entries] 1]
+        r config set hash-max-listpack-entries 0
+
+        r del hmgetbatchtest
+        for {set i 1} {$i <= 128} {incr i} {
+            r hset hmgetbatchtest [format "f%02d" $i] [format "v%02d" $i]
+        }
+
+        assert_encoding hashtable hmgetbatchtest
+        assert_equal {v01} [r hmget hmgetbatchtest f01]
+        assert_equal {v01 {} v01 v04} [r hmget hmgetbatchtest f01 missing f01 f04]
+
+        set fields {missing}
+        set expected [list {}]
+        for {set i 1} {$i <= 19} {incr i} {
+            lappend fields [format "f%02d" $i]
+            lappend expected [format "v%02d" $i]
+        }
+        assert_equal $expected [r hmget hmgetbatchtest {*}$fields]
+
+        r config set hash-max-listpack-entries $original_max
+    }
+
     test {HKEYS - small hash} {
         lsort [r hkeys smallhash]
     } [lsort [array names smallhash *]]

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -402,10 +402,9 @@ start_server {tags {"hash"}} {
         set _ $err
     } {}
 
+    set original_max [lindex [r config get hash-max-listpack-entries] 1]
+    r config set hash-max-listpack-entries 0
     test {HMGET uses hashtable batch lookup} {
-        set original_max [lindex [r config get hash-max-listpack-entries] 1]
-        r config set hash-max-listpack-entries 0
-
         r del hmgetbatchtest
         for {set i 1} {$i <= 128} {incr i} {
             r hset hmgetbatchtest [format "f%02d" $i] [format "v%02d" $i]
@@ -422,27 +421,8 @@ start_server {tags {"hash"}} {
             lappend expected [format "v%02d" $i]
         }
         assert_equal $expected [r hmget hmgetbatchtest {*}$fields]
-
-        r config set hash-max-listpack-entries $original_max
     }
-
-    test {HMGET batch lookup skips expired hash fields} {
-        set original_max [lindex [r config get hash-max-listpack-entries] 1]
-        r config set hash-max-listpack-entries 0
-        r DEBUG SET-ACTIVE-EXPIRE 0
-
-        r del hmgetbatchhfetest
-        r hset hmgetbatchhfetest alive value expired stale
-        assert_encoding hashtable hmgetbatchhfetest
-        assert_equal {1} [r hpexpire hmgetbatchhfetest 1 fields 1 expired]
-        after 2
-
-        assert_equal {value {} {}} [r hmget hmgetbatchhfetest alive expired missing]
-        assert_equal {} [r hget hmgetbatchhfetest expired]
-
-        r DEBUG SET-ACTIVE-EXPIRE 1
-        r config set hash-max-listpack-entries $original_max
-    } {OK} {needs:debug}
+    r config set hash-max-listpack-entries $original_max
 
     test {HKEYS - small hash} {
         lsort [r hkeys smallhash]

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -78,10 +78,9 @@ start_server {
         assert_match {*ERR*wrong*number*arg*} $e
     }
 
+    set original_max [lindex [r config get set-max-listpack-entries] 1]
+    r config set set-max-listpack-entries 0
     test {SMISMEMBER uses hashtable batch lookup} {
-        set original_max [lindex [r config get set-max-listpack-entries] 1]
-        r config set set-max-listpack-entries 0
-
         r del smismembertest
         for {set i 1} {$i <= 128} {incr i} {
             r sadd smismembertest [format "m%02d" $i]
@@ -98,9 +97,8 @@ start_server {
             lappend expected 1
         }
         assert_equal $expected [r smismember smismembertest {*}$members]
-
-        r config set set-max-listpack-entries $original_max
     }
+    r config set set-max-listpack-entries $original_max
 
     test {SADD against non set} {
         r lpush mylist foo

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -78,6 +78,30 @@ start_server {
         assert_match {*ERR*wrong*number*arg*} $e
     }
 
+    test {SMISMEMBER uses hashtable batch lookup} {
+        set original_max [lindex [r config get set-max-listpack-entries] 1]
+        r config set set-max-listpack-entries 0
+
+        r del smismembertest
+        for {set i 1} {$i <= 128} {incr i} {
+            r sadd smismembertest [format "m%02d" $i]
+        }
+
+        assert_encoding hashtable smismembertest
+        assert_equal {1} [r smismember smismembertest m01]
+        assert_equal {1 0 1 1} [r smismember smismembertest m01 missing m01 m04]
+
+        set members {missing}
+        set expected {0}
+        for {set i 1} {$i <= 19} {incr i} {
+            lappend members [format "m%02d" $i]
+            lappend expected 1
+        }
+        assert_equal $expected [r smismember smismembertest {*}$members]
+
+        r config set set-max-listpack-entries $original_max
+    }
+
     test {SADD against non set} {
         r lpush mylist foo
         assert_error WRONGTYPE* {r sadd mylist bar}

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1763,7 +1763,7 @@ start_server {tags {"zset"}} {
             r zadd zmscoretest $i [format "m%02d" $i]
         }
 
-        assert_encoding skiplist zmscoretest
+        assert_encoding btree zmscoretest
         assert_equal {1} [r zmscore zmscoretest m01]
         assert_equal {1 {} 1 4} [r zmscore zmscoretest m01 missing m01 m04]
 

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1755,10 +1755,9 @@ start_server {tags {"zset"}} {
         r zmscore zmscoretest x
     } {10}
 
+    set original_max [lindex [r config get zset-max-listpack-entries] 1]
+    r config set zset-max-listpack-entries 0
     test {ZMSCORE uses hashtable batch lookup} {
-        set original_max [lindex [r config get zset-max-listpack-entries] 1]
-        r config set zset-max-listpack-entries 0
-
         r del zmscoretest
         for {set i 1} {$i <= 128} {incr i} {
             r zadd zmscoretest $i [format "m%02d" $i]
@@ -1775,9 +1774,8 @@ start_server {tags {"zset"}} {
             lappend expected $i
         }
         assert_equal $expected [r zmscore zmscoretest {*}$members]
-
-        r config set zset-max-listpack-entries $original_max
     }
+    r config set zset-max-listpack-entries $original_max
 
     test {ZMSCORE retrieve requires one or more members} {
         r del zmscoretest

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1755,6 +1755,30 @@ start_server {tags {"zset"}} {
         r zmscore zmscoretest x
     } {10}
 
+    test {ZMSCORE uses hashtable batch lookup} {
+        set original_max [lindex [r config get zset-max-listpack-entries] 1]
+        r config set zset-max-listpack-entries 0
+
+        r del zmscoretest
+        for {set i 1} {$i <= 128} {incr i} {
+            r zadd zmscoretest $i [format "m%02d" $i]
+        }
+
+        assert_encoding skiplist zmscoretest
+        assert_equal {1} [r zmscore zmscoretest m01]
+        assert_equal {1 {} 1 4} [r zmscore zmscoretest m01 missing m01 m04]
+
+        set members {missing}
+        set expected [list {}]
+        for {set i 1} {$i <= 19} {incr i} {
+            lappend members [format "m%02d" $i]
+            lappend expected $i
+        }
+        assert_equal $expected [r zmscore zmscoretest {*}$members]
+
+        r config set zset-max-listpack-entries $original_max
+    }
+
     test {ZMSCORE retrieve requires one or more members} {
         r del zmscoretest
         r zadd zmscoretest 10 x


### PR DESCRIPTION
## Description

- Hashes, Sets, and the member index of Sorted Sets are backed by hashtables once they grow beyond their compact encodings.

- In large-dataset random-read workloads, multi-field/member lookup commands such as `HMGET`, `SMISMEMBER`, and `ZMSCORE` perform repeated hashtable point lookups. Accessing hashtable buckets and entries in this workload is often cache-miss-heavy, so command latency can become dominated by memory access latency.

- This PR reuses Valkey's incremental hashtable lookup APIs to add `hashtableFindBatch`, a simple batched lookup helper for the single-hashtable case used by `HMGET`, `SMISMEMBER`, and `ZMSCORE`, improving large-dataset random-read performance through memory-level parallelism.

- The batched lookup path is used only for multi-field/member requests on hashtable-backed encodings. Other encodings and single-field/member requests continue to use the existing lookup paths.


## Benchmark

**The benchmark focuses on two questions**:

1. Whether the new code introduces any noticeable regression for small-dataset hot-read workloads.

2. How much performance improves for large-dataset random-read workloads.

**The benchmark follows these steps**:

1. Start `valkey-server` with persistence disabled and compact encodings disabled:

       taskset -c 0 valkey-server --save "" --appendonly no --set-max-listpack-entries 0 --zset-max-listpack-entries 0 --hash-max-listpack-entries 0 --enable-debug-command yes

2. Load the datasets. `${RANDOM}` controls the dataset size.

       For Hash:
       valkey-benchmark -r ${RANDOM} -n ${RANDOM} --sequential -P 16 HSET hash hash_field:__rand_1st__ value:__rand_1st__

       For Set:
       valkey-benchmark -r ${RANDOM} -n ${RANDOM} --sequential -P 16 SADD set set_element:__rand_int__

       For Sorted Set:
       valkey-benchmark -r ${RANDOM} -n ${RANDOM} --sequential -P 16 ZADD zset __rand_1st__ zset_element:__rand_1st__

3. Before measurement, check the target key with `DEBUG HTSTATS-KEY` to ensure that no key-level hashtable rehash is in progress.

4. Benchmark `HMGET`, `SMISMEMBER`, and `ZMSCORE` with 1, 2, 4, and 8 fields/members per command.

       For HMGET:
       taskset -c 2,3 valkey-benchmark -r ${RANDOM} -n 3000000 --threads 2 HMGET hash hash_field:__rand_int__ ...

       For SMISMEMBER:
       taskset -c 2,3 valkey-benchmark -r ${RANDOM} -n 3000000 --threads 2 SMISMEMBER set set_element:__rand_int__ ...

       For ZMSCORE:
       taskset -c 2,3 valkey-benchmark -r ${RANDOM} -n 3000000 --threads 2 ZMSCORE zset zset_element:__rand_int__ ...

   Each benchmark case is run five times, and the median QPS is used for comparison.

**The benchmark results are shown in the table below**:

| Workload | RANDOM | Command | Fields/Members | Baseline QPS | Optimized QPS | Change |
| --- | ---: | --- | ---: | ---: | ---: | ---: |
| Small dataset, hot reads | 128 | HMGET | 1 | 307660.75 | 303815.38 | -1.25% |
| Small dataset, hot reads | 128 | HMGET | 2 | 299970.00 | 292654.38 | -2.44% |
| Small dataset, hot reads | 128 | HMGET | 4 | 285659.88 | 279030.84 | -2.32% |
| Small dataset, hot reads | 128 | HMGET | 8 | 249979.16 | 244877.97 | -2.04% |
| Large dataset, random reads | 68000000 | HMGET | 1 | 255297.41 | 255297.41 | +0.00% |
| Large dataset, random reads | 68000000 | HMGET | 2 | 222172.84 | 249979.16 | +12.52% |
| Large dataset, random reads | 68000000 | HMGET | 4 | 176449.83 | 237628.23 | +34.67% |
| Large dataset, random reads | 68000000 | HMGET | 8 | 122419.00 | 206882.28 | +69.00% |
| Small dataset, hot reads | 128 | SMISMEMBER | 1 | 285687.06 | 292668.66 | +2.44% |
| Small dataset, hot reads | 128 | SMISMEMBER | 2 | 279043.81 | 282325.27 | +1.18% |
| Small dataset, hot reads | 128 | SMISMEMBER | 4 | 272652.91 | 272677.69 | +0.01% |
| Small dataset, hot reads | 128 | SMISMEMBER | 8 | 244877.97 | 239971.20 | -2.00% |
| Large dataset, random reads | 65000000 | SMISMEMBER | 1 | 249958.34 | 244877.97 | -2.03% |
| Large dataset, random reads | 65000000 | SMISMEMBER | 2 | 214255.11 | 239980.80 | +12.01% |
| Large dataset, random reads | 65000000 | SMISMEMBER | 4 | 173882.80 | 230724.86 | +32.69% |
| Large dataset, random reads | 65000000 | SMISMEMBER | 8 | 124963.55 | 206875.15 | +65.55% |
| Small dataset, hot reads | 128 | ZMSCORE | 1 | 307597.66 | 299970.02 | -2.48% |
| Small dataset, hot reads | 128 | ZMSCORE | 2 | 299970.00 | 292640.11 | -2.44% |
| Small dataset, hot reads | 128 | ZMSCORE | 4 | 285687.06 | 279017.86 | -2.33% |
| Small dataset, hot reads | 128 | ZMSCORE | 8 | 249979.16 | 244857.98 | -2.05% |
| Large dataset, random reads | 52000000 | ZMSCORE | 1 | 255297.41 | 255297.41 | +0.00% |
| Large dataset, random reads | 52000000 | ZMSCORE | 2 | 218165.94 | 244877.97 | +12.24% |
| Large dataset, random reads | 52000000 | ZMSCORE | 4 | 171399.19 | 235432.71 | +37.36% |
| Large dataset, random reads | 52000000 | ZMSCORE | 8 | 119976.01 | 203369.15 | +69.51% |

**Benchmark env**:
CPU: AMD EPYC 9K65 192-Core Processor * 4
OS: Ubuntu Server 24.04 LTS 64bit
Memory: 16GB
VM: Tencent Cloud | SA9.LARGE16