### PR TITLE
Fix assert with CLUSTER REPLICATE for replicas that own slots

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -7958,6 +7958,10 @@ int clusterCommandSpecial(client *c) {
         }
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "flushslots") && c->argc == 2) {
         /* CLUSTER FLUSHSLOTS */
+        if (nodeIsReplica(myself)) {
+            addReplyError(c, "Please use FLUSHSLOTS only with primaries.");
+            return 1;
+        }
         if (!dbsHaveNoKeys()) {
             addReplyError(c, "DB must be empty to perform CLUSTER FLUSHSLOTS.");
             return 1;
@@ -7969,7 +7973,7 @@ int clusterCommandSpecial(client *c) {
         /* CLUSTER ADDSLOTS <slot> [slot] ... */
         /* CLUSTER DELSLOTS <slot> [slot] ... */
         if (nodeIsReplica(myself)) {
-            addReplyErrorFormat(c, "Please use %s only with primaries.", (char *)objectGetVal(c->argv[1]));
+            addReplyError(c, "Please use ADDSLOTS/DELSLOTS only with primaries.");
             return 1;
         }
         int j, slot;
@@ -8005,7 +8009,7 @@ int clusterCommandSpecial(client *c) {
         /* CLUSTER ADDSLOTSRANGE <start slot> <end slot> [<start slot> <end slot> ...] */
         /* CLUSTER DELSLOTSRANGE <start slot> <end slot> [<start slot> <end slot> ...] */
         if (nodeIsReplica(myself)) {
-            addReplyErrorFormat(c, "Please use %s only with primaries.", (char *)objectGetVal(c->argv[1]));
+            addReplyError(c, "Please use ADDSLOTSRANGE/DELSLOTSRANGE only with primaries.");
             return 1;
         }
         int j, startslot, endslot;

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -7968,6 +7968,10 @@ int clusterCommandSpecial(client *c) {
     } else if ((!strcasecmp(objectGetVal(c->argv[1]), "addslots") || !strcasecmp(objectGetVal(c->argv[1]), "delslots")) && c->argc >= 3) {
         /* CLUSTER ADDSLOTS <slot> [slot] ... */
         /* CLUSTER DELSLOTS <slot> [slot] ... */
+        if (nodeIsReplica(myself)) {
+            addReplyErrorFormat(c, "Please use %s only with primaries.", (char *)objectGetVal(c->argv[1]));
+            return 1;
+        }
         int j, slot;
         unsigned char *slots = zmalloc(CLUSTER_SLOTS);
         int del = !strcasecmp(objectGetVal(c->argv[1]), "delslots");
@@ -8000,6 +8004,10 @@ int clusterCommandSpecial(client *c) {
         }
         /* CLUSTER ADDSLOTSRANGE <start slot> <end slot> [<start slot> <end slot> ...] */
         /* CLUSTER DELSLOTSRANGE <start slot> <end slot> [<start slot> <end slot> ...] */
+        if (nodeIsReplica(myself)) {
+            addReplyErrorFormat(c, "Please use %s only with primaries.", (char *)objectGetVal(c->argv[1]));
+            return 1;
+        }
         int j, startslot, endslot;
         unsigned char *slots = zmalloc(CLUSTER_SLOTS);
         int del = !strcasecmp(objectGetVal(c->argv[1]), "delslotsrange");

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -13,6 +13,13 @@ start_cluster 2 2 {tags {external:skip cluster}} {
         R 0 ping
     } {PONG}
 
+    test "Replica should reject slot-management commands" {
+        assert_error {ERR Please use ADDSLOTS only with primaries*} {R 2 CLUSTER ADDSLOTS 100}
+        assert_error {ERR Please use delslots only with primaries*} {R 3 CLUSTER delslots 100}
+        assert_error {ERR Please use ADDSLOTSRANGE only with primaries*} {R 2 CLUSTER ADDSLOTSRANGE 100 200}
+        assert_error {ERR Please use delslotsrange only with primaries*} {R 3 CLUSTER delslotsrange 100 200}
+    }
+
     test "Coverage: Basic cluster commands" {
         assert_equal {OK} [R 0 CLUSTER saveconfig]
 

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -14,10 +14,11 @@ start_cluster 2 2 {tags {external:skip cluster}} {
     } {PONG}
 
     test "Replica should reject slot-management commands" {
-        assert_error {ERR Please use ADDSLOTS only with primaries*} {R 2 CLUSTER ADDSLOTS 100}
-        assert_error {ERR Please use delslots only with primaries*} {R 3 CLUSTER delslots 100}
-        assert_error {ERR Please use ADDSLOTSRANGE only with primaries*} {R 2 CLUSTER ADDSLOTSRANGE 100 200}
-        assert_error {ERR Please use delslotsrange only with primaries*} {R 3 CLUSTER delslotsrange 100 200}
+        assert_error {ERR Please use ADDSLOTS/DELSLOTS only with primaries*} {R 2 CLUSTER ADDSLOTS 100}
+        assert_error {ERR Please use ADDSLOTS/DELSLOTS only with primaries*} {R 3 CLUSTER DELSLOTS 100}
+        assert_error {ERR Please use ADDSLOTSRANGE/DELSLOTSRANGE only with primaries*} {R 2 CLUSTER ADDSLOTSRANGE 100 200}
+        assert_error {ERR Please use ADDSLOTSRANGE/DELSLOTSRANGE only with primaries*} {R 3 CLUSTER DELSLOTSRANGE 100 200}
+        assert_error {ERR Please use FLUSHSLOTS only with primaries*} {R 2 CLUSTER FLUSHSLOTS}
     }
 
     test "Coverage: Basic cluster commands" {


### PR DESCRIPTION
A replica must never own slots. However, CLUSTER ADDSLOTS / DELSLOTS /
ADDSLOTSRANGE / DELSLOTSRANGE had no check preventing a replica from
claiming slot ownership.

Once a replica owned a slot, running CLUSTER REPLICATE would hit the
assertion in clusterSetPrimary(): serverAssert(myself->numslots == 0)

Replicas are by design not supposed to own any slots, in this PR,
we update the judgements to prevent the replica from trying to take
ownership of slots. This mirrors the existing behavior of CLUSTER SETSLOT,
which already refuses to run on replicas.