### PR TITLE
Fix io_last_written bookmark desync that corrupts replies with IO threads

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1091,9 +1091,24 @@ void trimReplyUnusedTailSpace(client *c) {
     /* We only try to trim the space is relatively high (more than a 1/4 of the
      * allocation), otherwise there's a high chance realloc will NOP.
      * Also, to avoid large memmove which happens as part of realloc, we only do
-     * that if the used part is small.  */
+     * that if the used part is small.
+     *
+     * Two conditions gate the realloc, for two distinct reasons:
+     *  - io_write_state != CLIENT_PENDING_IO: while an IO thread is writing it
+     *    concurrently walks the whole reply list, so mutating any block races
+     *    with it. This is a thread-safety requirement, independent of which
+     *    block we touch.
+     *  - tail->buf != io_last_written.buf: never free/move the block the write
+     *    bookmark points at. If we did, the allocator could hand the same
+     *    address back for a new reply block; the bookmark would then match an
+     *    unrelated, shorter block while its data_len still claims more bytes
+     *    were sent, and the next write would over-skip (empty IOV) and drop the
+     *    reply's leading bytes. A pointer check is NOT enough at the consumer
+     *    side because that recycle reuses the same address (ABA); the only
+     *    robust fix is to not free the bookmarked block in the first place.
+     * See https://github.com/valkey-io/valkey/pull/4060 */
     if (tail->size - tail->used > tail->size / 4 && tail->used < PROTO_REPLY_CHUNK_BYTES &&
-        c->io_write_state != CLIENT_PENDING_IO && !tail->flag.buf_encoded) {
+        c->io_write_state != CLIENT_PENDING_IO && tail->buf != c->io_last_written.buf && !tail->flag.buf_encoded) {
         size_t usable_size;
         size_t old_size = tail->size;
         tail = zrealloc_usable(tail, tail->used + sizeof(clientReplyBlock), &usable_size);
@@ -1164,9 +1179,13 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
      * - The next node is non-NULL,
      * - It has enough room already allocated
      * - And not too large (avoid large memmove)
-     * - And the client is not in a pending I/O state */
+     * - And it is safe to mutate the target node: the client is not
+     *   CLIENT_PENDING_IO (an IO thread is not concurrently walking the reply
+     *   list) AND the target node is not the one io_last_written references
+     *   (mutating the bookmarked block desyncs the write bookmark).
+     *   See https://github.com/valkey-io/valkey/pull/4060 */
     if (ln->prev != NULL && (prev = listNodeValue(ln->prev)) && prev->size > prev->used &&
-        c->io_write_state != CLIENT_PENDING_IO && !prev->flag.buf_encoded) {
+        c->io_write_state != CLIENT_PENDING_IO && prev->buf != c->io_last_written.buf && !prev->flag.buf_encoded) {
         size_t len_to_copy = prev->size - prev->used;
         if (len_to_copy > length) len_to_copy = length;
         memcpy(prev->buf + prev->used, s, len_to_copy);
@@ -1181,7 +1200,8 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
     }
 
     if (ln->next != NULL && (next = listNodeValue(ln->next)) && next->size - next->used >= length &&
-        next->used < PROTO_REPLY_CHUNK_BYTES * 4 && c->io_write_state != CLIENT_PENDING_IO && !next->flag.buf_encoded) {
+        next->used < PROTO_REPLY_CHUNK_BYTES * 4 && c->io_write_state != CLIENT_PENDING_IO &&
+        next->buf != c->io_last_written.buf && !next->flag.buf_encoded) {
         memmove(next->buf + length, next->buf, next->used);
         memcpy(next->buf, s, length);
         c->net_output_bytes_curr_cmd += length;
@@ -2977,6 +2997,11 @@ static void _postWriteToClient(client *c) {
     if (c->bufpos > 0) {
         /* Is this buffer is last written? */
         last_written = (c->buf == c->io_last_written.buf);
+        /* Bookmark desync detector (debug builds only); see the comment in the
+         * reply-list loop below and https://github.com/valkey-io/valkey/pull/4060 */
+        if (last_written) {
+            debugServerAssert(c->io_last_written.bufpos == 0 || c->io_last_written.bufpos <= c->bufpos);
+        }
         /* If buffer is completely written */
         if (!last_written || c->bufpos == c->io_last_written.bufpos) {
             /* If encoded then release references to bulk string objects */
@@ -3000,6 +3025,16 @@ static void _postWriteToClient(client *c) {
         clientReplyBlock *o = listNodeValue(next);
         /* Is this buffer is last written? */
         last_written = (o->buf == c->io_last_written.buf);
+        /* Bookmark desync detector (debug builds only): for the bookmarked
+         * block, the recorded in-memory write position (bufpos) must never
+         * exceed the block's current content (used); a violation means the
+         * block was freed/shrunk/recycled while the bookmark was live. Catches
+         * any complete-write desync (plain or encoded); a partial write stores
+         * bufpos == 0 and is intentionally not checked here. See the PR for the
+         * full rationale: https://github.com/valkey-io/valkey/pull/4060 */
+        if (last_written) {
+            debugServerAssert(c->io_last_written.bufpos == 0 || c->io_last_written.bufpos <= o->used);
+        }
         /* If buffer is completely written */
         if (!last_written || o->used == c->io_last_written.bufpos) {
             c->reply_bytes -= o->size;
@@ -6703,4 +6738,8 @@ void testOnlyAddBufferToReplyIOV(int encoded, char *buf, size_t bufpos, replyIOV
 
 void testOnlySaveLastWrittenBuf(client *c, bufWriteMetadata *metadata, int bufcnt, size_t totlen, size_t totwritten) {
     saveLastWrittenBuf(c, metadata, bufcnt, totlen, totwritten);
+}
+
+void testOnlyTrimReplyUnusedTailSpace(client *c) {
+    trimReplyUnusedTailSpace(c);
 }

--- a/src/unit/test_networking.cpp
+++ b/src/unit/test_networking.cpp
@@ -77,6 +77,9 @@ void testOnlyAddBulkStringToReplyIOV(char *buf, size_t buf_len, replyIOV *reply,
 void testOnlyAddEncodedBufferToReplyIOV(char *buf, size_t bufpos, replyIOV *reply, bufWriteMetadata *metadata);
 void testOnlyAddBufferToReplyIOV(int encoded, char *buf, size_t bufpos, replyIOV *reply, bufWriteMetadata *metadata);
 void testOnlySaveLastWrittenBuf(client *c, bufWriteMetadata *metadata, int bufcnt, size_t totlen, size_t totwritten);
+void testOnlyTrimReplyUnusedTailSpace(client *c);
+/* Non-static engine function exercised directly by the deferred-reply tests. */
+void setDeferredReply(client *c, void *node, const char *s, size_t length);
 }
 
 /* Fake structures and functions */
@@ -767,4 +770,252 @@ TEST_F(NetworkingTest, TestAddBufferToReplyIOV) {
 
     releaseReplyReferences(c);
     freeReplyOffloadClient(c);
+}
+
+/* Helper: allocate a plain reply block with the given used/size and fill its
+ * used bytes with `fill`. Caller adds it to a reply list owned by a client
+ * created via createTestClient (freed by freeReplyOffloadClient). */
+static clientReplyBlock *makePlainReplyBlock(size_t size, size_t used, char fill) {
+    clientReplyBlock *blk = (clientReplyBlock *)zmalloc(sizeof(clientReplyBlock) + size);
+    blk->size = size;
+    blk->used = used;
+    blk->flag.buf_encoded = 0;
+    blk->last_header = NULL;
+    memset(blk->buf, fill, used);
+    return blk;
+}
+
+/* trimReplyUnusedTailSpace must not realloc the tail when the write bookmark
+ * (io_last_written.buf) points at it, since freeing/moving it desyncs the
+ * bookmark. The guard is pointer-based, so it fires regardless of io_write_state
+ * (COMPLETED_IO or IDLE), and it allows the trim when the bookmark points
+ * elsewhere. See https://github.com/valkey-io/valkey/pull/4060 */
+TEST_F(NetworkingTest, TestTrimReplyGuardsIoLastWritten) {
+    size_t alloc_size = PROTO_REPLY_CHUNK_BYTES * 2; /* waste > size/4, used small */
+
+    /* --- Case 1: tail IS the bookmarked block, CLIENT_COMPLETED_IO -> refuse --- */
+    {
+        client *c = createTestClient();
+        clientReplyBlock *blk = makePlainReplyBlock(alloc_size, 32, 'X');
+        listAddNodeTail(c->reply, blk);
+        c->reply_bytes = alloc_size;
+        c->io_last_written.buf = blk->buf; /* bookmark on the tail */
+        c->io_last_written.bufpos = blk->used;
+        c->io_last_written.data_len = blk->used;
+        c->io_write_state = CLIENT_COMPLETED_IO;
+
+        testOnlyTrimReplyUnusedTailSpace(c);
+
+        clientReplyBlock *after = (clientReplyBlock *)listNodeValue(listLast(c->reply));
+        ASSERT_EQ(after->size, alloc_size);          /* not reallocated */
+        ASSERT_EQ(c->io_last_written.buf, after->buf); /* bookmark still valid */
+        freeReplyOffloadClient(c);
+    }
+
+    /* --- Case 2: tail IS the bookmarked block, CLIENT_IDLE -> still refuse ---
+     * A partial main-thread write leaves the bookmark live (bufpos = 0 sentinel)
+     * while the state is IDLE; the pointer guard must still protect the block. */
+    {
+        client *c = createTestClient();
+        clientReplyBlock *blk = makePlainReplyBlock(alloc_size, 32, 'X');
+        listAddNodeTail(c->reply, blk);
+        c->reply_bytes = alloc_size;
+        c->io_last_written.buf = blk->buf; /* bookmark on the tail */
+        c->io_last_written.bufpos = 0;     /* partial-write sentinel */
+        c->io_last_written.data_len = 16;
+        c->io_write_state = CLIENT_IDLE;
+
+        testOnlyTrimReplyUnusedTailSpace(c);
+
+        clientReplyBlock *after = (clientReplyBlock *)listNodeValue(listLast(c->reply));
+        ASSERT_EQ(after->size, alloc_size); /* not reallocated */
+        freeReplyOffloadClient(c);
+    }
+
+    /* --- Case 3: bookmark points at a DIFFERENT block, CLIENT_COMPLETED_IO ->
+     * proceed. The tail is not the bookmarked block, so trimming it is safe even
+     * though an IO write just completed. --- */
+    {
+        client *c = createTestClient();
+        clientReplyBlock *head = makePlainReplyBlock(64, 20, 'H'); /* bookmarked */
+        clientReplyBlock *tail = makePlainReplyBlock(alloc_size, 32, 'T');
+        listAddNodeTail(c->reply, head);
+        listAddNodeTail(c->reply, tail);
+        c->reply_bytes = head->size + tail->size;
+        c->io_last_written.buf = head->buf; /* bookmark on the head, not the tail */
+        c->io_last_written.bufpos = head->used;
+        c->io_last_written.data_len = head->used;
+        c->io_write_state = CLIENT_COMPLETED_IO;
+
+        testOnlyTrimReplyUnusedTailSpace(c);
+
+        clientReplyBlock *after = (clientReplyBlock *)listNodeValue(listLast(c->reply));
+        ASSERT_LT(after->size, alloc_size); /* tail was trimmed */
+        ASSERT_EQ(after->used, 32u);
+        for (size_t i = 0; i < 32; i++) ASSERT_EQ(after->buf[i], 'T'); /* content preserved */
+        freeReplyOffloadClient(c);
+    }
+
+    /* --- Case 4: no bookmark, CLIENT_IDLE -> proceed --- */
+    {
+        client *c = createTestClient();
+        clientReplyBlock *blk = makePlainReplyBlock(alloc_size, 32, 'X');
+        listAddNodeTail(c->reply, blk);
+        c->reply_bytes = alloc_size;
+        c->io_write_state = CLIENT_IDLE;
+        resetLastWrittenBuf(c);
+
+        testOnlyTrimReplyUnusedTailSpace(c);
+
+        clientReplyBlock *after = (clientReplyBlock *)listNodeValue(listLast(c->reply));
+        ASSERT_LT(after->size, alloc_size); /* trimmed */
+        ASSERT_EQ(after->used, 32u);
+        freeReplyOffloadClient(c);
+    }
+}
+
+/* Even when the tail is not the bookmarked block, the trim must be refused while
+ * CLIENT_PENDING_IO, because an IO thread is concurrently walking the reply list
+ * and reallocating any block would race with it. */
+TEST_F(NetworkingTest, TestTrimReplyRefusedWhilePendingIO) {
+    client *c = createTestClient();
+    size_t alloc_size = PROTO_REPLY_CHUNK_BYTES * 2;
+    clientReplyBlock *blk = makePlainReplyBlock(alloc_size, 32, 'X');
+    listAddNodeTail(c->reply, blk);
+    c->reply_bytes = alloc_size;
+
+    resetLastWrittenBuf(c);              /* no bookmark on the tail */
+    c->io_write_state = CLIENT_PENDING_IO; /* IO thread actively writing */
+
+    testOnlyTrimReplyUnusedTailSpace(c);
+
+    clientReplyBlock *after = (clientReplyBlock *)listNodeValue(listLast(c->reply));
+    ASSERT_EQ(after->size, alloc_size); /* not reallocated */
+    freeReplyOffloadClient(c);
+}
+
+/* setDeferredReply's prev-merge (appending the length header into the node
+ * *before* the placeholder) must be skipped when io_last_written points at that
+ * prev node, and proceed when it points elsewhere. Guard is pointer-based. */
+TEST_F(NetworkingTest, TestSetDeferredReplyPrevMergeGuardsIoLastWritten) {
+    const char *hdr = "*2\r\n";
+    const size_t hdr_len = 4;
+
+    /* --- Case 1: prev IS the bookmarked block -> merge must be skipped --- */
+    {
+        client *c = createTestClient();
+        /* prev block is bookmarked and has room to append the header. */
+        clientReplyBlock *prev = makePlainReplyBlock(64, 10, 'P');
+        listAddNodeTail(c->reply, prev);
+        listAddNodeTail(c->reply, NULL); /* placeholder is the tail (no next) */
+        c->reply_bytes = prev->size;
+        listNode *placeholder = listLast(c->reply);
+
+        c->io_last_written.buf = prev->buf; /* bookmark on prev */
+        c->io_last_written.bufpos = prev->used;
+        c->io_last_written.data_len = prev->used;
+        c->io_write_state = CLIENT_COMPLETED_IO;
+
+        setDeferredReply(c, placeholder, hdr, hdr_len);
+
+        /* prev must be untouched: merge was refused, header went to a new node
+         * filling the placeholder instead. */
+        clientReplyBlock *prev_after = (clientReplyBlock *)listNodeValue(listFirst(c->reply));
+        ASSERT_EQ(prev_after, prev);
+        ASSERT_EQ(prev_after->used, 10u);
+        ASSERT_EQ(listLength(c->reply), 2u); /* placeholder filled, not deleted */
+        clientReplyBlock *filled = (clientReplyBlock *)listNodeValue(listLast(c->reply));
+        ASSERT_EQ(filled->used, hdr_len);
+        ASSERT_EQ(memcmp(filled->buf, hdr, hdr_len), 0);
+
+        freeReplyOffloadClient(c);
+    }
+
+    /* --- Case 2: bookmark points elsewhere (none) -> prev-merge proceeds --- */
+    {
+        client *c = createTestClient();
+        clientReplyBlock *prev = makePlainReplyBlock(64, 10, 'P');
+        listAddNodeTail(c->reply, prev);
+        listAddNodeTail(c->reply, NULL);
+        c->reply_bytes = prev->size;
+        listNode *placeholder = listLast(c->reply);
+
+        c->io_write_state = CLIENT_COMPLETED_IO; /* non-PENDING; bookmark not on prev */
+        resetLastWrittenBuf(c);
+
+        setDeferredReply(c, placeholder, hdr, hdr_len);
+
+        /* Header appended into prev; placeholder removed. */
+        clientReplyBlock *prev_after = (clientReplyBlock *)listNodeValue(listFirst(c->reply));
+        ASSERT_EQ(prev_after, prev);
+        ASSERT_EQ(prev_after->used, 10u + hdr_len);
+        ASSERT_EQ(memcmp(prev_after->buf + 10, hdr, hdr_len), 0);
+        ASSERT_EQ(listLength(c->reply), 1u);
+
+        freeReplyOffloadClient(c);
+    }
+}
+
+/* setDeferredReply's next-merge (memmove-ing the node *after* the placeholder to
+ * prepend the length header) must be skipped when io_last_written points at that
+ * next node, and proceed when it points elsewhere. Guard is pointer-based. */
+TEST_F(NetworkingTest, TestSetDeferredReplyNextMergeGuardsIoLastWritten) {
+    const char *hdr = "*2\r\n";
+    const size_t hdr_len = 4;
+
+    /* --- Case 1: next IS the bookmarked block -> next-merge must be skipped --- */
+    {
+        client *c = createTestClient();
+        listAddNodeTail(c->reply, NULL); /* placeholder is the head (no prev) */
+        listNode *placeholder = listFirst(c->reply);
+        clientReplyBlock *next = makePlainReplyBlock(64, 10, 'Y');
+        listAddNodeTail(c->reply, next);
+        c->reply_bytes = next->size;
+
+        c->io_last_written.buf = next->buf; /* bookmark on next */
+        c->io_last_written.bufpos = next->used;
+        c->io_last_written.data_len = next->used;
+        c->io_write_state = CLIENT_COMPLETED_IO;
+
+        setDeferredReply(c, placeholder, hdr, hdr_len);
+
+        /* next must be untouched (no memmove): header went to a new node filling
+         * the placeholder. */
+        clientReplyBlock *next_after = (clientReplyBlock *)listNodeValue(listLast(c->reply));
+        ASSERT_EQ(next_after, next);
+        ASSERT_EQ(next_after->used, 10u);
+        for (size_t i = 0; i < 10; i++) ASSERT_EQ(next_after->buf[i], 'Y');
+        ASSERT_EQ(listLength(c->reply), 2u); /* placeholder filled, not deleted */
+        clientReplyBlock *filled = (clientReplyBlock *)listNodeValue(listFirst(c->reply));
+        ASSERT_EQ(filled->used, hdr_len);
+        ASSERT_EQ(memcmp(filled->buf, hdr, hdr_len), 0);
+
+        freeReplyOffloadClient(c);
+    }
+
+    /* --- Case 2: bookmark points elsewhere (none) -> next-merge proceeds --- */
+    {
+        client *c = createTestClient();
+        listAddNodeTail(c->reply, NULL);
+        listNode *placeholder = listFirst(c->reply);
+        clientReplyBlock *next = makePlainReplyBlock(64, 10, 'Y');
+        listAddNodeTail(c->reply, next);
+        c->reply_bytes = next->size;
+
+        c->io_write_state = CLIENT_COMPLETED_IO; /* non-PENDING; bookmark not on next */
+        resetLastWrittenBuf(c);
+
+        setDeferredReply(c, placeholder, hdr, hdr_len);
+
+        /* Header prepended into next (existing content shifted right); placeholder
+         * removed. */
+        clientReplyBlock *next_after = (clientReplyBlock *)listNodeValue(listFirst(c->reply));
+        ASSERT_EQ(next_after, next);
+        ASSERT_EQ(next_after->used, 10u + hdr_len);
+        ASSERT_EQ(memcmp(next_after->buf, hdr, hdr_len), 0);
+        for (size_t i = 0; i < 10; i++) ASSERT_EQ(next_after->buf[hdr_len + i], 'Y');
+        ASSERT_EQ(listLength(c->reply), 1u);
+
+        freeReplyOffloadClient(c);
+    }
 }

--- a/src/unit/test_networking.cpp
+++ b/src/unit/test_networking.cpp
@@ -807,7 +807,7 @@ TEST_F(NetworkingTest, TestTrimReplyGuardsIoLastWritten) {
         testOnlyTrimReplyUnusedTailSpace(c);
 
         clientReplyBlock *after = (clientReplyBlock *)listNodeValue(listLast(c->reply));
-        ASSERT_EQ(after->size, alloc_size);          /* not reallocated */
+        ASSERT_EQ(after->size, alloc_size);            /* not reallocated */
         ASSERT_EQ(c->io_last_written.buf, after->buf); /* bookmark still valid */
         freeReplyOffloadClient(c);
     }
@@ -884,7 +884,7 @@ TEST_F(NetworkingTest, TestTrimReplyRefusedWhilePendingIO) {
     listAddNodeTail(c->reply, blk);
     c->reply_bytes = alloc_size;
 
-    resetLastWrittenBuf(c);              /* no bookmark on the tail */
+    resetLastWrittenBuf(c);                /* no bookmark on the tail */
     c->io_write_state = CLIENT_PENDING_IO; /* IO thread actively writing */
 
     testOnlyTrimReplyUnusedTailSpace(c);


### PR DESCRIPTION
## Summary

When IO threads are enabled, a client's reply can be corrupted on the wire: the leading bytes of a response (its RESP framing) are silently dropped. The trigger is a race between an IO thread finishing a write and the main thread processing a command that unblocks a blocked client and rebuilds its reply. Three reply-buffer optimizations mutate a reply block while the IO write-tracking bookmark (`io_last_written`) still references it, desyncing the bookmark from the block's contents.

This only affects builds running with IO threads.

## Sequence of events

Two clients on a node with `io-threads >= 2`:

- **Client 1 (pipelined consumer).** Pipelines commands and blocks on a stream read, e.g. `... ; XREADGROUP ... BLOCK 0 STREAMS s >`. A prior reply for client 1 is handed to an IO thread to write.
- **Client 2 (producer).** Sends `XADD s * ...`.

1. An IO thread finishes writing client 1's previous reply and records a bookmark on the last reply block it wrote (`io_last_written = {buf, bufpos, data_len}`). Client 1's IO state is now `CLIENT_COMPLETED_IO` — the write is done, but the main thread has **not yet** retired that block or cleared the bookmark.
2. On the main thread, client 2's `XADD` runs. As part of its own processing it unblocks client 1: `xaddCommand -> signalKeyAsReady -> handleClientsBlockedOnKeys -> unblockClientOnKey`, which re-enters client 1's `XREADGROUP` and builds a **new** reply for it.
3. Building that reply calls `addReplyDeferredLen -> trimReplyUnusedTailSpace`, which calls `zrealloc_usable` on the tail reply block to reclaim slack. That tail block is the one the bookmark still points at, so it is freed/moved and `io_last_written.buf` now dangles.
4. Reply building for the just-unblocked `XREADGROUP` continues: the `addReply*` calls flow through `_addReplyToBufferOrList -> _addReplyProtoToList -> _addReplyPayloadToList`, which needs a new reply node and calls `zmalloc_usable(size + sizeof(clientReplyBlock), ...)`. jemalloc's thread-local cache returns the address just freed in step 3, so the **new** `clientReplyBlock` lands at the bookmarked address. (The `zmalloc_usable` in `setDeferredReply`'s new-node branch can be the recycler too.) The bookmark now matches a freshly-built block holding a *different, shorter* portion of the new response, while its recorded `data_len`/`bufpos` describe the old, longer one.
5. The reply list now holds the new response as: `[leading blocks of the new response][... the recycled bookmarked block]`. Two distinct losses follow, the first on the **main thread before any further write**:
   - **Premature retirement (main thread).** In `beforeSleep`, `processIOThreadsWriteDone -> postWriteToClient -> _postWriteToClient` walks `c->reply` from the head to retire everything that was "already written". For each block it computes `last_written = (o->buf == c->io_last_written.buf)`; the retirement condition `if (!last_written || o->used == c->io_last_written.bufpos)` frees (`listDelNode`) every block whose address does not match the bookmark. The leading blocks of the brand-new response do not match, so they are freed **without ever being sent**, and the walk stops at the bookmarked block (`if (last_written) return;`). The start of the response is gone.
   - **Empty write (next `writevToClient`).** The bookmarked block survives but `data_len` (e.g. 261) exceeds its `used` (e.g. 255). `initReplyIOV` loads the stale `data_len` into the skip counter and `addPlainBufferToReplyIOV` skips the whole block (`last_written_len >= buf_len`), producing an empty `iovec` → `writev(fd, [], 0)`.

**Result:** client 1 receives a reply with its leading RESP framing missing — e.g. a stream entry payload arriving with no array header in front of it, a protocol violation.

## Root cause analysis

**The bookmark.** With IO threads, replies are written on an IO thread but reply blocks are freed on the main thread. To coordinate, after each successful write the IO thread records `io_last_written`:
- `buf` — the last reply block written from,
- `bufpos` — the in-memory offset in that block up to which data was sent (`0` is a sentinel for "written incompletely"),
- `data_len` — the number of *wire* bytes sent from that block; on the next `writevToClient`, `initReplyIOV` loads this into a skip counter so already-sent bytes are not re-sent.

The bookmark is set on the IO thread and cleared on the main thread by `_postWriteToClient` when the block is retired. The `io_write_state` machine has three values: `CLIENT_IDLE` (0, no IO in flight / bookmark cleared), `CLIENT_PENDING_IO` (1, IO thread actively writing), `CLIENT_COMPLETED_IO` (2, IO done but block not yet retired and bookmark not yet cleared).

**The IO-thread / main-thread race.** The bookmark is set on the IO thread but cleared on the main thread in a later `beforeSleep` pass. Between those two points the main thread runs other clients' commands. If one of them unblocks this client (the `XADD` → `XREADGROUP` path above), reply-building code runs for this client while the bookmark is still live. That window is exactly `CLIENT_COMPLETED_IO`.

**Why the trim corrupts.** `trimReplyUnusedTailSpace` calls `zrealloc_usable` on the tail block. If that block is the bookmarked one, it is freed/moved and `io_last_written.buf` dangles; the allocator commonly recycles the same address for the next reply allocation, so the bookmark silently re-associates with an unrelated block whose `used` is smaller than the recorded `data_len`. The skip counter (`data_len`) then exceeds the block's content, the whole block is skipped (empty IOV), and intermediate blocks holding the start of the response are retired without being written.

**Why the existing guard is not enough.** The trim already guarded with `c->io_write_state != CLIENT_PENDING_IO`. That excludes only the *actively writing* state. It does **not** exclude `CLIENT_COMPLETED_IO`, where the IO thread is done but the bookmark is still live and unretired — precisely the window the unblock path runs in. `CLIENT_COMPLETED_IO != CLIENT_PENDING_IO` is true, so the trim proceeds and frees the bookmarked block.

**Two more places with the same defect.** `setDeferredReply` has the same too-permissive guard on both of its node-merge optimizations:
- **next-merge:** `memmove(next->buf + length, next->buf, next->used)` shifts the block's already-sent bytes to prepend the array-length header. If `next` is the bookmarked block, the stale `data_len` skip counter then lands in the middle of the shifted/prepended data — corrupting, without any free.
- **prev-merge:** appends the header after `prev->used`. This does not corrupt output (already-sent bytes are untouched and the skip counter stays correct), but it grows `used` so `_postWriteToClient` can no longer match `used == bufpos`, stalling retirement and leaving the bookmark live longer than expected. It is guarded for the same reason regardless.

## Proposed fix

The correct invariant is: **never free, move, or shift the specific reply block that `io_last_written.buf` currently points at**, and never mutate the reply list while an IO thread is walking it. So all three optimizations now gate on two conditions instead of using `io_write_state` as a proxy:

```
   c->io_write_state != CLIENT_PENDING_IO      /* IO thread not concurrently walking the list */
&& <block>->buf     != c->io_last_written.buf   /* target is not the bookmarked block */
```

- `trimReplyUnusedTailSpace`: `tail->buf != io_last_written.buf`
- `setDeferredReply` prev-merge: `prev->buf != io_last_written.buf`
- `setDeferredReply` next-merge: `next->buf != io_last_written.buf`

Why pointer-based rather than a state check like `== CLIENT_IDLE`:
- It targets the actual hazard — mutating the bookmarked block — directly. `io_write_state` is a poor proxy in *both* directions: the original bug was a live bookmark in `CLIENT_COMPLETED_IO`, and the bookmark can *also* be live in `CLIENT_IDLE` after a partial main-thread write (`writeToClient` runs only in `CLIENT_IDLE` and never changes the state; `postWriteToClient` clears the bookmark only when there are no pending replies).
- It is more precise: it still allows trimming/merging a tail that is *not* the bookmarked block, even in `CLIENT_COMPLETED_IO`.
- The retained `!= CLIENT_PENDING_IO` term is a separate, necessary thread-safety guard: during `PENDING_IO` an IO thread concurrently walks the whole reply list in `writevToClient`, so reallocating any block races with it regardless of the bookmark.

Note that a pointer check at the *consumer* side (verifying the head block still matches `io_last_written.buf` before applying `data_len`) would **not** fix this: the desync is an ABA problem — the freed block is recycled at the **same address**, so the pointer compares equal while the contents differ. The only robust fix is to not free/mutate the bookmarked block in the first place, which is what these guards do.

**Unit tests** (`src/unit/test_networking.cpp`):
- `TestTrimReplyGuardsIoLastWritten` — refuses the trim when the tail is the bookmarked block (in both `CLIENT_COMPLETED_IO` and `CLIENT_IDLE`, since the guard is pointer-based), and proceeds when the bookmark points elsewhere or is absent (including a `CLIENT_COMPLETED_IO` case, demonstrating the newly-allowed behavior).
- `TestTrimReplyRefusedWhilePendingIO` — refuses the trim during `CLIENT_PENDING_IO` even when the tail is not the bookmarked block.
- `TestSetDeferredReplyPrevMergeGuardsIoLastWritten` / `TestSetDeferredReplyNextMergeGuardsIoLastWritten` — refuse the merge when the target (prev/next) node is the bookmarked block, and proceed otherwise.

These are deterministic regression guards; the live race is timing- and allocator-dependent and cannot be reproduced reliably end-to-end.

### Detector (defense in depth)

`_postWriteToClient` carries a debug-only assertion (`debugServerAssert`, active under `enable-debug-assert`, which the test suite enables): when a block is the bookmarked one, `io_last_written.bufpos == 0 || bufpos <= block->used`.

What it **catches**: any desync from a *completely* written block (`bufpos != 0`), regardless of which code path caused it. It covers both plain and encoded (copy-avoidance) blocks, because `bufpos` is always an in-memory offset — unlike `data_len`, which for copy-avoidance blocks is the larger expanded wire length and is intentionally not used here.

What it does **not** catch: a desync from a *partially* written block. On an incomplete write `saveLastWrittenBuf` stores `bufpos = 0` as a sentinel (resumption is driven by `data_len` instead), so there is no in-memory position to validate. Detecting that case would require summing the block's producible wire length — walking every payload header for encoded blocks — which is too costly for this hot path.