### PR TITLE
Require a [release-notes] or [no-release-notes] label on PRs

### DIFF
--- a/.github/workflows/release-notes-label.yml
+++ b/.github/workflows/release-notes-label.yml
@@ -1,0 +1,41 @@
+# Enforce that every pull request carries exactly one release-notes decision
+# label: `release-notes` (the change is user-facing and needs a note) or
+# `no-release-notes` (it does not). This requirement makes the release-notes
+# decision an explicit, reviewable step rather than something determined at
+# release time.
+#
+# The check reads the labels straight from the pull_request event payload, so
+# it needs no checkout, no token, and no write access. It re-runs whenever a
+# label is added or removed so the status reflects the current labels.
+name: Release Notes Label
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+concurrency:
+  group: release-notes-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check-label:
+    name: Require release-notes label
+    runs-on: ubuntu-latest
+    if: github.repository == 'valkey-io/valkey'
+    steps:
+      - name: Require exactly one of release-notes / no-release-notes
+        env:
+          HAS_RELEASE_NOTES: ${{ contains(github.event.pull_request.labels.*.name, 'release-notes') }}
+          HAS_NO_RELEASE_NOTES: ${{ contains(github.event.pull_request.labels.*.name, 'no-release-notes') }}
+        run: |
+          if [ "$HAS_RELEASE_NOTES" = "true" ] && [ "$HAS_NO_RELEASE_NOTES" = "true" ]; then
+            echo "::error::This PR has both 'release-notes' and 'no-release-notes'. Apply exactly one."
+            exit 1
+          fi
+          if [ "$HAS_RELEASE_NOTES" != "true" ] && [ "$HAS_NO_RELEASE_NOTES" != "true" ]; then
+            echo "::error::This PR must carry exactly one label: 'release-notes' if the change is user-facing, or 'no-release-notes' if it is not."
+            exit 1
+          fi
+          echo "Release-notes label check passed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ which includes documentation about various best practices for writing Valkey cod
 To link a pull request to an existing issue, please write "Fixes #xyz" somewhere
 in the pull request description, where xyz is the issue number.
 
-Every pull request must carry exactly one of the `release-notes` or `no-release-notes` labels (a CI check enforces this); use `release-notes` if the change is user-facing.
+For committers (with label permissions): Every pull request must carry exactly one of the `release-notes` or `no-release-notes` labels (a CI check enforces this); use `release-notes` if the change is user-facing. Contributors will see a failing check, but no action is requested at this time.
 
 ## Code formatting with clang-format
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,8 @@ which includes documentation about various best practices for writing Valkey cod
 To link a pull request to an existing issue, please write "Fixes #xyz" somewhere
 in the pull request description, where xyz is the issue number.
 
+Every pull request must carry exactly one of the `release-notes` or `no-release-notes` labels (a CI check enforces this); use `release-notes` if the change is user-facing.
+
 ## Code formatting with clang-format
 
 Valkey enforces code formatting using `clang-format-18`. A CI check runs on


### PR DESCRIPTION
This PR is one part of an updated resolution for [Issue #3952](https://github.com/valkey-io/valkey/issues/3952):

**Current Scope** 
> The post-release side is mostly automated now. Once a release is cut, valkey-release-automation updates valkey-hashes, opens the valkey-container PR, and updates the website downloads page.

> However, writing the release notes and bumping the version is still done by hand.

> For each release, someone has to walk every PR since the last tag, decide which ones are user-facing, drop them into the right section of 00-RELEASENOTES, reword commit titles into something a user can read, pick the upgrade urgency, edit the three macros in src/version.h, and open the PR. The 9.1 cycle had ~88 PRs carrying the release-notes label.

**In this PR** 
All PRs are to be gated such that contributors mark an active decision for whether or not to include their PR in version release notes. This change will be enforced through the CI check added by this PR. Contributors must attach exactly one of either the `release-notes` or `no-release-notes` label, the latter being created by a maintainer prior to merging this current PR.

**Tentative Future Implementation** 
Rather than requiring contributors to write their own release notes into a running file on `unstable`, a workflow will live on `valkey-io/valkey-ci-agent` to generate notes via LLM with context from PR titles and bodies. The workflow will trigger by manual dispatch with inputs `head ref`, `base branch`, `tag glob`, `version`, `urgency`, and `date`, parsing all PRs with the `release-notes` label from head until the most recent reachable version release candidate tag. For each labelled PR, Bedrock/Claude will then determine a category of release note and construct a note in the form 
  * `human-readable description` by @`github handle` (#`PR number`) 

Previous release candidates' release notes, pulled from a pre-release branch on `valkey-io/valkey`, will be placed beneath the latest notes, with a full running list of contributor names and handles (See [target formatting](https://github.com/valkey-io/valkey/blob/9.1/00-RELEASENOTES)). The workflow will then raise a PR to create a frozen pre-release branch (release candidates) or version branch (general access) with updated version macros. Any ambiguities from the AI for categorization or necessity of release notes will be surfaced in warnings within the workflow's PR for human review. 