### PR TITLE
Add per-command service time (end-to-end latency) tracking (#3718)

### DIFF
--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -65,6 +65,7 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/blocked.c
     ${CMAKE_SOURCE_DIR}/src/hyperloglog.c
     ${CMAKE_SOURCE_DIR}/src/latency.c
+    ${CMAKE_SOURCE_DIR}/src/service_time.c
     ${CMAKE_SOURCE_DIR}/src/sparkline.c
     ${CMAKE_SOURCE_DIR}/src/valkey-check-rdb.c
     ${CMAKE_SOURCE_DIR}/src/valkey-check-aof.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -513,6 +513,7 @@ ENGINE_SERVER_OBJ = \
     io_threads.o \
     kvstore.o \
     latency.o \
+    service_time.o \
     lazyfree.o \
     listpack.o \
     localtime.o \

--- a/src/ae.c
+++ b/src/ae.c
@@ -92,6 +92,7 @@ aeEventLoop *aeCreateEventLoop(int setsize) {
     eventLoop->aftersleep = NULL;
     eventLoop->custompoll = NULL;
     eventLoop->flags = 0;
+    eventLoop->currWakeTime = 0;
     /* Initialize the eventloop mutex with PTHREAD_MUTEX_ERRORCHECK type */
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
@@ -449,6 +450,10 @@ int aeProcessEvents(aeEventLoop *eventLoop, int flags) {
             numevents = aeApiPoll(eventLoop, tvp);
         }
 
+        /* Record event-loop wake time for service time tracking.
+         * AE_DONT_WAIT prevents resetting during recursive aeProcessEvents calls. */
+        if (!(flags & AE_DONT_WAIT)) eventLoop->currWakeTime = getMonotonicUs();
+
         /* Don't process file events if not requested. */
         if (!(flags & AE_FILE_EVENTS)) {
             numevents = 0;
@@ -568,4 +573,8 @@ void aeSetPollProtect(aeEventLoop *eventLoop, int protect) {
     } else {
         eventLoop->flags &= ~AE_PROTECT_POLL;
     }
+}
+
+monotime aeGetWakeTime(aeEventLoop *eventLoop) {
+    return eventLoop->currWakeTime;
 }

--- a/src/ae.h
+++ b/src/ae.h
@@ -115,6 +115,7 @@ typedef struct aeEventLoop {
     aeCustomPollProc *custompoll;
     pthread_mutex_t poll_mutex;
     int flags;
+    monotime currWakeTime; /* Timestamp of last event-loop wake from poll, for service time tracking. */
 } aeEventLoop;
 
 /* Prototypes */
@@ -143,5 +144,6 @@ int aePoll(aeEventLoop *eventLoop, struct timeval *tvp);
 int aeGetSetSize(aeEventLoop *eventLoop);
 int aeResizeSetSize(aeEventLoop *eventLoop, int setsize);
 void aeSetDontWait(aeEventLoop *eventLoop, int noWait);
+monotime aeGetWakeTime(aeEventLoop *eventLoop);
 
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -3382,6 +3382,7 @@ standardConfig static_configs[] = {
     createBoolConfig("cluster-allow-replica-migration", NULL, MODIFIABLE_CONFIG, server.cluster_allow_replica_migration, 1, NULL, NULL),
     createBoolConfig("replica-announced", NULL, MODIFIABLE_CONFIG, server.replica_announced, 1, NULL, NULL),
     createBoolConfig("latency-tracking", NULL, MODIFIABLE_CONFIG, server.latency_tracking_enabled, 1, NULL, NULL),
+    createBoolConfig("latency-service-time-tracking", NULL, MODIFIABLE_CONFIG, server.service_time_tracking_enabled, 0, NULL, NULL),
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
     createBoolConfig("extended-redis-compatibility", NULL, MODIFIABLE_CONFIG, server.extended_redis_compat, 0, NULL, updateExtendedRedisCompat),

--- a/src/latency.c
+++ b/src/latency.c
@@ -527,22 +527,26 @@ void fillCommandCDF(client *c, struct hdr_histogram *histogram) {
     setDeferredMapLen(c, replylen, samples);
 }
 
+static struct hdr_histogram *getCommandHistogram(struct serverCommand *cmd, int use_service_time) {
+    return use_service_time ? cmd->service_time_histogram : cmd->latency_histogram;
+}
+
 /* latencyCommand() helper to produce for all commands,
  * a per command cumulative distribution of latencies. */
-void latencyAllCommandsFillCDF(client *c, hashtable *commands, int *command_with_data) {
+void latencyAllCommandsFillCDF(client *c, hashtable *commands, int *command_with_data, int use_service_time) {
     hashtableIterator iter;
     hashtableInitIterator(&iter, commands, HASHTABLE_ITER_SAFE);
     void *next;
     while (hashtableNext(&iter, &next)) {
         struct serverCommand *cmd = next;
-        if (cmd->latency_histogram) {
+        struct hdr_histogram *h = getCommandHistogram(cmd, use_service_time);
+        if (h) {
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
-            fillCommandCDF(c, cmd->latency_histogram);
+            fillCommandCDF(c, h);
             (*command_with_data)++;
         }
-
         if (cmd->subcommands) {
-            latencyAllCommandsFillCDF(c, cmd->subcommands_ht, command_with_data);
+            latencyAllCommandsFillCDF(c, cmd->subcommands_ht, command_with_data, use_service_time);
         }
     }
     hashtableCleanupIterator(&iter);
@@ -550,19 +554,17 @@ void latencyAllCommandsFillCDF(client *c, hashtable *commands, int *command_with
 
 /* latencyCommand() helper to produce for a specific command set,
  * a per command cumulative distribution of latencies. */
-void latencySpecificCommandsFillCDF(client *c) {
+void latencySpecificCommandsFillCDF(client *c, int argc_end, int use_service_time) {
     void *replylen = addReplyDeferredLen(c);
     int command_with_data = 0;
-    for (int j = 2; j < c->argc; j++) {
+    for (int j = 2; j < argc_end; j++) {
         struct serverCommand *cmd = lookupCommandBySds(objectGetVal(c->argv[j]));
-        /* If the command does not exist we skip the reply */
-        if (cmd == NULL) {
-            continue;
-        }
+        if (cmd == NULL) continue;
 
-        if (cmd->latency_histogram) {
+        struct hdr_histogram *h = getCommandHistogram(cmd, use_service_time);
+        if (h) {
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
-            fillCommandCDF(c, cmd->latency_histogram);
+            fillCommandCDF(c, h);
             command_with_data++;
         }
 
@@ -572,9 +574,10 @@ void latencySpecificCommandsFillCDF(client *c) {
             void *next;
             while (hashtableNext(&iter, &next)) {
                 struct serverCommand *sub = next;
-                if (sub->latency_histogram) {
+                h = getCommandHistogram(sub, use_service_time);
+                if (h) {
                     addReplyBulkCBuffer(c, sub->fullname, sdslen(sub->fullname));
-                    fillCommandCDF(c, sub->latency_histogram);
+                    fillCommandCDF(c, h);
                     command_with_data++;
                 }
             }
@@ -724,14 +727,20 @@ void latencyCommand(client *c) {
             addReplyLongLong(c, resets);
         }
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "histogram") && c->argc >= 2) {
-        /* LATENCY HISTOGRAM*/
-        if (c->argc == 2) {
+        /* LATENCY HISTOGRAM [command ...] [SERVICE] */
+        int use_service_time = 0;
+        int argc_end = c->argc;
+        if (c->argc >= 3 && !strcasecmp(objectGetVal(c->argv[c->argc - 1]), "service")) {
+            use_service_time = 1;
+            argc_end = c->argc - 1;
+        }
+        if (argc_end == 2) {
             int command_with_data = 0;
             void *replylen = addReplyDeferredLen(c);
-            latencyAllCommandsFillCDF(c, server.commands, &command_with_data);
+            latencyAllCommandsFillCDF(c, server.commands, &command_with_data, use_service_time);
             setDeferredMapLen(c, replylen, command_with_data);
         } else {
-            latencySpecificCommandsFillCDF(c);
+            latencySpecificCommandsFillCDF(c, argc_end, use_service_time);
         }
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "help") && c->argc == 2) {
         const char *help[] = {
@@ -746,9 +755,10 @@ void latencyCommand(client *c) {
             "RESET [<event> ...]",
             "    Reset latency data of one or more <event> classes.",
             "    (default: reset all data for all event classes)",
-            "HISTOGRAM [COMMAND ...]",
+            "HISTOGRAM [COMMAND ...] [SERVICE]",
             "    Return a cumulative distribution of latencies in the format of a histogram for the specified command names.",
             "    If no commands are specified then all histograms are replied.",
+            "    Append SERVICE to get service time histograms instead of processing time.",
             NULL,
         };
         addReplyHelp(c, help);

--- a/src/module.c
+++ b/src/module.c
@@ -13244,6 +13244,10 @@ int moduleFreeCommand(struct ValkeyModule *module, struct serverCommand *cmd) {
         hdr_close(cmd->latency_histogram);
         cmd->latency_histogram = NULL;
     }
+    if (cmd->service_time_histogram) {
+        hdr_close(cmd->service_time_histogram);
+        cmd->service_time_histogram = NULL;
+    }
     for (int i = 0; i < RESP_CACHE_INDEX_MAX; i++) {
         if (cmd->info_cache[i]) {
             sdsfree(cmd->info_cache[i]);

--- a/src/networking.c
+++ b/src/networking.c
@@ -31,6 +31,7 @@
 #include "cluster.h"
 #include "cluster_slot_stats.h"
 #include "cluster_migrateslots.h"
+#include "service_time.h"
 #include "script.h"
 #include "intset.h"
 #include "sds.h"
@@ -345,6 +346,10 @@ client *createClient(connection *conn) {
     c->slot = -1;
     c->ctime = c->last_interaction = server.unixtime;
     c->duration = 0;
+    c->service_time_start = 0;
+    c->service_time_entry.cmd = NULL;
+    c->service_time_entry.count = 0;
+    c->service_time_pipeline_count = 0;
     clientSetDefaultAuth(c);
     c->slot_migration_job = NULL;
     c->reply = listCreate();
@@ -870,6 +875,7 @@ void afterErrorReply(client *c, const char *s, size_t len, int flags) {
     if (!(flags & ERR_REPLY_FLAG_NO_STATS_UPDATE)) {
         /* Increment the global error counter */
         server.stat_total_error_replies++;
+        serviceTime_reset(c);
         /* Increment the error stats
          * If the string already starts with "-..." then the error prefix
          * is provided by the caller (we limit the search to 32 chars). Otherwise we use "-ERR". */
@@ -3064,6 +3070,7 @@ int postWriteToClient(client *c) {
     server.stat_total_writes_processed++;
     if (getClientType(c) != CLIENT_TYPE_REPLICA) {
         _postWriteToClient(c);
+        serviceTime_recordLatencies(c);
     } else {
         postWriteToReplica(c);
     }
@@ -3371,6 +3378,8 @@ int handleClientsWithPendingWrites(void) {
 void resetClient(client *c) {
     serverCommandProc *prevcmd = c->cmd ? c->cmd->proc : NULL;
     serverCommandProc *prevParentCmd = c->cmd && c->cmd->parent ? c->cmd->parent->proc : NULL;
+
+    serviceTime_trackCmd(c);
 
     freeClientArgv(c);
     freeClientOriginalArgv(c);

--- a/src/server.c
+++ b/src/server.c
@@ -40,6 +40,7 @@
 #include "commandlog.h"
 #include "bio.h"
 #include "latency.h"
+#include "service_time.h"
 #include "mt19937-64.h"
 #include "functions.h"
 #include "hdr_histogram.h"
@@ -3359,6 +3360,7 @@ int populateCommandStructure(struct serverCommand *c) {
     /* We start with an unallocated histogram and only allocate memory when a command
      * has been issued for the first time */
     c->latency_histogram = NULL;
+    c->service_time_histogram = NULL;
 
     /* Initialize command info cache */
     for (int i = 0; i < RESP_CACHE_INDEX_MAX; i++) {
@@ -3425,6 +3427,10 @@ void resetCommandTableStats(hashtable *commands) {
         if (c->latency_histogram) {
             hdr_close(c->latency_histogram);
             c->latency_histogram = NULL;
+        }
+        if (c->service_time_histogram) {
+            hdr_close(c->service_time_histogram);
+            c->service_time_histogram = NULL;
         }
         if (c->subcommands_ht) resetCommandTableStats(c->subcommands_ht);
     }
@@ -3893,6 +3899,8 @@ void call(client *c, int flags) {
      * as an entry point is if a module triggers RM_Call outside of call()
      * context (for example, in a timer).
      * In that case, the module is in charge of propagation. */
+
+    serviceTime_startTimer(c);
 
     /* Call the command. */
     dirty = server.dirty;

--- a/src/server.h
+++ b/src/server.h
@@ -1296,6 +1296,12 @@ typedef struct LastWrittenBuf {
 /* Forward declaration of slotMigrationJob */
 typedef struct slotMigrationJob slotMigrationJob;
 
+/* Entry for tracking per-command service time in a pipelined batch. */
+typedef struct serviceTimeCmdEntry {
+    struct serverCommand *cmd;
+    int count;
+} serviceTimeCmdEntry;
+
 typedef struct client {
     /* Basic client information and connection. */
     uint64_t id; /* Client incremental unique ID. */
@@ -1330,15 +1336,21 @@ typedef struct client {
     multiState *mstate;               /* MULTI/EXEC state, lazily initialized when first needed */
     blockingState *bstate;            /* Blocking state, lazily initialized when first needed */
     /* Output buffer and reply handling */
-    long duration;                       /* Current command duration. Used for measuring latency of blocking/non-blocking cmds */
-    char *buf;                           /* Output buffer */
-    size_t buf_usable_size;              /* Usable size of buffer. */
-    list *reply;                         /* List of reply objects to send to the client. */
-    listNode *io_last_reply_block;       /* Last client reply block when sent to IO thread */
-    size_t io_last_bufpos;               /* The client's bufpos at the time it was sent to the IO thread */
-    LastWrittenBuf io_last_written;      /* Track state for last written buffer */
-    unsigned long long reply_bytes;      /* Tot bytes of objects in reply list. */
-    listNode clients_pending_write_node; /* list node in clients_pending_write or in clients_pending_io_write list */
+    long duration; /* Current command duration. Used for measuring latency of blocking/non-blocking cmds */
+    /* Service time latency tracking */
+    monotime service_time_start;            /* Event-loop wake time when this client's current cmd batch started. */
+    serviceTimeCmdEntry service_time_entry; /* First distinct command (covers non-pipelined case). */
+#define SERVICE_TIME_PIPELINE_CAP 3
+    serviceTimeCmdEntry service_time_pipeline[SERVICE_TIME_PIPELINE_CAP]; /* 2nd-4th distinct commands. */
+    int service_time_pipeline_count;                                      /* Number of pipeline slots in use. */
+    char *buf;                                                            /* Output buffer */
+    size_t buf_usable_size;                                               /* Usable size of buffer. */
+    list *reply;                                                          /* List of reply objects to send to the client. */
+    listNode *io_last_reply_block;                                        /* Last client reply block when sent to IO thread */
+    size_t io_last_bufpos;                                                /* The client's bufpos at the time it was sent to the IO thread */
+    LastWrittenBuf io_last_written;                                       /* Track state for last written buffer */
+    unsigned long long reply_bytes;                                       /* Tot bytes of objects in reply list. */
+    listNode clients_pending_write_node;                                  /* list node in clients_pending_write or in clients_pending_io_write list */
     size_t bufpos;
     payloadHeader *last_header; /* Pointer to the last header in a buffer when using copy avoidance */
     int original_argc;          /* Num of arguments of original command if arguments were rewritten. */
@@ -1996,6 +2008,7 @@ struct valkeyServer {
     int latency_tracking_enabled;              /* 1 if extended latency tracking is enabled, 0 otherwise. */
     double *latency_tracking_info_percentiles; /* Extended latency tracking info output percentile list configuration. */
     int latency_tracking_info_percentiles_len;
+    int service_time_tracking_enabled;        /* 1 if service time latency tracking is enabled. */
     unsigned int max_new_tls_conns_per_cycle; /* The maximum number of tls connections that will be accepted during each
                                                  invocation of the event loop. */
     unsigned int max_new_conns_per_cycle;     /* The maximum number of tcp connections that will be accepted during each
@@ -2720,7 +2733,9 @@ struct serverCommand {
     sds fullname;     /* Includes parent name if any: "parentcmd|childcmd". Unchanged if command is renamed. */
     sds current_name; /* Same as fullname, becomes a separate string if command is renamed. */
     struct hdr_histogram
-        *latency_histogram;        /* Points to the command latency command histogram (unit of time nanosecond). */
+        *latency_histogram; /* Points to the command latency command histogram (unit of time nanosecond). */
+    struct hdr_histogram
+        *service_time_histogram;   /* Per-command service time histogram (event-loop wake to response write, nanosecond). */
     keySpec legacy_range_key_spec; /* The legacy (first,last,step) key spec is
                                     * still maintained (if applicable) so that
                                     * we can still support the reply format of

--- a/src/service_time.c
+++ b/src/service_time.c
@@ -1,0 +1,99 @@
+#include "service_time.h"
+#include "hdr_histogram.h"
+
+#define SERVICE_TIME_MIN LATENCY_HISTOGRAM_MIN_VALUE
+#define SERVICE_TIME_MAX LATENCY_HISTOGRAM_MAX_VALUE
+#define SERVICE_TIME_SIGFIGS LATENCY_HISTOGRAM_PRECISION
+
+void serviceTime_startTimer(client *c) {
+    if (!server.service_time_tracking_enabled) return;
+
+    if (c->service_time_start == 0) {
+        c->service_time_start = aeGetWakeTime(server.el);
+    }
+}
+
+void serviceTime_trackCmd(client *c) {
+    if (!server.service_time_tracking_enabled) return;
+    if (c->service_time_start == 0) return;
+    if (c->flag.close_after_reply || c->flag.close_asap) {
+        serviceTime_reset(c);
+        return;
+    }
+    if (c->flag.reply_off || c->flag.reply_skip) {
+        serviceTime_reset(c);
+        return;
+    }
+    if (c->cmd == NULL) return;
+
+    /* Fast path: inline entry is unused or matches. */
+    if (c->service_time_entry.count == 0) {
+        c->service_time_entry.cmd = c->cmd;
+        c->service_time_entry.count = 1;
+        return;
+    }
+    if (c->service_time_entry.cmd == c->cmd) {
+        c->service_time_entry.count++;
+        return;
+    }
+
+    /* Scan pipeline entries for a match. */
+    for (int i = 0; i < c->service_time_pipeline_count; i++) {
+        if (c->service_time_pipeline[i].cmd == c->cmd) {
+            c->service_time_pipeline[i].count++;
+            return;
+        }
+    }
+
+    /* No match — add to pipeline entries if space, otherwise drop. */
+    if (c->service_time_pipeline_count < SERVICE_TIME_PIPELINE_CAP) {
+        c->service_time_pipeline[c->service_time_pipeline_count].cmd = c->cmd;
+        c->service_time_pipeline[c->service_time_pipeline_count].count = 1;
+        c->service_time_pipeline_count++;
+    }
+}
+
+static void updateCommandServiceTimeHistogram(struct hdr_histogram **histogram, int64_t duration_ns) {
+    if (*histogram == NULL) {
+        hdr_init(SERVICE_TIME_MIN, SERVICE_TIME_MAX, SERVICE_TIME_SIGFIGS, histogram);
+    }
+    if (duration_ns < SERVICE_TIME_MIN) duration_ns = SERVICE_TIME_MIN;
+    if (duration_ns > SERVICE_TIME_MAX) duration_ns = SERVICE_TIME_MAX;
+    hdr_record_value(*histogram, duration_ns);
+}
+
+void serviceTime_reset(client *c) {
+    c->service_time_start = 0;
+    c->service_time_entry.cmd = NULL;
+    c->service_time_entry.count = 0;
+    for (int i = 0; i < c->service_time_pipeline_count; i++) {
+        c->service_time_pipeline[i].cmd = NULL;
+        c->service_time_pipeline[i].count = 0;
+    }
+    c->service_time_pipeline_count = 0;
+}
+
+void serviceTime_recordLatencies(client *c) {
+    if (!server.service_time_tracking_enabled) return;
+    if (c->service_time_start == 0 || c->service_time_entry.count == 0) {
+        serviceTime_reset(c);
+        return;
+    }
+
+    monotime now = getMonotonicUs();
+    int64_t duration_ns = (int64_t)(now - c->service_time_start) * 1000;
+
+    /* Record inline entry. */
+    for (int i = 0; i < c->service_time_entry.count; i++) {
+        updateCommandServiceTimeHistogram(&c->service_time_entry.cmd->service_time_histogram, duration_ns);
+    }
+
+    /* Record pipeline entries. */
+    for (int i = 0; i < c->service_time_pipeline_count; i++) {
+        for (int j = 0; j < c->service_time_pipeline[i].count; j++) {
+            updateCommandServiceTimeHistogram(&c->service_time_pipeline[i].cmd->service_time_histogram, duration_ns);
+        }
+    }
+
+    serviceTime_reset(c);
+}

--- a/src/service_time.h
+++ b/src/service_time.h
@@ -1,0 +1,18 @@
+#ifndef SERVICE_TIME_H
+#define SERVICE_TIME_H
+
+#include "server.h"
+
+/* Record the event-loop wake time as the start of service time for this client. */
+void serviceTime_startTimer(client *c);
+
+/* After a command is fully processed, record it for service time attribution. */
+void serviceTime_trackCmd(client *c);
+
+/* Flush service time sample into the per-command histogram (called after write to client). */
+void serviceTime_recordLatencies(client *c);
+
+/* Reset service time tracking state on the client (on error or skip). */
+void serviceTime_reset(client *c);
+
+#endif

--- a/tests/unit/service-time-latency.tcl
+++ b/tests/unit/service-time-latency.tcl
@@ -1,0 +1,229 @@
+start_server {tags {"service-time-latency"}} {
+    test {Service time tracking disabled by default} {
+        assert_equal [r config get latency-service-time-tracking] {latency-service-time-tracking no}
+        r set a b
+        r get a
+        set histo [r latency histogram set get SERVICE]
+        assert_equal [llength $histo] 0
+    }
+
+    test {Service time tracking can be enabled} {
+        r config set latency-service-time-tracking yes
+        assert_equal [r config get latency-service-time-tracking] {latency-service-time-tracking yes}
+    }
+
+    test {LATENCY HISTOGRAM SERVICE basic recording} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r set a b
+        r set c d
+        r get a
+        set histo [dict create {*}[r latency histogram set get SERVICE]]
+        assert_match {calls 2 histogram_usec *} [dict get $histo set]
+        assert_match {calls 1 histogram_usec *} [dict get $histo get]
+    }
+
+    test {LATENCY HISTOGRAM SERVICE specific commands} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r set a b
+        r set c d
+        r get a
+        r hset f k v
+        set histo [dict create {*}[r latency histogram set hset SERVICE]]
+        assert_match {calls 2 histogram_usec *} [dict get $histo set]
+        assert_match {calls 1 histogram_usec *} [dict get $histo hset]
+        assert_equal [dict size $histo] 2
+    }
+
+    test {LATENCY HISTOGRAM SERVICE does not affect processing time histogram} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r set a b
+        r get a
+        # Processing time histogram (without SERVICE) should still work
+        set proc_histo [dict create {*}[r latency histogram set get]]
+        assert_match {calls 1 histogram_usec *} [dict get $proc_histo set]
+        assert_match {calls 1 histogram_usec *} [dict get $proc_histo get]
+        # Service time histogram should also have data
+        set svc_histo [dict create {*}[r latency histogram set get SERVICE]]
+        assert_match {calls 1 histogram_usec *} [dict get $svc_histo set]
+        assert_match {calls 1 histogram_usec *} [dict get $svc_histo get]
+    }
+
+    test {LATENCY HISTOGRAM SERVICE with unknown command returns empty} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r set a b
+        set histo [r latency histogram blabla SERVICE]
+        assert_equal [llength $histo] 0
+    }
+
+    test {LATENCY HISTOGRAM SERVICE all commands} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r set a b
+        r get a
+        r hset f k v
+        set histo [dict create {*}[r latency histogram SERVICE]]
+        assert {[dict exists $histo set]}
+        assert {[dict exists $histo get]}
+        assert {[dict exists $histo hset]}
+    }
+
+    test {Service time is greater than or equal to processing time} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r set a b
+        set svc_histo [dict create {*}[r latency histogram set SERVICE]]
+        set proc_histo [dict create {*}[r latency histogram set]]
+        # Extract the max bucket from each (last value in histogram_usec)
+        set svc_data [dict get [dict get $svc_histo set] histogram_usec]
+        set proc_data [dict get [dict get $proc_histo set] histogram_usec]
+        # Last bucket ceiling in service time should be >= processing time
+        set svc_max [lindex $svc_data end-1]
+        set proc_max [lindex $proc_data end-1]
+        assert {$svc_max >= $proc_max}
+    }
+
+    test {Service time not recorded when tracking is disabled} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r set a b
+        # Verify data exists
+        set histo [dict create {*}[r latency histogram set SERVICE]]
+        assert_match {calls 1 histogram_usec *} [dict get $histo set]
+        # Disable and send more commands
+        r config set latency-service-time-tracking no
+        r config resetstat
+        r set a b
+        r set c d
+        set histo [r latency histogram set SERVICE]
+        assert_equal [llength $histo] 0
+    }
+
+    test {Service time with MULTI/EXEC records once for EXEC} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r multi
+        r set a b
+        r set c d
+        r get a
+        r exec
+        # Sub-commands should not be recorded individually
+        # Only exec should have a service time entry
+        set histo [dict create {*}[r latency histogram exec SERVICE]]
+        assert_match {calls 1 histogram_usec *} [dict get $histo exec]
+    }
+
+    test {Service time with pipeline records correct call counts} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        # Use a pipeline
+        set rd [valkey_deferring_client]
+        $rd write "*3\r\n\$3\r\nSET\r\n\$1\r\na\r\n\$1\r\nb\r\n"
+        $rd write "*3\r\n\$3\r\nSET\r\n\$1\r\nc\r\n\$1\r\nd\r\n"
+        $rd write "*2\r\n\$3\r\nGET\r\n\$1\r\na\r\n"
+        $rd flush
+        $rd read
+        $rd read
+        $rd read
+        $rd close
+        # Wait for write to complete
+        after 100
+        set histo [dict create {*}[r latency histogram set get SERVICE]]
+        assert_match {calls 2 histogram_usec *} [dict get $histo set]
+        assert_match {calls 1 histogram_usec *} [dict get $histo get]
+    }
+
+    test {LATENCY HISTOGRAM without SERVICE is unchanged} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r set a b
+        r get a
+        # Default (no SERVICE keyword) returns processing time
+        set histo [dict create {*}[r latency histogram set get]]
+        assert_match {calls 1 histogram_usec *} [dict get $histo set]
+        assert_match {calls 1 histogram_usec *} [dict get $histo get]
+    }
+
+    test {Error replies do not record service time} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r set mykey myval
+        # INCR on a string value will fail
+        catch {r incr mykey}
+        # The failed INCR should not appear in service time histogram
+        set histo [r latency histogram incr SERVICE]
+        assert_equal [llength $histo] 0
+    }
+
+    test {BLPOP service time includes blocked wait} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r del mylist
+        # Start a blocking pop in a separate client
+        set rd [valkey_deferring_client]
+        $rd blpop mylist 5
+        $rd flush
+        # Wait for client to block
+        wait_for_condition 50 100 {
+            [s blocked_clients] == 1
+        } else {
+            fail "Client not blocked"
+        }
+        # Wait 1 second then push to unblock
+        after 1000
+        r lpush mylist value
+        # Read the BLPOP result — this ensures the write has completed
+        set res [$rd read]
+        $rd close
+        after 100
+        r ping
+        # BLPOP is rewritten to LPOP internally when data is available,
+        # so service time is recorded under lpop.
+        set histo [dict create {*}[r latency histogram lpop SERVICE]]
+        assert {[dict exists $histo lpop]}
+        set data [dict get [dict get $histo lpop] histogram_usec]
+        # Last bucket ceiling should be at least 500ms (500000 usec) — includes blocked wait
+        set max_bucket [lindex $data end-1]
+        assert {$max_bucket >= 500000}
+    }
+
+    test {BLPOP timeout does not record service time} {
+        r config set latency-service-time-tracking yes
+        r config resetstat
+        r del mylist
+        # BLPOP with 1 second timeout — will time out (nothing pushed)
+        set rd [valkey_deferring_client]
+        $rd blpop mylist 1
+        wait_for_condition 50 100 {
+            [s blocked_clients] == 1
+        } else {
+            fail "Client not blocked"
+        }
+        # Wait for timeout
+        wait_for_condition 50 200 {
+            [s blocked_clients] == 0
+        } else {
+            fail "Client still blocked after timeout"
+        }
+        $rd read
+        $rd close
+        after 100
+        # Timed-out BLPOP returns nil — still gets recorded since it's a valid response
+        set histo [dict create {*}[r latency histogram blpop SERVICE]]
+        assert_match {calls 1 histogram_usec *} [dict get $histo blpop]
+    }
+
+    test {Config resetstat clears service time histograms} {
+        r config set latency-service-time-tracking yes
+        r set a b
+        r get a
+        set histo [dict create {*}[r latency histogram set get SERVICE]]
+        assert {[dict size $histo] >= 2}
+        r config resetstat
+        set histo [r latency histogram set get SERVICE]
+        assert_equal [llength $histo] 0
+    }
+}


### PR DESCRIPTION
## Summary

  Implements per-command service time tracking as proposed in #3718. Unlike the existing per-command processing time (`LATENCY HISTOGRAM`) which measures only CPU time inside call(), service time captures the full server-side delay from event-loop wake to response write — including queueing behind slow commands, pipeline batching, and blocking waits.

  ## Motivation

  Processing time alone hides queueing impact: one slow command produces one slow entry, while all commands queued behind it report fast processing time despite the client waiting.

  ## Design

  **Start point**: Event-loop wake time (`aeGetWakeTime`), recorded once per iteration after `aeApiPoll` returns. Excludes slow senders (timer starts after bytes are fully received and parsed).

  **End point**: After `write()` returns in `postWriteToClient`. Excludes slow receivers (response is in kernel buffer, not waiting for client ACK).

  **Per-command attribution**: Each `serverCommand` gets a `service_time_histogram` (HdrHistogram, allocated lazily on first use). Same histogram library and parameters as existing `latency_histogram`.

  **Pipeline handling**: An inline entry on the client struct handles the common single-command case. A capped array (3 additional slots) handles pipelines with multiple distinct commands. Commands beyond the cap are silently dropped.

  **MULTI/EXEC**: Sub-commands inside EXEC don't trigger recording (commandProcessed bails on flag.blocked). Only EXEC itself is recorded — one sample covering the whole transaction.

  **Blocking commands (BLPOP, WAIT)**: Service time includes the blocked wait, matching the proposal's intent to capture "the full server-side experience."

  ## Configuration

  | Parameter | Default | Description |
  |-----------|---------|-------------|
  | `latency-service-time-tracking` | no | Enable/disable service time collection |

  ## Commands

  LATENCY HISTOGRAM [command ...] SERVICE

  Appending `SERVICE` returns service time distributions instead of processing time. Without `SERVICE`, behaviour is unchanged (backward compatible).

  ## Memory overhead

  76 bytes per client (inline):
  - `service_time_start`: 8 bytes
  - `service_time_entry`: 16 bytes
  - `service_time_pipeline[3]`: 48 bytes
  - `service_time_pipeline_count`: 4 bytes

  Per-command histogram allocated only on first recording.

  ## Testing

  16 integration tests added (`tests/unit/service-time-latency.tcl`) covering:
  - Config enable/disable at runtime
  - Basic recording and per-command attribution
  - Pipeline correct call counts
  - MULTI/EXEC (records once for EXEC)
  - BLPOP (includes blocked wait)
  - Error replies (not recorded)
  - Backward compatibility (existing histogram unchanged)
  - Config resetstat clears histograms

 **Not included in this PR (follow-up once the design is finalized):**
  - Unit tests
  - Performance benchmarks with tracking on vs off

 ## Open questions / Feedback requested

  1. **BLPOP attribution**: Blocking commands are attributed to LPOP (not BLPOP) because Valkey rewrites the command vector for replication. Should we capture `c->cmd` before the rewrite to attribute to the original command?

  2. **Pipeline overflow cap**: Currently capped at 4 distinct commands per batch (silent drop beyond). Is this sufficient, or should we make it configurable?

  3. **IO threads interaction**: The proposal notes that with IO threads, the command is read by the IO thread but the timer starts when the main thread wakes. Is the current placement (after `aeApiPoll` returns) correct for the IO threads case, or do we need additional instrumentation?

  4. **Config naming**: We used `latency-service-time-tracking` to match the proposal. The existing processing time config is `latency-tracking`. Should these be unified under a single config with multiple modes (e.g., `latency-tracking-mode processing|service|both`)?

  5. **Histogram RESET**: The proposal mentions `LATENCY HISTOGRAM RESET [PROCESSING|SERVICE|ALL]` for periodic external collection. Should this be part of this PR or a follow-up?

  Fixes #3718