### PR TITLE
Streaming Compression support for fullsync

### DIFF
--- a/src/compression_stream.c
+++ b/src/compression_stream.c
@@ -171,6 +171,7 @@ int streamReaderInit(streamReader *reader, const streamReaderConfig *cfg, stream
     reader->buffer_size = cfg->buffer_size < STREAM_READER_BUFFER_SIZE_MIN
                               ? STREAM_READER_BUFFER_SIZE_MIN
                               : cfg->buffer_size;
+    reader->eof_mid_frame_is_truncation = cfg->eof_mid_frame_is_truncation;
     compressionAlgo algo = ALGO_NONE;
     while (true) {
         size_t need = reader->probe.header_len < VCS_MAGIC_SIZE
@@ -359,7 +360,11 @@ ssize_t streamReaderRead(streamReader *reader, void *buf, size_t len) {
             available = reader->decompressed_buf_len;
             if (available == 0 && fill_result == C_ERR) return total > 0 ? (ssize_t)total : -1;
             if (available == 0 && !reader->decompressor.frame_done) {
-                streamReaderSetError(reader, STREAM_READER_ERROR_CORRUPT);
+                /* A codec failure would already have latched an error above, so
+                 * this is a short read: recoverable only if more bytes can arrive. */
+                streamReaderSetError(reader, reader->eof_mid_frame_is_truncation
+                                                 ? STREAM_READER_ERROR_TRUNCATED
+                                                 : STREAM_READER_ERROR_CORRUPT);
                 return total > 0 ? (ssize_t)total : -1;
             }
             if (available == 0) break;

--- a/src/compression_stream.h
+++ b/src/compression_stream.h
@@ -86,6 +86,7 @@ typedef struct {
     bool allow_passthrough;
     bool skip_codec_checksum_validation;
     size_t buffer_size;
+    bool eof_mid_frame_is_truncation; /* Set for sources that can deliver the rest later. */
 } streamReaderConfig;
 
 typedef enum {
@@ -94,6 +95,7 @@ typedef enum {
     STREAM_READER_ERROR_INCOMPATIBLE = 2,
     STREAM_READER_ERROR_CORRUPT = 3,
     STREAM_READER_ERROR_INTERNAL = 4,
+    STREAM_READER_ERROR_TRUNCATED = 5, /* Clean EOF before frame end: recoverable short read, not corruption. */
 } streamReaderErrorKind;
 
 typedef enum {
@@ -111,6 +113,7 @@ typedef struct streamReader {
     } probe;
     size_t probe_replay_pos; /* Passthrough bytes left to replay from probe. */
     size_t buffer_size;
+    bool eof_mid_frame_is_truncation;
     streamReaderErrorKind error_kind;
     streamReaderState state;
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -163,6 +163,13 @@ void rdbReportError(int corruption_error, int linenum, char *reason, ...) {
     exit(1);
 }
 
+/* Route a corrupt compressed frame through the parser's fatal path, so a bad
+ * stream logs and terminates instead of driving a full-sync retry loop. */
+void rdbReportCorruptCompressedStream(const char *source) {
+    serverLog(LL_WARNING, "Corrupt streaming-compressed RDB input. Unrecoverable error, aborting now.");
+    rdbReportCorruptRDB("Corrupt compressed RDB stream from %s", source);
+}
+
 typedef struct {
     rdbAuxFieldEncoder encoder;
     rdbAuxFieldDecoder decoder;
@@ -1533,6 +1540,9 @@ werr:
     return C_ERR;
 }
 
+static int rdbCompressionInit(rio *rdb, streamWriter *writer, compressionAlgo algo, bool codec_checksum);
+static void rdbCompressionFree(rio *rdb, streamWriter *writer);
+
 /* This helper function is only used for diskless replication.
  * This is just a wrapper to rdbSaveRio() that additionally adds a prefix
  * and a suffix to the generated RDB dump. The prefix is:
@@ -1542,8 +1552,10 @@ werr:
  * While the suffix is the 40 bytes hex string we announced in the prefix.
  * This way processes receiving the payload can understand when it ends
  * without doing any processing of the content. */
-int rdbSaveRioWithEOFMark(int req, int rdbver, rio *rdb, int *error, rdbSaveInfo *rsi) {
+static int rdbSaveRioWithEOFMark(int req, int rdbver, rio *rdb, int *error, rdbSaveInfo *rsi, compressionAlgo compression_algo) {
     char eofmark[RDB_EOF_MARK_SIZE];
+    streamWriter compression_writer;
+    bool compression_initialized = false;
 
     startSaving(RDBFLAGS_REPLICATION);
     getRandomHexChars(eofmark, RDB_EOF_MARK_SIZE);
@@ -1551,7 +1563,31 @@ int rdbSaveRioWithEOFMark(int req, int rdbver, rio *rdb, int *error, rdbSaveInfo
     if (rioWrite(rdb, "$EOF:", 5) == 0) goto werr;
     if (rioWrite(rdb, eofmark, RDB_EOF_MARK_SIZE) == 0) goto werr;
     if (rioWrite(rdb, "\r\n", 2) == 0) goto werr;
+
+    /* Compress only the RDB body; the $EOF prefix/suffix stay plaintext. The
+     * VCS frame owns checksum policy, so drop the outer RDB CRC64. */
+    if (compression_algo != ALGO_NONE) {
+        if (rdbCompressionInit(rdb, &compression_writer, compression_algo, server.rdb_checksum) == C_ERR) {
+            if (error && *error == 0) *error = EIO;
+            goto werr;
+        }
+        compression_initialized = true;
+        rdb->flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
+        rdb->update_cksum = NULL;
+        rdb->cksum = 0;
+    }
+
     if (rdbSaveRio(req, rdbver, rdb, error, RDBFLAGS_REPLICATION, rsi) == C_ERR) goto werr;
+
+    if (compression_initialized) {
+        if (streamWriterFinish(&compression_writer) == C_ERR) {
+            if (error && *error == 0) *error = EIO;
+            goto werr;
+        }
+        rdbCompressionFree(rdb, &compression_writer);
+        compression_initialized = false;
+    }
+
     if (rioWrite(rdb, eofmark, RDB_EOF_MARK_SIZE) == 0) goto werr;
     stopSaving(1);
     return C_OK;
@@ -1559,6 +1595,7 @@ int rdbSaveRioWithEOFMark(int req, int rdbver, rio *rdb, int *error, rdbSaveInfo
 werr: /* Write error. */
     /* Set 'error' only if not already set by rdbSaveRio() call. */
     if (error && *error == 0) *error = errno;
+    if (compression_initialized) rdbCompressionFree(rdb, &compression_writer);
     stopSaving(0);
     return C_ERR;
 }
@@ -1589,10 +1626,11 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi, int 
     char *err_op; /* For a detailed log */
     compressionAlgo compression_algo = rdbCompressionAlgorithm(server.rdb_compression);
     bool use_streaming_compression = compression_algo == ALGO_LZ4;
-    /* Keep replication snapshots plain until full sync negotiates compression.
-     * Disk-based sync snapshots can also become AOF bases, which currently do
-     * not record whether the reused RDB has whole-stream compression. */
-    if (rdbflags & RDBFLAGS_REPLICATION) use_streaming_compression = false;
+    /* Replication full sync uses the codec selected before the child was forked. */
+    if (rdbflags & RDBFLAGS_REPLICATION) {
+        compression_algo = server.rdb_child_sync_algo;
+        use_streaming_compression = compression_algo != ALGO_NONE;
+    }
     streamWriter compression_writer;
     bool compression_initialized = false;
 
@@ -1811,6 +1849,7 @@ int rdbSaveBackground(int req, char *filename, rdbSaveInfo *rsi, int rdbflags) {
     } else {
         /* Parent */
         if (childpid == -1) {
+            server.rdb_child_sync_algo = ALGO_NONE; /* Roll back the caller's sync-algo assignment. */
             server.lastbgsave_status = C_ERR;
             server.lastbgsave_try = time(NULL);
             serverLog(LL_WARNING, "Can't save in background: fork: %s", strerror(errno));
@@ -3338,7 +3377,10 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
     /* Dual-channel loads on the rdb channel before REPL_STATE_TRANSFER, so count those bytes too. */
     if ((server.repl_state == REPL_STATE_TRANSFER || server.repl_rdb_channel_state == REPL_DUAL_CHANNEL_RDB_LOAD) &&
         rioCheckType(r) == RIO_TYPE_CONN) {
-        server.stat_net_repl_input_bytes += len;
+        /* The stream reader accounts encoded bytes in rdbStreamReadRaw(). */
+        if (!r->stream_reader) {
+            server.stat_net_repl_input_bytes += len;
+        }
     }
 }
 
@@ -3354,7 +3396,14 @@ bool rdbRioHasInternalStreamReaderError(rio *rdb) {
 }
 
 static ssize_t rdbStreamReadRaw(void *ctx, void *buf, size_t len) {
-    return rioReadRawPartial((rio *)ctx, buf, len);
+    rio *rdb = ctx;
+    ssize_t nread = rioReadRawPartial(rdb, buf, len);
+    if (nread > 0 && rioCheckType(rdb) == RIO_TYPE_CONN &&
+        (server.repl_state == REPL_STATE_TRANSFER ||
+         server.repl_rdb_channel_state == REPL_DUAL_CHANNEL_RDB_LOAD)) {
+        server.stat_net_repl_input_bytes += nread;
+    }
+    return nread;
 }
 
 rdbStreamReaderInitResult rdbInitStreamReader(rio *rdb,
@@ -3365,6 +3414,8 @@ rdbStreamReaderInitResult rdbInitStreamReader(rio *rdb,
         .allow_passthrough = true,
         .skip_codec_checksum_validation = skip_codec_checksum_validation,
         .buffer_size = STREAM_READER_BUFFER_SIZE_DEFAULT,
+        /* A file is fully present, so a short frame there is corruption. */
+        .eof_mid_frame_is_truncation = (rioCheckType(rdb) == RIO_TYPE_CONN),
     };
     compressionAlgo detected_algo = ALGO_NONE;
 
@@ -3968,7 +4019,7 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     rio rdb;
     streamReader stream_reader;
     bool stream_reader_initialized = false;
-    compressionAlgo streaming_algo = ALGO_NONE;
+    compressionAlgo compression_algo = ALGO_NONE;
     int retval = RDB_FAILED;
     struct stat sb;
     int rdb_fd;
@@ -3995,7 +4046,7 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
      * For VCS input the parser sees the header produced by the decoder. */
     bool skip_codec_checksum_validation = !server.rdb_checksum || server.skip_checksum_validation;
     rdbStreamReaderInitResult init_rc =
-        rdbInitStreamReader(&rdb, &stream_reader, skip_codec_checksum_validation, &streaming_algo);
+        rdbInitStreamReader(&rdb, &stream_reader, skip_codec_checksum_validation, &compression_algo);
     if (init_rc == RDB_STREAM_READER_INIT_INCOMPATIBLE) {
         serverLog(LL_WARNING,
                   "Invalid or unsupported RDB stream envelope in %s. "
@@ -4010,15 +4061,23 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
         goto done;
     }
     stream_reader_initialized = true;
+    if (rsi) {
+        rsi->loaded_compressed = compression_algo != ALGO_NONE;
+    }
 
     if (rdb.flags & RIO_FLAG_STREAMING_COMPRESSION) {
         serverLog(LL_NOTICE, "Loading compressed RDB (algo=%s) from %s",
-                  compressionAlgoName(streaming_algo), filename);
+                  compressionAlgoName(compression_algo), filename);
     }
 
     retval = rdbLoadRio(&rdb, rdbflags, rsi);
     if (retval == RDB_OK && streamReaderFinish(&stream_reader) == C_ERR) {
-        serverLog(LL_WARNING, "Compressed RDB stream in %s did not end cleanly", filename);
+        if (stream_reader.error_kind == STREAM_READER_ERROR_CORRUPT) {
+            /* Treat a corrupt frame end like mid-parse corruption via the fatal path. */
+            rdbReportCorruptCompressedStream(filename);
+        } else {
+            serverLog(LL_WARNING, "Compressed RDB stream in %s did not end cleanly", filename);
+        }
         retval = RDB_FAILED;
     }
 
@@ -4100,6 +4159,7 @@ void backgroundSaveDoneHandler(int exitcode, int bysignal) {
     }
 
     rdbClearSaveState(save_end);
+    server.rdb_child_sync_algo = ALGO_NONE;
 
     /* Possibly there are replicas waiting for a BGSAVE in order to be served
      * (the first stage of SYNC is a bulk transfer of dump.rdb) */
@@ -4164,6 +4224,7 @@ int rdbSaveToReplicasSockets(int req, int rdbver, rdbSaveInfo *rsi) {
      * Otherwise, use checksum for this RDB transfer.
      */
     int skip_rdb_checksum = 1;
+    int common_capa = -1;
     /* Collect the connections of the replicas we want to transfer
      * the RDB to, which are in WAIT_BGSAVE_START state. */
     int connsnum = 0;
@@ -4182,6 +4243,8 @@ int rdbSaveToReplicasSockets(int req, int rdbver, rdbSaveInfo *rsi) {
             /* Check replica has the exact requirements */
             if (replica->repl_data->replica_req != req) continue;
             if (replicaRdbVersion(replica) != rdbver) continue;
+
+            common_capa &= replica->repl_data->replica_capa;
 
             conns[connsnum++] = replica->conn;
             if (dual_channel) {
@@ -4203,6 +4266,11 @@ int rdbSaveToReplicasSockets(int req, int rdbver, rdbSaveInfo *rsi) {
         if (!connIsIntegrityChecked(replica->conn) || !(replica->repl_data->replica_capa & REPLICA_CAPA_SKIP_RDB_CHECKSUM))
             skip_rdb_checksum = 0;
     }
+
+    compressionAlgo sync_compression_algo =
+        connsnum > 0 ? replSelectFullSyncCompression(common_capa) : ALGO_NONE;
+    if (sync_compression_algo != ALGO_NONE)
+        serverLog(LL_NOTICE, "Diskless full sync with compression: %s", compressionAlgoName(sync_compression_algo));
 
     /* Create the child process. */
     if ((childpid = serverFork(CHILD_TYPE_RDB)) == 0) {
@@ -4227,16 +4295,17 @@ int rdbSaveToReplicasSockets(int req, int rdbver, rdbSaveInfo *rsi) {
 
         if (skip_rdb_checksum) rdb.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
 
-        retval = rdbSaveRioWithEOFMark(req, rdbver, &rdb, NULL, rsi);
+        retval = rdbSaveRioWithEOFMark(req, rdbver, &rdb, NULL, rsi, sync_compression_algo);
         if (retval == C_OK && rioFlush(&rdb) == 0) retval = C_ERR;
 
         if (retval == C_OK) {
             sendChildCowInfo(CHILD_INFO_TYPE_RDB_COW_SIZE, "RDB");
-            if (dual_channel) {
-                sendChildInfoGeneric(CHILD_INFO_TYPE_REPL_OUTPUT_BYTES, 0, rdb.processed_bytes, -1, "RDB");
-            }
         }
         if (dual_channel) {
+            /* Bytes actually written across all replica sockets: correct whether
+             * or not compressed, and reported on both success and failure so a
+             * mid-transfer failure still counts what went out. */
+            sendChildInfoGeneric(CHILD_INFO_TYPE_REPL_OUTPUT_BYTES, 0, rdb.io.connset.net_output_bytes, -1, "RDB");
             rioFreeConnset(&rdb);
         } else {
             rioFreeFd(&rdb);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3335,7 +3335,9 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
         processEventsWhileBlocked();
         processModuleLoadingProgressEvent(0);
     }
-    if (server.repl_state == REPL_STATE_TRANSFER && rioCheckType(r) == RIO_TYPE_CONN) {
+    /* Dual-channel loads on the rdb channel before REPL_STATE_TRANSFER, so count those bytes too. */
+    if ((server.repl_state == REPL_STATE_TRANSFER || server.repl_rdb_channel_state == REPL_DUAL_CHANNEL_RDB_LOAD) &&
+        rioCheckType(r) == RIO_TYPE_CONN) {
         server.stat_net_repl_input_bytes += len;
     }
 }

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -227,6 +227,7 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi);
 int rdbLoadRioWithLoadingCtxScopedRdb(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadingCtx *rdb_loading_ctx);
 bool rdbRioHasCorruptCompressedInput(rio *rdb);
 bool rdbRioHasInternalStreamReaderError(rio *rdb);
+void rdbReportCorruptCompressedStream(const char *source);
 
 typedef enum {
     RDB_STREAM_READER_INIT_ERROR = -1,

--- a/src/replication.c
+++ b/src/replication.c
@@ -997,6 +997,18 @@ need_full_resync:
     return C_ERR;
 }
 
+/* LZ4 full-sync payloads require the replica to advertise its LZ4 decoder. */
+bool replicaCanUseFullSyncFormat(int replica_capa, compressionAlgo compression_algo) {
+    return compression_algo == ALGO_NONE || (replica_capa & REPLICA_CAPA_LZ4);
+}
+
+compressionAlgo replSelectFullSyncCompression(int replica_capa) {
+    /* Only whole-stream LZ4 can frame a sync payload; rdbcompression yes and lzf
+     * select per-string LZF, which is not a stream codec. */
+    compressionAlgo configured_algo = server.rdb_compression == RDB_COMPRESSION_LZ4 ? ALGO_LZ4 : ALGO_NONE;
+    return replicaCanUseFullSyncFormat(replica_capa, configured_algo) ? configured_algo : ALGO_NONE;
+}
+
 /* Start a BGSAVE for replication goals, which is, selecting the disk or
  * socket target depending on the configuration, and making sure that
  * the script cache is flushed before to start.
@@ -1021,6 +1033,7 @@ need_full_resync:
 int startBgsaveForReplication(int mincapa, int req, int rdbver) {
     int retval;
     int socket_target = 0;
+    compressionAlgo sync_compression_algo = ALGO_NONE;
     listIter li;
     listNode *ln;
 
@@ -1050,6 +1063,12 @@ int startBgsaveForReplication(int mincapa, int req, int rdbver) {
         if (socket_target)
             retval = rdbSaveToReplicasSockets(req, rdbver, rsiptr);
         else {
+            /* mincapa is the trigger's own mask on the eager path but the group AND on the cron path, so a mixed group downgrades to plain. */
+            sync_compression_algo = replSelectFullSyncCompression(mincapa);
+            if (sync_compression_algo != ALGO_NONE)
+                serverLog(LL_NOTICE, "Disk-based full sync with compression: %s", compressionAlgoName(sync_compression_algo));
+            /* The forked child reads this global to pick the sync codec. */
+            server.rdb_child_sync_algo = sync_compression_algo;
             /* Keep the page cache since it'll get used soon */
             retval = rdbSaveBackground(req, server.rdb_filename, rsiptr, RDBFLAGS_REPLICATION | RDBFLAGS_KEEP_CACHE);
         }
@@ -1098,6 +1117,10 @@ int startBgsaveForReplication(int mincapa, int req, int rdbver) {
                 /* Check replica has the exact requirements */
                 if (replica->repl_data->replica_req != req) continue;
                 if (replicaRdbVersion(replica) != rdbver) continue;
+                /* A non-capable waiter must not receive a compressed sync; it
+                 * stays parked and the next cron round, whose AND includes it,
+                 * is plain. A capable waiter may still join a plain round. */
+                if (!replicaCanUseFullSyncFormat(replica->repl_data->replica_capa, sync_compression_algo)) continue;
                 replicationSetupReplicaForFullResync(replica, getPsyncInitialOffset());
             }
         }
@@ -1264,10 +1287,15 @@ void syncCommand(client *c) {
                 break;
         }
         /* To attach this replica, we check that it has at least all the
-         * capabilities of the replica that triggered the current BGSAVE
-         * and its exact requirements. */
-        if (ln && ((c->repl_data->replica_capa & replica->repl_data->replica_capa) == replica->repl_data->replica_capa) &&
-            c->repl_data->replica_req == replica->repl_data->replica_req) {
+         * capabilities of the replica that triggered the current BGSAVE and its
+         * exact requirements. Compression is asymmetric: a plain running save is
+         * joinable by anyone, but a compressed one only by a capable replica.
+         * The LZ4 capability is masked out of the capability superset check so a
+         * capable newcomer can still join a plain running save. */
+        int trigger_capa = ln ? (replica->repl_data->replica_capa & ~REPLICA_CAPA_LZ4) : 0;
+        if (ln && ((c->repl_data->replica_capa & trigger_capa) == trigger_capa) &&
+            c->repl_data->replica_req == replica->repl_data->replica_req &&
+            replicaCanUseFullSyncFormat(c->repl_data->replica_capa, server.rdb_child_sync_algo)) {
             /* Perfect, the server is already registering differences for
              * another replica. Set the right state, and copy the buffer.
              * We don't copy buffer if clients don't want. */
@@ -1391,13 +1419,14 @@ void freeClientReplicationData(client *c) {
  * the primary can accurately lists replicas and their listening ports in the
  * INFO output.
  *
- * - capa <eof|psync2|dual-channel|skip-rdb-checksum>
+ * - capa <eof|psync2|dual-channel|skip-rdb-checksum|lz4>
  * What is the capabilities of this instance.
  * eof: supports EOF-style RDB transfer for diskless replication.
  * psync2: supports PSYNC v2, so understands +CONTINUE <new repl ID>.
  * dual-channel: supports full sync using rdb channel.
  * skip-rdb-checksum: supports skipping RDB checksum calculations during diskless sync using
  *                    a connection that has integrity checks (such as TLS).
+ * lz4: can decode LZ4 streaming-compressed payloads.
  *
  * - ack <offset> [fack <aofofs>]
  * Replica informs the primary the amount of replication stream that it
@@ -1479,6 +1508,9 @@ void replconfCommand(client *c) {
                 }
             } else if (!strcasecmp(objectGetVal(c->argv[j + 1]), REPLICA_CAPA_SKIP_RDB_CHECKSUM_STR))
                 c->repl_data->replica_capa |= REPLICA_CAPA_SKIP_RDB_CHECKSUM;
+            /* "lz4": the replica can decode LZ4 streaming-compressed payloads. */
+            else if (!strcasecmp(objectGetVal(c->argv[j + 1]), REPLICA_CAPA_LZ4_STR))
+                c->repl_data->replica_capa |= REPLICA_CAPA_LZ4;
         } else if (!strcasecmp(objectGetVal(c->argv[j]), "ack")) {
             /* REPLCONF ACK is used by replica to inform the primary the amount
              * of replication stream that it processed so far. It is an
@@ -2463,11 +2495,17 @@ void replicaAfterLoadPrimaryRDB(connection *conn, rdbSaveInfo *rsi, int disk_bas
      * directly, avoiding a redundant bgrewriteaof. Otherwise (diskless
      * sync or rdb-preamble disabled), fall back to bgrewriteaof. */
     if (server.aof_enabled) {
-        if (disk_based_sync && server.aof_use_rdb_preamble) {
+        bool aof_rdb_base_candidate = disk_based_sync && server.aof_use_rdb_preamble;
+        if (aof_rdb_base_candidate && !rsi->loaded_compressed) {
             if (restartAOFWithSyncRdb() == C_ERR) {
                 restartAOFAfterSYNC();
             }
         } else {
+            if (aof_rdb_base_candidate) {
+                serverLog(LL_NOTICE,
+                          "Sync RDB file %s is streaming-compressed, falling back to BGREWRITEAOF instead of reusing it as an AOF base",
+                          server.rdb_filename);
+            }
             restartAOFAfterSYNC();
         }
     }
@@ -2482,6 +2520,9 @@ void replicaAfterLoadPrimaryRDB(connection *conn, rdbSaveInfo *rsi, int disk_bas
 
 int replicaLoadPrimaryRDBFromSocket(connection *conn, char *buf, char *eofmark, int *usemark, rdbSaveInfo *rsi) {
     rio rdb;
+    streamReader stream_reader;
+    bool stream_reader_initialized = false;
+    compressionAlgo compression_algo = ALGO_NONE;
     serverDb **dbarray;
     functionsLibCtx *functions_lib_ctx;
     serverDb **diskless_load_tempDb = NULL;
@@ -2524,26 +2565,84 @@ int replicaLoadPrimaryRDBFromSocket(connection *conn, char *buf, char *eofmark, 
     startLoading(server.repl_transfer_size, RDBFLAGS_REPLICATION, asyncLoading);
     if (replicationSupportSkipRDBChecksum(conn, 1, *usemark)) rdb.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
     int loadingFailed = 0;
+    int retval = RDB_FAILED;
+    /* Always attach a stream reader that probes the envelope: decode a compressed RDB, or pass through plaintext. */
+    bool skip_codec_checksum = (rdb.flags & RIO_FLAG_SKIP_RDB_CHECKSUM) != 0;
+    rdbStreamReaderInitResult init_rc =
+        rdbInitStreamReader(&rdb, &stream_reader, skip_codec_checksum, &compression_algo);
+    if (init_rc == RDB_STREAM_READER_INIT_INCOMPATIBLE) {
+        serverLog(LL_WARNING,
+                  "Unsupported RDB stream envelope from primary. This replica "
+                  "cannot decode it; a Valkey version with streaming RDB "
+                  "compression support may be required on the replica.");
+        /* Nothing loaded yet: take the data-preserving incompatibility path below. */
+        retval = RDB_INCOMPATIBLE;
+        loadingFailed = 1;
+    } else if (init_rc == RDB_STREAM_READER_INIT_ERROR) {
+        serverLog(LL_WARNING, "Failed to initialize RDB stream reader from primary");
+        loadingFailed = 1;
+    } else {
+        stream_reader_initialized = true;
+        /* rdbInitStreamReader sets RIO_FLAG_SKIP_RDB_CHECKSUM on a codec match. */
+        if (compression_algo != ALGO_NONE)
+            serverLog(LL_NOTICE, "Loading compressed RDB (algo=%s) from primary", compressionAlgoName(compression_algo));
+    }
     rdbLoadingCtx loadingCtx = {.dbarray = dbarray, .functions_lib_ctx = functions_lib_ctx};
     /* If we aren't using the swapdb method, then we want to empty the data before loading the rdb */
     int flags = RDBFLAGS_REPLICATION;
     if (server.repl_diskless_load != REPL_DISKLESS_LOAD_SWAPDB) flags |= RDBFLAGS_EMPTY_DATA;
-    int retval = rdbLoadRioWithLoadingCtxScopedRdb(&rdb, flags, rsi, &loadingCtx);
+    if (!loadingFailed) retval = rdbLoadRioWithLoadingCtxScopedRdb(&rdb, flags, rsi, &loadingCtx);
     if (retval != RDB_OK) {
         /* RDB loading failed. */
         serverLog(LL_WARNING, "Failed trying to load the PRIMARY synchronization DB "
                               "from socket, check server logs.");
         loadingFailed = 1;
-    } else if (*usemark) {
-        /* Verify the end mark is correct. */
-        if (!rioRead(&rdb, buf, RDB_EOF_MARK_SIZE) || memcmp(buf, eofmark, RDB_EOF_MARK_SIZE) != 0) {
-            serverLog(LL_WARNING, "Replication stream EOF marker is broken");
-            loadingFailed = 1;
+    } else {
+        if (compression_algo != ALGO_NONE) {
+            /* Close the compressed frame; streamReaderFinish stops at the frame boundary. */
+            int finish_rc = streamReaderFinish(&stream_reader);
+            if (finish_rc == C_ERR) {
+                if (stream_reader.error_kind == STREAM_READER_ERROR_TRUNCATED) {
+                    serverLog(LL_WARNING, "Compressed RDB stream from primary was truncated; will resync");
+                } else if (stream_reader.error_kind == STREAM_READER_ERROR_CORRUPT) {
+                    /* Same fatal path as parse-time corruption, so a corrupt stream cannot retry-loop. */
+                    rdbReportCorruptCompressedStream("primary socket");
+                } else {
+                    serverLog(LL_WARNING, "Compressed RDB stream from primary did not end cleanly");
+                }
+                loadingFailed = 1;
+            }
+        }
+        if (!loadingFailed) {
+            /* Detach so trailing-framing reads hit the raw socket. */
+            if (stream_reader_initialized) {
+                rdbFreeStreamReader(&rdb, &stream_reader);
+                stream_reader_initialized = false;
+            }
+            if (*usemark) {
+                /* Verify the end mark is correct (plaintext, follows any frame). */
+                if (!rioRead(&rdb, buf, RDB_EOF_MARK_SIZE) || memcmp(buf, eofmark, RDB_EOF_MARK_SIZE) != 0) {
+                    serverLog(LL_WARNING, "Replication stream EOF marker is broken");
+                    loadingFailed = 1;
+                }
+            } else if (compression_algo != ALGO_NONE) {
+                /* Size-framed compressed: consumed wire bytes must equal the announced
+                 * transfer size; an early close otherwise looks like success. */
+                if (rdb.io.conn.read_so_far != rdb.io.conn.read_limit) {
+                    serverLog(LL_WARNING,
+                              "Compressed RDB stream from primary ended before the announced "
+                              "transfer size; got %llu of %llu bytes",
+                              (unsigned long long)rdb.io.conn.read_so_far,
+                              (unsigned long long)rdb.io.conn.read_limit);
+                    loadingFailed = 1;
+                }
+            }
         }
     }
 
     if (loadingFailed) {
         stopLoading(0);
+        if (stream_reader_initialized) rdbFreeStreamReader(&rdb, &stream_reader);
         rioFreeConn(&rdb, NULL);
 
         if (server.repl_diskless_load == REPL_DISKLESS_LOAD_SWAPDB) {
@@ -2599,6 +2698,7 @@ int replicaLoadPrimaryRDBFromSocket(connection *conn, char *buf, char *eofmark, 
 
     /* Cleanup and restore the socket to the original state to continue
      * with the normal replication. */
+    if (stream_reader_initialized) rdbFreeStreamReader(&rdb, &stream_reader);
     rioFreeConn(&rdb, NULL);
     connNonBlock(conn);
     connRecvTimeout(conn, 0);
@@ -3132,9 +3232,15 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     }
     /* Send replica listening port to primary for clarification */
     sds portstr = getReplicaPortString();
-    /* Also inform the primary of our (replica) version */
-    *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1", "rdb-channel", "1", "listening-port", portstr,
-                       "version", VALKEY_VERSION, NULL);
+    /* Also inform the primary of our (replica) version, and advertise compressed
+     * full-sync support when this replica's own rdbcompression is lz4. */
+    if (server.rdb_compression == RDB_COMPRESSION_LZ4) {
+        *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1", "rdb-channel", "1", "listening-port",
+                           portstr, "version", VALKEY_VERSION, "capa", REPLICA_CAPA_LZ4_STR, NULL);
+    } else {
+        *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1", "rdb-channel", "1", "listening-port",
+                           portstr, "version", VALKEY_VERSION, NULL);
+    }
     sdsfree(portstr);
     if (*err) {
         dualChannelServerLog(LL_WARNING, "Sending command to primary in dual channel replication handshake: %s", *err);
@@ -3943,8 +4049,8 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
 
     // we can ignore primary's conditions when sending capa (is_primary_stream_verified=1)
     int send_skip_rdb_checksum_capa = replicationSupportSkipRDBChecksum(conn, useDisklessLoad(), 1);
-    char *argv[9] = {"REPLCONF", "capa", "eof", "capa", "psync2", NULL, NULL, NULL, NULL};
-    size_t lens[9] = {8, 4, 3, 4, 6, 0, 0, 0, 0};
+    char *argv[11] = {"REPLCONF", "capa", "eof", "capa", "psync2", NULL, NULL, NULL, NULL, NULL, NULL};
+    size_t lens[11] = {8, 4, 3, 4, 6, 0, 0, 0, 0, 0, 0};
     int argc = 5;
     if (send_skip_rdb_checksum_capa) {
         argv[argc] = "capa";
@@ -3960,6 +4066,15 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
         argc++;
         argv[argc] = "dual-channel";
         lens[argc] = strlen("dual-channel");
+        argc++;
+    }
+    /* Advertise compressed full-sync support when this replica's own rdbcompression is lz4. */
+    if (server.rdb_compression == RDB_COMPRESSION_LZ4) {
+        argv[argc] = "capa";
+        lens[argc] = strlen("capa");
+        argc++;
+        argv[argc] = REPLICA_CAPA_LZ4_STR;
+        lens[argc] = strlen(REPLICA_CAPA_LZ4_STR);
         argc++;
     }
     err = sendCommandArgv(conn, argc, argv, lens);

--- a/src/rio.c
+++ b/src/rio.c
@@ -225,50 +225,87 @@ static size_t rioConnWrite(rio *r, const void *buf, size_t len) {
     return 0; /* Error, this target does not yet support writing. */
 }
 
-/* Returns 1 or 0 for success/failure. */
-static size_t rioConnRead(rio *r, void *buf, size_t len) {
+/* Fill the connection read buffer until at least min_available bytes are available.
+ * Returns 1 on success, 0 on EOF, -1 on error. */
+static int rioConnEnsureBuffered(rio *r, size_t min_available) {
     size_t avail = sdslen(r->io.conn.buf) - r->io.conn.pos;
 
     /* If the buffer is too small for the entire request: realloc. */
-    if (sdslen(r->io.conn.buf) + sdsavail(r->io.conn.buf) < len)
-        r->io.conn.buf = sdsMakeRoomFor(r->io.conn.buf, len - sdslen(r->io.conn.buf));
+    if (sdslen(r->io.conn.buf) + sdsavail(r->io.conn.buf) < min_available)
+        r->io.conn.buf = sdsMakeRoomFor(r->io.conn.buf, min_available - sdslen(r->io.conn.buf));
 
     /* If the remaining unused buffer is not large enough: memmove so that we
      * can read the rest. */
-    if (len > avail && sdsavail(r->io.conn.buf) < len - avail) {
+    if (min_available > avail && sdsavail(r->io.conn.buf) < min_available - avail) {
         sdsrange(r->io.conn.buf, r->io.conn.pos, -1);
         r->io.conn.pos = 0;
     }
 
-    /* Make sure the caller didn't request to read past the limit.
-     * If they didn't we'll buffer till the limit, if they did, we'll
-     * return an error. */
-    if (r->io.conn.read_limit != 0 && r->io.conn.read_limit < r->io.conn.read_so_far + len) {
-        errno = EOVERFLOW;
-        return 0;
-    }
-
-    /* If we don't already have all the data in the sds, read more */
-    while (len > sdslen(r->io.conn.buf) - r->io.conn.pos) {
-        size_t buffered = sdslen(r->io.conn.buf) - r->io.conn.pos;
-        size_t needs = len - buffered;
+    while (avail < min_available) {
+        size_t needs = min_available - avail;
         /* Read either what's missing, or PROTO_IOBUF_LEN, the bigger of
          * the two. */
         size_t toread = needs < PROTO_IOBUF_LEN ? PROTO_IOBUF_LEN : needs;
         if (toread > sdsavail(r->io.conn.buf)) toread = sdsavail(r->io.conn.buf);
-        if (r->io.conn.read_limit != 0 && r->io.conn.read_so_far + buffered + toread > r->io.conn.read_limit) {
-            toread = r->io.conn.read_limit - r->io.conn.read_so_far - buffered;
+        if (r->io.conn.read_limit != 0) {
+            size_t remaining =
+                r->io.conn.read_so_far >= r->io.conn.read_limit ? 0 : r->io.conn.read_limit - r->io.conn.read_so_far;
+            if (avail >= remaining) {
+                toread = 0;
+            } else if (toread > remaining - avail) {
+                toread = remaining - avail;
+            }
         }
+        if (toread == 0) return 0;
+
         int retval = connRead(r->io.conn.conn, (char *)r->io.conn.buf + sdslen(r->io.conn.buf), toread);
         if (retval == 0) {
             return 0;
         } else if (retval < 0) {
             if (connLastErrorRetryable(r->io.conn.conn)) continue;
             if (errno == EWOULDBLOCK) errno = ETIMEDOUT;
-            return 0;
+            return -1;
         }
         sdsIncrLen(r->io.conn.buf, retval);
+        avail = sdslen(r->io.conn.buf) - r->io.conn.pos;
     }
+
+    return 1;
+}
+
+/* Partial-read variant: returns bytes read, 0 on EOF, -1 on error. */
+static ssize_t rioConnReadSome(rio *r, void *buf, size_t len) {
+    size_t avail = sdslen(r->io.conn.buf) - r->io.conn.pos;
+
+    if (r->io.conn.read_limit != 0 && r->io.conn.read_so_far >= r->io.conn.read_limit) {
+        return 0;
+    }
+    if (avail == 0) {
+        int fill_rc = rioConnEnsureBuffered(r, 1);
+        if (fill_rc <= 0) return fill_rc;
+        avail = sdslen(r->io.conn.buf) - r->io.conn.pos;
+    }
+    if (r->io.conn.read_limit != 0) {
+        size_t remaining = r->io.conn.read_limit - r->io.conn.read_so_far;
+        if (len > remaining) len = remaining;
+    }
+
+    size_t got = avail < len ? avail : len;
+    memcpy(buf, (char *)r->io.conn.buf + r->io.conn.pos, got);
+    r->io.conn.read_so_far += got;
+    r->io.conn.pos += got;
+    return (ssize_t)got;
+}
+
+/* Returns 1 or 0 for success/failure. */
+static size_t rioConnRead(rio *r, void *buf, size_t len) {
+    if (r->io.conn.read_limit != 0 &&
+        (r->io.conn.read_so_far > r->io.conn.read_limit ||
+         len > r->io.conn.read_limit - r->io.conn.read_so_far)) {
+        errno = EOVERFLOW;
+        return 0;
+    }
+    if (rioConnEnsureBuffered(r, len) != 1) return 0;
 
     memcpy(buf, (char *)r->io.conn.buf + r->io.conn.pos, len);
     r->io.conn.read_so_far += len;
@@ -294,7 +331,7 @@ static const rio rioConnIO = {
     .write = rioConnWrite,
     .tell = rioConnTell,
     .flush = rioConnFlush,
-    .read_some = NULL,
+    .read_some = rioConnReadSome,
     .update_cksum = NULL,
     .cksum = 0,
     .flags = 0,
@@ -636,6 +673,9 @@ static size_t rioConnsetWrite(rio *r, const void *buf, size_t len) {
                     if (retval == -1 && errno == EWOULDBLOCK) errno = ETIMEDOUT;
                     break;
                 }
+                /* Count bytes actually written to this connection, including a
+                 * partial write before an error. */
+                r->io.connset.net_output_bytes += retval;
                 nwritten += retval;
             }
 
@@ -701,6 +741,7 @@ void rioInitWithConnset(rio *r, connection **conns, int numconns) {
     r->io.connset.numconns = numconns;
     r->io.connset.pos = 0;
     r->io.connset.buf = sdsempty();
+    r->io.connset.net_output_bytes = 0;
 }
 
 /* release the rio stream. */

--- a/src/rio.h
+++ b/src/rio.h
@@ -138,6 +138,7 @@ struct _rio {
             int numconns;
             off_t pos;
             sds buf;
+            size_t net_output_bytes; /* Total bytes written across all connections. */
         } connset;
     } io;
 };

--- a/src/server.h
+++ b/src/server.h
@@ -32,6 +32,7 @@
 
 #include "fmacros.h"
 #include "config.h"
+#include "compression.h"
 #include "solarisfixes.h"
 #include "rio.h"
 #include "commands.h"
@@ -465,9 +466,11 @@ typedef enum {
 #define REPLICA_CAPA_PSYNC2 (1 << 1)            /* Supports PSYNC2 protocol. */
 #define REPLICA_CAPA_DUAL_CHANNEL (1 << 2)      /* Supports dual channel replication sync */
 #define REPLICA_CAPA_SKIP_RDB_CHECKSUM (1 << 3) /* Supports skipping RDB checksum for sync requests. */
+#define REPLICA_CAPA_LZ4 (1 << 4)               /* Can decode LZ4 streaming-compressed payloads. */
 
 /* Replica capability strings */
 #define REPLICA_CAPA_SKIP_RDB_CHECKSUM_STR "skip-rdb-checksum" /* Supports skipping RDB checksum for sync requests. */
+#define REPLICA_CAPA_LZ4_STR "lz4"                             /* Can decode LZ4 streaming-compressed payloads. */
 
 /* Replica requirements */
 #define REPLICA_REQ_NONE 0
@@ -1670,9 +1673,10 @@ typedef struct rdbSaveInfo {
     int repl_id_is_set;                   /* True if repl_id field is set. */
     char repl_id[CONFIG_RUN_ID_SIZE + 1]; /* Replication ID. */
     long long repl_offset;                /* Replication offset. */
+    bool loaded_compressed;               /* True if rdbLoad() read a streaming-compressed file. */
 } rdbSaveInfo;
 
-#define RDB_SAVE_INFO_INIT {-1, 0, "0000000000000000000000000000000000000000", -1}
+#define RDB_SAVE_INFO_INIT {-1, 0, "0000000000000000000000000000000000000000", -1, false}
 
 struct malloc_stats {
     size_t zmalloc_used;
@@ -2118,6 +2122,7 @@ struct valkeyServer {
     rdbWriteTarget rdb_write_target;      /* Type of save by active child. */
     rdbBgsaveType cur_bgsave_type;        /* Current bgsave type. */
     rdbBgsaveType lastbgsave_type;        /* Last completed bgsave type. */
+    compressionAlgo rdb_child_sync_algo;  /* Streaming compression used by the active replication disk child. */
     int lastbgsave_status;                /* C_OK or C_ERR */
     int stop_writes_on_bgsave_err;        /* Don't allow writes if can't BGSAVE */
     int rdb_pipe_read;                    /* RDB pipe used to transfer the rdb data */
@@ -3363,6 +3368,9 @@ const char *getFailoverStateString(void);
 sds getReplicaPortString(void);
 int sendCurrentOffsetToReplica(client *replica);
 int replicaRdbVersion(client *replica);
+/* Full-sync compression policy: select the codec and gate replica eligibility on capability. */
+compressionAlgo replSelectFullSyncCompression(int replica_capa);
+bool replicaCanUseFullSyncFormat(int replica_capa, compressionAlgo compression_algo);
 void addRdbReplicaToPsyncWait(client *replica);
 void initClientReplicationData(client *c);
 void freeClientReplicationData(client *c);

--- a/src/unit/test_compression.cpp
+++ b/src/unit/test_compression.cpp
@@ -1254,39 +1254,86 @@ TEST(CompressionTest, streamReaderFinishStopsAtFrameEndBeforeTrailingBytes) {
     dynamicBufFree(&db);
 }
 
-TEST(CompressionTest, streamReaderRejectsTruncatedFrameTrailer) {
+/* Classify damaged frames: clean EOF before the frame end is recoverable
+ * TRUNCATED (the replica retries the sync), a mutated frame body is CORRUPT
+ * (the replica aborts the load). The writer always enables the LZ4 block and
+ * content checksums, so corruption is deterministically detectable. Late
+ * damage is checked through both Read and Finish, the two loader paths. */
+TEST(CompressionTest, streamReaderClassifiesDamagedFrames) {
     const size_t payload_len = 256;
     uint8_t payload[payload_len];
     for (size_t i = 0; i < payload_len; i++) {
         payload[i] = (uint8_t)(i & 0xFF);
     }
 
-    DynamicBuf db;
-    dynamicBufInit(&db);
-    streamWriter w;
-    ASSERT_EQ(streamWriterInit(&w, ALGO_LZ4, true, emitToDynamicBuf, &db), C_OK);
-    ASSERT_EQ(streamWriterWrite(&w, payload, payload_len), C_OK);
-    ASSERT_EQ(streamWriterFinish(&w), C_OK);
-    streamWriterFree(&w);
+    sds encoded = NULL;
+    ASSERT_EQ(encodeRoundTripPayload(TEST_COMPRESSION_LAYER_STREAM,
+                                     payload, payload_len, &encoded),
+              C_OK);
 
-    ASSERT_GT(sdslen((const char *)db.data), (size_t)VCS_ENVELOPE_SIZE + 1);
-    MemReader mr = {};
-    mr.data = db.data;
-    mr.len = sdslen((const char *)db.data) - 1;
-    mr.max_chunk = 7;
-    streamReaderConfig rcfg = makeReaderConfig(false, STREAM_READER_BUFFER_SIZE_MIN, false);
-    streamReader r;
-    ASSERT_EQ(streamReaderInit(&r, &rcfg, memReaderRead, &mr, NULL), C_OK);
+    const size_t frame_len = sdslen(encoded);
+    /* A mid-buffer flip lands beyond the VCS envelope and the (at most
+     * 19-byte) LZ4 frame header, in checksum-covered block data. */
+    const size_t middle_offset = (VCS_ENVELOPE_SIZE + frame_len) / 2;
+    ASSERT_GT(middle_offset, (size_t)VCS_ENVELOPE_SIZE + 19);
 
-    uint8_t out[payload_len];
-    ASSERT_EQ(streamReaderRead(&r, out, payload_len), (ssize_t)payload_len);
-    EXPECT_EQ(memcmp(out, payload, payload_len), 0);
-    ASSERT_LT(streamReaderRead(&r, out, 1), 0) << "EOF before frame end should be treated as corruption";
-    ASSERT_EQ(r.error_kind, STREAM_READER_ERROR_CORRUPT)
-        << "truncated compressed frame should latch corruption, not I/O";
+    struct {
+        const char *name;
+        size_t source_len;
+        size_t flip_offset; /* 0 => no flip */
+        streamReaderErrorKind expected_error;
+        bool payload_readable;
+        bool finish_detects_damage;
+        bool eof_is_truncation; /* Retryable source: mid-frame EOF => TRUNCATED, else CORRUPT. */
+    } cases[] = {
+        /* Retryable (socket-like) source: a clean mid-frame EOF is a recoverable short read. */
+        {"EOF one byte into frame", VCS_ENVELOPE_SIZE + 1, 0, STREAM_READER_ERROR_TRUNCATED, false, false, true},
+        {"EOF mid-frame", middle_offset, 0, STREAM_READER_ERROR_TRUNCATED, false, false, true},
+        {"EOF one byte before frame end on read", frame_len - 1, 0, STREAM_READER_ERROR_TRUNCATED, true, false, true},
+        {"EOF one byte before frame end on finish", frame_len - 1, 0, STREAM_READER_ERROR_TRUNCATED, true, true, true},
+        /* Seekable (file-like) source: no more bytes are coming, so a clean mid-frame EOF is corruption. */
+        {"EOF one byte into frame (file source)", VCS_ENVELOPE_SIZE + 1, 0, STREAM_READER_ERROR_CORRUPT, false, false, false},
+        {"EOF mid-frame (file source)", middle_offset, 0, STREAM_READER_ERROR_CORRUPT, false, false, false},
+        /* A flipped byte latches a codec error regardless of source type. */
+        {"flipped byte mid-frame", frame_len, middle_offset, STREAM_READER_ERROR_CORRUPT, false, false, false},
+        {"flipped last byte (content checksum)", frame_len, frame_len - 1, STREAM_READER_ERROR_CORRUPT, true, true, false},
+    };
 
-    streamReaderFree(&r);
-    dynamicBufFree(&db);
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        if (cases[i].flip_offset) encoded[cases[i].flip_offset] ^= 0xFF;
+
+        MemReader mr = {};
+        mr.data = (const uint8_t *)encoded;
+        mr.len = cases[i].source_len;
+        mr.max_chunk = 7; /* odd chunk size to exercise refill boundaries */
+        streamReaderConfig rcfg = makeReaderConfig(false, STREAM_READER_BUFFER_SIZE_MIN, false);
+        rcfg.eof_mid_frame_is_truncation = cases[i].eof_is_truncation;
+        streamReader r;
+        ASSERT_EQ(streamReaderInit(&r, &rcfg, memReaderRead, &mr, NULL), C_OK) << cases[i].name;
+
+        uint8_t out[payload_len];
+        if (cases[i].payload_readable) {
+            ASSERT_EQ(streamReaderRead(&r, out, payload_len), (ssize_t)payload_len) << cases[i].name;
+            ASSERT_EQ(memcmp(out, payload, payload_len), 0) << cases[i].name;
+            if (cases[i].finish_detects_damage) {
+                ASSERT_EQ(streamReaderFinish(&r), C_ERR) << cases[i].name;
+            } else {
+                ASSERT_EQ(streamReaderRead(&r, out, 1), -1) << cases[i].name;
+            }
+        } else {
+            /* The error may surface on the first or a later read depending on
+             * how much the codec buffers before validating. */
+            ssize_t n = streamReaderRead(&r, out, payload_len);
+            while (n > 0) n = streamReaderRead(&r, out, payload_len);
+            ASSERT_LT(n, 0) << cases[i].name;
+        }
+        ASSERT_EQ(r.error_kind, cases[i].expected_error) << cases[i].name;
+
+        streamReaderFree(&r);
+        if (cases[i].flip_offset) encoded[cases[i].flip_offset] ^= 0xFF;
+    }
+
+    sdsfree(encoded);
 }
 
 TEST(CompressionTest, streamWriterWriteAfterFinish) {

--- a/tests/helpers/fake_primary.tcl
+++ b/tests/helpers/fake_primary.tcl
@@ -1,0 +1,51 @@
+# A single-shot fake primary for full-sync negative tests. Answers the
+# replication handshake (PING -> +PONG, REPLCONF -> +OK each, PSYNC ->
+# +FULLRESYNC), announces a bulk transfer of ANNOUNCE_SIZE bytes, sends the
+# contents of PAYLOAD_FILE, then closes the connection and exits.
+#
+# Usage: tclsh fake_primary.tcl PORT PAYLOAD_FILE ANNOUNCE_SIZE
+
+set port [lindex $argv 0]
+set payload_file [lindex $argv 1]
+set announce_size [lindex $argv 2]
+
+set fd [open $payload_file r]
+fconfigure $fd -translation binary
+set payload [read $fd]
+close $fd
+
+# The replica sends RESP-encoded commands. Reading line by line and replying
+# once per command-name line keeps replies in step with pipelined commands;
+# RESP framing lines (*N, $N) and argument lines fall through unmatched.
+proc accept {sock host port} {
+    global payload announce_size done
+    fconfigure $sock -translation binary -blocking 1
+    set served 0
+    catch {
+        while {[gets $sock line] >= 0} {
+            set cmd [string toupper [string trim $line]]
+            if {$cmd eq "PING"} {
+                puts -nonewline $sock "+PONG\r\n"
+                flush $sock
+            } elseif {$cmd eq "REPLCONF"} {
+                puts -nonewline $sock "+OK\r\n"
+                flush $sock
+            } elseif {$cmd eq "PSYNC"} {
+                puts -nonewline $sock "+FULLRESYNC [string repeat 0 40] 0\r\n"
+                puts -nonewline $sock "\$$announce_size\r\n"
+                puts -nonewline $sock $payload
+                flush $sock
+                set served 1
+                break
+            }
+        }
+    }
+    catch {close $sock}
+    # Port-probe connections come and go without a PSYNC; only a served
+    # transfer completes the single shot.
+    if {$served} {set done served}
+}
+
+socket -server accept $port
+after 60000 set done timeout
+vwait done

--- a/tests/integration/rdb-compression.tcl
+++ b/tests/integration/rdb-compression.tcl
@@ -349,6 +349,8 @@ start_server {tags {"rdb-compression repl external:skip"} overrides {save ""}} {
 
             $primary config set repl-diskless-sync-delay 0
             $replica config set repl-diskless-load swapdb
+            # Keep the replica non-capable so this covers the cohort downgrade.
+            $replica config set rdbcompression no
 
             foreach diskless {no yes} {
                 $replica replicaof no one

--- a/tests/integration/repl-fullsync-compression.tcl
+++ b/tests/integration/repl-fullsync-compression.tcl
@@ -1,0 +1,749 @@
+# Full-sync streaming compression: end-to-end coverage across disk-based,
+# diskless, and dual-channel full sync, both replica load paths, negative cases
+# (truncation, corruption, premature EOF, non-capable cohorts), and byte
+# accounting. Asymmetric policy: an all-capable group gets a compressed round; any
+# non-capable member forces one plaintext round for all.
+
+# --- helpers --------------------------------------------------------------
+
+proc rdb_is_compressed {client} {
+    set header [read_binary_file_prefix [server_rdb_path $client] 3]
+    return [expr {$header eq "VCS"}]
+}
+
+# Compressible, multi-type dataset so an LZ4 frame is actually produced.
+proc populate_compressible_dataset {client prefix {n 300}} {
+    $client flushall
+    for {set i 0} {$i < $n} {incr i} {
+        $client set "${prefix}:str:$i" [string repeat "${prefix}:payload:$i " 16]
+    }
+    $client rpush "${prefix}:list" a b c d e f g h
+    $client sadd "${prefix}:set" alpha beta gamma delta
+    $client zadd "${prefix}:zset" 1 one 2 two 3 three 4 four
+    $client hset "${prefix}:hash" f1 v1 f2 [string repeat "${prefix}:hashval " 8]
+    $client xadd "${prefix}:stream" * f1 s1 f2 [string repeat "${prefix}:streamval " 4]
+    $client xadd "${prefix}:stream" * f1 s2 f2 tail
+}
+
+# Wait for the link up, then assert digests match. Generous 300x100 budget for
+# slow/shared primaries and the macOS timing fix for the delay-based piggyback tests.
+proc assert_replica_synced {primary replica {tag ""}} {
+    wait_for_condition 300 100 {
+        [status $replica master_link_status] eq "up"
+    } else {
+        fail "replica link not up after full sync $tag"
+    }
+    assert_equal [$primary debug digest] [$replica debug digest] "replica digest mismatch after full sync $tag"
+}
+
+# Single-shot fake primary (tests/helpers/fake_primary.tcl): answers the handshake,
+# announces $announce bytes, sends $payload, closes. Returns {pid port}.
+proc start_fake_primary {payload announce} {
+    set payload_file [tmpfile fake-primary-payload]
+    write_binary_file $payload_file $payload
+    set port [find_available_port $::baseport $::portcount]
+    set pid [exec [info nameofexecutable] tests/helpers/fake_primary.tcl $port $payload_file $announce &]
+    wait_for_condition 50 50 {
+        [ping_server 127.0.0.1 $port]
+    } else {
+        fail "Failed to start fake primary"
+    }
+    return [list $pid $port]
+}
+
+# Park both replicas in WAIT_BGSAVE_START together: a slow manual BGSAVE
+# occupies the RDB child slot (syncCommand defers to replicationCron), so the
+# following grouped round makes its group-AND capability decision over both
+# waiters deterministically. Resetting the delay lets that round run fast.
+proc park_replicas_for_grouped_bgsave {primary replica1 replica2 primary_host primary_port} {
+    $primary config set rdb-key-save-delay 5000
+    assert_match {*Background saving started*} [$primary bgsave]
+    wait_for_condition 200 10 {
+        [status $primary rdb_bgsave_in_progress] eq 1
+    } else {
+        $primary config set rdb-key-save-delay 0
+        fail "manual BGSAVE did not start"
+    }
+
+    $replica1 replicaof $primary_host $primary_port
+    $replica2 replicaof $primary_host $primary_port
+    wait_for_condition 200 10 {
+        [status $primary connected_slaves] == 2 &&
+        [status $primary rdb_bgsave_in_progress] eq 1
+    } else {
+        $primary config set rdb-key-save-delay 0
+        fail "both replicas did not register before manual BGSAVE finished (grouping not achieved)"
+    }
+
+    $primary config set rdb-key-save-delay 0
+}
+
+# ============================================================================
+# Disk-based full sync: ONE shared primary fixture. rdbcompression is MODIFIABLE,
+# so each test sets its mode and repopulates its own prefix; the compression-off
+# test restores the fixture default (lz4) at its end for later shared tests.
+# Replicas are per-test nested start_servers because their capability configs differ.
+# ============================================================================
+
+start_server {tags {"repl rdb-compression external:skip needs:debug"} overrides {save "" enable-debug-command local}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+
+    $primary config set repl-diskless-sync no
+    $primary config set rdbcompression lz4
+    $primary config set rdb-del-sync-files no
+
+    start_server {overrides {save "" enable-debug-command local rdbcompression lz4}} {
+        set replica [srv 0 client]
+
+        test {Disk full sync: all-capable group produces a compressed RDB that loads} {
+            $primary config set rdbcompression lz4
+            populate_compressible_dataset $primary "cap"
+            set primary_loglines [count_log_lines -1]
+
+            $replica replicaof $primary_host $primary_port
+            assert_replica_synced $primary $replica "(case1 capable)"
+
+            assert {[file exists [server_rdb_path $primary]]}
+            assert_equal 1 [rdb_is_compressed $primary]
+            wait_for_log_messages -1 {"*Disk-based full sync with compression: lz4*"} $primary_loglines 50 100
+
+            $primary set cap:post "after-sync"
+            wait_for_value_to_propagate_to_replica $primary $replica cap:post
+
+            $replica replicaof no one
+        }
+    }
+
+    # Both scenarios fall back to plaintext: the replica advertises LZ4
+    # per its own rdbcompression, and the primary's mode is set per iteration.
+    start_server {overrides {save "" enable-debug-command local rdbcompression lz4}} {
+        set replica [srv 0 client]
+
+        foreach {scenario primary_mode replica_mode prefix} {
+            primary-compression-off yes lz4 off
+            replica-not-capable     lz4 yes nocap
+        } {
+            test "Disk full sync: $scenario yields a plaintext RDB that loads" {
+                $primary config set rdbcompression $primary_mode
+                $replica config set rdbcompression $replica_mode
+                populate_compressible_dataset $primary $prefix
+
+                $replica replicaof $primary_host $primary_port
+                assert_replica_synced $primary $replica "($scenario)"
+
+                assert_equal 0 [rdb_is_compressed $primary]
+
+                $replica replicaof no one
+            }
+        }
+        # Restore the fixture default for subsequent shared-primary tests.
+        $primary config set rdbcompression lz4
+    }
+
+    # Regression: a size-framed ($<len>, no EOF mark) compressed disk RDB, loaded
+    # directly from the socket via replicaLoadPrimaryRDBFromSocket. Decompression
+    # was once gated on the EOF mark (usemark), so the VCS frame was read as a raw
+    # RDB ("Wrong signature ... VCS"), causing an infinite resync loop.
+    start_server {overrides {save "" enable-debug-command local rdbcompression lz4 repl-diskless-load swapdb}} {
+        set replica [srv 0 client]
+
+        test {Disk-based compressed full sync is decompressed on a diskless-load (swapdb) replica} {
+            $primary config set rdbcompression lz4
+            populate_compressible_dataset $primary "diskmaster"
+            set replica_loglines [count_log_lines 0]
+
+            $replica replicaof $primary_host $primary_port
+            assert_replica_synced $primary $replica "(disk-master, diskless-load swapdb)"
+
+            assert_equal 1 [rdb_is_compressed $primary]
+            # Socket decode path logs "from primary"; match it so a file load cannot satisfy this.
+            wait_for_log_messages 0 {"*Loading compressed RDB (algo=lz4) from primary*"} $replica_loglines 50 100
+
+            $primary set diskmaster:post "after-sync"
+            wait_for_value_to_propagate_to_replica $primary $replica diskmaster:post
+
+            $replica replicaof no one
+        }
+    }
+}
+
+# Mixed disk group: force both replicas to park in WAIT_BGSAVE_START together so
+# the group-AND decision is exercised directly. A slow manual BGSAVE occupies the
+# RDB child slot; a disk replica can't start its own BGSAVE (syncCommand defers to
+# replicationCron), so both park. The cron then groups both waiters and the AND
+# clears the LZ4 capability. Deterministic because the manual BGSAVE is still
+# running when both register (asserted via connected_slaves==2); one round is
+# asserted via the "Starting BGSAVE for SYNC" delta.
+
+start_server {tags {"repl rdb-compression external:skip needs:debug"} overrides {save "" enable-debug-command local}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+
+    $primary config set repl-diskless-sync no
+    $primary config set rdbcompression lz4
+    $primary config set rdb-del-sync-files no
+    # Enough keys so the manual BGSAVE stays alive for both replicas to register.
+    populate_compressible_dataset $primary "grp" 800
+
+    start_server {overrides {save "" enable-debug-command local rdbcompression lz4}} {
+        set capable [srv 0 client]
+
+        start_server {overrides {save "" enable-debug-command local rdbcompression yes}} {
+            set noncap [srv 0 client]
+
+            test {Disk full sync: a single grouped BGSAVE with a non-capable member is plaintext for all} {
+                # One round == one "Starting BGSAVE for SYNC" in the primary log.
+                # srv -2 is the primary inside this doubly-nested scope.
+                set rounds_before [count_log_message -2 {Starting BGSAVE for SYNC}]
+                set primary_loglines [count_log_lines -2]
+
+                park_replicas_for_grouped_bgsave $primary $capable $noncap $primary_host $primary_port
+
+                assert_replica_synced $primary $capable "(case3b capable, grouped)"
+                assert_replica_synced $primary $noncap   "(case3b non-capable, grouped)"
+
+                # Exactly one BGSAVE served both -> they were grouped (AND precondition).
+                assert_equal 1 [expr {[count_log_message -2 {Starting BGSAVE for SYNC}] - $rounds_before}]
+
+                # AND result: the grouped RDB is plaintext (capable replica downgraded too).
+                assert_equal 0 [rdb_is_compressed $primary]
+                verify_no_log_message -2 "*Disk-based full sync with compression: lz4*" $primary_loglines
+
+                $noncap replicaof no one
+                $capable replicaof no one
+            }
+        }
+    }
+}
+
+# ============================================================================
+# Piggyback (in-flight BGSAVE join): all four quadrants of (running save
+# format) x (joiner capability). A joiner attaches whenever it can load the
+# running save's format; a non-capable joiner must NOT attach to a compressed
+# save and waits for the next, plaintext, save. Capability is advertised from
+# rdbcompression at handshake time, so one shared replica pair serves every
+# row via CONFIG SET. rdb-key-save-delay 13000 (~2s over 155 keys x 13ms: above
+# one PSYNC round trip, under wait_for_sync's ~5s budget on slow runners) keeps
+# the save in flight while the joiner arrives.
+# ============================================================================
+
+start_server {tags {"repl rdb-compression external:skip needs:debug"} overrides {save "" enable-debug-command local}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+
+    $primary config set repl-diskless-sync no
+    $primary config set rdb-del-sync-files no
+
+    start_server {overrides {save "" enable-debug-command local rdbcompression lz4}} {
+        set trigger [srv 0 client]
+
+        start_server {overrides {save "" enable-debug-command local rdbcompression lz4}} {
+            set joiner [srv 0 client]
+
+            foreach {name primary_mode joiner_mode should_join expected_compressed} {
+                "plain save, non-capable joiner attaches"                   yes yes 1 0
+                "plain save, capable joiner attaches"                       yes lz4 1 0
+                "compressed save, non-capable joiner waits for a new save"  lz4 yes 0 0
+                "compressed save, capable joiner attaches"                  lz4 lz4 1 1
+            } {
+                test "Piggyback: $name" {
+                    with_cleanup {
+                        $primary config set rdbcompression $primary_mode
+                        $joiner config set rdbcompression $joiner_mode
+                        $primary config set rdb-key-save-delay 13000
+                        populate_compressible_dataset $primary piggy 150
+                        set primary_loglines [count_log_lines -2]
+
+                        $trigger replicaof $primary_host $primary_port
+                        if {$primary_mode eq "lz4"} {
+                            wait_for_log_messages -2 {"*Disk-based full sync with compression: lz4*"} \
+                                $primary_loglines 50 100
+                        } else {
+                            wait_for_log_messages -2 {"*Starting BGSAVE for SYNC with target: disk*"} \
+                                $primary_loglines 50 100
+                        }
+
+                        $joiner replicaof $primary_host $primary_port
+                        if {$should_join} {
+                            wait_for_log_messages -2 {"*Waiting for end of BGSAVE for SYNC*"} \
+                                $primary_loglines 50 100
+                            # Prove the joiner piggybacked onto the running save rather than
+                            # triggering a second BGSAVE round: the primary is -2 in this
+                            # doubly-nested start_server scope, so neither the attach-refusal
+                            # nor the next-save-wait message must appear.
+                            verify_no_log_message -2 "*Can't attach the replica to the current BGSAVE*" $primary_loglines
+                            verify_no_log_message -2 "*Waiting for next BGSAVE for SYNC*" $primary_loglines
+                        } else {
+                            wait_for_log_messages -2 {"*Can't attach the replica to the current BGSAVE*"} \
+                                $primary_loglines 50 100
+                        }
+
+                        $primary config set rdb-key-save-delay 0
+                        assert_replica_synced $primary $trigger "($name, trigger)"
+                        assert_replica_synced $primary $joiner "($name, joiner)"
+                        assert_equal $expected_compressed [rdb_is_compressed $primary]
+                    } {
+                        $primary config set rdb-key-save-delay 0
+                        $joiner replicaof no one
+                        $trigger replicaof no one
+                    }
+                }
+            }
+        }
+    }
+}
+
+# ============================================================================
+# Cross-cutting transfer-path coverage: disk-receive (BIO) load, dual-channel,
+# diskless payload compression, and byte-accounting. Needs rdbcompression lz4.
+# ============================================================================
+
+tags {"repl external:skip"} {
+
+# --- dual-channel: ONE shared primary fixture ------------------------------
+# The byte-accounting test raises repl-diskless-sync-delay and
+# repl-diskless-sync-max-replicas (both MODIFIABLE) at its start and restores them
+# at its end so the shared primary stays neutral for the other tests.
+
+start_server {overrides {save "" rdbcompression lz4 repl-diskless-sync yes repl-diskless-sync-delay 0 dual-channel-replication-enabled yes}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+
+    # Both load paths under dual-channel: disabled -> RDB to disk (BIO), rdbLoad()
+    # decompresses; swapdb -> load compressed payload from the socket (also exercises
+    # capa-compression advertising in the dual-channel handshake).
+    foreach load_mode {disabled swapdb} {
+        test "Dual-channel + compression full sync delivers identical data (repl-diskless-load $load_mode)" {
+            set primary_loglines [count_log_lines 0]
+            populate_compressible_dataset $primary "dc-$load_mode"
+
+            start_server [list overrides [list save "" rdbcompression lz4 repl-diskless-load $load_mode dual-channel-replication-enabled yes]] {
+                set replica [srv 0 client]
+                set replica_loglines [count_log_lines 0]
+                $replica replicaof $primary_host $primary_port
+
+                assert_replica_synced $primary $replica "(dual-channel $load_mode)"
+
+                wait_for_log_messages -1 {"*using: dual-channel*"} $primary_loglines 50 100
+                wait_for_log_messages -1 {"*Diskless full sync with compression: lz4*"} $primary_loglines 50 100
+                # swapdb loads inline from the socket ("from primary"); disabled loads from the received file.
+                if {$load_mode eq "swapdb"} {
+                    wait_for_log_messages 0 {"*Loading compressed RDB (algo=lz4) from primary*"} $replica_loglines 50 100
+                } else {
+                    wait_for_log_messages 0 {"*Loading compressed RDB (algo=lz4) from *.rdb*"} $replica_loglines 50 100
+                }
+
+                $replica replicaof no one
+            }
+        }
+    }
+
+    # Aggregate output accounting: one BGSAVE serving TWO dual-channel replicas
+    # writes the payload to both sockets from a single connset, so
+    # total_net_repl_output_bytes must cover both. Old single-stream accounting
+    # reported ~half and fails the >=75% check below. Needs the delay window + 2-replica cap (restored at the end).
+    test {Dual-channel diskless full sync counts output bytes across all sockets} {
+        $primary config set repl-diskless-sync-delay 1000
+        $primary config set repl-diskless-sync-max-replicas 2
+        populate_compressible_dataset $primary agg 2000
+
+        start_server {overrides {save "" rdbcompression lz4 repl-diskless-load swapdb dual-channel-replication-enabled yes}} {
+            set replica1 [srv 0 client]
+
+            start_server {overrides {save "" rdbcompression lz4 repl-diskless-load swapdb dual-channel-replication-enabled yes}} {
+                set replica2 [srv 0 client]
+
+                # Attach both within the delay window so one BGSAVE groups both channels into one connset.
+                set rounds_before [count_log_message -2 {Starting BGSAVE for SYNC}]
+                $primary config resetstat
+                $replica1 replicaof $primary_host $primary_port
+                $replica2 replicaof $primary_host $primary_port
+
+                assert_replica_synced $primary $replica1 "(agg r1)"
+                assert_replica_synced $primary $replica2 "(agg r2)"
+
+                # One grouped BGSAVE served both: precondition for the aggregation to be exercised.
+                assert_equal 1 [expr {[count_log_message -2 {Starting BGSAVE for SYNC}] - $rounds_before}]
+
+                # The child reports per-connset output bytes over the child-info pipe,
+                # which the parent drains asynchronously after link-up. Wait for that
+                # to land before sampling the counters.
+                wait_for_condition 50 100 {
+                    [status $primary total_net_repl_output_bytes] > 0
+                } else {
+                    fail "primary did not aggregate dual-channel output bytes"
+                }
+
+                set out [status $primary total_net_repl_output_bytes]
+                set in1 [status $replica1 total_net_repl_input_bytes]
+                set in2 [status $replica2 total_net_repl_input_bytes]
+                set total_in [expr {$in1 + $in2}]
+
+                assert_morethan $in1 0
+                assert_morethan $in2 0
+                # Lower bound catches old single-stream (~half) accounting; upper bound guards double-counting.
+                assert {$out >= $total_in * 0.75}
+                assert {$out <= $total_in * 1.25}
+
+                $replica2 replicaof no one
+                $replica1 replicaof no one
+            }
+        }
+
+        # Restore the fixture defaults for the shared dual-channel primary.
+        $primary config set repl-diskless-sync-delay 0
+        $primary config set repl-diskless-sync-max-replicas 0
+    }
+}
+
+# --- ordinary diskless: ONE shared primary fixture -------------------------
+# Shared by the receive-to-disk (disabled) and direct-socket-load (swapdb) tests;
+# replicas differ only in repl-diskless-load so they stay per-test.
+
+start_server {overrides {save "" rdbcompression lz4 repl-diskless-sync yes repl-diskless-sync-delay 0}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+
+    # disabled: replica copies the payload to a temp file, then rdbLoad() auto-decompresses.
+    test {Disk-receive (repl-diskless-load disabled) + diskless compressed save loads correctly} {
+        set primary_loglines [count_log_lines 0]
+        populate_compressible_dataset $primary "diskrecv"
+
+        start_server {overrides {save "" rdbcompression lz4 repl-diskless-load disabled}} {
+            set replica [srv 0 client]
+            set replica_loglines [count_log_lines 0]
+            $replica replicaof $primary_host $primary_port
+
+            assert_replica_synced $primary $replica "(disk-receive default load)"
+
+            wait_for_log_messages -1 {"*target: replicas sockets*"} $primary_loglines 50 100
+            wait_for_log_messages -1 {"*Diskless full sync with compression: lz4*"} $primary_loglines 50 100
+            # Path B: disabled load reads from the received file; match "from <file>.rdb", not "from primary".
+            wait_for_log_messages 0 {"*Loading compressed RDB (algo=lz4) from *.rdb*"} $replica_loglines 50 100
+
+            $replica replicaof no one
+        }
+    }
+
+    # Diskless compresses the RDB payload as an LZ4 VCS frame over the socket; the
+    # $EOF:<mark> framing stays uncompressed so transfer boundaries are unchanged.
+    test {Diskless full sync compresses the RDB payload for a capable replica} {
+        set primary_loglines [count_log_lines 0]
+        populate_compressible_dataset $primary diskless-full-sync
+
+        start_server {overrides {save "" rdbcompression lz4 repl-diskless-load swapdb}} {
+            set replica [srv 0 client]
+            set replica_loglines [count_log_lines 0]
+            $replica replicaof $primary_host $primary_port
+
+            assert_replica_synced $primary $replica "(compressed diskless full sync)"
+
+            wait_for_log_messages -1 {"*target: replicas sockets*"} $primary_loglines 50 100
+            wait_for_log_messages -1 {"*Diskless full sync with compression: lz4*"} $primary_loglines 50 100
+            wait_for_log_messages 0 {"*Loading compressed RDB (algo=lz4) from primary*"} $replica_loglines 50 100
+
+            $primary set diskless-full-sync:post after
+            wait_for_value_to_propagate_to_replica $primary $replica diskless-full-sync:post
+
+            $replica replicaof no one
+        }
+    }
+
+}
+
+# Checksum interaction: a compressed diskless full sync loads under rdbchecksum no.
+# Isolated because rdbchecksum is an immutable startup-only override.
+
+start_server {overrides {save "" rdbcompression lz4 repl-diskless-sync yes repl-diskless-sync-delay 0 rdbchecksum no}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+
+    test {Compressed diskless full sync loads with rdbchecksum no on the primary} {
+        assert_equal "no" [lindex [$primary config get rdbchecksum] 1]
+        set primary_loglines [count_log_lines 0]
+        populate_compressible_dataset $primary "cksum-off"
+
+        start_server {overrides {save "" rdbcompression lz4 repl-diskless-load disabled}} {
+            set replica [srv 0 client]
+            set replica_loglines [count_log_lines 0]
+            $replica replicaof $primary_host $primary_port
+
+            assert_replica_synced $primary $replica "(checksum off)"
+
+            wait_for_log_messages -1 {"*Diskless full sync with compression: lz4*"} $primary_loglines 50 100
+            # Disabled load reads from the received file; match "from <file>.rdb", not "from primary".
+            wait_for_log_messages 0 {"*Loading compressed RDB (algo=lz4) from *.rdb*"} $replica_loglines 50 100
+
+            $replica replicaof no one
+        }
+    }
+}
+
+# Mid-transfer link drop on a compressed diskless full sync: swapdb's inline
+# socket decompressor (replicaLoadPrimaryRDBFromSocket TRUNCATED path) sees a clean
+# EOF before the LZ4 frame end. That is recoverable truncation, NOT corruption, so
+# the replica must survive, retry, and resync. Determinism: compression finishes
+# almost instantly, so stretch the child with a per-key save delay over a large
+# dataset; watch the replica log (not INFO) since it is blocked in the synchronous load.
+
+start_server {overrides {save "" rdbcompression lz4 repl-diskless-sync yes repl-diskless-sync-delay 0}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+
+    test {Compressed diskless full sync recovers from a mid-transfer link drop (truncation, not corruption)} {
+        populate_compressible_dataset $primary "trunc" 2000
+        set sync_full_before [status $primary sync_full]
+
+        start_server {overrides {save "" rdbcompression lz4 repl-diskless-load swapdb}} {
+            set replica [srv 0 client]
+            set replica_loglines [count_log_lines 0]
+
+            # 5ms/key over ~2000 keys keeps the compressed stream in flight long enough to interrupt.
+            $primary config set rdb-key-save-delay 5000
+
+            $replica replicaof $primary_host $primary_port
+
+            # Catch the replica once it starts the inline socket decode (the TRUNCATED
+            # path under test); the log line is emitted at decode start.
+            wait_for_log_messages 0 {"*Loading compressed RDB*"} $replica_loglines 300 100
+
+            # Kill the in-flight transfer so the stream reader hits a clean EOF mid-frame.
+            # The ~5s remaining load window dwarfs the detect-and-kill latency.
+            $primary client kill type replica
+
+            $primary config set rdb-key-save-delay 0
+
+            assert_equal {PONG} [$replica ping]
+
+            # Retries and converges on a clean resync (reconnect driven by the cron, ~1s).
+            assert_replica_synced $primary $replica "(truncation recovery)"
+
+            # Interrupted attempt + retry each count one full sync, proving the kill landed mid-transfer.
+            assert {[status $primary sync_full] >= $sync_full_before + 2}
+
+            # The interrupted transfer was handled as a recoverable load failure, not a
+            # crash or corruption abort (no panic/assertion below).
+            assert {[count_log_message 0 "Loading compressed RDB"] >= 1}
+            assert {[count_log_message 0 "Failed trying to load the PRIMARY synchronization DB"] >= 1}
+            assert_equal 0 [count_log_message 0 "=== ASSERTION FAILED ==="]
+            assert {[count_log_message 0 "REPLICA sync: Finished with success"] >= 1}
+
+            $primary set trunc:post "after-recovery"
+            wait_for_value_to_propagate_to_replica $primary $replica trunc:post
+
+            $replica replicaof no one
+        }
+    }
+}
+
+# Mixed diskless cohort (one capable, one not) falls back to plaintext for all: the
+# group-AND clears the LZ4 capability. A slow manual BGSAVE occupies the child
+# slot so both replicas park in WAIT_BGSAVE_START together, exercising the AND deterministically.
+start_server {overrides {save "" rdbcompression lz4 repl-diskless-sync yes repl-diskless-sync-delay 0}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+
+    # Enough keys so the manual BGSAVE stays alive for both replicas to register.
+    populate_compressible_dataset $primary mixed-diskless 800
+
+    start_server {overrides {save "" rdbcompression lz4 repl-diskless-load swapdb}} {
+        set replica_capable [srv 0 client]
+
+        start_server {overrides {save "" rdbcompression yes repl-diskless-load swapdb}} {
+            set replica_plain [srv 0 client]
+
+            test {Mixed diskless cohort falls back to a plaintext RDB payload} {
+                set rounds_before [count_log_message -2 {Starting BGSAVE for SYNC}]
+                set primary_loglines [count_log_lines -2]
+
+                park_replicas_for_grouped_bgsave $primary $replica_capable $replica_plain $primary_host $primary_port
+
+                assert_replica_synced $primary $replica_capable "(mixed diskless capable)"
+                assert_replica_synced $primary $replica_plain "(mixed diskless plain)"
+
+                # A single grouped diskless round served both replicas.
+                assert_equal 1 [expr {[count_log_message -2 {Starting BGSAVE for SYNC}] - $rounds_before}]
+
+                # AND result: plaintext round, so no compression NOTICE.
+                verify_no_log_message -2 "*Diskless full sync with compression: lz4*" $primary_loglines
+
+                $replica_plain replicaof no one
+                $replica_capable replicaof no one
+            }
+        }
+    }
+}
+
+# Fake-primary negative coverage for the size-framed compressed socket load. A
+# complete VCS/LZ4 stream is captured from a throwaway server's dump.rdb (SAVE with
+# rdbcompression lz4 writes a full VCS stream), then replayed by fake_primary.tcl
+# with a controlled bulk header and payload. The fake primary is plain TCP, so skip under TLS.
+
+if {!$::tls} {
+
+# Capture a complete compressed stream once for all fake-primary tests.
+set compressed_payload ""
+start_server {overrides {save "" rdbcompression lz4}} {
+    set src [srv 0 client]
+    for {set i 0} {$i < 32} {incr i} {
+        $src set src:key:$i [string repeat "srcval:$i " 8]
+    }
+    $src save
+    set src_dump [server_rdb_path $src]
+    set compressed_payload [read_binary_file $src_dump]
+    assert_equal "VCS" [string range $compressed_payload 0 2]
+}
+
+# Recoverable outcomes share one replica. Each test clears the dataset and
+# counters, then always detaches and stops its fake primary.
+
+start_server {overrides {save "" rdbcompression lz4 repl-diskless-load swapdb}} {
+    set replica [srv 0 client]
+
+    # Both size-framing mismatches decode a complete frame but fail the
+    # consumed-equals-announced check: either fewer bytes arrive than announced,
+    # or trailing bytes remain after the frame boundary.
+    set padded_payload "$compressed_payload[string repeat J 100]"
+    foreach {name payload announced_size} [list \
+        "stream ends before the announced size" \
+            $compressed_payload [expr {[string length $compressed_payload] + 100}] \
+        "trailing bytes remain inside the announced size" \
+            $padded_payload [string length $padded_payload] \
+    ] {
+        test "Compressed socket load fails when $name" {
+            set fake_pid ""
+            with_cleanup {
+                $replica replicaof no one
+                $replica flushall
+                $replica config resetstat
+                set replica_loglines [count_log_lines 0]
+                lassign [start_fake_primary $payload $announced_size] fake_pid fake_port
+
+                $replica replicaof 127.0.0.1 $fake_port
+                wait_for_log_messages 0 {"*ended before the announced transfer size*"} \
+                    $replica_loglines 100 100
+
+                assert_equal {PONG} [$replica ping]
+                assert_equal 0 [$replica dbsize]
+            } {
+                $replica replicaof no one
+                if {$fake_pid ne ""} {catch {exec kill $fake_pid}}
+            }
+        }
+    }
+
+    # Complete frame with the exact announced size: the load succeeds and input
+    # accounting must count every encoded wire byte: total_net_repl_input_bytes ==
+    # N + "$<N>\r\n" bulk header. Tight enough to catch a lost footer.
+    test {Compressed socket load counts exactly the encoded wire bytes on a successful load} {
+        set fake_pid ""
+        with_cleanup {
+            $replica replicaof no one
+            $replica flushall
+            $replica config resetstat
+            set n [string length $compressed_payload]
+            lassign [start_fake_primary $compressed_payload $n] fake_pid fake_port
+
+            $replica replicaof 127.0.0.1 $fake_port
+            wait_for_condition 100 100 {
+                [$replica dbsize] > 0
+            } else {
+                fail "replica did not load the compressed payload"
+            }
+            # Stop before the dropped link (fake primary closed) can reconnect.
+            $replica replicaof no one
+
+            # Bulk header "$<N>\r\n" = 1 ('$') + digits(N) + 2 ("\r\n").
+            set meta [expr {3 + [string length $n]}]
+            set expected [expr {$n + $meta}]
+            set got [status $replica total_net_repl_input_bytes]
+            assert_equal $expected $got \
+                "net-input $got != N $n + bulk header $meta (expected $expected)"
+        } {
+            $replica replicaof no one
+            if {$fake_pid ne ""} {catch {exec kill $fake_pid}}
+        }
+    }
+
+    # Announce N but send a truncated prefix and close: the load fails before the
+    # frame end, but residual wire bytes must be counted first. Truncation is
+    # recoverable, so the replica survives; input == bytes sent + "$<N>\r\n" header.
+    test {Compressed socket load counts every wire byte received on a failing (truncated) transfer} {
+        set fake_pid ""
+        with_cleanup {
+            $replica replicaof no one
+            $replica flushall
+            $replica config resetstat
+            set full_len [string length $compressed_payload]
+            set bytes_sent [expr {$full_len / 2}]
+            set truncated [string range $compressed_payload 0 [expr {$bytes_sent - 1}]]
+            set announce $full_len
+
+            set replica_loglines [count_log_lines 0]
+            lassign [start_fake_primary $truncated $announce] fake_pid fake_port
+
+            $replica replicaof 127.0.0.1 $fake_port
+            wait_for_log_messages 0 {"*Failed trying to load the PRIMARY synchronization DB*"} \
+                $replica_loglines 100 100
+
+            # Stop retrying before reading stats to keep the accounting window clean.
+            $replica replicaof no one
+            assert_equal {PONG} [$replica ping]
+
+            # "$<N>\r\n" bulk header = 1 ('$') + digits(N) + 2 ("\r\n").
+            set meta [expr {3 + [string length $announce]}]
+            set expected [expr {$bytes_sent + $meta}]
+            set got [status $replica total_net_repl_input_bytes]
+            assert_equal $expected $got \
+                "net-input $got != bytes_sent $bytes_sent + bulk header $meta (expected $expected)"
+        } {
+            $replica replicaof no one
+            if {$fake_pid ne ""} {catch {exec kill $fake_pid}}
+        }
+    }
+}
+
+# Corrupt compressed payloads: a flipped byte mid-frame (caught during parse) and a
+# flipped last byte (checksum mismatch at frame finish) converge on the same fatal
+# path. A corrupt diskless load is terminal (rdbReportError exits), so each variant runs in its own fresh replica.
+test {Corrupted compressed stream (mid-frame and footer) aborts the diskless load} {
+    foreach {label offset_expr} {
+        mid-frame {[string length $compressed_payload] / 2}
+        footer    {[string length $compressed_payload] - 1}
+    } {
+        start_server {overrides {save "" rdbcompression lz4 repl-diskless-load swapdb}} {
+            set replica [srv 0 client]
+            set corrupt_at [expr $offset_expr]
+            assert {$corrupt_at > 8} ;# flip a byte well past the 7-byte VCS envelope
+            binary scan [string index $compressed_payload $corrupt_at] c byte_val
+            set corrupted [string replace $compressed_payload $corrupt_at $corrupt_at \
+                               [binary format c [expr {$byte_val ^ 0xff}]]]
+            lassign [start_fake_primary $corrupted [string length $corrupted]] fake_pid fake_port
+
+            $replica replicaof 127.0.0.1 $fake_port
+
+            wait_for_condition 100 100 {
+                ![is_alive [srv 0 pid]]
+            } else {
+                fail "replica did not exit on a corrupt compressed stream ($label)"
+            }
+            set stdout [srv 0 stdout]
+            assert_equal 1 [count_message_lines $stdout "Corrupt streaming-compressed RDB input"]
+            assert_equal 1 [count_message_lines $stdout "Terminating server after rdb file reading failure."]
+            catch {exec kill $fake_pid}
+        }
+    }
+}
+
+} ;# end !tls
+
+} ;# end tags

--- a/tests/integration/replication-aof-sync.tcl
+++ b/tests/integration/replication-aof-sync.tcl
@@ -164,6 +164,62 @@ tags {"repl external:skip"} {
         }
     }
 
+    # A streaming-compressed disk-based sync RDB (rdbcompression lz4 on
+    # both ends) cannot be reused as an AOF base, so the replica falls back to
+    # BGREWRITEAOF. Inverse of the plaintext RDB-reuse tests above.
+    test "Disk-based full sync with rdbcompression lz4 falls back to BGREWRITEAOF for AOF base" {
+        start_server {overrides {repl-diskless-sync no rdbcompression lz4 save ""}} {
+            set primary [srv 0 client]
+            set primary_host [srv 0 host]
+            set primary_port [srv 0 port]
+
+            for {set i 0} {$i < 40} {incr i} {
+                $primary set "rcomp-key:$i" "value:$i"
+            }
+
+            start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync no rdbcompression lz4 save ""}} {
+                set replica [srv 0 client]
+                set replica_log [srv 0 stdout]
+
+                $replica replicaof $primary_host $primary_port
+                wait_for_sync $replica
+
+                # Replica detects the compressed sync RDB and falls back to BGREWRITEAOF.
+                wait_for_condition 50 100 {
+                    [log_file_matches $replica_log "*falling back to BGREWRITEAOF instead of reusing it as an AOF base*"]
+                } else {
+                    fail "Expected streaming-compression AOF fallback log not found"
+                }
+
+                # And it must NOT have reused the sync RDB as the AOF base.
+                assert {![log_file_matches $replica_log "*Reused RDB file from primary sync as AOF base file*"]}
+
+                # AOF comes up via BGREWRITEAOF; a base file must exist.
+                waitForBgrewriteaof $replica
+                set manifest_path [get_aof_manifest_path $replica]
+                set base_name [get_cur_base_aof_name $manifest_path]
+                assert {$base_name ne ""}
+
+                # Data correct at runtime (loaded from the compressed socket stream).
+                assert_equal 40 [$replica dbsize]
+                for {set i 0} {$i < 40} {incr i} {
+                    assert_equal "value:$i" [$replica get "rcomp-key:$i"]
+                }
+
+                # After restart: AOF loads from the rewritten base, not the compressed RDB.
+                $replica replicaof no one
+                restart_server 0 true false
+                set replica [srv 0 client]
+                wait_done_loading $replica
+
+                assert_equal 40 [$replica dbsize]
+                for {set i 0} {$i < 40} {incr i} {
+                    assert_equal "value:$i" [$replica get "rcomp-key:$i"]
+                }
+            }
+        }
+    }
+
     # Test 4: aof-use-rdb-preamble no should fall back to bgrewriteaof
     test "Disk-based sync with aof-use-rdb-preamble no uses bgrewriteaof" {
         start_server {overrides {appendonly yes aof-use-rdb-preamble no repl-diskless-sync no save ""}} {

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1114,6 +1114,69 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
     }
 }
 
+# Compressed sibling of the drop-during-pipe family above. Compression finishes
+# the transfer too quickly for the size-based throttling used there, so a
+# per-key save delay keeps the compressed diskless transfer in flight while one
+# replica is killed. The primary's RDB child must complete without crashing and
+# the surviving replica must converge.
+start_server {tags {"repl external:skip"} overrides {save "" rdbcompression lz4}} {
+    set master [srv 0 client]
+    $master config set repl-diskless-sync yes
+    $master config set repl-diskless-sync-delay 5
+    $master config set repl-diskless-sync-max-replicas 2
+    $master config set dual-channel-replication-enabled "no"; # dual-channel-replication doesn't use pipe
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+    $master debug populate 4000 test 1000
+    # 1ms per key over 4k keys keeps the compressed transfer in flight for
+    # about 4 seconds; resetting the delay later does not speed up the
+    # already-forked child, so the kill below always lands mid-transfer.
+    $master config set rdb-key-save-delay 1000
+
+    test "diskless replica drops during compressed rdb pipe" {
+        start_server {overrides {save "" rdbcompression lz4 repl-diskless-load swapdb}} {
+            set survivor [srv 0 client]
+            start_server {overrides {save "" rdbcompression lz4}} {
+                set loglines [count_log_lines -2]
+                $survivor replicaof $master_host $master_port
+                [srv 0 client] replicaof $master_host $master_port
+
+                # Wait for a compressed transfer to be in flight: the cohort
+                # negotiated compression and the survivor began the socket load.
+                wait_for_log_messages -2 {"*Diskless full sync with compression: lz4*"} $loglines 1500 10
+                wait_for_log_messages -1 {"*Loading DB in memory*"} 0 1500 10
+
+                # Kill one replica mid-transfer.
+                exec kill [srv 0 pid]
+
+                wait_for_condition 2400 100 {
+                    [s -2 rdb_bgsave_in_progress] == 0
+                } else {
+                    fail "rdb child didn't terminate"
+                }
+                wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"} $loglines 1000 10
+                $master config set rdb-key-save-delay 0
+
+                # Verify the surviving replica converged on the compressed sync.
+                wait_for_condition 600 100 {
+                    [lindex [$survivor role] 3] eq {connected}
+                } else {
+                    fail "surviving replica still not connected after some time"
+                }
+                wait_for_condition 50 100 {
+                    [$master dbsize] == [$survivor dbsize]
+                } else {
+                    fail "Different number of keys between master and surviving replica after too long time."
+                }
+                set digest [$master debug digest]
+                set digest0 [$survivor debug digest]
+                assert {$digest ne 0000000000000000000000000000000000000000}
+                assert {$digest eq $digest0}
+            }
+        }
+    }
+}
+
 test "diskless replication child being killed is collected" {
     # when diskless master is waiting for the replica to become writable
     # it removes the read event from the rdb pipe so if the child gets killed

--- a/tests/integration/valkey-check-rdb.tcl
+++ b/tests/integration/valkey-check-rdb.tcl
@@ -124,6 +124,35 @@ tags {"check-rdb network external:skip logreqres:skip"} {
             }
         }
 
+        test "valkey-check-rdb rejects a compressed RDB truncated mid-frame" {
+            r config set rdbcompression lz4
+            set dir [lindex [r config get dir] 1]
+            set midframe_rdb [file join $dir midframe-vcs.rdb]
+            with_cleanup {
+                r flushall
+                r set lz4:midframe [string repeat "payload " 200]
+                r save
+
+                set dump_rdb [file join $dir dump.rdb]
+                set data [read_binary_file $dump_rdb]
+                # Cut mid-frame rather than dropping the trailer: a file has no
+                # more bytes coming, so this is corruption.
+                set keep [expr {[string length $data] * 6 / 10}]
+                write_binary_file $midframe_rdb [string range $data 0 [expr {$keep - 1}]]
+
+                set failed [catch {
+                    exec $::VALKEY_CHECK_RDB_BIN $midframe_rdb
+                } result]
+
+                assert_equal 1 $failed
+                assert_match {*Corrupt compressed RDB stream*} $result
+                assert_no_match {*RDB looks OK*} $result
+            } {
+                file delete -force $midframe_rdb
+                catch {r config set rdbcompression yes}
+            }
+        }
+
         test "valkey-check-rdb ignores trailing data after a compressed RDB" {
             r config set rdbcompression lz4
             set dir [lindex [r config get dir] 1]

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -83,6 +83,11 @@ proc createComplexDatasetForVerification {r count {prefix ""}} {
     }
 }
 
+# Path of the RDB file a server saves to (dir + dbfilename).
+proc server_rdb_path {client} {
+    return [file join [lindex [$client config get dir] 1] [lindex [$client config get dbfilename] 1]]
+}
+
 # Useful for some test
 proc zlistAlikeSort {a b} {
     if {[lindex $a 0] > [lindex $b 0]} {return 1}

--- a/valkey.conf
+++ b/valkey.conf
@@ -620,9 +620,13 @@ stop-writes-on-bgsave-error yes
 #   lz4        - streaming LZ4 frame compression for the entire RDB file.
 #                Supported by Valkey 9.2 and later.
 #
-# Streaming compression currently applies only to on-disk snapshots.
-# Replication full synchronization continues to use the plain RDB format until
-# compressed full-sync capability negotiation is implemented.
+# This setting selects compression for regular RDB persistence. With lz4, the
+# payload of a full sync (disk-based, diskless and dual-channel) is also LZ4
+# framed. A replica advertises support for this when its own rdbcompression is
+# lz4. If any replica attaching to that sync does not support it, the payload is
+# sent plaintext to all of them and that sync writes a plain snapshot. When AOF
+# is enabled, a compressed sync snapshot is not reused as an AOF base and the
+# replica runs BGREWRITEAOF instead.
 #
 # Before downgrading a server that may load an existing lz4 snapshot,
 # rewrite the snapshot in the legacy format and verify it with the older binary:


### PR DESCRIPTION
## Summary

Compresses the full-sync RDB payload with the LZ4 stream codec from #3531, across
disk-based, diskless, and dual-channel sync (on the wire, and on the shared disk file for
disk-based).

No new config. Sync compression is driven by the existing `rdbcompression lz4` on both
ends, negotiated per replica so no replica ever receives a payload it cannot load.

Negotiation:
- A replica whose own `rdbcompression` is `lz4` advertises `REPLCONF capa lz4`. The
  capability names the codec, so a replica advertises only what its binary can decode and a
  future codec adds its own capability.
- The primary compresses only when its own `rdbcompression` is `lz4` and every replica
  attaching to that sync advertised the capability. If any replica is not capable, everyone
  gets plaintext and that sync writes a plain snapshot.
- A replica arriving during an in-flight disk BGSAVE can join a plain save regardless of
  capability; a compressed save requires it.
- `rdbcompression yes` and `lzf` select per-string LZF, which is not a stream codec and
  cannot frame a payload, so only `lz4` enables this.

## What this changes about `rdbcompression`

`rdbcompression` gains a second meaning: it now also selects the full-sync wire format.
Setting `lz4` for persistence opts a server into compressed sync, and a replica must be
willing to write `lz4` snapshots in order to accept them. This was chosen over a dedicated
knob because both formats are the same codec, and a separate switch would only let them
disagree.

Two consequences follow:
- With a non-capable replica attached, a disk-based round writes a plain `dump.rdb` even
  under `rdbcompression lz4`, so the persisted format depends on which replicas attached to
  that round.
- When AOF is enabled, a compressed sync snapshot is not reused as an AOF base; the replica
  runs `BGREWRITEAOF` instead.

## Framing and failure handling

The `$EOF:<mark>` preamble and its 40-byte suffix stay plaintext; only the payload is
compressed. A link dropped mid-frame is recoverable truncation and retries as a full
resync. A corrupt frame is fatal and terminates the load rather than driving a resync loop,
matching how the RDB parser already treats corruption.

## Metrics

Replica-side input counts wire (compressed) bytes at the read source, so
`total_net_repl_input_bytes` reflects what crossed the network rather than the logical RDB
size. Dual-channel output aggregates the bytes actually written across every socket in the
connset and is reported even when the save fails partway, which also corrects a
pre-existing undercount on the plain dual-channel path.

## How configs affect full sync

| Config | Where | Effect on full sync |
|--------|-------|---------------------|
| `rdbcompression` (`no` / `yes` / `lzf` / `lz4`) | primary and replica | Drives this feature: a replica with `lz4` advertises the capability, and a primary with `lz4` compresses only when the whole cohort is capable (otherwise plaintext). Codec-default level, no separate level knob. Runtime changes apply to subsequent syncs. |
| `repl-diskless-sync` (`yes`/`no`) | primary | Unchanged path selection; compression is layered onto each path (`no` = one shared compressed disk file, `yes` = compressed socket stream with the `$EOF:<mark>` framing kept plaintext). |
| `repl-diskless-sync-delay` / `repl-diskless-sync-max-replicas` | primary | Unchanged: defines the cohort window that the capability AND is computed over. |
| `repl-diskless-load` (`disabled`/`swapdb`/`on-empty-db`) | replica | Unchanged: both load paths decompress transparently (inline for `swapdb`/`on-empty-db`, via temp-file `rdbLoad` auto-detect for `disabled`). A file received to disk is kept in the received format; existing configs govern its retention. |
| `dual-channel-replication-enabled` | both | Rides the diskless path; the dual-channel handshake also advertises the `lz4` capability so the RDB-channel payload negotiates the same way. |
| `rdbchecksum` (`yes`/`no`) | primary | Unchanged when uncompressed; under `lz4` the logical CRC64 trailer is zero and this instead controls the LZ4 block and content checksums that protect the stream. |

All other replication and RDB configs are unaffected by this change.
