### PR TITLE
Validate cluster-announce-ip is an IP address or hostname

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2459,6 +2459,18 @@ static int isValidAnnouncedNodename(char *val, const char **err) {
     return 1;
 }
 
+/* Validates the character set of a hostname (alphanumeric, hyphens and dots),
+ * without checking the length. Returns 1 if valid, 0 otherwise. */
+static int isValidHostname(const char *val) {
+    for (int i = 0; val[i]; i++) {
+        char c = val[i];
+        if (!((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || (c == '-') || (c == '.'))) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 static int isValidAnnouncedIp(char *val, const char **err) {
     if (sdslen(val) >= NET_IP_STR_LEN) {
         *err = "cluster-announce-ip is too long";
@@ -2468,12 +2480,12 @@ static int isValidAnnouncedIp(char *val, const char **err) {
         *err = "cluster-announce-ip contains invalid character";
         return 0;
     }
-    if (val[0] != '\0') {
-        char dst[sizeof(struct in6_addr)];
-        if (inet_pton(AF_INET, val, dst) != 1 && inet_pton(AF_INET6, val, dst) != 1) {
-            *err = "cluster-announce-ip is not a valid IPv4 or IPv6 address";
-            return 0;
-        }
+    /* Empty resets the announced ip. Otherwise accept a literal IPv4/IPv6, or a
+     * hostname, since some users set a hostname here before
+     * cluster-announce-hostname existed. */
+    if (val[0] != '\0' && anetResolve(NULL, val, NULL, 0, ANET_IP_ONLY) != ANET_OK && !isValidHostname(val)) {
+        *err = "cluster-announce-ip is not a valid IP address or hostname";
+        return 0;
     }
     return 1;
 }
@@ -2483,18 +2495,10 @@ static int isValidAnnouncedHostname(char *val, const char **err) {
         *err = "Hostnames must be less than " STRINGIFY(NET_HOST_STR_LEN) " characters";
         return 0;
     }
-
-    int i = 0;
-    char c;
-    while ((c = val[i])) {
-        /* We just validate the character set to make sure that everything
-         * is parsed and handled correctly. */
-        if (!((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || (c == '-') || (c == '.'))) {
-            *err = "Hostnames may only contain alphanumeric characters, "
-                   "hyphens or dots";
-            return 0;
-        }
-        c = val[i++];
+    if (!isValidHostname(val)) {
+        *err = "Hostnames may only contain alphanumeric characters, "
+               "hyphens or dots";
+        return 0;
     }
     return 1;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -2468,6 +2468,13 @@ static int isValidAnnouncedIp(char *val, const char **err) {
         *err = "cluster-announce-ip contains invalid character";
         return 0;
     }
+    if (val[0] != '\0') {
+        char dst[sizeof(struct in6_addr)];
+        if (inet_pton(AF_INET, val, dst) != 1 && inet_pton(AF_INET6, val, dst) != 1) {
+            *err = "cluster-announce-ip is not a valid IPv4 or IPv6 address";
+            return 0;
+        }
+    }
     return 1;
 }
 

--- a/tests/unit/cluster/cluster-aux-field-validation.tcl
+++ b/tests/unit/cluster/cluster-aux-field-validation.tcl
@@ -74,6 +74,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
     }
 
     test "cluster-announce-ip accepts empty string to reset" {
+        R 0 CONFIG SET cluster-announce-ip "192.168.1.100"
         R 0 CONFIG SET cluster-announce-ip ""
         assert_equal "" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
     }

--- a/tests/unit/cluster/cluster-aux-field-validation.tcl
+++ b/tests/unit/cluster/cluster-aux-field-validation.tcl
@@ -73,20 +73,27 @@ start_cluster 1 0 {tags {external:skip cluster}} {
         assert_equal "::1" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
     }
 
+    test "cluster-announce-ip accepts empty string to reset" {
+        R 0 CONFIG SET cluster-announce-ip ""
+        assert_equal "" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
+    }
+
+    test "cluster-announce-ip rejects IP with port" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*not a valid*" {
+            R 0 CONFIG SET cluster-announce-ip "10.1.131.239:6380"
+        }
+    }
+
+    test "cluster-announce-ip rejects non-IP string" {
+        assert_error "ERR CONFIG SET failed*cluster-announce-ip*not a valid*" {
+            R 0 CONFIG SET cluster-announce-ip "NotIPv4NorIPv6"
+        }
+    }
+
     test "cluster-announce-ip rejects value exceeding length limit" {
         assert_error "ERR CONFIG SET failed*cluster-announce-ip*too long*" {
             R 0 CONFIG SET cluster-announce-ip [string repeat "a" 100]
         }
-    }
-
-    test "cluster-announce-ip accepts hyphen, dot, colon, slash, underscore" {
-        R 0 CONFIG SET cluster-announce-ip "my-host_1.example:8080/path"
-        assert_equal "my-host_1.example:8080/path" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
-    }
-
-    test "cluster-announce-ip accepts high-byte UTF-8 characters" {
-        R 0 CONFIG SET cluster-announce-ip "\xc3\xa9"
-        assert_equal "\xc3\xa9" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
     }
 
     test "cluster-announce-human-nodename rejects control characters" {

--- a/tests/unit/cluster/cluster-aux-field-validation.tcl
+++ b/tests/unit/cluster/cluster-aux-field-validation.tcl
@@ -79,15 +79,20 @@ start_cluster 1 0 {tags {external:skip cluster}} {
         assert_equal "" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
     }
 
+    test "cluster-announce-ip accepts a hostname" {
+        R 0 CONFIG SET cluster-announce-ip "my-node.example.com"
+        assert_equal "my-node.example.com" [lindex [R 0 CONFIG GET cluster-announce-ip] 1]
+    }
+
     test "cluster-announce-ip rejects IP with port" {
         assert_error "ERR CONFIG SET failed*cluster-announce-ip*not a valid*" {
             R 0 CONFIG SET cluster-announce-ip "10.1.131.239:6380"
         }
     }
 
-    test "cluster-announce-ip rejects non-IP string" {
+    test "cluster-announce-ip rejects value that is neither IP nor hostname" {
         assert_error "ERR CONFIG SET failed*cluster-announce-ip*not a valid*" {
-            R 0 CONFIG SET cluster-announce-ip "NotIPv4NorIPv6"
+            R 0 CONFIG SET cluster-announce-ip "under_score"
         }
     }
 


### PR DESCRIPTION
cluster-announce-ip only checked length and aux-string characters, so values like `10.1.131.239:6380` were accepted and ended up in the gossip nodes.conf, breaking cluster bus addressing (the port got doubled: `10.1.131.239:6380:6380@16380`).

It now must be empty, a literal IPv4/IPv6 (via anetResolve with ANET_IP_ONLY), or a hostname. Hostnames are still accepted on purpose — some users set one here before cluster-announce-hostname existed, per @zuiderkwast on #3211. The hostname charset check is factored out into isValidHostname and shared with isValidAnnouncedHostname so there is no duplication.

Picking up #3211 which stalled; implements the approach @zuiderkwast outlined there. Closes #3199.