### PR TITLE
Share pubsub pattern and watched key across clients

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -381,11 +381,14 @@ void watchForKey(client *c, robj *key) {
     }
 
     /* This key is not already watched in this DB. Let's add it */
-    clients = dictFetchValue(c->db->watched_keys, key);
-    if (!clients) {
+    dictEntry *de = dictFind(c->db->watched_keys, key);
+    if (de == NULL) {
         clients = listCreate();
         dictAdd(c->db->watched_keys, key, clients);
         incrRefCount(key);
+    } else {
+        key = dictGetKey(de);
+        clients = dictGetVal(de);
     }
 
     /* Add the new key to the list of keys watched by this client */

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -399,9 +399,11 @@ void pubsubShardUnsubscribeAllChannelsInSlot(unsigned int slot) {
  * or false if the client was already subscribed to that pattern. */
 bool pubsubSubscribePattern(client *c, robj *pattern) {
     if (!c->pubsub_data) initClientPubSubData(c);
-    bool pattern_added = hashtableAdd(c->pubsub_data->pubsub_patterns, pattern);
+
+    /* Add the pattern to the client -> patterns hash table */
+    hashtablePosition position;
+    bool pattern_added = hashtableFindPositionForInsert(c->pubsub_data->pubsub_patterns, pattern, &position, NULL);
     if (pattern_added) {
-        incrRefCount(pattern);
         /* Add the client to the pattern -> list of clients hash table */
         hashtable *clients;
         dictEntry *de = dictFind(server.pubsub_patterns, pattern);
@@ -410,9 +412,12 @@ bool pubsubSubscribePattern(client *c, robj *pattern) {
             dictAdd(server.pubsub_patterns, pattern, clients);
             incrRefCount(pattern);
         } else {
+            pattern = dictGetKey(de);
             clients = dictGetVal(de);
         }
         serverAssert(hashtableAdd(clients, c));
+        hashtableInsertAtPosition(c->pubsub_data->pubsub_patterns, pattern, &position);
+        incrRefCount(pattern);
     }
     /* Notify the client */
     addReplyPubsubPatSubscribed(c, pattern);

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -19,59 +19,77 @@ start_server {tags {"introspection"}} {
         r client info
     } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N capa= db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* tot-net-in=* tot-net-out=* tot-cmds=*}
 
-    test {Multiple clients WATCH same key share robj memory} {
-        set big_string [string repeat "x" 5000000]
-        r set $big_string myvalue
-
+    test {Multiple clients WATCH same key} {
         set rd1 [valkey_client]
         set rd2 [valkey_client]
+        set rd3 [valkey_client]
 
-        set mem_before [s used_memory]
-        $rd1 watch $big_string
-        set delta_first [expr {[s used_memory] - $mem_before}]
+        # Watch the same key.
+        r del mykey
+        $rd1 watch mykey
+        $rd2 watch mykey
+        $rd3 watch mykey
 
-        $rd2 watch $big_string
-        set delta_second [expr {[s used_memory] - $mem_before - $delta_first}]
+        # Have rd3 unwatch, and have rd1/rd2 unwatch via multi.
+        $rd3 unwatch
+        r set mykey value
+        foreach rd [list $rd1 $rd2] {
+            $rd multi
+            $rd set mykey other
+            $rd exec
+        }
 
-        # The second WATCH should use much less server memory
-        # because it shares the same key robj as the first.
-        assert_morethan $delta_first 0
-        assert_lessthan $delta_second $delta_first
+        # The multi must have been discarded, so the key keeps its value.
+        assert_equal {value} [r get mykey]
 
-        $rd1 unwatch
-        $rd2 unwatch
         $rd1 close
         $rd2 close
-        r del $big_string
+        $rd3 close
     }
 
-    foreach {subscribe unsubscribe} {subscribe unsubscribe psubscribe punsubscribe ssubscribe sunsubscribe} {
-        test "Multiple clients $subscribe to same name share robj memory" {
-            set big_string [string repeat "x" 5000000]
-
+    foreach {subscribe unsubscribe publish check_registered} {
+        subscribe   unsubscribe   publish   {llength [r pubsub channels $channel]}
+        psubscribe  punsubscribe  publish   {r pubsub numpat}
+        ssubscribe  sunsubscribe  spublish  {llength [r pubsub shardchannels $channel]}
+    } {
+        test "Multiple clients $subscribe to same name" {
             set rd1 [valkey_deferring_client]
             set rd2 [valkey_deferring_client]
+            set rd3 [valkey_deferring_client]
 
-            set mem_before [s used_memory]
-            $rd1 $subscribe $big_string
+            # Subscribe to the same channel.
+            set channel "shared-channel"
+            $rd1 $subscribe $channel
             $rd1 read
-            set delta_first [expr {[s used_memory] - $mem_before}]
-
-            $rd2 $subscribe $big_string
+            $rd2 $subscribe $channel
             $rd2 read
-            set delta_second [expr {[s used_memory] - $mem_before - $delta_first}]
+            $rd3 $subscribe $channel
+            $rd3 read
 
-            # The second subscriber should use much less server memory
-            # because it shares the same robj as the first.
-            assert_morethan $delta_first 0
-            assert_lessthan $delta_second $delta_first
+            # The name is registered exactly once, no matter how many clients
+            # subscribe to it (all of them share the same robj).
+            assert_equal 1 [eval $check_registered]
 
-            $rd1 $unsubscribe
+            # Every subscriber receives the published message. The delivery
+            # payload is the last element of the reply for all messages.
+            r $publish $channel hello
+            assert_equal hello [lindex [$rd1 read] end]
+            assert_equal hello [lindex [$rd2 read] end]
+            assert_equal hello [lindex [$rd3 read] end]
+
+            $rd1 $unsubscribe $channel
             $rd1 read
-            $rd2 $unsubscribe
+            $rd2 $unsubscribe $channel
             $rd2 read
+            $rd3 $unsubscribe $channel
+            $rd3 read
+
+            # No subscriber left.
+            assert_equal 0 [eval $check_registered]
+
             $rd1 close
             $rd2 close
+            $rd3 close
         }
     }
 

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -19,6 +19,62 @@ start_server {tags {"introspection"}} {
         r client info
     } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N capa= db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* tot-net-in=* tot-net-out=* tot-cmds=*}
 
+    test {Multiple clients WATCH same key share robj memory} {
+        set big_string [string repeat "x" 5000000]
+        r set $big_string myvalue
+
+        set rd1 [valkey_client]
+        set rd2 [valkey_client]
+
+        set mem_before [s used_memory]
+        $rd1 watch $big_string
+        set delta_first [expr {[s used_memory] - $mem_before}]
+
+        $rd2 watch $big_string
+        set delta_second [expr {[s used_memory] - $mem_before - $delta_first}]
+
+        # The second WATCH should use much less server memory
+        # because it shares the same key robj as the first.
+        assert_morethan $delta_first 0
+        assert_lessthan $delta_second $delta_first
+
+        $rd1 unwatch
+        $rd2 unwatch
+        $rd1 close
+        $rd2 close
+        r del $big_string
+    }
+
+    foreach {subscribe unsubscribe} {subscribe unsubscribe psubscribe punsubscribe ssubscribe sunsubscribe} {
+        test "Multiple clients $subscribe to same name share robj memory" {
+            set big_string [string repeat "x" 5000000]
+
+            set rd1 [valkey_deferring_client]
+            set rd2 [valkey_deferring_client]
+
+            set mem_before [s used_memory]
+            $rd1 $subscribe $big_string
+            $rd1 read
+            set delta_first [expr {[s used_memory] - $mem_before}]
+
+            $rd2 $subscribe $big_string
+            $rd2 read
+            set delta_second [expr {[s used_memory] - $mem_before - $delta_first}]
+
+            # The second subscriber should use much less server memory
+            # because it shares the same robj as the first.
+            assert_morethan $delta_first 0
+            assert_lessthan $delta_second $delta_first
+
+            $rd1 $unsubscribe
+            $rd1 read
+            $rd2 $unsubscribe
+            $rd2 read
+            $rd1 close
+            $rd2 close
+        }
+    }
+
     test {CLIENT LIST with ADDR filter} {
         set client_info [r client info]
         regexp {addr=([^ ]+)} $client_info match myaddr


### PR DESCRIPTION
In ad127303, channel robj objects were changed to be shared between the
pubsub kvstore and all subscribing clients, saving memory when many
clients subscribe to the same channel.

Apply the same idea to pubsub patterns and WATCH keys:

- pubsubSubscribePattern: use hashtableFindPositionForInsert to check
  for duplicates before insertion, then retrieve the canonical robj
  from server.pubsub_patterns via dictGetKey so that all clients
  subscribing to the same pattern share a single robj.

- watchForKey: use dictFind + dictGetKey to retrieve the canonical robj
  from db->watched_keys, so that multiple clients WATCHing the same key
  share a single robj instead of each holding an independent copy.

This reduces server memory usage when multiple clients subscribe to the
same pattern or WATCH the same key.

Might related #3362.