### PR TITLE
Cleanup redundant incrRefCount and fix new_argv alloc size around HDEL

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1465,7 +1465,6 @@ void hsetexCommand(client *c) {
     if (set_expired) {
         new_argv = zmalloc(sizeof(robj *) * (num_fields + 2));
         new_argv[new_argc++] = shared.hdel;
-        incrRefCount(shared.hdel);
         new_argv[new_argc++] = c->argv[1];
         incrRefCount(c->argv[1]);
     } else if (need_rewrite_argv) {
@@ -1939,9 +1938,8 @@ void hexpireGenericCommand(client *c, mstime_t basetime, int unit) {
         else if (result == EXPIRATION_MODIFICATION_EXPIRE_ASAP) {
             /* In case we are expiring all the elements prepare a new argv since we are going to delete all the expired fields. */
             if (new_argv == NULL) {
-                new_argv = zmalloc(sizeof(robj *) * (num_fields + 3));
+                new_argv = zmalloc(sizeof(robj *) * (num_fields + 2));
                 new_argv[new_argc++] = shared.hdel;
-                incrRefCount(shared.hdel);
                 new_argv[new_argc++] = c->argv[1];
                 incrRefCount(c->argv[1]);
             }


### PR DESCRIPTION
Two minor cleanups:
- Remove unnecessary incrRefCount(shared.hdel) just like other shared object.
- Fix new_argv allocation size since HDEL only need (num_fields + 2) size.