### PR TITLE
Add logging for rejected MFSTART messages in cluster primary

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4422,7 +4422,15 @@ int clusterProcessPacket(clusterLink *link) {
     } else if (type == CLUSTERMSG_TYPE_MFSTART) {
         /* This message is acceptable only if I'm a primary and the sender
          * is one of my replicas. */
-        if (!sender || sender->replicaof != myself) return 1;
+        if (!sender) {
+            serverLog(LL_NOTICE, "Ignoring MFSTART message from unknown node %.40s.", msg->sender);
+            return 1;
+        }
+        if (sender->replicaof != myself) {
+            serverLog(LL_NOTICE, "Ignoring MFSTART message from node %.40s (%s) that is not my replica.",
+                      sender->name, humanNodename(sender));
+            return 1;
+        }
         /* Manual failover requested from replicas. Initialize the state
          * accordingly. */
         resetManualFailover();


### PR DESCRIPTION
When a primary receives an MFSTART (manual failover start) message,
it was silently ignored if the sender was unknown or not a replica of
this primary. This made it impossible to diagnose why a manual failover
was timing out on the replica side — the primary had no indication that
it ever received the request.

In particular, cluster gossip may not have propagated the new replica
relationship to the primary yet, so the primary may legitimately not
recognize the sender as its replica. Without logging, this scenario
leaves no trace on the primary side.