### PR TITLE
Reject bare "(" and empty string in zset score ranges

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -633,7 +633,9 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
     } else {
         char *s = objectGetVal(min);
         size_t len = sdslen(s);
+        if (len == 0) return C_ERR;
         if (s[0] == '(') {
+            if (len == 1) return C_ERR; /* bare "(" with no score */
             spec->min = valkey_strtod_n(s + 1, len - 1, &eptr);
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
             spec->minex = 1;
@@ -647,7 +649,9 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
     } else {
         char *s = objectGetVal(max);
         size_t len = sdslen(s);
+        if (len == 0) return C_ERR;
         if (s[0] == '(') {
+            if (len == 1) return C_ERR; /* bare "(" with no score */
             spec->max = valkey_strtod_n(s + 1, len - 1, &eptr);
             if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
             spec->maxex = 1;

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -613,7 +613,9 @@ start_server {tags {"zset"}} {
             assert_error "*not*float*" {r zrangebyscore fooz ( +inf}
             assert_error "*not*float*" {r zrangebyscore fooz -inf (}
             assert_error "*not*float*" {r zrangebyscore fooz {} +inf}
+            assert_error "*not*float*" {r zrangebyscore fooz -inf {}}
             assert_error "*not*float*" {r zcount fooz ( +inf}
+            assert_error "*not*float*" {r zrangestore dest fooz ( +inf BYSCORE}
         }
 
         proc create_default_lex_zset {} {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -610,6 +610,10 @@ start_server {tags {"zset"}} {
             assert_error "*not*float*" {r zrangebyscore fooz str 1}
             assert_error "*not*float*" {r zrangebyscore fooz 1 str}
             assert_error "*not*float*" {r zrangebyscore fooz 1 NaN}
+            assert_error "*not*float*" {r zrangebyscore fooz ( +inf}
+            assert_error "*not*float*" {r zrangebyscore fooz -inf (}
+            assert_error "*not*float*" {r zrangebyscore fooz {} +inf}
+            assert_error "*not*float*" {r zcount fooz ( +inf}
         }
 
         proc create_default_lex_zset {} {


### PR DESCRIPTION
zslParseRange accepted a bare `(` as a score, silently treating it as `(0`, and an empty string as `0`. The `(` branch parses a zero-length number, which returns 0.0 with the end pointer already sitting on the terminator, so the existing `eptr[0] != '\0'` check passes.

Guard both branches with a length check so `(` with no number, and an empty string, return "not a float" like any other invalid score. Affects ZRANGEBYSCORE/ZREVRANGEBYSCORE/ZCOUNT/ZRANGESTORE.

Closes #3483.