### PR TITLE
Fix HRANDFIELD CASE 4 infinite loop when valid fields fewer than count

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2310,10 +2310,11 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     else {
         /* Hashtable encoding (generic implementation) */
         unsigned long added = 0;
+        unsigned long maxtries = (count > ULONG_MAX / 10) ? ULONG_MAX : count * 10;
         listpackEntry field, value;
         hashtable *ht = hashtableCreate(&setHashtableType);
         hashtableExpand(ht, count);
-        while (added < count) {
+        while (added < count && maxtries--) {
             /* In case we were unable to locate random element, it is probably because there is no such element
              * since all elements are expired. */
             if (hashTypeRandomElement(hash, size, &field, withvalues ? &value : NULL) != C_OK)

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1557,13 +1557,8 @@ start_server {tags {"hashexpire"}} {
         after 100
         assert_equal 100 [r HLEN myhash]
 
-        # Should return at most 29 valid fields without hanging
-        set start [clock milliseconds]
-        set result [r hrandfield myhash 30]
-        set elapsed [expr {[clock milliseconds] - $start}]
-
+        # Should return at most 29 valid fields without
         assert_lessthan_equal [llength $result] 29
-        assert_lessthan $elapsed 3000
 
         r DEBUG SET-ACTIVE-EXPIRE 1
     } {OK} {needs:debug}

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1540,6 +1540,34 @@ start_server {tags {"hashexpire"}} {
         }
     }
 
+    test "HRANDFIELD - CASE 4: does not loop forever when valid fields fewer than count" {
+        r FLUSHALL
+        r DEBUG SET-ACTIVE-EXPIRE 0
+
+        # 71 expired fields + 29 valid fields = 100 total
+        # count=30, count*3=90 < 100 -> CASE 4
+        for {set i 1} {$i <= 71} {incr i} {
+            r HSETEX myhash PX 1 FIELDS 1 f$i v$i
+        }
+        for {set i 72} {$i <= 100} {incr i} {
+            r HSET myhash f$i v$i
+        }
+
+        # Wait for fields to expire
+        after 100
+        assert_equal 100 [r HLEN myhash]
+
+        # Should return at most 29 valid fields without hanging
+        set start [clock milliseconds]
+        set result [r hrandfield myhash 30]
+        set elapsed [expr {[clock milliseconds] - $start}]
+
+        assert_lessthan_equal [llength $result] 29
+        assert_lessthan $elapsed 3000
+
+        r DEBUG SET-ACTIVE-EXPIRE 1
+    } {OK} {needs:debug}
+
     test "HRANDFIELD - returns null response when all fields are expired" {
         r FLUSHALL
         r DEBUG SET-ACTIVE-EXPIRE 0


### PR DESCRIPTION
### Problem

`HRANDFIELD` with a positive `count` can enter an infinite loop (CASE 4) when the number of non-expired fields in a hash is less than `count`.

**Example:**

A hash has 100 fields total: 71 with short TTLs (already expired) and 29 persistent fields. A client runs:

```
HRANDFIELD myhash 30
```

Since `count * 3 = 90 < 100 = size`, CASE 4 is selected. 
The loop calls `hashTypeRandomElement()`, which skips expired fields (via `validateEntry`), so it always returns one of the 29 valid fields. 
`hashTypeRandomElement()` retries up to 100 times internally to find a non-expired field. However, as long as any valid fields exist, this retry limit is rarely exhausted.
After collecting all 29 unique valid fields, every subsequent `hashtableAdd()` returns false (duplicate), but `added = 29 < count = 30`, so the loop never breaks.

This is reproducible when active expiry hasn't cleaned up the expired fields yet (e.g. on a replica, or during a burst of expirations).

### Fix

Add a `maxiter = count * 10` limit to the CASE 4 loop. When the iteration budget is exhausted, return whatever unique fields have been collected so far — returning fewer results is acceptable.
