### PR TITLE
Optimize sendBulkToReplica to reduce lseek syscalls

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1722,8 +1722,16 @@ void sendBulkToReplica(connection *conn) {
         }
     }
 
-    /* If the preamble was already transferred, send the RDB bulk data. */
-    lseek(replica->repl_data->repldbfd, replica->repl_data->repldboff, SEEK_SET);
+    /* If the preamble was already transferred, send the RDB bulk data.
+     *
+     * Each replica holds its own private fd (opened independently via open()),
+     * so in the normal case (full write succeeds) read() advances the file
+     * offset by exactly buflen and repldboff is incremented by the same amount,
+     * keeping them in sync without needing lseek().
+     *
+     * We only need to lseek() on the retry paths where the file offset has
+     * drifted ahead of repldboff (EAGAIN or short write). Error paths that
+     * call freeClient() don't need recovery since the fd will be closed. */
     buflen = read(replica->repl_data->repldbfd, buf, PROTO_IOBUF_LEN);
     if (buflen <= 0) {
         serverLog(LL_WARNING, "Read error sending DB to replica: %s",
@@ -1735,11 +1743,30 @@ void sendBulkToReplica(connection *conn) {
         if (connGetState(conn) != CONN_STATE_CONNECTED) {
             serverLog(LL_WARNING, "Write error sending DB to replica: %s", connGetLastError(conn));
             freeClient(replica);
+        } else {
+            /* EAGAIN: write blocked, but read() already advanced the file
+             * offset by buflen. Seek back to repldboff so the next invocation
+             * re-reads the same chunk. */
+            if (lseek(replica->repl_data->repldbfd, replica->repl_data->repldboff, SEEK_SET) == -1) {
+                serverLog(LL_WARNING, "Seek error sending DB to replica: %s", strerror(errno));
+                freeClient(replica);
+                return;
+            }
         }
         return;
     }
     replica->repl_data->repldboff += nwritten;
     server.stat_net_repl_output_bytes += nwritten;
+    if (nwritten < buflen) {
+        /* Short write: only part of the data was sent. The file offset is
+         * now at repldboff_old + buflen, but we need it at the new repldboff
+         * (repldboff_old + nwritten) for the next read. Seek back. */
+        if (lseek(replica->repl_data->repldbfd, replica->repl_data->repldboff, SEEK_SET) == -1) {
+            serverLog(LL_WARNING, "Seek error sending DB to replica: %s", strerror(errno));
+            freeClient(replica);
+            return;
+        }
+    }
     if (replica->repl_data->repldboff == replica->repl_data->repldbsize) {
         closeRepldbfd(replica);
         connSetWriteHandler(replica->conn, NULL);


### PR DESCRIPTION
Previously, sendBulkToReplica() unconditionally called lseek() before
every read(), even though each replica has its own private file
descriptor (independently opened via open()). In the normal case where
connWrite() successfully sends all data, the file offset naturally
stays in sync with repldboff, making the lseek() redundant.

Move lseek() to only the recovery paths where the file offset has
drifted ahead of repldboff:

1. EAGAIN: connWrite() returns -1 but the connection is still alive.
 read() already advanced the file offset by buflen, so we must seek
 back to repldboff before the next invocation.

2. Short write: connWrite() returns fewer bytes than buflen. The file
 offset is at repldboff_old + buflen, but repldboff only advanced by
 nwritten, so we seek back to the new repldboff.

Error paths that call freeClient() do not need lseek() since the fd
will be closed during client cleanup. This eliminates one lseek syscall
per bulk write in the common case, significantly reducing system call
overhead during disk-based replication.
