### PR TITLE
Fix HGETDEL FIELDS token validation

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1162,7 +1162,7 @@ void hgetdelCommand(client *c) {
     long long num_fields = 0;
     bool keyremoved = false;
 
-    if (strcasecmp(objectGetVal(c->argv[2]),"fields")) {
+    if (strcasecmp(objectGetVal(c->argv[fields_index - 2]), "fields")) {
         addReplyErrorObject(c, shared.syntaxerr);
         return;
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1162,6 +1162,11 @@ void hgetdelCommand(client *c) {
     long long num_fields = 0;
     bool keyremoved = false;
 
+    if (strcasecmp(objectGetVal(c->argv[2]),"fields")) {
+        addReplyErrorObject(c, shared.syntaxerr);
+        return;
+    }
+
     if (getLongLongFromObjectOrReply(c, c->argv[fields_index - 1], &num_fields, NULL) != C_OK) return;
 
     /* Check that the parsed fields number matches the real provided number of fields */

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -512,7 +512,7 @@ start_server {tags {"hash"}} {
     }
 
     test {HGETDEL - check for syntax and type errors} {
-        assert_error "*value is not an integer or out of range" {r hgetdel myhash a b c}
+        assert_error "*ERR syntax error" {r hgetdel myhash a b c}
         assert_error "*value is not an integer or out of range" {r hgetdel myhash FIELDS a b c}
         assert_error "*numfields should be greater than 0 and match the provided number of fields" {r hgetdel myhash FIELDS 2 a b c}
         assert_error "*numfields should be greater than 0 and match the provided number of fields" {r hgetdel myhash FIELDS 4 a b c}

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -512,7 +512,7 @@ start_server {tags {"hash"}} {
     }
 
     test {HGETDEL - check for syntax and type errors} {
-        assert_error "*ERR syntax error" {r hgetdel myhash a b c}
+        assert_error "*ERR syntax error" {r hgetdel myhash a 1 c}
         assert_error "*value is not an integer or out of range" {r hgetdel myhash FIELDS a b c}
         assert_error "*numfields should be greater than 0 and match the provided number of fields" {r hgetdel myhash FIELDS 2 a b c}
         assert_error "*numfields should be greater than 0 and match the provided number of fields" {r hgetdel myhash FIELDS 4 a b c}


### PR DESCRIPTION
Add explicit validation for the FIELDS token before parsing numfields.

Fixes #4045.