### PR TITLE
Add commandlog-retention-policy magnitude mode (#3895)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -526,6 +526,7 @@ ENGINE_SERVER_OBJ = \
     lzf_d.o \
     memory_prefetch.o \
     memtest.o \
+    minheap.o \
     module.o \
     monotonic.o \
     mt19937-64.o \

--- a/src/commandlog.c
+++ b/src/commandlog.c
@@ -23,6 +23,7 @@
  */
 
 #include "commandlog.h"
+#include "minheap.h"
 #include "script.h"
 
 /* Create a new commandlog entry.
@@ -95,6 +96,7 @@ void commandlogInit(void) {
     for (int i = 0; i < COMMANDLOG_TYPE_NUM; i++) {
         server.commandlog[i].entries = listCreate();
         server.commandlog[i].entry_id = 0;
+        server.commandlog[i].heap = minheapCreate();
         listSetFreeMethod(server.commandlog[i].entries, commandlogFreeEntry);
     }
 }
@@ -103,43 +105,96 @@ void commandlogInit(void) {
  * This function will make sure to trim the command log accordingly to the
  * configured max length. */
 static void commandlogPushEntryIfNeeded(client *c, robj **argv, int argc, long long value, int type) {
-    if (server.commandlog[type].threshold < 0 || server.commandlog[type].max_len == 0) return; /* The corresponding commandlog disabled */
-    if (value >= server.commandlog[type].threshold)
-        listAddNodeHead(server.commandlog[type].entries, commandlogCreateEntry(c, argv, argc, value, type));
+    commandlog *cl = &server.commandlog[type];
+    if (cl->threshold < 0 || cl->max_len == 0) return;
+    if (value < cl->threshold) return;
 
-    /* Remove old entries if needed. */
-    while (listLength(server.commandlog[type].entries) > server.commandlog[type].max_len) listDelNode(server.commandlog[type].entries, listLast(server.commandlog[type].entries));
+    if (cl->retention_policy == COMMANDLOG_RETENTION_MAGNITUDE) {
+        /* Magnitude mode: keep the N highest-value entries. */
+        minheap *heap = cl->heap;
+        if (minheapLen(heap) < cl->max_len) {
+            minheapInsert(heap, value, commandlogCreateEntry(c, argv, argc, value, type));
+        } else {
+            if (value <= minheapPeekMinKey(heap)) return;
+            commandlogFreeEntry(minheapExtractMin(heap));
+            minheapInsert(heap, value, commandlogCreateEntry(c, argv, argc, value, type));
+        }
+    } else {
+        /* Recency mode (default): keep the most recent entries. */
+        listAddNodeHead(cl->entries, commandlogCreateEntry(c, argv, argc, value, type));
+        while (listLength(cl->entries) > cl->max_len)
+            listDelNode(cl->entries, listLast(cl->entries));
+    }
 }
 
 /* Remove all the entries from the current command log of the specified type. */
 static void commandlogReset(int type) {
-    while (listLength(server.commandlog[type].entries) > 0) listDelNode(server.commandlog[type].entries, listLast(server.commandlog[type].entries));
+    commandlog *cl = &server.commandlog[type];
+    while (minheapLen(cl->heap) > 0) {
+        commandlogFreeEntry(minheapExtractMin(cl->heap));
+    }
+    while (listLength(cl->entries) > 0) {
+        listDelNode(cl->entries, listLast(cl->entries));
+    }
+}
+
+static unsigned long commandlogLength(int type) {
+    commandlog *cl = &server.commandlog[type];
+    if (cl->retention_policy == COMMANDLOG_RETENTION_MAGNITUDE) {
+        return minheapLen(cl->heap);
+    }
+    return listLength(cl->entries);
+}
+
+static void commandlogReplyWithEntry(client *c, commandlogEntry *ce) {
+    addReplyArrayLen(c, 6);
+    addReplyLongLong(c, ce->id);
+    addReplyLongLong(c, ce->time);
+    addReplyLongLong(c, ce->value);
+    addReplyArrayLen(c, ce->argc);
+    for (int j = 0; j < ce->argc; j++) addReplyBulk(c, ce->argv[j]);
+    addReplyBulkCBuffer(c, ce->peerid, sdslen(ce->peerid));
+    addReplyBulkCBuffer(c, ce->cname, sdslen(ce->cname));
+}
+
+static int commandlogEntryCompareDesc(const void *a, const void *b) {
+    const commandlogEntry *ea = *(const commandlogEntry **)a;
+    const commandlogEntry *eb = *(const commandlogEntry **)b;
+    if (eb->value > ea->value) return 1;
+    if (eb->value < ea->value) return -1;
+    return 0;
 }
 
 /* Reply command logs to client. */
 static void commandlogGetReply(client *c, int type, long count) {
-    listIter li;
-    listNode *ln;
-    commandlogEntry *ce;
+    commandlog *cl = &server.commandlog[type];
+    if (cl->retention_policy == COMMANDLOG_RETENTION_MAGNITUDE) {
+        unsigned long total = minheapLen(cl->heap);
+        if (count > (long)total) count = total;
+        /* Sort entries by value descending for display. */
+        commandlogEntry **sorted = zmalloc(sizeof(commandlogEntry *) * total);
+        for (unsigned long i = 0; i < total; i++) {
+            sorted[i] = minheapGet(cl->heap, i);
+        }
+        qsort(sorted, total, sizeof(commandlogEntry *), commandlogEntryCompareDesc);
+        addReplyArrayLen(c, count);
+        for (long i = 0; i < count; i++) {
+            commandlogReplyWithEntry(c, sorted[i]);
+        }
+        zfree(sorted);
+    } else {
+        listIter li;
+        listNode *ln;
 
-    if (count > (long)listLength(server.commandlog[type].entries)) {
-        count = listLength(server.commandlog[type].entries);
-    }
-    addReplyArrayLen(c, count);
-    listRewind(server.commandlog[type].entries, &li);
-    while (count--) {
-        int j;
-
-        ln = listNext(&li);
-        ce = ln->value;
-        addReplyArrayLen(c, 6);
-        addReplyLongLong(c, ce->id);
-        addReplyLongLong(c, ce->time);
-        addReplyLongLong(c, ce->value);
-        addReplyArrayLen(c, ce->argc);
-        for (j = 0; j < ce->argc; j++) addReplyBulk(c, ce->argv[j]);
-        addReplyBulkCBuffer(c, ce->peerid, sdslen(ce->peerid));
-        addReplyBulkCBuffer(c, ce->cname, sdslen(ce->cname));
+        if (count > (long)listLength(cl->entries)) {
+            count = listLength(cl->entries);
+        }
+        addReplyArrayLen(c, count);
+        listRewind(cl->entries, &li);
+        while (count--) {
+            ln = listNext(&li);
+            commandlogReplyWithEntry(c, ln->value);
+        }
     }
 }
 
@@ -192,7 +247,7 @@ void slowlogCommand(client *c) {
         commandlogReset(COMMANDLOG_TYPE_SLOW);
         addReply(c, shared.ok);
     } else if (c->argc == 2 && !strcasecmp(objectGetVal(c->argv[1]), "len")) {
-        addReplyLongLong(c, listLength(server.commandlog[COMMANDLOG_TYPE_SLOW].entries));
+        addReplyLongLong(c, commandlogLength(COMMANDLOG_TYPE_SLOW));
     } else if ((c->argc == 2 || c->argc == 3) && !strcasecmp(objectGetVal(c->argv[1]), "get")) {
         long count = 10;
 
@@ -205,7 +260,7 @@ void slowlogCommand(client *c) {
             if (count == -1) {
                 /* We treat -1 as a special value, which means to get all slow logs.
                  * Simply set count to the length of server.commandlog. */
-                count = listLength(server.commandlog[COMMANDLOG_TYPE_SLOW].entries);
+                count = commandlogLength(COMMANDLOG_TYPE_SLOW);
             }
         }
 
@@ -251,7 +306,7 @@ void commandlogCommand(client *c) {
         addReply(c, shared.ok);
     } else if (c->argc == 3 && !strcasecmp(objectGetVal(c->argv[1]), "len")) {
         if ((type = commandlogGetTypeOrReply(c, c->argv[2])) == -1) return;
-        addReplyLongLong(c, listLength(server.commandlog[type].entries));
+        addReplyLongLong(c, commandlogLength(type));
     } else if (c->argc == 4 && !strcasecmp(objectGetVal(c->argv[1]), "get")) {
         long count;
 
@@ -263,9 +318,7 @@ void commandlogCommand(client *c) {
         if ((type = commandlogGetTypeOrReply(c, c->argv[3])) == -1) return;
 
         if (count == -1) {
-            /* We treat -1 as a special value, which means to get all command logs.
-             * Simply set count to the length of server.commandlog. */
-            count = listLength(server.commandlog[type].entries);
+            count = commandlogLength(type);
         }
 
         commandlogGetReply(c, type, count);

--- a/src/config.c
+++ b/src/config.c
@@ -167,6 +167,11 @@ configEnum propagation_error_behavior_enum[] = {
 
 configEnum log_format_enum[] = {{"legacy", LOG_FORMAT_LEGACY}, {"logfmt", LOG_FORMAT_LOGFMT}, {"json", LOG_FORMAT_JSON}, {NULL, 0}};
 
+configEnum commandlog_retention_policy_enum[] = {
+    {"recency", COMMANDLOG_RETENTION_RECENCY},
+    {"magnitude", COMMANDLOG_RETENTION_MAGNITUDE},
+    {NULL, 0}};
+
 configEnum log_timestamp_format_enum[] = {{"legacy", LOG_TIMESTAMP_LEGACY},
                                           {"iso8601", LOG_TIMESTAMP_ISO8601},
                                           {"milliseconds", LOG_TIMESTAMP_MILLISECONDS},
@@ -3378,6 +3383,9 @@ standardConfig static_configs[] = {
     createEnumConfig("shutdown-on-sigterm", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, shutdown_on_sig_enum, server.shutdown_on_sigterm, 0, isValidShutdownOnSigFlags, NULL),
     createEnumConfig("log-format", NULL, MODIFIABLE_CONFIG, log_format_enum, server.log_format, LOG_FORMAT_LEGACY, NULL, NULL),
     createEnumConfig("log-timestamp-format", NULL, MODIFIABLE_CONFIG, log_timestamp_format_enum, server.log_timestamp_format, LOG_TIMESTAMP_LEGACY, NULL, NULL),
+    createEnumConfig("commandlog-slow-retention-policy", NULL, MODIFIABLE_CONFIG, commandlog_retention_policy_enum, server.commandlog[COMMANDLOG_TYPE_SLOW].retention_policy, COMMANDLOG_RETENTION_RECENCY, NULL, NULL),
+    createEnumConfig("commandlog-large-request-retention-policy", NULL, MODIFIABLE_CONFIG, commandlog_retention_policy_enum, server.commandlog[COMMANDLOG_TYPE_LARGE_REQUEST].retention_policy, COMMANDLOG_RETENTION_RECENCY, NULL, NULL),
+    createEnumConfig("commandlog-large-reply-retention-policy", NULL, MODIFIABLE_CONFIG, commandlog_retention_policy_enum, server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].retention_policy, COMMANDLOG_RETENTION_RECENCY, NULL, NULL),
     createEnumConfig("rdb-version-check", NULL, MODIFIABLE_CONFIG, rdb_version_check_enum, server.rdb_version_check, RDB_VERSION_CHECK_STRICT, NULL, NULL),
 
     /* Integer configs */

--- a/src/minheap.c
+++ b/src/minheap.c
@@ -1,0 +1,94 @@
+#include "minheap.h"
+#include "zmalloc.h"
+#include <assert.h>
+
+#define MINHEAP_INITIAL_CAPACITY 8
+
+static void swap(minheapNode *a, minheapNode *b) {
+    minheapNode tmp = *a;
+    *a = *b;
+    *b = tmp;
+}
+
+static void swim(minheap *heap, unsigned long idx) {
+    while (idx > 1) {
+        unsigned long parent = idx / 2;
+        if (heap->nodes[idx].key < heap->nodes[parent].key) {
+            swap(&heap->nodes[idx], &heap->nodes[parent]);
+            idx = parent;
+        } else {
+            break;
+        }
+    }
+}
+
+static void sink(minheap *heap, unsigned long idx) {
+    while (1) {
+        unsigned long smallest = idx;
+        unsigned long left = 2 * idx;
+        unsigned long right = 2 * idx + 1;
+
+        if (left <= heap->len && heap->nodes[left].key < heap->nodes[smallest].key)
+            smallest = left;
+        if (right <= heap->len && heap->nodes[right].key < heap->nodes[smallest].key)
+            smallest = right;
+
+        if (smallest != idx) {
+            swap(&heap->nodes[idx], &heap->nodes[smallest]);
+            idx = smallest;
+        } else {
+            break;
+        }
+    }
+}
+
+minheap *minheapCreate(void) {
+    minheap *heap = zmalloc(sizeof(minheap));
+    heap->nodes = NULL;
+    heap->len = 0;
+    heap->capacity = 0;
+    return heap;
+}
+
+void minheapRelease(minheap *heap) {
+    if (heap->nodes) zfree(heap->nodes);
+    zfree(heap);
+}
+
+void *minheapPeekMin(minheap *heap) {
+    if (heap->len == 0) return NULL;
+    return heap->nodes[1].value;
+}
+
+long long minheapPeekMinKey(minheap *heap) {
+    assert(heap->len > 0);
+    return heap->nodes[1].key;
+}
+
+void minheapInsert(minheap *heap, long long key, void *value) {
+    if (heap->len + 1 >= heap->capacity) {
+        unsigned long new_cap = heap->capacity == 0 ? MINHEAP_INITIAL_CAPACITY : heap->capacity * 2;
+        heap->nodes = zrealloc(heap->nodes, new_cap * sizeof(minheapNode));
+        heap->capacity = new_cap;
+    }
+    heap->len++;
+    heap->nodes[heap->len].key = key;
+    heap->nodes[heap->len].value = value;
+    swim(heap, heap->len);
+}
+
+void *minheapExtractMin(minheap *heap) {
+    if (heap->len == 0) return NULL;
+    void *min_value = heap->nodes[1].value;
+    heap->nodes[1] = heap->nodes[heap->len];
+    heap->len--;
+    if (heap->len > 0) {
+        sink(heap, 1);
+    }
+    return min_value;
+}
+
+void *minheapGet(minheap *heap, unsigned long idx) {
+    if (idx >= heap->len) return NULL;
+    return heap->nodes[idx + 1].value;
+}

--- a/src/minheap.h
+++ b/src/minheap.h
@@ -1,0 +1,29 @@
+#ifndef __MINHEAP_H__
+#define __MINHEAP_H__
+
+/* Min-heap implementation. 1-indexed: root at nodes[1], nodes[0] unused. */
+
+#include <stddef.h>
+
+typedef struct minheapNode {
+    long long key;
+    void *value;
+} minheapNode;
+
+typedef struct minheap {
+    minheapNode *nodes;
+    unsigned long len;
+    unsigned long capacity;
+} minheap;
+
+minheap *minheapCreate(void);
+void minheapRelease(minheap *heap);
+void minheapInsert(minheap *heap, long long key, void *value);
+void *minheapExtractMin(minheap *heap);
+void *minheapPeekMin(minheap *heap);
+long long minheapPeekMinKey(minheap *heap);
+void *minheapGet(minheap *heap, unsigned long idx);
+
+#define minheapLen(h) ((h)->len)
+
+#endif

--- a/src/server.h
+++ b/src/server.h
@@ -375,12 +375,20 @@ typedef enum {
     COMMANDLOG_TYPE_NUM
 } commandlog_type;
 
+/* Retention policy for commandlog */
+#define COMMANDLOG_RETENTION_RECENCY 0
+#define COMMANDLOG_RETENTION_MAGNITUDE 1
+
+struct minheap;
+
 /* Configuration and entry list of different types of command logs */
 typedef struct commandlog {
-    list *entries;
+    list *entries;        /* Used in recency mode. */
+    struct minheap *heap; /* Used in magnitude mode. */
     long long entry_id;
     long long threshold;
     unsigned long max_len;
+    int retention_policy;
 } commandlog;
 
 /* Replica replication state. Used in server.repl_state for replicas to remember

--- a/tests/unit/commandlog-magnitude.tcl
+++ b/tests/unit/commandlog-magnitude.tcl
@@ -1,0 +1,142 @@
+start_server {tags {"commandlog-magnitude"} overrides {commandlog-execution-slower-than 0 commandlog-slow-execution-max-len 5 commandlog-slow-retention-policy magnitude}} {
+
+    test {Magnitude mode - config is set correctly} {
+        assert_equal [lindex [r config get commandlog-slow-retention-policy] 1] {magnitude}
+    }
+
+    test {Magnitude mode - reset works} {
+        r commandlog reset slow
+        # The reset command itself may be logged (threshold=0), so len <= 1
+        assert {[r commandlog len slow] <= 1}
+    }
+
+    test {Magnitude mode - entries are added up to max-len} {
+        r commandlog reset slow
+        for {set i 0} {$i < 10} {incr i} {
+            r set key$i val$i
+        }
+        assert_equal [r commandlog len slow] 5
+    }
+
+    test {Magnitude mode - keeps highest value entries} {
+        r commandlog reset slow
+        # Send fast commands to fill the log
+        for {set i 0} {$i < 10} {incr i} {
+            r set key$i val$i
+        }
+        # All 5 entries should have non-zero values
+        set entries [r slowlog get 5]
+        foreach entry $entries {
+            set value [lindex $entry 2]
+            assert {$value > 0}
+        }
+    }
+
+    test {Magnitude mode - slow command displaces fast ones} {
+        r commandlog reset slow
+        # Fill with fast commands
+        for {set i 0} {$i < 10} {incr i} {
+            r set key$i val$i
+        }
+        # Record the current minimum value
+        set entries [r slowlog get 5]
+        set min_val [lindex [lindex $entries 0] 2]
+        foreach entry $entries {
+            set val [lindex $entry 2]
+            if {$val < $min_val} { set min_val $val }
+        }
+        # Now do a slow command (sleep 10ms)
+        r debug sleep 0.01
+        # The slow command should be in the log
+        set entries [r slowlog get 5]
+        set found_slow 0
+        foreach entry $entries {
+            set val [lindex $entry 2]
+            if {$val > 5000} { set found_slow 1 }
+        }
+        assert_equal $found_slow 1
+    } {} {needs:debug}
+
+    test {Magnitude mode - O(1) rejection of below-minimum values} {
+        r commandlog reset slow
+        # Fill with debug sleep commands (high value)
+        for {set i 0} {$i < 5} {incr i} {
+            r debug sleep 0.01
+        }
+        # All entries should be > 5000 usec
+        set entries [r slowlog get 5]
+        foreach entry $entries {
+            set val [lindex $entry 2]
+            assert {$val > 5000}
+        }
+        # Now send fast commands - they should be rejected
+        for {set i 0} {$i < 20} {incr i} {
+            r set key$i val$i
+        }
+        # Log should still only have the slow commands
+        set entries [r slowlog get 5]
+        foreach entry $entries {
+            set val [lindex $entry 2]
+            assert {$val > 5000}
+        }
+    } {} {needs:debug}
+
+    test {Magnitude mode - reset clears entries} {
+        for {set i 0} {$i < 10} {incr i} {
+            r set key$i val$i
+        }
+        assert_equal [r commandlog len slow] 5
+        r commandlog reset slow
+        # After reset, only the reset command itself may remain (threshold=0)
+        assert {[r commandlog len slow] <= 1}
+    }
+
+    test {Magnitude mode - len grows with commands} {
+        r commandlog reset slow
+        set baseline [r commandlog len slow]
+        r set a b
+        r set c d
+        r set e f
+        assert {[r commandlog len slow] >= [expr {$baseline + 3}]}
+    }
+
+    test {Magnitude mode - max-len bounds the log size} {
+        r commandlog reset slow
+        for {set i 0} {$i < 100} {incr i} {
+            r set key$i val$i
+        }
+        assert_equal [r commandlog len slow] 5
+    }
+
+    test {Magnitude mode - disabled with threshold -1} {
+        r config set commandlog-execution-slower-than -1
+        r commandlog reset slow
+        for {set i 0} {$i < 10} {incr i} {
+            r set key$i val$i
+        }
+        assert_equal [r commandlog len slow] 0
+        r config set commandlog-execution-slower-than 0
+    }
+
+    test {Magnitude mode - disabled with max-len 0} {
+        r config set commandlog-slow-execution-max-len 0
+        r commandlog reset slow
+        for {set i 0} {$i < 10} {incr i} {
+            r set key$i val$i
+        }
+        assert_equal [r commandlog len slow] 0
+        r config set commandlog-slow-execution-max-len 5
+    }
+
+    test {Recency mode still works when configured} {
+        r config set commandlog-slow-retention-policy recency
+        r commandlog reset slow
+        for {set i 0} {$i < 10} {incr i} {
+            r set key$i val$i
+        }
+        # Should keep at most max-len entries (5)
+        assert_equal [r commandlog len slow] 5
+        # Restore
+        r config set commandlog-slow-retention-policy magnitude
+    }
+}


### PR DESCRIPTION
 ## Summary

  Implements dynamic top-N retention mode for COMMANDLOG/SLOWLOG as proposed in #3895.

  In magnitude mode, the command log keeps the N highest-value entries instead of the most recent N. When the log is full, a new entry displaces the current minimum only if its value exceeds it. This allows operators to set `threshold=0` and let the log self-tune to genuine outliers without threshold guessing.

  ## Design

  **Data structure**: A min-heap (`minheap.h/c`) provides O(1) rejection of below-minimum entries and O(log N) insert/evict when displacement occurs. The heap is array-based and cache-friendly for small N.
  
**Hot path optimization**: When the heap is full, entries below the current minimum are rejected in O(1) via `minheapPeekMinKey()` — no allocation, no heap traversal. This is critical since with `threshold=0` every command is a candidate.
  
**Display order**: `SLOWLOG GET` / `COMMANDLOG GET` in magnitude mode returns entries sorted by value descending (highest first). Sorting is done at query time via `qsort` — not on the hot path.
  
**Backward compatibility**: Default retention policy is `recency` (current behavior unchanged). Magnitude mode is opt-in per type.

  ## Configuration

  | Parameter | Default | Description |
  |-----------|---------|-------------|
  | `commandlog-slow-retention-policy` | recency | recency or magnitude |
  | `commandlog-large-request-retention-policy` | recency | recency or magnitude |
  | `commandlog-large-reply-retention-policy` | recency | recency or magnitude |

  ## Usage

  CONFIG SET commandlog-slow-retention-policy magnitude
  SLOWLOG GET 10

  ## Testing

  12 integration tests (`tests/unit/commandlog-magnitude.tcl`) covering:
  - Config set/get
  - Entries bounded to max-len
  - Highest values retained, fast commands rejected
  - Reset, disable via threshold/max-len
  - Recency mode backward compatibility

## Pending tests (after design is finalised)
  - Min-heap unit tests: insert/extract ordering, duplicate keys, resize, empty heap edge cases
  - Runtime policy switch: verify behaviour when switching between recency/magnitude
  - Performance benchmark: measure overhead of magnitude mode vs recency on hot path

  ## Open questions / Feedback requested

  1. High level feedback on the implementation.
 
  2. **SLOWLOG GET self-logging**: the SLOWLOG GET command itself gets logged and can displace useful entries. Should SLOWLOG/COMMANDLOG commands have `CMD_SKIP_COMMANDLOG` in magnitude mode?

  3. **Runtime policy switch**: Switching from magnitude to recency (or vice versa) leaves stale entries in the unused data structure. Should we drain on switch, or is manual `COMMANDLOG RESET` sufficient?

  4. **Entry aging**: Entries in magnitude mode live until displaced. Should there be an optional TTL to age out very old entries?

  5. **Heap vs flat array**: For the default `max_len=128`, a linear scan with cached-min would be equally fast and simpler. The heap is better for large N. Is there a preference from the community?

  Fixes #3895