### PR TITLE
Restore client's selected DB after module keyspace notification

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -9494,6 +9494,14 @@ void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid)
     /* Remove irrelevant flags from the type mask */
     type &= ~(NOTIFY_KEYEVENT | NOTIFY_KEYSPACE);
 
+    /* When notifying via the executing client, the callbacks below select
+     * 'dbid' on its context. 'dbid' may differ from the client's currently
+     * selected DB (e.g. MOVE/COPY notify on the destination DB), so save the
+     * original DB and restore it afterwards to avoid leaving the client on the
+     * wrong DB for subsequent commands. */
+    client *executing_client = server.executing_client;
+    int origin_dbid = (executing_client != NULL) ? executing_client->db->id : -1;
+
     while ((ln = listNext(&li))) {
         ValkeyModuleKeyspaceSubscriber *sub = ln->value;
         /* Only notify subscribers on events matching the registration,
@@ -9522,6 +9530,9 @@ void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid)
             moduleFreeContext(&ctx);
         }
     }
+
+    /* Restore the executing client's originally selected DB. */
+    if (executing_client != NULL) selectDb(executing_client, origin_dbid);
 
     exitExecutionUnit();
 }

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -94,6 +94,42 @@ tags "modules" {
             assert_equal [r get testkeyspace:expired] 1
         }
 
+        test {MOVE restores client DB after module keyspace notification} {
+            # MOVE fires move_from/move_to notifications on the source and
+            # destination DBs. The module subscribes to NOTIFY_GENERIC, and
+            # the bug left the client selected on the destination DB.
+            r flushall
+            r select 0
+            r set movekey value
+
+            # The client must stay on its original DB (c->db unchanged).
+            assert_equal 1 [r move movekey 10]
+            assert_match {*db=0*} [r client info]
+
+            # If the client was still on db10, this would fail with
+            # "source and destination objects are the same" instead of 0.
+            assert_equal 0 [r move movekey 10]
+            assert_match {*db=0*} [r client info]
+        } {} {singledb:skip}
+
+        test {COPY restores client DB after module keyspace notification} {
+            # COPY fires a copy_to notification on the destination DB. The
+            # module subscribes to NOTIFY_GENERIC, and the bug left the client
+            # selected on the destination DB.
+            r flushall
+            r select 0
+            r set copykey value
+
+            # The client must stay on its original DB (c->db unchanged).
+            assert_equal 1 [r copy copykey copykey DB 10]
+            assert_match {*db=0*} [r client info]
+
+            # If the client was still on db10, this would fail with
+            # "source and destination objects are the same" instead of 0
+            assert_equal 0 [r copy copykey copykey DB 10]
+            assert_match {*db=0*} [r client info]
+        } {} {singledb:skip}
+
         test "Unload the module - testkeyspace" {
             assert_equal {OK} [r module unload testkeyspace]
         }


### PR DESCRIPTION
moduleNotifyKeyspaceEvent() runs subscriber callbacks on the executing
client and calls selectDb(dbid) on it, but never restores the DB. When
dbid differs from the client's current DB (e.g. MOVE/COPY notify on the
destination DB), the client is left on the wrong DB, breaking subsequent
commands.

This was introduced by #1819, which started reusing the executing client
instead of a temporary one. Save the executing client's DB before the
subscriber loop and restore it afterwards. Covers both MOVE and COPY.