### PR TITLE
stream: strip redundant LIMIT when rewriting XADD/XTRIM for propagation

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -3148,6 +3148,7 @@ robj *tryObjectEncoding(robj *o);
 robj *tryObjectEncodingEx(robj *o, int try_trim);
 robj *getDecodedObject(robj *o);
 size_t stringObjectLen(robj *o);
+size_t getStringObjectLen(robj *o);
 robj *createStringObjectFromLongLong(long long value);
 robj *createStringObjectFromLongLongForValue(long long value);
 robj *createStringObjectFromLongLongWithSds(long long value);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -670,6 +670,9 @@ typedef struct {
     /* XADD + XTRIM common options */
     int trim_strategy;         /* TRIM_STRATEGY_* */
     int trim_strategy_arg_idx; /* Index of the count in MAXLEN/MINID, for rewriting. */
+    int limit_arg_idx;         /* Index of the LIMIT token in argv if it was given,
+                                * 0 otherwise. Used to strip the redundant LIMIT
+                                * option when rewriting the command for propagation. */
     int approx_trim;           /* If 1 only delete whole radix tree nodes, so
                                 * the trim argument is not applied verbatim. */
     long long limit;           /* Maximum amount of entries to trim. If 0, no limitation
@@ -960,6 +963,8 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
                 return -1;
             }
             limit_given = 1;
+            args->limit_arg_idx = i; /* Remember LIMIT position so the rewrite path
+                                      * can drop the two-arg LIMIT option entirely. */
             i++;
         } else if (xadd && !strcasecmp(opt, "nomkstream")) {
             args->no_mkstream = 1;
@@ -1999,6 +2004,40 @@ void streamRewriteTrimArgument(client *c, stream *s, int trim_strategy, int idx)
     decrRefCount(arg);
 }
 
+/* Drop the two-argument "LIMIT <count>" option from the rewritten command.
+ *
+ * Once we have rewritten "MAXLEN ~ N" to "MAXLEN = <resulting-len>",
+ * the trim that will run on the replay side is fully deterministic
+ * and the LIMIT cap can no longer fire.
+ * More critically, when the migration tool sends the rewritten command
+ * without marking it as 'mustObeyClient', the destination DB will return an error.*/
+void streamRewriteStripLimit(client *c, int limit_idx) {
+    /* limit_idx points at the "LIMIT" token; limit_idx + 1 is the count. */
+    serverAssert(limit_idx > 0 && limit_idx + 1 < c->argc);
+    serverAssert(c->argv != c->original_argv);
+
+    robj *limit_tok = c->argv[limit_idx];
+    robj *limit_val = c->argv[limit_idx + 1];
+
+    c->argv_len_sum -= stringObjectLen(limit_tok);
+    c->argv_len_sum -= stringObjectLen(limit_val);
+
+    /* Shift the tail (everything after "LIMIT <count>") two slots left. */
+    int tail = c->argc - (limit_idx + 2);
+    if (tail > 0) {
+        memmove(&c->argv[limit_idx],
+                &c->argv[limit_idx + 2],
+                sizeof(robj *) * tail);
+    }
+
+    c->argc -= 2;
+    c->argv[c->argc] = NULL;
+    c->argv[c->argc + 1] = NULL;
+
+    decrRefCount(limit_tok);
+    decrRefCount(limit_val);
+}
+
 /* XADD key [(MAXLEN [~|=] <count> | MINID [~|=] <id>) [LIMIT <entries>]] [NOMKSTREAM] <ID or *> [field value] [field
  * value] ... */
 void xaddCommand(client *c) {
@@ -2067,6 +2106,12 @@ void xaddCommand(client *c) {
              * way LIMIT is given without the ~ option. */
             streamRewriteApproxSpecifier(c, parsed_args.trim_strategy_arg_idx - 1);
             streamRewriteTrimArgument(c, s, parsed_args.trim_strategy, parsed_args.trim_strategy_arg_idx);
+
+            if (parsed_args.limit_arg_idx) {
+                serverAssert(parsed_args.limit_arg_idx < idpos);
+                streamRewriteStripLimit(c, parsed_args.limit_arg_idx);
+                idpos -= 2;
+            }
         }
     }
 
@@ -3606,6 +3651,10 @@ void xtrimCommand(client *c) {
              * way LIMIT is given without the ~ option. */
             streamRewriteApproxSpecifier(c, parsed_args.trim_strategy_arg_idx - 1);
             streamRewriteTrimArgument(c, s, parsed_args.trim_strategy, parsed_args.trim_strategy_arg_idx);
+
+            if (parsed_args.limit_arg_idx) {
+                streamRewriteStripLimit(c, parsed_args.limit_arg_idx);
+            }
         }
 
         /* Propagate the write. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2019,10 +2019,11 @@ void streamRewriteStripLimit(client *c, int limit_idx) {
     robj *limit_tok = c->argv[limit_idx];
     robj *limit_val = c->argv[limit_idx + 1];
 
-    c->argv_len_sum -= stringObjectLen(limit_tok);
-    c->argv_len_sum -= stringObjectLen(limit_val);
+    c->argv_len_sum -= getStringObjectLen(limit_tok);
+    c->argv_len_sum -= getStringObjectLen(limit_val);
 
-    /* Shift the tail (everything after "LIMIT <count>") two slots left. */
+    /* Intentionally shrink the argv vector by dropping the two "LIMIT <count>" slots,
+     * shifting the tail (everything after them) two slots left. */
     int tail = c->argc - (limit_idx + 2);
     if (tail > 0) {
         memmove(&c->argv[limit_idx],

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -908,12 +908,12 @@ start_server {tags {"stream needs:debug"} overrides {appendonly yes stream-node-
         r XADD mystream * xitem v
         incr j
         assert {[r xlen mystream] == 91}
+        r flushall
     }
-}
 
-start_server {tags {"stream"} overrides {appendonly yes appendfsync always stream-node-max-entries 10}} {
     test {XADD/XTRIM strip redundant LIMIT when rewriting for propagation} {
         set aof [get_last_incr_aof_path r]
+        r config set stream-node-max-entries 10
 
         for {set j 0} {$j < 100} {incr j} {
             r XADD mystream * xitem v

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -911,6 +911,34 @@ start_server {tags {"stream needs:debug"} overrides {appendonly yes stream-node-
     }
 }
 
+start_server {tags {"stream"} overrides {appendonly yes appendfsync always stream-node-max-entries 10}} {
+    test {XADD/XTRIM strip redundant LIMIT when rewriting for propagation} {
+        set aof [get_last_incr_aof_path r]
+
+        for {set j 0} {$j < 100} {incr j} {
+            r XADD mystream * xitem v
+        }
+        assert_equal 100 [r xlen mystream]
+
+        r XADD mystream MAXLEN ~ 55 LIMIT 30 * xitem v
+        assert_equal 71 [r xlen mystream]
+
+        set len_before_trim [r xlen mystream]
+        set trimmed [r XTRIM mystream MAXLEN ~ 50 LIMIT 30]
+        assert {$trimmed > 0 && $trimmed <= 30}
+        assert_equal [expr {$len_before_trim - $trimmed}] [r xlen mystream]
+
+        set fp [open $aof r]
+        fconfigure $fp -translation binary
+        set blob [read $fp]
+        close $fp
+        assert_equal -1 [string first "LIMIT" $blob]
+
+        r debug loadaof
+        assert_equal [expr {$len_before_trim - $trimmed}] [r xlen mystream]
+    }
+}
+
 start_server {tags {"stream"}} {
     test {XADD can CREATE an empty stream} {
         r XADD mystream MAXLEN 0 * a b


### PR DESCRIPTION
## Problem

When `XADD ... MAXLEN ~ N LIMIT M ...` or `XTRIM ... MAXLEN ~ N LIMIT M` is executed on a primary, the command is rewritten before propagation so that replicas / AOF replay perform a fully deterministic trim:

- `~` is rewritten to `=` via `streamRewriteApproxSpecifier`.
- The user-supplied threshold is replaced with the primary's actual resulting `s->length` via `streamRewriteTrimArgument`.

After these rewrites the `LIMIT` argument is left untouched in the command vector, even though:

1. **It is meaningless.** `LIMIT` only caps work in the approximate (`~`) path, once the command has been rewritten to `=`, the trim is exact and deterministic.

2. **It makes the rewritten command syntactically illegal as a plain client command.** Today the grammar enforced in
   `streamParseAddOrTrimArgsOrReply` rejects `LIMIT` unless `~` was given:

   ```text
   ERR syntax error, LIMIT cannot be used without the special ~ option
   ```
 Although this does not affect primary-replica synchronization, the migration tool sends the rewritten command without marking it as `mustObeyClient`, which causes the destination node to return an error.