### PR TITLE
Fix sentinel failover coordinated segfault when old leader's client is disconnected

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -4810,6 +4810,8 @@ int sentinelFailoverTo(sentinelValkeyInstance *ri, const sentinelAddr *addr, mst
 int sentinelKillClients(sentinelValkeyInstance *ri) {
     int retval;
 
+    if (ri->link->cc == NULL) return C_ERR;
+
     /* 1) Rewrite the configuration (the instance just switched roles)
      * 2) Disconnect all clients (but this one sending the command) in order
      *    to trigger the ask-master-on-reconnection protocol for connected

--- a/tests/sentinel/tests/19-coordinated-failover-killed-link.tcl
+++ b/tests/sentinel/tests/19-coordinated-failover-killed-link.tcl
@@ -51,7 +51,7 @@ test "Coordinated failover tolerates old primary command link disconnect" {
     S $sentinel_id sentinel debug ping-period 10000
     catch {R $old_master_id CLIENT KILL NAME $sentinel_client_name}
 
-    wait_for_condition 100 10 {
+    wait_for_condition 1000 10 {
         [string match "*disconnected*" [dict get [S $sentinel_id SENTINEL PRIMARY mymaster] flags]]
     } else {
         fail "Sentinel command link to the old primary did not disconnect"

--- a/tests/sentinel/tests/19-coordinated-failover-killed-link.tcl
+++ b/tests/sentinel/tests/19-coordinated-failover-killed-link.tcl
@@ -1,0 +1,67 @@
+# Regression test for coordinated failover when the Sentinel command link to
+# the old primary is disconnected just as the promoted replica reports its new
+# role.  In that window Sentinel must not dereference a NULL command link while
+# doing its best-effort client cleanup on the old primary.
+
+source "../tests/includes/init-tests.tcl"
+
+foreach_sentinel_id id {
+    S $id sentinel debug info-period 1000
+    S $id sentinel debug publish-period 100
+    S $id sentinel debug ping-period 100
+}
+
+proc sentinel_cmd_client_name {sentinel_id} {
+    set myid [S $sentinel_id SENTINEL MYID]
+    return "sentinel-[string range $myid 0 7]-cmd"
+}
+
+test "Coordinated failover tolerates old primary command link disconnect" {
+    set sentinel_id 0
+    set old_master_id $master_id
+    set old_port [RPort $old_master_id]
+    set old_addr [S $sentinel_id SENTINEL GET-PRIMARY-ADDR-BY-NAME mymaster]
+    assert {[lindex $old_addr 1] == $old_port}
+
+    set sentinel_client_name [sentinel_cmd_client_name $sentinel_id]
+
+    wait_for_condition 1000 50 {
+        [string match "*name=$sentinel_client_name*" [R $old_master_id CLIENT LIST]]
+    } else {
+        fail "Sentinel command client $sentinel_client_name was not connected to the old primary"
+    }
+
+    wait_for_condition 300 50 {
+        [catch {S $sentinel_id SENTINEL FAILOVER mymaster COORDINATED}] == 0
+    } else {
+        catch {S $sentinel_id SENTINEL FAILOVER mymaster COORDINATED} reply
+        fail "Sentinel manual coordinated failover did not start, got: $reply"
+    }
+
+    wait_for_condition 1000 10 {
+        [dict get [S $sentinel_id SENTINEL PRIMARY mymaster] failover-state] eq {wait_promotion}
+    } else {
+        fail "Sentinel did not reach wait_promotion state"
+    }
+
+    # Keep the command connection from this Sentinel to the old primary closed
+    # while the next INFO reply from the promoted replica advances the failover.
+    # Before the fix, sentinelKillClients(old-primary) calls
+    # valkeyAsyncCommand(NULL, ...) in this window, and the Sentinel crashes.
+    S $sentinel_id sentinel debug ping-period 10000
+    catch {R $old_master_id CLIENT KILL NAME $sentinel_client_name}
+
+    wait_for_condition 100 10 {
+        [string match "*disconnected*" [dict get [S $sentinel_id SENTINEL PRIMARY mymaster] flags]]
+    } else {
+        fail "Sentinel command link to the old primary did not disconnect"
+    }
+
+    assert_equal {PONG} [S $sentinel_id PING]
+
+    wait_for_condition 1000 50 {
+        [lindex [S $sentinel_id SENTINEL GET-PRIMARY-ADDR-BY-NAME mymaster] 1] != $old_port
+    } else {
+        fail "Sentinel did not complete the coordinated failover"
+    }
+}


### PR DESCRIPTION
Prevent a segfault that can happen during a sentinel coordinated
failover (a new feature introduced in #1292) that can happen when
the coordinated failover attempting to clean up the former leader
races with that leader disconnecting.

Add a check for `link->cc` in `sentinelKillClients`. Otherwise the
sentinel node will segfault in this case.

Fixes #4066.