### PR TITLE
Rename reserved-identifier header guards to the NAME_H convention

### DIFF
--- a/src/adlist.h
+++ b/src/adlist.h
@@ -28,8 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __ADLIST_H__
-#define __ADLIST_H__
+#ifndef ADLIST_H
+#define ADLIST_H
 
 /* Node, List, and Iterator are the only data structures used currently. */
 
@@ -98,4 +98,4 @@ void listUnlinkNode(list *list, listNode *node);
 #define AL_START_HEAD 0
 #define AL_START_TAIL 1
 
-#endif /* __ADLIST_H__ */
+#endif /* ADLIST_H */

--- a/src/ae.h
+++ b/src/ae.h
@@ -30,8 +30,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __AE_H__
-#define __AE_H__
+#ifndef AE_H
+#define AE_H
 
 #include "monotonic.h"
 #include <pthread.h>

--- a/src/allocator_defrag.h
+++ b/src/allocator_defrag.h
@@ -1,5 +1,5 @@
-#ifndef __ALLOCATOR_DEFRAG_H
-#define __ALLOCATOR_DEFRAG_H
+#ifndef ALLOCATOR_DEFRAG_H
+#define ALLOCATOR_DEFRAG_H
 
 #if defined(USE_JEMALLOC)
 #include <jemalloc/jemalloc.h>
@@ -21,4 +21,4 @@ unsigned long allocatorDefragGetFragSmallbins(void);
 int allocatorShouldDefrag(void *ptr);
 float getAllocatorFragmentation(size_t *out_frag_bytes);
 
-#endif /* __ALLOCATOR_DEFRAG_H */
+#endif /* ALLOCATOR_DEFRAG_H */

--- a/src/bio.h
+++ b/src/bio.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __BIO_H
-#define __BIO_H
+#ifndef BIO_H
+#define BIO_H
 
 typedef void lazy_free_fn(void *args[]);
 

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -1,5 +1,5 @@
-#ifndef __CLICOMMON_H
-#define __CLICOMMON_H
+#ifndef CLICOMMON_H
+#define CLICOMMON_H
 
 #include <valkey/valkey.h>
 #include "sds.h"
@@ -58,4 +58,4 @@ valkeyContext *valkeyConnectWrapper(enum valkeyConnectionType ct, const char *ip
  * state is unlocked and callers are multi-threaded. Seed via srandom(). */
 uint64_t rand62(void);
 
-#endif /* __CLICOMMON_H */
+#endif /* CLICOMMON_H */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -1,5 +1,5 @@
-#ifndef __CLUSTER_H
-#define __CLUSTER_H
+#ifndef CLUSTER_H
+#define CLUSTER_H
 
 #include <stdbool.h>
 /*-----------------------------------------------------------------------------
@@ -159,4 +159,4 @@ int clusterAddSlot(clusterNode *n, int slot);
 int clusterBumpConfigEpochWithoutConsensus(void);
 void clusterDoBeforeSleep(int flags);
 
-#endif /* __CLUSTER_H */
+#endif /* CLUSTER_H */

--- a/src/cluster_migrateslots.h
+++ b/src/cluster_migrateslots.h
@@ -1,5 +1,5 @@
-#ifndef __CLUSTER_MIGRATESLOTS_H
-#define __CLUSTER_MIGRATESLOTS_H
+#ifndef CLUSTER_MIGRATESLOTS_H
+#define CLUSTER_MIGRATESLOTS_H
 
 #include "server.h"
 #include "cluster.h"
@@ -40,4 +40,4 @@ void clusterCleanSlotImportsAfterLoad(void);
 int clusterRDBSaveSlotImports(rio *rdb, int rdbver);
 int clusterRDBLoadSlotImport(rio *rdb);
 
-#endif /* __CLUSTER_MIGRATESLOTS_H */
+#endif /* CLUSTER_MIGRATESLOTS_H */

--- a/src/commandlog.h
+++ b/src/commandlog.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __COMMANDLOG_H__
-#define __COMMANDLOG_H__
+#ifndef COMMANDLOG_H
+#define COMMANDLOG_H
 
 #include "server.h"
 
@@ -49,4 +49,4 @@ typedef struct commandlogEntry {
 /* Exported API */
 void commandlogInit(void);
 
-#endif /* __COMMANDLOG_H__ */
+#endif /* COMMANDLOG_H */

--- a/src/crc16_slottable.h
+++ b/src/crc16_slottable.h
@@ -1,5 +1,5 @@
-#ifndef _CRC16_TABLE_H__
-#define _CRC16_TABLE_H__
+#ifndef CRC16_TABLE_H
+#define CRC16_TABLE_H
 
 /* A table of the shortest possible alphanumeric string that is mapped by crc16
  * to any given cluster slot. */

--- a/src/debugmacro.h
+++ b/src/debugmacro.h
@@ -30,8 +30,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _REDIS_DEBUGMACRO_H_
-#define _REDIS_DEBUGMACRO_H_
+#ifndef REDIS_DEBUGMACRO_H
+#define REDIS_DEBUGMACRO_H
 
 #include <stdio.h>
 #define D(...)                                                    \
@@ -43,4 +43,4 @@
         fclose(fp);                                               \
     } while (0)
 
-#endif /* _REDIS_DEBUGMACRO_H_ */
+#endif /* REDIS_DEBUGMACRO_H */

--- a/src/dict.h
+++ b/src/dict.h
@@ -31,8 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __DICT_H
-#define __DICT_H
+#ifndef DICT_H
+#define DICT_H
 
 #include "hashtable.h"
 #include "zmalloc.h"
@@ -295,4 +295,4 @@ static inline dictEntry *dictNext(dictIterator *iter) {
     return NULL;
 }
 
-#endif /* __DICT_H */
+#endif /* DICT_H */

--- a/src/endianconv.h
+++ b/src/endianconv.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __ENDIANCONV_H
-#define __ENDIANCONV_H
+#ifndef ENDIANCONV_H
+#define ENDIANCONV_H
 
 #include "config.h"
 #include <stdint.h>

--- a/src/entry.h
+++ b/src/entry.h
@@ -1,5 +1,5 @@
-#ifndef _ENTRY_H_
-#define _ENTRY_H_
+#ifndef ENTRY_H
+#define ENTRY_H
 
 /* Ensure feature macros from fmacros.h are active even if entry.h is
  * included before server.h */

--- a/src/eval.h
+++ b/src/eval.h
@@ -1,5 +1,5 @@
-#ifndef _EVAL_H_
-#define _EVAL_H_
+#ifndef EVAL_H
+#define EVAL_H
 
 typedef struct scriptingEngine scriptingEngine;
 
@@ -8,4 +8,4 @@ void evalReset(int async);
 void evalRemoveScriptsFromEngine(scriptingEngine *engine);
 void *evalActiveDefragScript(void *ptr);
 
-#endif /* _EVAL_H_ */
+#endif /* EVAL_H */

--- a/src/fifo.h
+++ b/src/fifo.h
@@ -22,8 +22,8 @@
  * The implementation makes no assumptions about the stored values and keeps them intact.
  */
 
-#ifndef __FIFO_H_
-#define __FIFO_H_
+#ifndef FIFO_H
+#define FIFO_H
 
 #include <stdbool.h>
 

--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _REDIS_FMACRO_H
-#define _REDIS_FMACRO_H
+#ifndef REDIS_FMACRO_H
+#define REDIS_FMACRO_H
 
 #define _BSD_SOURCE
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __FUNCTIONS_H_
-#define __FUNCTIONS_H_
+#ifndef FUNCTIONS_H
+#define FUNCTIONS_H
 
 /*
  * functions.c unit provides the Functions API:
@@ -99,4 +99,4 @@ void functionsRemoveLibFromEngine(scriptingEngine *engine);
 
 int functionsInit(void);
 
-#endif /* __FUNCTIONS_H_ */
+#endif /* FUNCTIONS_H */

--- a/src/geo.h
+++ b/src/geo.h
@@ -1,5 +1,5 @@
-#ifndef __GEO_H__
-#define __GEO_H__
+#ifndef GEO_H
+#define GEO_H
 
 #include "server.h"
 

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -1,5 +1,5 @@
-#ifndef __INTRINSICS_H
-#define __INTRINSICS_H
+#ifndef INTRINSICS_H
+#define INTRINSICS_H
 
 #include <stdint.h>
 
@@ -18,4 +18,4 @@ static inline int32_t builtin_ctzll(uint64_t value) {
 #endif
 }
 
-#endif /* __INTRINSICS_H */
+#endif /* INTRINSICS_H */

--- a/src/intset.h
+++ b/src/intset.h
@@ -28,8 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __INTSET_H
-#define __INTSET_H
+#ifndef INTSET_H
+#define INTSET_H
 #include <stdint.h>
 
 typedef struct intset {
@@ -52,4 +52,4 @@ int intsetValidateIntegrity(const unsigned char *is, size_t size, int deep);
 void intsetFree(intset *is);
 intset *intsetDup(intset *is);
 
-#endif // __INTSET_H
+#endif // INTSET_H

--- a/src/latency.h
+++ b/src/latency.h
@@ -31,8 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __LATENCY_H
-#define __LATENCY_H
+#ifndef LATENCY_H
+#define LATENCY_H
 
 #include "trace/trace.h"
 
@@ -113,4 +113,4 @@ typedef enum {
 
 void durationAddSample(int type, monotime duration);
 
-#endif /* __LATENCY_H */
+#endif /* LATENCY_H */

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -32,8 +32,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __LISTPACK_H
-#define __LISTPACK_H
+#ifndef LISTPACK_H
+#define LISTPACK_H
 
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/lolwut.h
+++ b/src/lolwut.h
@@ -35,8 +35,8 @@
  * It's up to each LOLWUT versions to translate what they draw to the
  * screen, depending on the result to accomplish. */
 
-#ifndef __LOLWUT_H
-#define __LOLWUT_H
+#ifndef LOLWUT_H
+#define LOLWUT_H
 
 typedef struct lwCanvas {
     int width;

--- a/src/lrulfu.h
+++ b/src/lrulfu.h
@@ -1,5 +1,5 @@
-#ifndef __LRULFU_H__
-#define __LRULFU_H__
+#ifndef LRULFU_H
+#define LRULFU_H
 
 /*
  * Important: include fmacros.h before any system header

--- a/src/module.h
+++ b/src/module.h
@@ -1,5 +1,5 @@
-#ifndef _MODULE_H_
-#define _MODULE_H_
+#ifndef MODULE_H
+#define MODULE_H
 
 /* This header file exposes a set of functions defined in module.c that are
  * not part of the module API, but are used by the core to interact with modules
@@ -249,4 +249,4 @@ void freeClientModuleData(client *c);
 int checkModuleAuthentication(client *c, robj *username, robj *password, robj **err);
 void moduleFireAuthenticationEvent(uint64_t client_id, const char *username, const char *module_name, int is_granted);
 
-#endif /* _MODULE_H_ */
+#endif /* MODULE_H */

--- a/src/monotonic.h
+++ b/src/monotonic.h
@@ -1,5 +1,5 @@
-#ifndef __MONOTONIC_H
-#define __MONOTONIC_H
+#ifndef MONOTONIC_H
+#define MONOTONIC_H
 /* The monotonic clock is an always increasing clock source.  It is unrelated to
  * the actual time of day and should only be used for relative timings.  The
  * monotonic clock is also not guaranteed to be chronologically precise; there

--- a/src/mt19937-64.h
+++ b/src/mt19937-64.h
@@ -53,8 +53,8 @@
    email: m-mat @ math.sci.hiroshima-u.ac.jp (remove spaces)
 */
 
-#ifndef __MT19937_64_H
-#define __MT19937_64_H
+#ifndef MT19937_64_H
+#define MT19937_64_H
 
 /* initializes mt[NN] with a seed */
 void init_genrand64(unsigned long long seed);

--- a/src/mutexqueue.h
+++ b/src/mutexqueue.h
@@ -30,8 +30,8 @@
  * The caller is responsible for memory management for items in the mutexQueue.
  */
 
-#ifndef __MUTEXQUEUE_H
-#define __MUTEXQUEUE_H
+#ifndef MUTEXQUEUE_H
+#define MUTEXQUEUE_H
 
 #include <stdbool.h>
 #include "fifo.h"

--- a/src/pqsort.h
+++ b/src/pqsort.h
@@ -30,8 +30,8 @@
  *
  * See the pqsort.c file for the original copyright notice. */
 
-#ifndef __PQSORT_H
-#define __PQSORT_H
+#ifndef PQSORT_H
+#define PQSORT_H
 
 void
 pqsort(void *a, size_t n, size_t es,

--- a/src/queues.h
+++ b/src/queues.h
@@ -20,8 +20,8 @@
  *    - Allows producer to batch jobs
  */
 
-#ifndef __QUEUES_H__
-#define __QUEUES_H__
+#ifndef QUEUES_H
+#define QUEUES_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -141,4 +141,4 @@ size_t spscDequeueBatch(spscQueue *q, void **jobs_out, size_t num_jobs);
 /* Check if queue is empty from producer's perspective. */
 bool spscIsEmpty(spscQueue *q);
 
-#endif /* __QUEUES_H__ */
+#endif /* QUEUES_H */

--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -30,8 +30,8 @@
 
 #include <stdint.h> // for UINTPTR_MAX
 
-#ifndef __QUICKLIST_H__
-#define __QUICKLIST_H__
+#ifndef QUICKLIST_H
+#define QUICKLIST_H
 
 /* Node, quicklist, and Iterator are the only data structures used currently. */
 
@@ -202,4 +202,4 @@ int quicklistSetPackedThreshold(size_t sz);
 #define AL_START_HEAD 0
 #define AL_START_TAIL 1
 
-#endif /* __QUICKLIST_H__ */
+#endif /* QUICKLIST_H */

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __RDB_H
-#define __RDB_H
+#ifndef RDB_H
+#define RDB_H
 
 #include <stdio.h>
 #include "rio.h"

--- a/src/script.h
+++ b/src/script.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __SCRIPT_H_
-#define __SCRIPT_H_
+#ifndef SCRIPT_H
+#define SCRIPT_H
 
 #include "valkeymodule.h"
 
@@ -129,4 +129,4 @@ void scriptClusterSlotStatsInvalidateSlotIfApplicable(void);
 
 sds scriptGetRunningEngineName(void);
 
-#endif /* __SCRIPT_H_ */
+#endif /* SCRIPT_H */

--- a/src/scripting_engine.h
+++ b/src/scripting_engine.h
@@ -1,5 +1,5 @@
-#ifndef _SCRIPTING_ENGINE_H_
-#define _SCRIPTING_ENGINE_H_
+#ifndef SCRIPTING_ENGINE_H
+#define SCRIPTING_ENGINE_H
 
 #include "server.h"
 #include "valkeymodule.h"
@@ -138,4 +138,4 @@ int scriptingEngineDebuggerPendingChildren(void);
 void scriptingEngineDebuggerKillForkedSessions(void);
 
 
-#endif /* _SCRIPTING_ENGINE_H_ */
+#endif /* SCRIPTING_ENGINE_H */

--- a/src/sds.h
+++ b/src/sds.h
@@ -29,8 +29,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __SDS_H
-#define __SDS_H
+#ifndef SDS_H
+#define SDS_H
 
 #define SDS_MAX_PREALLOC (1024 * 1024)
 extern const char *SDS_NOINIT;

--- a/src/sdsalloc.h
+++ b/src/sdsalloc.h
@@ -35,8 +35,8 @@
  * the include of your alternate allocator if needed (not needed in order
  * to use the default libc allocator). */
 
-#ifndef __SDS_ALLOC_H__
-#define __SDS_ALLOC_H__
+#ifndef SDS_ALLOC_H
+#define SDS_ALLOC_H
 
 #include "zmalloc.h"
 #define s_malloc zmalloc

--- a/src/sparkline.h
+++ b/src/sparkline.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __SPARKLINE_H
-#define __SPARKLINE_H
+#ifndef SPARKLINE_H
+#define SPARKLINE_H
 
 /* A sequence is represented of many "samples" */
 struct sample {
@@ -53,4 +53,4 @@ void freeSparklineSequence(struct sequence *seq);
 sds sparklineRenderRange(sds output, struct sequence *seq, int rows, int offset, int len, int flags);
 sds sparklineRender(sds output, struct sequence *seq, int columns, int rows, int flags);
 
-#endif /* __SPARKLINE_H */
+#endif /* SPARKLINE_H */

--- a/src/syscheck.h
+++ b/src/syscheck.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __SYSCHECK_H
-#define __SYSCHECK_H
+#ifndef SYSCHECK_H
+#define SYSCHECK_H
 
 #include "sds.h"
 #include "config.h"

--- a/src/testhelp.h
+++ b/src/testhelp.h
@@ -36,8 +36,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __TESTHELP_H
-#define __TESTHELP_H
+#ifndef TESTHELP_H
+#define TESTHELP_H
 
 #define TEST_ACCURATE (1 << 0)
 #define TEST_LARGE_MEMORY (1 << 1)

--- a/src/tls.h
+++ b/src/tls.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __VALKEY_TLS_H
-#define __VALKEY_TLS_H
+#ifndef VALKEY_TLS_H
+#define VALKEY_TLS_H
 
 /* TLS reload functions - only available when TLS is built-in, not as a module */
 #if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
@@ -14,4 +14,4 @@ void tlsApplyPendingReload(void);
 void tlsConfigureAsync(void);
 #endif
 
-#endif /* __VALKEY_TLS_H */
+#endif /* VALKEY_TLS_H */

--- a/src/tls.h
+++ b/src/tls.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef VALKEY_TLS_H
-#define VALKEY_TLS_H
+#ifndef TLS_H
+#define TLS_H
 
 /* TLS reload functions - only available when TLS is built-in, not as a module */
 #if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
@@ -14,4 +14,4 @@ void tlsApplyPendingReload(void);
 void tlsConfigureAsync(void);
 #endif
 
-#endif /* VALKEY_TLS_H */
+#endif /* TLS_H */

--- a/src/vector.h
+++ b/src/vector.h
@@ -1,5 +1,5 @@
-#ifndef __VECTOR_H_
-#define __VECTOR_H_
+#ifndef VECTOR_H
+#define VECTOR_H
 
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/ziplist.h
+++ b/src/ziplist.h
@@ -28,8 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _ZIPLIST_H
-#define _ZIPLIST_H
+#ifndef ZIPLIST_H
+#define ZIPLIST_H
 
 #define ZIPLIST_HEAD 0
 #define ZIPLIST_TAIL 1
@@ -71,4 +71,4 @@ void ziplistRandomPairs(unsigned char *zl, unsigned int count, ziplistEntry *key
 unsigned int ziplistRandomPairsUnique(unsigned char *zl, unsigned int count, ziplistEntry *keys, ziplistEntry *vals);
 int ziplistSafeToAdd(unsigned char *zl, size_t add);
 
-#endif /* _ZIPLIST_H */
+#endif /* ZIPLIST_H */

--- a/src/zipmap.h
+++ b/src/zipmap.h
@@ -32,8 +32,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _ZIPMAP_H
-#define _ZIPMAP_H
+#ifndef ZIPMAP_H
+#define ZIPMAP_H
 
 unsigned char *zipmapRewind(unsigned char *zm);
 unsigned char *

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -28,8 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __ZMALLOC_H
-#define __ZMALLOC_H
+#ifndef ZMALLOC_H
+#define ZMALLOC_H
 
 #include <stddef.h>
 
@@ -168,4 +168,4 @@ __attribute__((alloc_size(2), noinline)) void *extend_to_usable(void *ptr, size_
 
 int get_proc_stat_ll(int i, long long *res);
 
-#endif /* __ZMALLOC_H */
+#endif /* ZMALLOC_H */


### PR DESCRIPTION
Header guards with a leading underscore followed by an uppercase letter (`__BIO_H`, `__GEO_H__`, `_EVAL_H_`, ...) are reserved for the implementation by the C standard. This renames all 44 of them in src/*.h to the plain `NAME_H` form already used by the newer headers (ANET_H, CONFIG_H, STREAM_H, ...). Feature-test macros (_GNU_SOURCE etc.) are left untouched.

Mechanical, no behavior change, builds clean. Closes #3850.

I know from the issue thread there is hesitation about churn here and a preference for enforcing this via clang-tidy instead. Happy to close this if you would rather wait for the tooling route, or follow up with a CI check that only flags reserved identifiers on changed lines.