### PR TITLE
Route INFO generation (core + module API) through a pluggable info emitter

### DIFF
--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -64,6 +64,7 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/setproctitle.c
     ${CMAKE_SOURCE_DIR}/src/blocked.c
     ${CMAKE_SOURCE_DIR}/src/hyperloglog.c
+    ${CMAKE_SOURCE_DIR}/src/info_emitter.c
     ${CMAKE_SOURCE_DIR}/src/latency.c
     ${CMAKE_SOURCE_DIR}/src/sparkline.c
     ${CMAKE_SOURCE_DIR}/src/valkey-check-rdb.c

--- a/design-docs/info-emitter.md
+++ b/design-docs/info-emitter.md
@@ -1,0 +1,233 @@
+# Info Emitter: a pluggable sink for INFO field generation
+
+## Status
+
+Proposal / RFC. Prerequisite for direct OpenTelemetry (OTLP) metric export
+without an INFO string round-trip.
+
+## Problem
+
+`genValkeyInfoString()` (`src/server.c`) builds the `INFO` output by writing
+`key:value\r\n` text directly into an `sds`, using inline `sdscatfmt`/
+`sdscatprintf` calls across ~13 sections (~700 lines). Anything that wants
+INFO data as *structured* values must generate this text and then parse it back:
+
+- `VM_GetServerInfo()` (module API) does exactly this: `genValkeyInfoString()`
+  then `sdssplitlen()` + parse into a rax.
+- A metrics exporter (e.g. OpenTelemetry/OTLP) must do the same: generate the
+  string, split it, re-parse each `key:value`, classify the number, and
+  re-encode. A build -> parse -> build round trip.
+
+The round trip is wasteful (format numbers to text, then parse text back to
+numbers) and loses type information (counter vs gauge, int vs double) that the
+producing code knew but the text does not carry.
+
+## Goal
+
+Introduce an **info emitter**: an abstraction over "emit a section / emit a
+field" so the *same* generation code can target multiple backends:
+
+1. **text backend** — reproduces the current `INFO` output byte-for-byte (used
+   by the `INFO` command, crash reports, sentinel, etc.).
+2. **structured backends** — e.g. an OTLP metrics backend that receives typed
+   values directly, with no string round trip. (Also usable by
+   `VM_GetServerInfo` to build the rax directly.)
+
+Non-goals: changing the `INFO` wire format, or changing module-facing APIs in a
+breaking way.
+
+## Prior art in the codebase
+
+The module INFO API is already an emitter in everything but name
+(`src/module.c`): modules call `ValkeyModule_InfoAddSection()` and
+`ValkeyModule_InfoAddField{LongLong,ULongLong,Double,CString,String}()`, plus
+`ValkeyModule_InfoBeginDictField()/EndDictField()` for composite lines. Today
+those functions write text into `ctx->info`. The refactor generalizes this
+shape (add a backend vtable) and, ideally, **routes both core sections and
+module callbacks through the same emitter** — so any backend automatically
+covers module-provided fields with no extra work.
+
+## Interface
+
+As shipped (see `src/info_emitter.h`):
+
+```c
+/* Metric semantics carried on every numeric field (ignored by the text backend
+ * except INFO_UNIT_PERCENT; used by structured backends). */
+typedef enum { INFO_KIND_GAUGE = 0, INFO_KIND_COUNTER } infoKind;
+typedef enum {
+    INFO_UNIT_NONE = 0, INFO_UNIT_BYTES, INFO_UNIT_SECONDS,
+    INFO_UNIT_MILLISECONDS, INFO_UNIT_MICROSECONDS, INFO_UNIT_PERCENT,
+} infoUnit;
+
+/* prec >= 0 renders "%.*f"; prec == INFO_PREC_FULL renders "%.17g". */
+#define INFO_PREC_FULL (-1)
+
+typedef struct infoEmitter infoEmitter;
+
+typedef struct infoEmitterOps {
+    void (*begin_section)(infoEmitter *e, const char *name);
+    void (*field_ll)(infoEmitter *e, const char *key, long long v, infoKind kind, infoUnit unit);
+    void (*field_ull)(infoEmitter *e, const char *key, unsigned long long v, infoKind kind, infoUnit unit);
+    void (*field_double)(infoEmitter *e, const char *key, double v, int prec, infoKind kind, infoUnit unit);
+    void (*field_str)(infoEmitter *e, const char *key, const char *v);
+    /* Length-aware string, reproducing sds %S semantics (embedded NULs). */
+    void (*field_strn)(infoEmitter *e, const char *key, const char *v, size_t vlen);
+    /* Fixed-point seconds.microseconds (%lld.%06lld); CPU/duration fields. */
+    void (*field_usec)(infoEmitter *e, const char *key, long long usec, infoKind kind);
+    /* Composite ("dict") lines: key:sub1=v1,sub2=v2  (keyspace, commandstats). */
+    void (*begin_dict)(infoEmitter *e, const char *key);
+    void (*dict_ll)(infoEmitter *e, const char *sub, long long v, infoKind kind, infoUnit unit);
+    void (*dict_ull)(infoEmitter *e, const char *sub, unsigned long long v, infoKind kind, infoUnit unit);
+    void (*dict_double)(infoEmitter *e, const char *sub, double v, int prec, infoKind kind, infoUnit unit);
+    void (*dict_str)(infoEmitter *e, const char *sub, const char *v);
+    void (*dict_strn)(infoEmitter *e, const char *sub, const char *v, size_t vlen);
+    void (*end_dict)(infoEmitter *e);
+    /* Escape hatch for irregular lines. Text backend prints it verbatim;
+     * structured backends may skip it. */
+    void (*raw)(infoEmitter *e, const char *fmt, va_list ap);
+} infoEmitterOps;
+
+/* The emitter is embedded as the first member of a backend-specific container
+ * (e.g. infoEmitterText), so the container is recovered from the base pointer. */
+struct infoEmitter {
+    const infoEmitterOps *ops;
+};
+
+/* Terse dispatch helpers default kind/unit to the common cases, e.g.
+ * infoEmitFieldLL (gauge), infoEmitCounterLL (counter),
+ * infoEmitMetricULL(e, key, v, kind, unit), infoEmitFieldDouble(e, key, v, prec). */
+```
+
+### Why these field kinds
+
+Auditing `genValkeyInfoString()` shows every field is one of:
+
+| Current format         | Emitter call            | Notes                                  |
+|------------------------|-------------------------|----------------------------------------|
+| `%lld`, `%d`, `%ld`    | `field_ll`              | signed integers                        |
+| `%llu`, `%lu`, `%zu`   | `field_ull`             | unsigned/size_t (same digits as `%llu`)|
+| `%.2f`, `%.3f`, `%.6f` | `field_double(.., prec)`| precision preserved via `prec`; `INFO_PREC_FULL` (-1) = `%.17g` |
+| `%s`                   | `field_str`             | NUL-terminated strings                 |
+| `%S` (sds)             | `field_strn`            | length-aware (preserves embedded NULs) |
+| `%ld.%06ld` (sec.usec) | `field_usec`            | CPU times; text = sec.usec, OTLP = seconds/usec |
+| `db0:keys=..,..`       | `begin_dict`/`dict_*`   | keyspace, commandstats, latencystats (`dict_ull` for unsigned) |
+| irregular              | `raw`                   | rare; verbatim in text, skipped in OTLP|
+
+## Byte-for-byte parity strategy
+
+Integers and strings reproduce exactly by construction. The only formatting
+that varies per field is floating point, which the `prec` argument preserves
+(`field_double(e,"mem_fragmentation_ratio",v,2)` -> `%.2f`). The `field_usec`
+kind preserves the `sec.usec` layout. The `raw` escape hatch covers anything
+that does not fit, guaranteeing the text backend can always reproduce the
+current output.
+
+Parity is enforced by a test that captures `INFO everything` from an unmodified
+build and from the emitter build and diffs them (value-independent fields), plus
+a unit test that asserts the text backend produces the exact legacy string for
+each field kind and precision.
+
+## Migration plan (incremental, always green)
+
+1. Land the emitter interface + text backend (no behavior change).
+2. Convert core sections one at a time, verifying INFO parity after each. Start
+   with a self-contained section (CPU or Cluster), then the large ones (Stats,
+   Memory, Persistence, Replication, Keyspace).
+3. Route the module INFO API (`VM_InfoAddField*`) through the emitter so module
+   fields flow to any backend. Keep the public module API unchanged.
+4. Only after core + modules are on the emitter, add the OTLP backend and switch
+   the exporter to run `genValkeyInfoString()` with the OTLP emitter — deleting
+   its INFO-parsing code.
+
+Each step is independently shippable and reviewable; steps 1-3 are pure
+refactors with zero functional change, which is the bar for maintainer review.
+
+## Performance
+
+The text backend replaces one big batched `sdscatfmt` per section with N
+per-field calls. This is a few extra function calls per field (indirect through
+the vtable) but the same number of `sds` appends; net cost is negligible and off
+the command hot path (INFO is not a hot path). Structured backends avoid the
+round-trip entirely. No change to command processing.
+
+## Risks
+
+- **Parity regressions** in floating-point/edge formats — mitigated by the
+  parity + unit tests above and incremental conversion.
+- **Large diff** to a core file — mitigated by section-at-a-time PRs.
+- **Module API coupling** — step 3 must keep the public API and output identical.
+
+## Open questions
+
+- Should `field_ull` values above `INT64_MAX` be represented in structured
+  backends as double or as a string? (Text is unaffected.)
+- Do we want per-field unit/type metadata (By, seconds, counter vs gauge) in the
+  emitter so structured backends get correct semantics without heuristics?
+  **Resolved: implemented.** The interface carries `infoKind` (GAUGE/COUNTER)
+  and `infoUnit` (NONE/BYTES/SECONDS/MILLISECONDS/MICROSECONDS/PERCENT) on every
+  numeric field. The text backend ignores them except `PERCENT` (which appends a
+  literal `%` to reproduce `%.2f%%`); structured backends read them directly.
+
+## Implementation status
+
+The emitter interface + text backend are in place, and **every section** of
+`genValkeyInfoString()` and its helpers (`genValkeyInfoStringCommandStats`,
+`genValkeyInfoStringLatencyStats`, `genValkeyInfoStringACLStats`,
+`genValkeyInfoStringScriptingEngines`, `fillPercentileDistributionLatencies`)
+now emit through the emitter. The inter-section separator is owned by
+`begin_section` (format-agnostic).
+
+The module INFO callback API (`VM_InfoAddSection` / `VM_InfoAddField*` /
+`VM_InfoBeginDictField` / `VM_InfoEndDictField` in `module.c`) is **also routed
+through the emitter** via `modulesCollectInfo()`, so module-provided fields reach
+structured backends as typed values too. The public module header
+(`valkeymodule.h`) and the opaque `ValkeyModuleInfoCtx` are unchanged, so
+existing third-party modules are unaffected and their INFO output is
+byte-identical. Small interface additions support the module formats exactly:
+`dict_ull` (unsigned dict fields), `INFO_PREC_FULL`/`%.17g`
+(`VM_InfoAddFieldDouble`), and `field_strn`/`dict_strn` (sds `%S` semantics).
+
+With both core and module INFO on the emitter, the only remaining step for OTLP
+is adding the OTLP backend and switching the exporter to run
+`genValkeyInfoString()` with it.
+
+### Parity
+
+`INFO everything` from an unmodified build and the emitter build are
+byte-for-byte identical, after normalizing inherently non-deterministic values
+(timestamps, memory, random ids, build path) and accounting for the
+process-nondeterministic hashtable iteration order of the `Commandstats` and
+`Latencystats` sections (identical field sets, different order between
+processes). Verified via a diff harness plus GoogleTest unit tests
+(`src/unit/test_info_emitter.cpp`) covering each field kind, the `PERCENT`
+suffix, the section separator, and byte-parity of the CPU/Cluster/Stats
+formatting.
+
+### Performance
+
+Measured with `valkey-benchmark`, CPU-pinned, interleaved base-vs-modified over
+multiple rounds:
+
+- **Command hot path unaffected:** SET/GET throughput is identical (the emitter
+  is not on the command path).
+- **INFO generation:** a naive one-`sdscatprintf`-per-field text backend
+  regressed `INFO everything` generation by ~19–24% vs the legacy
+  one-`sdscatprintf`-per-section batching. This was closed — and then reversed
+  into a speedup — in stages:
+  1. format integers with `ll2string`/`ull2string`, dropping per-field
+     `vsnprintf` → ~11–14% slower;
+  2. assemble each line with a single `sdscatlen` → ~5% slower;
+  3. a per-emitter scratch buffer (memcpy fields, flush per chunk) → ~1% slower,
+     within noise — but still double-copied the bytes (field→scratch→sds);
+  4. **write fields directly into the sds buffer**: `ie_reserve()` grows the sds
+     in chunks and commits the length per-chunk, and each field is formatted in
+     place (`ll2string`/`ull2string`, or one `snprintf` for doubles/usec). This
+     is a single copy per byte with no format parsing for integers, so it does
+     strictly less work than the legacy `vsnprintf`-per-section path.
+  Result: the emitter build is **faster than the unmodified baseline** at INFO
+  generation — roughly +5% single-client and +10% at concurrency 10 (medians,
+  CPU-pinned, interleaved, 8 rounds; the emitter beat baseline in every round),
+  with output still byte-for-byte identical. Structured backends avoid text
+  formatting entirely.
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -509,6 +509,7 @@ ENGINE_SERVER_OBJ = \
     geohash_helper.o \
     hashtable.o \
     hyperloglog.o \
+    info_emitter.o \
     intset.o \
     io_threads.o \
     kvstore.o \

--- a/src/info_emitter.c
+++ b/src/info_emitter.c
@@ -144,9 +144,14 @@ static void textFieldDouble(infoEmitter *e, const char *key, double v, int prec,
     memcpy(p, key, klen);
     p += klen;
     *p++ = ':';
-    /* INFO_UNIT_PERCENT reproduces the legacy "%.2f%%" (trailing literal '%'). */
+    /* INFO_UNIT_PERCENT reproduces the legacy "%.2f%%" (trailing literal '%');
+     * prec == INFO_PREC_FULL reproduces the module API's "%.17g". These are
+     * mutually exclusive: INFO_PREC_FULL takes precedence (no current caller
+     * combines them). */
     int n;
-    if (unit == INFO_UNIT_PERCENT)
+    if (prec < 0)
+        n = snprintf(p, INFO_EMIT_NUMBUF, "%.17g", v);
+    else if (unit == INFO_UNIT_PERCENT)
         n = snprintf(p, INFO_EMIT_NUMBUF, "%.*f%%", prec, v);
     else
         n = snprintf(p, INFO_EMIT_NUMBUF, "%.*f", prec, v);
@@ -158,9 +163,8 @@ static void textFieldDouble(infoEmitter *e, const char *key, double v, int prec,
     ie_commit(t, (size_t)(p - p0));
 }
 
-static void textFieldStr(infoEmitter *e, const char *key, const char *v) {
-    infoEmitterText *t = textOf(e);
-    size_t klen = strlen(key), vlen = strlen(v);
+static void textEmitScalarStr(infoEmitterText *t, const char *key, const char *v, size_t vlen) {
+    size_t klen = strlen(key);
     char *p0 = ie_reserve(t, klen + 1 + vlen + 2);
     char *p = p0;
     memcpy(p, key, klen);
@@ -171,6 +175,14 @@ static void textFieldStr(infoEmitter *e, const char *key, const char *v) {
     *p++ = '\r';
     *p++ = '\n';
     ie_commit(t, (size_t)(p - p0));
+}
+
+static void textFieldStr(infoEmitter *e, const char *key, const char *v) {
+    textEmitScalarStr(textOf(e), key, v, strlen(v));
+}
+
+static void textFieldStrn(infoEmitter *e, const char *key, const char *v, size_t vlen) {
+    textEmitScalarStr(textOf(e), key, v, vlen);
 }
 
 static void textFieldUsec(infoEmitter *e, const char *key, long long usec, infoKind kind) {
@@ -223,28 +235,48 @@ static void textDictLL(infoEmitter *e, const char *sub, long long v, infoKind ki
     ie_commit(t, (size_t)(p - p0));
 }
 
-static void textDictDouble(infoEmitter *e, const char *sub, double v, int prec, infoKind kind, infoUnit unit) {
+static void textDictULL(infoEmitter *e, const char *sub, unsigned long long v, infoKind kind, infoUnit unit) {
     (void)kind;
     (void)unit;
     infoEmitterText *t = textOf(e);
     size_t slen = strlen(sub);
-    char *p0 = ie_reserve(t, 1 + slen + 1 + INFO_EMIT_NUMBUF);
+    char *p0 = ie_reserve(t, 1 + slen + 1 + LONG_STR_SIZE);
     char *p = textDictSub(t, p0, sub, slen);
-    int n = snprintf(p, INFO_EMIT_NUMBUF, "%.*f", prec, v);
+    p += ull2string(p, LONG_STR_SIZE, v);
+    ie_commit(t, (size_t)(p - p0));
+}
+
+static void textDictDouble(infoEmitter *e, const char *sub, double v, int prec, infoKind kind, infoUnit unit) {
+    (void)kind;
+    (void)unit;
+    infoEmitterText *t = textOf(e);
+    char *p0 = ie_reserve(t, 1 + strlen(sub) + 1 + INFO_EMIT_NUMBUF);
+    char *p = textDictSub(t, p0, sub, strlen(sub));
+    int n;
+    if (prec < 0)
+        n = snprintf(p, INFO_EMIT_NUMBUF, "%.17g", v);
+    else
+        n = snprintf(p, INFO_EMIT_NUMBUF, "%.*f", prec, v);
     if (n < 0) n = 0;
     if (n >= INFO_EMIT_NUMBUF) n = INFO_EMIT_NUMBUF - 1;
     p += n;
     ie_commit(t, (size_t)(p - p0));
 }
 
-static void textDictStr(infoEmitter *e, const char *sub, const char *v) {
-    infoEmitterText *t = textOf(e);
-    size_t slen = strlen(sub), vlen = strlen(v);
-    char *p0 = ie_reserve(t, 1 + slen + 1 + vlen);
-    char *p = textDictSub(t, p0, sub, slen);
+static void textEmitDictStr(infoEmitterText *t, const char *sub, const char *v, size_t vlen) {
+    char *p0 = ie_reserve(t, 1 + strlen(sub) + 1 + vlen);
+    char *p = textDictSub(t, p0, sub, strlen(sub));
     memcpy(p, v, vlen);
     p += vlen;
     ie_commit(t, (size_t)(p - p0));
+}
+
+static void textDictStr(infoEmitter *e, const char *sub, const char *v) {
+    textEmitDictStr(textOf(e), sub, v, strlen(v));
+}
+
+static void textDictStrn(infoEmitter *e, const char *sub, const char *v, size_t vlen) {
+    textEmitDictStr(textOf(e), sub, v, vlen);
 }
 
 static void textEndDict(infoEmitter *e) {
@@ -264,11 +296,14 @@ static const infoEmitterOps textOps = {
     .field_ull = textFieldULL,
     .field_double = textFieldDouble,
     .field_str = textFieldStr,
+    .field_strn = textFieldStrn,
     .field_usec = textFieldUsec,
     .begin_dict = textBeginDict,
     .dict_ll = textDictLL,
+    .dict_ull = textDictULL,
     .dict_double = textDictDouble,
     .dict_str = textDictStr,
+    .dict_strn = textDictStrn,
     .end_dict = textEndDict,
     .raw = textRaw,
 };

--- a/src/info_emitter.c
+++ b/src/info_emitter.c
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* Text backend for the info emitter (see info_emitter.h).
+ *
+ * Byte-for-byte parity with the legacy genValkeyInfoString() formatting is the
+ * hard requirement here, since the INFO wire format is depended on by clients,
+ * tooling and tests:
+ *   - integers reproduce exactly: %lld/%d/%ld render the same digits, so
+ *     field_ll uses ll2string; field_ull uses ull2string (%llu/%lu/%zu family);
+ *   - floating point preserves the per-field precision via `prec`;
+ *     INFO_UNIT_PERCENT appends a literal '%' to reproduce "%.2f%%";
+ *   - field_usec reproduces the "sec.usec" layout (%lld.%06lld);
+ *   - dict lines render as "key:sub1=v1,sub2=v2\r\n";
+ *   - raw() prints verbatim for anything that does not fit a typed field.
+ *
+ * Performance: the legacy code batched a whole section into one sdscatprintf(),
+ * which parses a format string but writes each field's bytes into the sds
+ * buffer exactly once. To be at least as fast per field, this backend writes
+ * fields DIRECTLY into the sds's own buffer: ie_reserve() ensures room at the
+ * tail (growing on demand and committing the length only then), and each field
+ * is formatted in place with ll2string()/ull2string() (integers, no vsnprintf)
+ * or a single snprintf() (doubles/usec). This is one copy per byte (vs a scratch
+ * buffer's two) with the sds length committed on grow rather
+ * than per-field, and no format parsing for integers.
+ *
+ * The (kind, unit) metadata is otherwise ignored by the text backend; it exists
+ * for structured backends (OTLP). */
+
+#include "fmacros.h"
+#include "info_emitter.h"
+#include "util.h"
+#include <stdio.h>
+#include <string.h>
+
+/* Large enough for any single INFO numeric value: %.6f of the largest double is
+ * ~322 chars; usec ("%lld.%06lld") and integers are far smaller. */
+#define INFO_EMIT_NUMBUF 340
+
+/* The emitter is the first member of infoEmitterText, so the container can be
+ * recovered from the base pointer without an offset. */
+static infoEmitterText *textOf(infoEmitter *e) {
+    return (infoEmitterText *)e;
+}
+
+/* Commit any bytes written past the sds length. */
+static void ie_flush(infoEmitterText *t) {
+    if (t->pend) {
+        sdsIncrLen(t->s, (ssize_t)t->pend);
+        t->pend = 0;
+    }
+}
+
+/* Ensure `n` writable bytes exist at the sds tail beyond the committed length
+ * plus the currently-pending (written-but-not-committed) bytes, and return the
+ * write pointer. Commits + grows only when necessary. We request exactly `n`
+ * from sdsMakeRoomFor and rely on its own greedy doubling for amortization —
+ * requesting a larger minimum would compound with the doubling and leave the
+ * INFO reply buffer noticeably over-allocated (which inflates the reported
+ * used_memory, since the buffer is live while INFO is being generated). The
+ * caller writes up to `n` bytes and then calls ie_commit(); it must not call
+ * ie_reserve() again before committing (a grow may reallocate the buffer). */
+static char *ie_reserve(infoEmitterText *t, size_t n) {
+    if (sdsavail(t->s) < t->pend + n) {
+        ie_flush(t);
+        t->s = sdsMakeRoomFor(t->s, n);
+    }
+    return t->s + sdslen(t->s) + t->pend;
+}
+
+static void ie_commit(infoEmitterText *t, size_t n) {
+    t->pend += n;
+}
+
+/* Write raw bytes directly into the sds tail. */
+static void ie_put(infoEmitterText *t, const char *data, size_t n) {
+    char *p = ie_reserve(t, n);
+    memcpy(p, data, n);
+    ie_commit(t, n);
+}
+
+static void textBeginSection(infoEmitter *e, const char *name) {
+    infoEmitterText *t = textOf(e);
+    /* Reproduce the legacy per-call-site separator: emit "\r\n" before every
+     * section except the first (post-increment matches "if (sections++)"). */
+    size_t nlen = strlen(name);
+    int sep = (t->section_counter && (*t->section_counter)++) ? 1 : 0;
+    char *p0 = ie_reserve(t, (sep ? 2 : 0) + 2 + nlen + 2);
+    char *p = p0;
+    if (sep) {
+        *p++ = '\r';
+        *p++ = '\n';
+    }
+    *p++ = '#';
+    *p++ = ' ';
+    memcpy(p, name, nlen);
+    p += nlen;
+    *p++ = '\r';
+    *p++ = '\n';
+    ie_commit(t, (size_t)(p - p0));
+}
+
+static void textFieldLL(infoEmitter *e, const char *key, long long v, infoKind kind, infoUnit unit) {
+    (void)kind;
+    (void)unit;
+    infoEmitterText *t = textOf(e);
+    size_t klen = strlen(key);
+    char *p0 = ie_reserve(t, klen + 1 + LONG_STR_SIZE + 2);
+    char *p = p0;
+    memcpy(p, key, klen);
+    p += klen;
+    *p++ = ':';
+    p += ll2string(p, LONG_STR_SIZE, v);
+    *p++ = '\r';
+    *p++ = '\n';
+    ie_commit(t, (size_t)(p - p0));
+}
+
+static void textFieldULL(infoEmitter *e, const char *key, unsigned long long v, infoKind kind, infoUnit unit) {
+    (void)kind;
+    (void)unit;
+    infoEmitterText *t = textOf(e);
+    size_t klen = strlen(key);
+    char *p0 = ie_reserve(t, klen + 1 + LONG_STR_SIZE + 2);
+    char *p = p0;
+    memcpy(p, key, klen);
+    p += klen;
+    *p++ = ':';
+    p += ull2string(p, LONG_STR_SIZE, v);
+    *p++ = '\r';
+    *p++ = '\n';
+    ie_commit(t, (size_t)(p - p0));
+}
+
+static void textFieldDouble(infoEmitter *e, const char *key, double v, int prec, infoKind kind, infoUnit unit) {
+    (void)kind;
+    infoEmitterText *t = textOf(e);
+    size_t klen = strlen(key);
+    char *p0 = ie_reserve(t, klen + 1 + INFO_EMIT_NUMBUF + 2);
+    char *p = p0;
+    memcpy(p, key, klen);
+    p += klen;
+    *p++ = ':';
+    /* INFO_UNIT_PERCENT reproduces the legacy "%.2f%%" (trailing literal '%'). */
+    int n;
+    if (unit == INFO_UNIT_PERCENT)
+        n = snprintf(p, INFO_EMIT_NUMBUF, "%.*f%%", prec, v);
+    else
+        n = snprintf(p, INFO_EMIT_NUMBUF, "%.*f", prec, v);
+    if (n < 0) n = 0;
+    if (n >= INFO_EMIT_NUMBUF) n = INFO_EMIT_NUMBUF - 1;
+    p += n;
+    *p++ = '\r';
+    *p++ = '\n';
+    ie_commit(t, (size_t)(p - p0));
+}
+
+static void textFieldStr(infoEmitter *e, const char *key, const char *v) {
+    infoEmitterText *t = textOf(e);
+    size_t klen = strlen(key), vlen = strlen(v);
+    char *p0 = ie_reserve(t, klen + 1 + vlen + 2);
+    char *p = p0;
+    memcpy(p, key, klen);
+    p += klen;
+    *p++ = ':';
+    memcpy(p, v, vlen);
+    p += vlen;
+    *p++ = '\r';
+    *p++ = '\n';
+    ie_commit(t, (size_t)(p - p0));
+}
+
+static void textFieldUsec(infoEmitter *e, const char *key, long long usec, infoKind kind) {
+    (void)kind;
+    infoEmitterText *t = textOf(e);
+    size_t klen = strlen(key);
+    char *p0 = ie_reserve(t, klen + 1 + INFO_EMIT_NUMBUF + 2);
+    char *p = p0;
+    memcpy(p, key, klen);
+    p += klen;
+    *p++ = ':';
+    int n = snprintf(p, INFO_EMIT_NUMBUF, "%lld.%06lld", usec / 1000000, usec % 1000000);
+    if (n < 0) n = 0;
+    if (n >= INFO_EMIT_NUMBUF) n = INFO_EMIT_NUMBUF - 1;
+    p += n;
+    *p++ = '\r';
+    *p++ = '\n';
+    ie_commit(t, (size_t)(p - p0));
+}
+
+static void textBeginDict(infoEmitter *e, const char *key) {
+    infoEmitterText *t = textOf(e);
+    size_t klen = strlen(key);
+    char *p0 = ie_reserve(t, klen + 1);
+    memcpy(p0, key, klen);
+    p0[klen] = ':';
+    ie_commit(t, klen + 1);
+    t->dict_empty = 1;
+}
+
+/* Write "sub=" preceded by "," for every sub-field except the first, into a
+ * region already reserved by the caller; returns the advanced write pointer. */
+static char *textDictSub(infoEmitterText *t, char *p, const char *sub, size_t slen) {
+    if (!t->dict_empty) *p++ = ',';
+    t->dict_empty = 0;
+    memcpy(p, sub, slen);
+    p += slen;
+    *p++ = '=';
+    return p;
+}
+
+static void textDictLL(infoEmitter *e, const char *sub, long long v, infoKind kind, infoUnit unit) {
+    (void)kind;
+    (void)unit;
+    infoEmitterText *t = textOf(e);
+    size_t slen = strlen(sub);
+    char *p0 = ie_reserve(t, 1 + slen + 1 + LONG_STR_SIZE);
+    char *p = textDictSub(t, p0, sub, slen);
+    p += ll2string(p, LONG_STR_SIZE, v);
+    ie_commit(t, (size_t)(p - p0));
+}
+
+static void textDictDouble(infoEmitter *e, const char *sub, double v, int prec, infoKind kind, infoUnit unit) {
+    (void)kind;
+    (void)unit;
+    infoEmitterText *t = textOf(e);
+    size_t slen = strlen(sub);
+    char *p0 = ie_reserve(t, 1 + slen + 1 + INFO_EMIT_NUMBUF);
+    char *p = textDictSub(t, p0, sub, slen);
+    int n = snprintf(p, INFO_EMIT_NUMBUF, "%.*f", prec, v);
+    if (n < 0) n = 0;
+    if (n >= INFO_EMIT_NUMBUF) n = INFO_EMIT_NUMBUF - 1;
+    p += n;
+    ie_commit(t, (size_t)(p - p0));
+}
+
+static void textDictStr(infoEmitter *e, const char *sub, const char *v) {
+    infoEmitterText *t = textOf(e);
+    size_t slen = strlen(sub), vlen = strlen(v);
+    char *p0 = ie_reserve(t, 1 + slen + 1 + vlen);
+    char *p = textDictSub(t, p0, sub, slen);
+    memcpy(p, v, vlen);
+    p += vlen;
+    ie_commit(t, (size_t)(p - p0));
+}
+
+static void textEndDict(infoEmitter *e) {
+    infoEmitterText *t = textOf(e);
+    ie_put(t, "\r\n", 2);
+}
+
+static void textRaw(infoEmitter *e, const char *fmt, va_list ap) {
+    infoEmitterText *t = textOf(e);
+    ie_flush(t); /* Preserve ordering: pending bytes come first. */
+    t->s = sdscatvprintf(t->s, fmt, ap);
+}
+
+static const infoEmitterOps textOps = {
+    .begin_section = textBeginSection,
+    .field_ll = textFieldLL,
+    .field_ull = textFieldULL,
+    .field_double = textFieldDouble,
+    .field_str = textFieldStr,
+    .field_usec = textFieldUsec,
+    .begin_dict = textBeginDict,
+    .dict_ll = textDictLL,
+    .dict_double = textDictDouble,
+    .dict_str = textDictStr,
+    .end_dict = textEndDict,
+    .raw = textRaw,
+};
+
+void infoEmitterTextInit(infoEmitterText *t, sds s, int *section_counter) {
+    t->e.ops = &textOps;
+    t->s = s;
+    t->section_counter = section_counter;
+    t->dict_empty = 1;
+    t->pend = 0;
+}
+
+sds infoEmitterTextResult(infoEmitterText *t) {
+    ie_flush(t);
+    return t->s;
+}

--- a/src/info_emitter.h
+++ b/src/info_emitter.h
@@ -47,6 +47,11 @@ typedef enum {
     INFO_UNIT_PERCENT, /* Text backend appends '%' to reproduce "%.2f%%". */
 } infoUnit;
 
+/* Precision sentinel for the double field/dict calls: prec >= 0 renders "%.*f";
+ * INFO_PREC_FULL renders "%.17g" (full round-trippable form, used by the module
+ * INFO API's VM_InfoAddFieldDouble). */
+#define INFO_PREC_FULL (-1)
+
 typedef struct infoEmitter infoEmitter;
 
 /* Backend operations. Numeric fields carry (kind, unit) metadata; the text
@@ -61,16 +66,23 @@ typedef struct infoEmitterOps {
     void (*field_ull)(infoEmitter *e, const char *key, unsigned long long v, infoKind kind, infoUnit unit);
     /* `prec` preserves per-field precision (e.g. 2 for %.2f, 6 for %.6f). */
     void (*field_double)(infoEmitter *e, const char *key, double v, int prec, infoKind kind, infoUnit unit);
-    /* Strings are identity/metadata, not metrics: no kind/unit. */
+    /* Strings are identity/metadata, not metrics: no kind/unit. field_strn takes
+     * an explicit length to reproduce sds-length semantics (%S) exactly, even
+     * for values containing embedded NULs. */
     void (*field_str)(infoEmitter *e, const char *key, const char *v);
+    void (*field_strn)(infoEmitter *e, const char *key, const char *v, size_t vlen);
     /* Fixed-point seconds.microseconds (%lld.%06lld); `usec` is total us. */
     void (*field_usec)(infoEmitter *e, const char *key, long long usec, infoKind kind);
 
     /* Composite ("dict") lines: key:sub1=v1,sub2=v2\r\n */
     void (*begin_dict)(infoEmitter *e, const char *key);
     void (*dict_ll)(infoEmitter *e, const char *sub, long long v, infoKind kind, infoUnit unit);
+    void (*dict_ull)(infoEmitter *e, const char *sub, unsigned long long v, infoKind kind, infoUnit unit);
+    /* prec >= 0 renders "%.*f"; prec == INFO_PREC_FULL renders "%.17g" (the
+     * full round-trippable form used by the module INFO API). */
     void (*dict_double)(infoEmitter *e, const char *sub, double v, int prec, infoKind kind, infoUnit unit);
     void (*dict_str)(infoEmitter *e, const char *sub, const char *v);
+    void (*dict_strn)(infoEmitter *e, const char *sub, const char *v, size_t vlen);
     void (*end_dict)(infoEmitter *e);
 
     /* Escape hatch for irregular lines that do not map to a typed field. The
@@ -136,6 +148,9 @@ static inline void infoEmitCounterULL(infoEmitter *e, const char *k, unsigned lo
 static inline void infoEmitFieldStr(infoEmitter *e, const char *k, const char *v) {
     e->ops->field_str(e, k, v);
 }
+static inline void infoEmitFieldStrn(infoEmitter *e, const char *k, const char *v, size_t vlen) {
+    e->ops->field_strn(e, k, v, vlen);
+}
 /* CPU times are cumulative (counter); current_* durations are gauges. */
 static inline void infoEmitFieldUsec(infoEmitter *e, const char *k, long long usec) {
     e->ops->field_usec(e, k, usec, INFO_KIND_COUNTER);
@@ -155,11 +170,20 @@ static inline void infoEmitDictCounterLL(infoEmitter *e, const char *sub, long l
 static inline void infoEmitDictMetricLL(infoEmitter *e, const char *sub, long long v, infoKind kind, infoUnit unit) {
     e->ops->dict_ll(e, sub, v, kind, unit);
 }
+static inline void infoEmitDictULL(infoEmitter *e, const char *sub, unsigned long long v) {
+    e->ops->dict_ull(e, sub, v, INFO_KIND_GAUGE, INFO_UNIT_NONE);
+}
+static inline void infoEmitDictMetricULL(infoEmitter *e, const char *sub, unsigned long long v, infoKind kind, infoUnit unit) {
+    e->ops->dict_ull(e, sub, v, kind, unit);
+}
 static inline void infoEmitDictDouble(infoEmitter *e, const char *sub, double v, int prec) {
     e->ops->dict_double(e, sub, v, prec, INFO_KIND_GAUGE, INFO_UNIT_NONE);
 }
 static inline void infoEmitDictStr(infoEmitter *e, const char *sub, const char *v) {
     e->ops->dict_str(e, sub, v);
+}
+static inline void infoEmitDictStrn(infoEmitter *e, const char *sub, const char *v, size_t vlen) {
+    e->ops->dict_strn(e, sub, v, vlen);
 }
 static inline void infoEmitEndDict(infoEmitter *e) {
     e->ops->end_dict(e);

--- a/src/info_emitter.h
+++ b/src/info_emitter.h
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* Info emitter: a pluggable sink for INFO field generation.
+ *
+ * `genValkeyInfoString()` historically formatted the INFO output by writing
+ * "key:value\r\n" text directly into an sds. Anything that wants INFO data as
+ * structured values (the module API, a metrics exporter) then has to parse that
+ * text back into numbers, losing the type information the producing code had.
+ *
+ * The info emitter abstracts "emit a section / emit a typed field" behind a
+ * backend vtable so the same generation code can target multiple backends:
+ *   - the text backend reproduces the current INFO output byte-for-byte;
+ *   - structured backends (e.g. OTLP metrics) receive typed values plus
+ *     semantic metadata (counter vs gauge, unit) directly, with no round trip.
+ *
+ * This header defines the interface and the built-in text backend. */
+
+#ifndef INFO_EMITTER_H
+#define INFO_EMITTER_H
+
+#include "sds.h"
+#include <stdarg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Metric semantics carried alongside each numeric field. The text backend
+ * ignores these except INFO_UNIT_PERCENT (which appends a literal '%'); structured
+ * backends (OTLP) use them to choose sum-vs-gauge and set the unit, so they no
+ * longer need name-based heuristics. */
+typedef enum {
+    INFO_KIND_GAUGE = 0, /* Point-in-time value that can go up or down. */
+    INFO_KIND_COUNTER,   /* Monotonically increasing cumulative total. */
+} infoKind;
+
+typedef enum {
+    INFO_UNIT_NONE = 0,
+    INFO_UNIT_BYTES,
+    INFO_UNIT_SECONDS,
+    INFO_UNIT_MILLISECONDS,
+    INFO_UNIT_MICROSECONDS,
+    INFO_UNIT_PERCENT, /* Text backend appends '%' to reproduce "%.2f%%". */
+} infoUnit;
+
+typedef struct infoEmitter infoEmitter;
+
+/* Backend operations. Numeric fields carry (kind, unit) metadata; the text
+ * backend renders each exactly as the legacy inline formatting did. */
+typedef struct infoEmitterOps {
+    /* Section header, e.g. "# CPU\r\n". `name` excludes the leading "# ". The
+     * text backend also owns the inter-section blank-line separator. */
+    void (*begin_section)(infoEmitter *e, const char *name);
+
+    /* Scalar fields ("key:value\r\n"). */
+    void (*field_ll)(infoEmitter *e, const char *key, long long v, infoKind kind, infoUnit unit);
+    void (*field_ull)(infoEmitter *e, const char *key, unsigned long long v, infoKind kind, infoUnit unit);
+    /* `prec` preserves per-field precision (e.g. 2 for %.2f, 6 for %.6f). */
+    void (*field_double)(infoEmitter *e, const char *key, double v, int prec, infoKind kind, infoUnit unit);
+    /* Strings are identity/metadata, not metrics: no kind/unit. */
+    void (*field_str)(infoEmitter *e, const char *key, const char *v);
+    /* Fixed-point seconds.microseconds (%lld.%06lld); `usec` is total us. */
+    void (*field_usec)(infoEmitter *e, const char *key, long long usec, infoKind kind);
+
+    /* Composite ("dict") lines: key:sub1=v1,sub2=v2\r\n */
+    void (*begin_dict)(infoEmitter *e, const char *key);
+    void (*dict_ll)(infoEmitter *e, const char *sub, long long v, infoKind kind, infoUnit unit);
+    void (*dict_double)(infoEmitter *e, const char *sub, double v, int prec, infoKind kind, infoUnit unit);
+    void (*dict_str)(infoEmitter *e, const char *sub, const char *v);
+    void (*end_dict)(infoEmitter *e);
+
+    /* Escape hatch for irregular lines that do not map to a typed field. The
+     * text backend prints it verbatim; structured backends may skip it. */
+    void (*raw)(infoEmitter *e, const char *fmt, va_list ap);
+} infoEmitterOps;
+
+struct infoEmitter {
+    const infoEmitterOps *ops;
+};
+
+/* ---- Text backend --------------------------------------------------------
+ * Appends INFO-formatted text into an sds, byte-for-byte identical to the
+ * legacy inline formatting. Stack-allocate an infoEmitterText, init it with the
+ * sds to append to, pass &t.e to the generation code, then read the (possibly
+ * reallocated) result back with infoEmitterTextResult(). */
+/* Text backend state. Fields are written directly into the sds's own buffer
+ * (no intermediate copy); the sds length is committed only when the buffer must
+ * grow rather than once per field. */
+typedef struct infoEmitterText {
+    infoEmitter e; /* Must be the first member: &t.e aliases the container. */
+    sds s;
+    int *section_counter; /* Shared inter-section counter (see begin_section). */
+    int dict_empty;       /* No dict sub-field written yet (controls the comma). */
+    size_t pend;          /* Bytes written past sdslen(s) but not yet committed. */
+} infoEmitterText;
+
+void infoEmitterTextInit(infoEmitterText *t, sds s, int *section_counter);
+sds infoEmitterTextResult(infoEmitterText *t);
+
+/* ---- Dispatch helpers ----------------------------------------------------
+ * Full-control forms take explicit (kind, unit); the terse Field/Counter forms
+ * default to the common cases so most call sites stay short. */
+static inline void infoEmitBeginSection(infoEmitter *e, const char *name) {
+    e->ops->begin_section(e, name);
+}
+static inline void infoEmitMetricLL(infoEmitter *e, const char *k, long long v, infoKind kind, infoUnit unit) {
+    e->ops->field_ll(e, k, v, kind, unit);
+}
+static inline void infoEmitMetricULL(infoEmitter *e, const char *k, unsigned long long v, infoKind kind, infoUnit unit) {
+    e->ops->field_ull(e, k, v, kind, unit);
+}
+static inline void infoEmitMetricDouble(infoEmitter *e, const char *k, double v, int prec, infoKind kind, infoUnit unit) {
+    e->ops->field_double(e, k, v, prec, kind, unit);
+}
+/* Gauge shorthands (kind=GAUGE, unit=NONE). */
+static inline void infoEmitFieldLL(infoEmitter *e, const char *k, long long v) {
+    e->ops->field_ll(e, k, v, INFO_KIND_GAUGE, INFO_UNIT_NONE);
+}
+static inline void infoEmitFieldULL(infoEmitter *e, const char *k, unsigned long long v) {
+    e->ops->field_ull(e, k, v, INFO_KIND_GAUGE, INFO_UNIT_NONE);
+}
+static inline void infoEmitFieldDouble(infoEmitter *e, const char *k, double v, int prec) {
+    e->ops->field_double(e, k, v, prec, INFO_KIND_GAUGE, INFO_UNIT_NONE);
+}
+/* Counter shorthands (kind=COUNTER, unit=NONE). */
+static inline void infoEmitCounterLL(infoEmitter *e, const char *k, long long v) {
+    e->ops->field_ll(e, k, v, INFO_KIND_COUNTER, INFO_UNIT_NONE);
+}
+static inline void infoEmitCounterULL(infoEmitter *e, const char *k, unsigned long long v) {
+    e->ops->field_ull(e, k, v, INFO_KIND_COUNTER, INFO_UNIT_NONE);
+}
+static inline void infoEmitFieldStr(infoEmitter *e, const char *k, const char *v) {
+    e->ops->field_str(e, k, v);
+}
+/* CPU times are cumulative (counter); current_* durations are gauges. */
+static inline void infoEmitFieldUsec(infoEmitter *e, const char *k, long long usec) {
+    e->ops->field_usec(e, k, usec, INFO_KIND_COUNTER);
+}
+static inline void infoEmitGaugeUsec(infoEmitter *e, const char *k, long long usec) {
+    e->ops->field_usec(e, k, usec, INFO_KIND_GAUGE);
+}
+static inline void infoEmitBeginDict(infoEmitter *e, const char *k) {
+    e->ops->begin_dict(e, k);
+}
+static inline void infoEmitDictLL(infoEmitter *e, const char *sub, long long v) {
+    e->ops->dict_ll(e, sub, v, INFO_KIND_GAUGE, INFO_UNIT_NONE);
+}
+static inline void infoEmitDictCounterLL(infoEmitter *e, const char *sub, long long v) {
+    e->ops->dict_ll(e, sub, v, INFO_KIND_COUNTER, INFO_UNIT_NONE);
+}
+static inline void infoEmitDictMetricLL(infoEmitter *e, const char *sub, long long v, infoKind kind, infoUnit unit) {
+    e->ops->dict_ll(e, sub, v, kind, unit);
+}
+static inline void infoEmitDictDouble(infoEmitter *e, const char *sub, double v, int prec) {
+    e->ops->dict_double(e, sub, v, prec, INFO_KIND_GAUGE, INFO_UNIT_NONE);
+}
+static inline void infoEmitDictStr(infoEmitter *e, const char *sub, const char *v) {
+    e->ops->dict_str(e, sub, v);
+}
+static inline void infoEmitEndDict(infoEmitter *e) {
+    e->ops->end_dict(e);
+}
+static inline void infoEmitRaw(infoEmitter *e, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    e->ops->raw(e, fmt, ap);
+    va_end(ap);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INFO_EMITTER_H */

--- a/src/module.c
+++ b/src/module.c
@@ -11189,13 +11189,11 @@ int VM_RegisterInfoFunc(ValkeyModuleCtx *ctx, ValkeyModuleInfoFunc cb) {
     return VALKEYMODULE_OK;
 }
 
-sds modulesCollectInfo(sds info, dict *sections_dict, int for_crash_report, int sections) {
-    if (dictSize(modules) == 0) return info;
-
-    /* One emitter for the whole pass; its section counter continues from the
-     * core sections already emitted so the inter-section separator is correct. */
-    infoEmitterText te;
-    infoEmitterTextInit(&te, info, &sections);
+/* Drive every loaded module's INFO callback through the given emitter, so both
+ * the text backend and structured backends (OTLP) receive module-provided
+ * fields as typed values. */
+void modulesCollectInfoToEmitter(infoEmitter *e, dict *sections_dict, int for_crash_report) {
+    if (dictSize(modules) == 0) return;
 
     dictIterator *di = dictGetIterator(modules);
     dictEntry *de;
@@ -11204,12 +11202,19 @@ sds modulesCollectInfo(sds info, dict *sections_dict, int for_crash_report, int 
         struct ValkeyModule *module = dictGetVal(de);
         if (!module->info_cb) continue;
         ValkeyModuleInfoCtx info_ctx = {
-            .module = module, .requested_sections = sections_dict, .emitter = &te.e, .in_section = 0, .in_dict_field = 0};
+            .module = module, .requested_sections = sections_dict, .emitter = e, .in_section = 0, .in_dict_field = 0};
         module->info_cb(&info_ctx, for_crash_report);
         /* Implicitly end dicts (no way to handle errors, and we must add the newline). */
         if (info_ctx.in_dict_field) VM_InfoEndDictField(&info_ctx);
     }
     dictReleaseIterator(di);
+}
+
+/* Backward-compatible text wrapper (see modulesCollectInfoToEmitter). */
+sds modulesCollectInfo(sds info, dict *sections_dict, int for_crash_report, int sections) {
+    infoEmitterText te;
+    infoEmitterTextInit(&te, info, &sections);
+    modulesCollectInfoToEmitter(&te.e, sections_dict, for_crash_report);
     return infoEmitterTextResult(&te);
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -56,6 +56,7 @@
  * function names. For details, see the script src/modules/gendoc.rb.
  * -------------------------------------------------------------------------- */
 #include "server.h"
+#include "info_emitter.h"
 #include "cluster.h"
 #include "commandlog.h"
 #include "rdb.h"
@@ -90,10 +91,9 @@ struct moduleLoadQueueEntry {
 struct ValkeyModuleInfoCtx {
     struct ValkeyModule *module;
     dict *requested_sections;
-    sds info;          /* info string we collected so far */
-    int sections;      /* number of sections we collected so far */
-    int in_section;    /* indication if we're in an active section or not */
-    int in_dict_field; /* indication that we're currently appending to a dict */
+    infoEmitter *emitter; /* Backend the info fields are emitted through. */
+    int in_section;       /* indication if we're in an active section or not */
+    int in_dict_field;    /* indication that we're currently appending to a dict */
 };
 
 /* This represents a shared API. Shared APIs will be used to populate
@@ -11077,8 +11077,8 @@ int VM_InfoAddSection(ValkeyModuleInfoCtx *ctx, const char *name) {
             return VALKEYMODULE_ERR;
         }
     }
-    if (ctx->sections++) ctx->info = sdscat(ctx->info, "\r\n");
-    ctx->info = sdscatfmt(ctx->info, "# %S\r\n", full_name);
+    /* begin_section owns the inter-section separator via the shared counter. */
+    infoEmitBeginSection(ctx->emitter, full_name);
     ctx->in_section = 1;
     sdsfree(full_name);
     return VALKEYMODULE_OK;
@@ -11092,11 +11092,13 @@ int VM_InfoBeginDictField(ValkeyModuleInfoCtx *ctx, const char *name) {
     /* Implicitly end dicts, instead of returning an error which is likely un checked. */
     if (ctx->in_dict_field) VM_InfoEndDictField(ctx);
     char *tmpmodname, *tmpname;
-    ctx->info =
-        sdscatfmt(ctx->info, "%s_%s:", getSafeInfoString(ctx->module->name, strlen(ctx->module->name), &tmpmodname),
-                  getSafeInfoString(name, strlen(name), &tmpname));
+    sds key = sdscatfmt(sdsempty(), "%s_%s",
+                        getSafeInfoString(ctx->module->name, strlen(ctx->module->name), &tmpmodname),
+                        getSafeInfoString(name, strlen(name), &tmpname));
     if (tmpmodname != NULL) zfree(tmpmodname);
     if (tmpname != NULL) zfree(tmpname);
+    infoEmitBeginDict(ctx->emitter, key);
+    sdsfree(key);
     ctx->in_dict_field = 1;
     return VALKEYMODULE_OK;
 }
@@ -11104,9 +11106,7 @@ int VM_InfoBeginDictField(ValkeyModuleInfoCtx *ctx, const char *name) {
 /* Ends a dict field, see ValkeyModule_InfoBeginDictField */
 int VM_InfoEndDictField(ValkeyModuleInfoCtx *ctx) {
     if (!ctx->in_dict_field) return VALKEYMODULE_ERR;
-    /* trim the last ',' if found. */
-    if (ctx->info[sdslen(ctx->info) - 1] == ',') sdsIncrLen(ctx->info, -1);
-    ctx->info = sdscat(ctx->info, "\r\n");
+    infoEmitEndDict(ctx->emitter);
     ctx->in_dict_field = 0;
     return VALKEYMODULE_OK;
 }
@@ -11116,11 +11116,16 @@ int VM_InfoEndDictField(ValkeyModuleInfoCtx *ctx) {
  * Field names or values must not include `\r\n` or `:`. */
 int VM_InfoAddFieldString(ValkeyModuleInfoCtx *ctx, const char *field, ValkeyModuleString *value) {
     if (!ctx->in_section) return VALKEYMODULE_ERR;
+    sds val = (sds)objectGetVal(value);
+    /* Use the sds length (matching the legacy %S) so values are reproduced
+     * exactly, including any embedded NULs. */
     if (ctx->in_dict_field) {
-        ctx->info = sdscatfmt(ctx->info, "%s=%S,", field, (sds)objectGetVal(value));
+        infoEmitDictStrn(ctx->emitter, field, val, sdslen(val));
         return VALKEYMODULE_OK;
     }
-    ctx->info = sdscatfmt(ctx->info, "%s_%s:%S\r\n", ctx->module->name, field, (sds)objectGetVal(value));
+    sds key = sdscatfmt(sdsempty(), "%s_%s", ctx->module->name, field);
+    infoEmitFieldStrn(ctx->emitter, key, val, sdslen(val));
+    sdsfree(key);
     return VALKEYMODULE_OK;
 }
 
@@ -11128,21 +11133,26 @@ int VM_InfoAddFieldString(ValkeyModuleInfoCtx *ctx, const char *field, ValkeyMod
 int VM_InfoAddFieldCString(ValkeyModuleInfoCtx *ctx, const char *field, const char *value) {
     if (!ctx->in_section) return VALKEYMODULE_ERR;
     if (ctx->in_dict_field) {
-        ctx->info = sdscatfmt(ctx->info, "%s=%s,", field, value);
+        infoEmitDictStr(ctx->emitter, field, value);
         return VALKEYMODULE_OK;
     }
-    ctx->info = sdscatfmt(ctx->info, "%s_%s:%s\r\n", ctx->module->name, field, value);
+    sds key = sdscatfmt(sdsempty(), "%s_%s", ctx->module->name, field);
+    infoEmitFieldStr(ctx->emitter, key, value);
+    sdsfree(key);
     return VALKEYMODULE_OK;
 }
 
 /* See ValkeyModule_InfoAddFieldString(). */
 int VM_InfoAddFieldDouble(ValkeyModuleInfoCtx *ctx, const char *field, double value) {
     if (!ctx->in_section) return VALKEYMODULE_ERR;
+    /* The module API prints doubles with %.17g (full round-trip precision). */
     if (ctx->in_dict_field) {
-        ctx->info = sdscatprintf(ctx->info, "%s=%.17g,", field, value);
+        infoEmitDictDouble(ctx->emitter, field, value, INFO_PREC_FULL);
         return VALKEYMODULE_OK;
     }
-    ctx->info = sdscatprintf(ctx->info, "%s_%s:%.17g\r\n", ctx->module->name, field, value);
+    sds key = sdscatfmt(sdsempty(), "%s_%s", ctx->module->name, field);
+    infoEmitFieldDouble(ctx->emitter, key, value, INFO_PREC_FULL);
+    sdsfree(key);
     return VALKEYMODULE_OK;
 }
 
@@ -11150,10 +11160,12 @@ int VM_InfoAddFieldDouble(ValkeyModuleInfoCtx *ctx, const char *field, double va
 int VM_InfoAddFieldLongLong(ValkeyModuleInfoCtx *ctx, const char *field, long long value) {
     if (!ctx->in_section) return VALKEYMODULE_ERR;
     if (ctx->in_dict_field) {
-        ctx->info = sdscatfmt(ctx->info, "%s=%I,", field, value);
+        infoEmitDictLL(ctx->emitter, field, value);
         return VALKEYMODULE_OK;
     }
-    ctx->info = sdscatfmt(ctx->info, "%s_%s:%I\r\n", ctx->module->name, field, value);
+    sds key = sdscatfmt(sdsempty(), "%s_%s", ctx->module->name, field);
+    infoEmitFieldLL(ctx->emitter, key, value);
+    sdsfree(key);
     return VALKEYMODULE_OK;
 }
 
@@ -11161,10 +11173,12 @@ int VM_InfoAddFieldLongLong(ValkeyModuleInfoCtx *ctx, const char *field, long lo
 int VM_InfoAddFieldULongLong(ValkeyModuleInfoCtx *ctx, const char *field, unsigned long long value) {
     if (!ctx->in_section) return VALKEYMODULE_ERR;
     if (ctx->in_dict_field) {
-        ctx->info = sdscatfmt(ctx->info, "%s=%U,", field, value);
+        infoEmitDictULL(ctx->emitter, field, value);
         return VALKEYMODULE_OK;
     }
-    ctx->info = sdscatfmt(ctx->info, "%s_%s:%U\r\n", ctx->module->name, field, value);
+    sds key = sdscatfmt(sdsempty(), "%s_%s", ctx->module->name, field);
+    infoEmitFieldULL(ctx->emitter, key, value);
+    sdsfree(key);
     return VALKEYMODULE_OK;
 }
 
@@ -11178,21 +11192,25 @@ int VM_RegisterInfoFunc(ValkeyModuleCtx *ctx, ValkeyModuleInfoFunc cb) {
 sds modulesCollectInfo(sds info, dict *sections_dict, int for_crash_report, int sections) {
     if (dictSize(modules) == 0) return info;
 
+    /* One emitter for the whole pass; its section counter continues from the
+     * core sections already emitted so the inter-section separator is correct. */
+    infoEmitterText te;
+    infoEmitterTextInit(&te, info, &sections);
+
     dictIterator *di = dictGetIterator(modules);
     dictEntry *de;
 
     while ((de = dictNext(di)) != NULL) {
         struct ValkeyModule *module = dictGetVal(de);
         if (!module->info_cb) continue;
-        ValkeyModuleInfoCtx info_ctx = {module, sections_dict, info, sections, 0, 0};
+        ValkeyModuleInfoCtx info_ctx = {
+            .module = module, .requested_sections = sections_dict, .emitter = &te.e, .in_section = 0, .in_dict_field = 0};
         module->info_cb(&info_ctx, for_crash_report);
         /* Implicitly end dicts (no way to handle errors, and we must add the newline). */
         if (info_ctx.in_dict_field) VM_InfoEndDictField(&info_ctx);
-        info = info_ctx.info;
-        sections = info_ctx.sections;
     }
     dictReleaseIterator(di);
-    return info;
+    return infoEmitterTextResult(&te);
 }
 
 /* Get information about the server similar to the one that returns from the

--- a/src/server.c
+++ b/src/server.c
@@ -6132,11 +6132,21 @@ void totalNumberOfStatefulKeys(unsigned long *blocking_keys,
 /* Create the string returned by the INFO command. This is decoupled
  * by the INFO command itself as we need to report the same information
  * on memory corruption problems. */
-sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
-    sds info = sdsempty();
+/* Emit an sds's contents through the emitter's raw hook, then free the sds.
+ * Used for legacy helpers that still build INFO text directly (listeners,
+ * cluster info, the module version list). Structured backends skip raw output.
+ * The sds is passed as an argument to "%s", so any '%' in it stays literal. */
+static void infoEmitRawSds(infoEmitter *e, sds s) {
+    infoEmitRaw(e, "%s", s);
+    sdsfree(s);
+}
+
+/* Drive INFO generation into an arbitrary emitter backend. 'section_counter' is
+ * shared with the backend (which owns the inter-section separator) and is read
+ * here to decide whether module info collection is needed. */
+void genValkeyInfoToEmitter(infoEmitter *e, int *section_counter, dict *section_dict, int all_sections, int everything) {
     time_t uptime = server.unixtime - server.stat_starttime;
     int j;
-    int sections = 0;
     if (everything) all_sections = 1;
 
     /* Server */
@@ -6179,9 +6189,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         char os_buf[sizeof(name.sysname) + sizeof(name.release) + sizeof(name.machine) + 3];
         snprintf(os_buf, sizeof(os_buf), "%s %s %s", name.sysname, name.release, name.machine);
 
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Server");
         infoEmitFieldStr(e, "redis_version", REDIS_VERSION);
         infoEmitFieldStr(e, "server_name", SERVER_NAME);
@@ -6211,16 +6218,16 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         infoEmitFieldStr(e, "config_file", server.configfile ? server.configfile : "");
         infoEmitFieldLL(e, "io_threads_active", server.active_io_threads_num > 1);
         infoEmitFieldStr(e, "availability_zone", server.availability_zone);
-        info = infoEmitterTextResult(&te);
 
         /* Conditional properties */
         if (isShutdownInitiated()) {
-            info = sdscatfmt(info, "shutdown_in_milliseconds:%I\r\n",
-                             (int64_t)(server.shutdown_mstime - commandTimeSnapshot()));
+            infoEmitMetricLL(e, "shutdown_in_milliseconds",
+                             (long long)(server.shutdown_mstime - commandTimeSnapshot()), INFO_KIND_GAUGE,
+                             INFO_UNIT_MILLISECONDS);
         }
 
-        /* get all the listeners information */
-        info = getListensInfoString(info);
+        /* get all the listeners information (raw text; skipped by structured backends) */
+        infoEmitRawSds(e, getListensInfoString(sdsempty()));
     }
 
     /* TLS */
@@ -6240,9 +6247,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             tls_ca_seconds_remaining = server.tls_ca_cert_expire_time - (long long)server.unixtime;
             if (tls_ca_seconds_remaining < 0) tls_ca_seconds_remaining = 0;
         }
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "TLS");
         infoEmitFieldStr(e, "tls_server_cert_serial",
                          server.tls_server_cert_serial ? server.tls_server_cert_serial : "none");
@@ -6255,7 +6259,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         infoEmitFieldStr(e, "tls_ca_cert_serial", server.tls_ca_cert_serial ? server.tls_ca_cert_serial : "none");
         infoEmitMetricLL(e, "tls_ca_cert_expires_in_seconds", tls_ca_seconds_remaining, INFO_KIND_GAUGE,
                          INFO_UNIT_SECONDS);
-        info = infoEmitterTextResult(&te);
     }
 
     /* Clients */
@@ -6279,9 +6282,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             paused_reason = getPausedReason(purpose);
         }
 
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Clients");
         infoEmitFieldULL(e, "connected_clients", listLength(server.clients) - listLength(server.replicas));
         infoEmitFieldULL(e, "cluster_connections", getClusterConnectionsCount());
@@ -6299,7 +6299,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         infoEmitFieldStr(e, "paused_reason", paused_reason);
         infoEmitFieldStr(e, "paused_actions", paused_actions);
         infoEmitMetricLL(e, "paused_timeout_milliseconds", paused_timeout, INFO_KIND_GAUGE, INFO_UNIT_MILLISECONDS);
-        info = infoEmitterTextResult(&te);
     }
 
     /* Memory */
@@ -6334,9 +6333,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         bytesToHuman(used_memory_rss_hmem, sizeof(used_memory_rss_hmem), server.cron_malloc_stats.process_rss);
         bytesToHuman(maxmemory_hmem, sizeof(maxmemory_hmem), server.maxmemory);
 
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Memory");
         infoEmitMetricULL(e, "used_memory", zmalloc_used, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
         infoEmitFieldStr(e, "used_memory_human", hmem);
@@ -6412,7 +6408,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         infoEmitFieldLL(e, "active_defrag_running", server.active_defrag_cpu_percent);
         infoEmitFieldULL(e, "lazyfree_pending_objects", lazyfreeGetPendingObjectsCount());
         infoEmitFieldULL(e, "lazyfreed_objects", lazyfreeGetFreedObjectsCount());
-        info = infoEmitterTextResult(&te);
         freeMemoryOverheadData(mh);
     }
 
@@ -6426,9 +6421,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         }
         int aof_bio_fsync_status = atomic_load_explicit(&server.aof_bio_fsync_status, memory_order_relaxed);
 
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Persistence");
         infoEmitFieldLL(e, "loading", (int)(server.loading && !server.async_loading));
         infoEmitFieldLL(e, "async_loading", (int)server.async_loading);
@@ -6517,7 +6509,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             infoEmitFieldDouble(e, "loading_loaded_perc", perc, 2);
             infoEmitMetricLL(e, "loading_eta_seconds", (long long)eta, INFO_KIND_GAUGE, INFO_UNIT_SECONDS);
         }
-        info = infoEmitterTextResult(&te);
     }
 
     /* Stats */
@@ -6527,9 +6518,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         ustime_t current_active_defrag_time =
             server.stat_last_active_defrag_time ? (ustime_t)elapsedUs(server.stat_last_active_defrag_time) : 0;
 
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Stats");
         infoEmitCounterLL(e, "total_connections_received", server.stat_numconnections);
         infoEmitCounterLL(e, "total_commands_processed", server.stat_numcommands);
@@ -6629,14 +6617,10 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         infoEmitFieldULL(e, "instantaneous_eventloop_duration_usec",
                          (unsigned long long)getInstantaneousMetric(STATS_METRIC_EL_DURATION));
         genValkeyInfoStringACLStats(e);
-        info = infoEmitterTextResult(&te);
     }
 
     /* Replication */
     if (all_sections || (dictFind(section_dict, "replication") != NULL)) {
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Replication");
         infoEmitFieldStr(e, "role", server.primary_host == NULL ? "master" : "slave");
         if (server.primary_host) {
@@ -6760,7 +6744,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         infoEmitFieldLL(e, "repl_backlog_first_byte_offset", server.repl_backlog ? server.repl_backlog->offset : 0);
         infoEmitMetricLL(e, "repl_backlog_histlen", server.repl_backlog ? server.repl_backlog->histlen : 0,
                          INFO_KIND_GAUGE, INFO_UNIT_BYTES);
-        info = infoEmitterTextResult(&te);
     }
 
     /* CPU */
@@ -6773,9 +6756,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
          * microseconds and renders "sec.usec", reproducing the legacy
          * "%ld.%06ld" / "%lld.%06lld" formatting byte-for-byte. begin_section
          * owns the inter-section separator via the shared counter. */
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "CPU");
         infoEmitFieldUsec(e, "used_cpu_sys", (long long)self_ru.ru_stime.tv_sec * 1000000 + self_ru.ru_stime.tv_usec);
         infoEmitFieldUsec(e, "used_cpu_user", (long long)self_ru.ru_utime.tv_sec * 1000000 + self_ru.ru_utime.tv_usec);
@@ -6796,37 +6776,25 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             snprintf(key, sizeof(key), "used_active_time_io_thread_%d", i);
             infoEmitFieldUsec(e, key, getIOThreadActiveTimeMicroseconds(i));
         }
-        info = infoEmitterTextResult(&te);
     }
 
     /* Modules */
     if (all_sections || (dictFind(section_dict, "module_list") != NULL) ||
         (dictFind(section_dict, "modules") != NULL)) {
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitBeginSection(&te.e, "Modules");
-        info = infoEmitterTextResult(&te);
-        /* Module-provided fields are still built by the module INFO callbacks
-         * (VM_InfoAddField*); routing that API through the emitter is a
-         * follow-up. The section header is emitted via the emitter above. */
-        info = genModulesInfoString(info);
+        infoEmitBeginSection(e, "Modules");
+        /* The module version list is legacy raw text; module-provided INFO
+         * fields are emitted (typed) via modulesCollectInfoToEmitter() below. */
+        infoEmitRawSds(e, genModulesInfoString(sdsempty()));
     }
 
     /* Command statistics */
     if (all_sections || (dictFind(section_dict, "commandstats") != NULL)) {
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Commandstats");
         genValkeyInfoStringCommandStats(e, server.commands);
-        info = infoEmitterTextResult(&te);
     }
 
     /* Error statistics */
     if (all_sections || (dictFind(section_dict, "errorstats") != NULL)) {
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Errorstats");
         raxIterator ri;
         raxStart(&ri, server.errors);
@@ -6844,53 +6812,35 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             infoEmitEndDict(e);
         }
         raxStop(&ri);
-        info = infoEmitterTextResult(&te);
     }
 
     /* Latency by percentile distribution per command */
     if (all_sections || (dictFind(section_dict, "latencystats") != NULL)) {
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Latencystats");
         if (server.latency_tracking_enabled) {
             genValkeyInfoStringLatencyStats(e, server.commands);
         }
-        info = infoEmitterTextResult(&te);
     }
 
     /* Cluster */
     if (all_sections || (dictFind(section_dict, "cluster") != NULL)) {
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Cluster");
         infoEmitFieldLL(e, "cluster_enabled", server.cluster_enabled);
-        info = infoEmitterTextResult(&te);
     }
 
     /* Cluster Info */
     if (all_sections || (dictFind(section_dict, "cluster_info") != NULL)) {
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitBeginSection(&te.e, "Cluster Info");
-        info = infoEmitterTextResult(&te);
-        if (server.cluster_enabled) info = genClusterInfoString(info);
+        infoEmitBeginSection(e, "Cluster Info");
+        if (server.cluster_enabled) infoEmitRawSds(e, genClusterInfoString(sdsempty()));
     }
 
     /* Scripting engines */
     if (all_sections || (dictFind(section_dict, "scriptingengines") != NULL)) {
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        genValkeyInfoStringScriptingEngines(&te.e);
-        info = infoEmitterTextResult(&te);
+        genValkeyInfoStringScriptingEngines(e);
     }
 
     /* Key space */
     if (all_sections || (dictFind(section_dict, "keyspace") != NULL)) {
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Keyspace");
         for (j = 0; j < server.dbnum; j++) {
             serverDb *db = server.db[j];
@@ -6912,7 +6862,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 infoEmitEndDict(e);
             }
         }
-        info = infoEmitterTextResult(&te);
     }
 
     /* Get info from modules.
@@ -6920,17 +6869,13 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
      * We're not aware of the module section names here, and we rather avoid the search when we can.
      * so we proceed if there's a requested section name that's not found yet, or when the user asked
      * for "all" with any additional section names. */
-    if (everything || dictFind(section_dict, "modules") != NULL || sections < (int)dictSize(section_dict) ||
+    if (everything || dictFind(section_dict, "modules") != NULL || *section_counter < (int)dictSize(section_dict) ||
         (all_sections && dictSize(section_dict))) {
-        info = modulesCollectInfo(info, everything || dictFind(section_dict, "modules") != NULL ? NULL : section_dict,
-                                  0, /* not a crash report */
-                                  sections);
+        modulesCollectInfoToEmitter(e, everything || dictFind(section_dict, "modules") != NULL ? NULL : section_dict,
+                                    0 /* not a crash report */);
     }
 
     if (dictFind(section_dict, "debug") != NULL) {
-        infoEmitterText te;
-        infoEmitterTextInit(&te, info, &sections);
-        infoEmitter *e = &te.e;
         infoEmitBeginSection(e, "Debug");
         infoEmitMetricULL(e, "eventloop_duration_aof_sum", server.duration_stats[EL_DURATION_TYPE_AOF].sum,
                           INFO_KIND_COUNTER, INFO_UNIT_MICROSECONDS);
@@ -6941,10 +6886,20 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         infoEmitFieldLL(e, "eventloop_cmd_per_cycle_max", server.el_cmd_cnt_max);
         infoEmitFieldLL(e, "io_threaded_reads_pending", server.stat_io_reads_pending);
         infoEmitFieldLL(e, "io_threaded_writes_pending", server.stat_io_writes_pending);
-        info = infoEmitterTextResult(&te);
     }
 
-    return info;
+    return;
+}
+
+/* Backward-compatible wrapper: render INFO to a text sds using the text
+ * backend, preserving the exact legacy output byte-for-byte. */
+sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
+    sds info = sdsempty();
+    int sections = 0;
+    infoEmitterText te;
+    infoEmitterTextInit(&te, info, &sections);
+    genValkeyInfoToEmitter(&te.e, &sections, section_dict, all_sections, everything);
+    return infoEmitterTextResult(&te);
 }
 
 /* INFO [<section> [<section> ...]] */

--- a/src/server.c
+++ b/src/server.c
@@ -40,6 +40,7 @@
 #include "commandlog.h"
 #include "bio.h"
 #include "latency.h"
+#include "info_emitter.h"
 #include "mt19937-64.h"
 #include "functions.h"
 #include "hdr_histogram.h"
@@ -5876,19 +5877,21 @@ void bytesToHuman(char *s, size_t size, unsigned long long n) {
 }
 
 /* Fill percentile distribution of latencies. */
-sds fillPercentileDistributionLatencies(sds info, const char *histogram_name, struct hdr_histogram *histogram) {
-    info = sdscatfmt(info, "latency_percentiles_usec_%s:", histogram_name);
+void fillPercentileDistributionLatencies(infoEmitter *e, const char *histogram_name, struct hdr_histogram *histogram) {
+    sds key = sdscatfmt(sdsempty(), "latency_percentiles_usec_%s", histogram_name);
+    infoEmitBeginDict(e, key);
+    sdsfree(key);
     for (int j = 0; j < server.latency_tracking_info_percentiles_len; j++) {
         char fbuf[128];
         size_t len = snprintf(fbuf, sizeof(fbuf), "%f", server.latency_tracking_info_percentiles[j]);
         trimDoubleString(fbuf, len);
-        info = sdscatprintf(info, "p%s=%.3f", fbuf,
-                            ((double)hdr_value_at_percentile(histogram, server.latency_tracking_info_percentiles[j])) /
-                                1000.0f);
-        if (j != server.latency_tracking_info_percentiles_len - 1) info = sdscatlen(info, ",", 1);
+        char sub[130];
+        snprintf(sub, sizeof(sub), "p%s", fbuf);
+        infoEmitDictDouble(
+            e, sub,
+            ((double)hdr_value_at_percentile(histogram, server.latency_tracking_info_percentiles[j])) / 1000.0f, 3);
     }
-    info = sdscatprintf(info, "\r\n");
-    return info;
+    infoEmitEndDict(e);
 }
 
 const char *replstateToString(int replstate) {
@@ -5920,7 +5923,7 @@ const char *getSafeInfoString(const char *s, size_t len, char **tmp) {
     return memmapchars(new, len, unsafe_info_chars, unsafe_info_chars_substs, sizeof(unsafe_info_chars) - 1);
 }
 
-sds genValkeyInfoStringCommandStats(sds info, hashtable *commands) {
+void genValkeyInfoStringCommandStats(infoEmitter *e, hashtable *commands) {
     hashtableIterator iter;
     void *next;
     hashtableInitIterator(&iter, commands, HASHTABLE_ITER_SAFE);
@@ -5928,39 +5931,36 @@ sds genValkeyInfoStringCommandStats(sds info, hashtable *commands) {
         struct serverCommand *c = next;
         char *tmpsafe;
         if (c->calls || c->failed_calls || c->rejected_calls) {
-            info = sdscatprintf(info,
-                                "cmdstat_%s:calls=%lld,usec=%lld,usec_per_call=%.2f"
-                                ",rejected_calls=%lld,failed_calls=%lld\r\n",
-                                getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->calls,
-                                c->microseconds, (c->calls == 0) ? 0 : ((float)c->microseconds / c->calls),
-                                c->rejected_calls, c->failed_calls);
+            sds key =
+                sdscatprintf(sdsempty(), "cmdstat_%s", getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe));
             if (tmpsafe != NULL) zfree(tmpsafe);
+            infoEmitBeginDict(e, key);
+            sdsfree(key);
+            infoEmitDictCounterLL(e, "calls", c->calls);
+            infoEmitDictMetricLL(e, "usec", c->microseconds, INFO_KIND_COUNTER, INFO_UNIT_MICROSECONDS);
+            infoEmitDictDouble(e, "usec_per_call", (c->calls == 0) ? 0 : ((float)c->microseconds / c->calls), 2);
+            infoEmitDictCounterLL(e, "rejected_calls", c->rejected_calls);
+            infoEmitDictCounterLL(e, "failed_calls", c->failed_calls);
+            infoEmitEndDict(e);
         }
         if (c->subcommands_ht) {
-            info = genValkeyInfoStringCommandStats(info, c->subcommands_ht);
+            genValkeyInfoStringCommandStats(e, c->subcommands_ht);
         }
     }
     hashtableCleanupIterator(&iter);
-
-    return info;
 }
 
 /* Writes the ACL metrics to the info */
-sds genValkeyInfoStringACLStats(sds info) {
-    info = sdscatprintf(info,
-                        "acl_access_denied_auth:%lld\r\n"
-                        "acl_access_denied_cmd:%lld\r\n"
-                        "acl_access_denied_key:%lld\r\n"
-                        "acl_access_denied_channel:%lld\r\n"
-                        "acl_access_denied_tls_cert:%lld\r\n"
-                        "acl_access_denied_db:%lld\r\n",
-                        server.acl_info.user_auth_failures, server.acl_info.invalid_cmd_accesses,
-                        server.acl_info.invalid_key_accesses, server.acl_info.invalid_channel_accesses,
-                        server.acl_info.acl_access_denied_tls_cert, server.acl_info.invalid_db_accesses);
-    return info;
+void genValkeyInfoStringACLStats(infoEmitter *e) {
+    infoEmitCounterLL(e, "acl_access_denied_auth", server.acl_info.user_auth_failures);
+    infoEmitCounterLL(e, "acl_access_denied_cmd", server.acl_info.invalid_cmd_accesses);
+    infoEmitCounterLL(e, "acl_access_denied_key", server.acl_info.invalid_key_accesses);
+    infoEmitCounterLL(e, "acl_access_denied_channel", server.acl_info.invalid_channel_accesses);
+    infoEmitCounterLL(e, "acl_access_denied_tls_cert", server.acl_info.acl_access_denied_tls_cert);
+    infoEmitCounterLL(e, "acl_access_denied_db", server.acl_info.invalid_db_accesses);
 }
 
-sds genValkeyInfoStringLatencyStats(sds info, hashtable *commands) {
+void genValkeyInfoStringLatencyStats(infoEmitter *e, hashtable *commands) {
     hashtableIterator iter;
     void *next;
     hashtableInitIterator(&iter, commands, HASHTABLE_ITER_SAFE);
@@ -5968,17 +5968,15 @@ sds genValkeyInfoStringLatencyStats(sds info, hashtable *commands) {
         struct serverCommand *c = next;
         char *tmpsafe;
         if (c->latency_histogram) {
-            info = fillPercentileDistributionLatencies(
-                info, getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->latency_histogram);
+            fillPercentileDistributionLatencies(
+                e, getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->latency_histogram);
             if (tmpsafe != NULL) zfree(tmpsafe);
         }
         if (c->subcommands_ht) {
-            info = genValkeyInfoStringLatencyStats(info, c->subcommands_ht);
+            genValkeyInfoStringLatencyStats(e, c->subcommands_ht);
         }
     }
     hashtableCleanupIterator(&iter);
-
-    return info;
 }
 
 /* Takes a null terminated sections list, and adds them to the dict. */
@@ -5997,9 +5995,18 @@ void releaseInfoSectionDict(dict *sec) {
     if (sec != cached_default_info_sections) dictRelease(sec);
 }
 
+typedef struct scriptingEngineInfoRecord {
+    sds name;
+    const char *module_name;
+    uint64_t abi_version;
+    size_t used_memory;
+    size_t memory_overhead;
+} scriptingEngineInfoRecord;
+
 typedef struct scriptingEngineInfoCollector {
-    sds info;
-    int total_engines;
+    scriptingEngineInfoRecord *records;
+    int count;
+    int capacity;
     size_t total_used_memory;
     size_t total_overhead;
 } scriptingEngineInfoCollector;
@@ -6007,50 +6014,50 @@ typedef struct scriptingEngineInfoCollector {
 static void collectScriptingEngineInfo(scriptingEngine *engine, void *context) {
     scriptingEngineInfoCollector *collector = (scriptingEngineInfoCollector *)context;
 
-    sds engine_name = scriptingEngineGetName(engine);
-    ValkeyModule *module = scriptingEngineGetModule(engine);
-    uint64_t abi_version = scriptingEngineGetAbiVersion(engine);
-
-    /* Get memory information for the engine */
+    /* Query each engine's memory info exactly once and cache its record, so the
+     * header totals and the per-engine fields come from a single consistent
+     * snapshot (and we emit typed dict fields, not raw text). */
     engineMemoryInfo mem_info = scriptingEngineCallGetMemoryInfo(engine, VMSE_ALL);
+    ValkeyModule *module = scriptingEngineGetModule(engine);
 
-    collector->info = sdscatprintf(collector->info,
-                                   "engine_%d:name=%s,module=%s,abi_version=%lu,used_memory=%zu,memory_overhead=%zu\r\n",
-                                   collector->total_engines,
-                                   engine_name,
-                                   module ? module->name : "built-in",
-                                   (unsigned long)abi_version,
-                                   mem_info.used_memory,
-                                   mem_info.engine_memory_overhead);
+    if (collector->count == collector->capacity) {
+        collector->capacity = collector->capacity ? collector->capacity * 2 : 4;
+        collector->records = zrealloc(collector->records, collector->capacity * sizeof(*collector->records));
+    }
+    scriptingEngineInfoRecord *rec = &collector->records[collector->count++];
+    rec->name = scriptingEngineGetName(engine);
+    rec->module_name = module ? module->name : "built-in";
+    rec->abi_version = scriptingEngineGetAbiVersion(engine);
+    rec->used_memory = mem_info.used_memory;
+    rec->memory_overhead = mem_info.engine_memory_overhead;
 
-    collector->total_engines++;
     collector->total_used_memory += mem_info.used_memory;
     collector->total_overhead += mem_info.engine_memory_overhead;
 }
 
-sds genValkeyInfoStringScriptingEngines(sds info) {
-    scriptingEngineInfoCollector collector = {
-        .info = sdsempty(),
-        .total_engines = 0,
-        .total_used_memory = 0,
-        .total_overhead = 0};
-
-    /* Collect information from all registered engines */
+void genValkeyInfoStringScriptingEngines(infoEmitter *e) {
+    /* Collect all engine records (and totals) in a single pass, then emit the
+     * section header + totals followed by the per-engine dict fields. */
+    scriptingEngineInfoCollector collector = {NULL, 0, 0, 0, 0};
     scriptingEngineManagerForEachEngine(collectScriptingEngineInfo, &collector);
 
-    info = sdscatprintf(info,
-                        "# Scripting Engines\r\n"
-                        "engines_count:%d\r\n"
-                        "engines_total_used_memory:%zu\r\n"
-                        "engines_total_memory_overhead:%zu\r\n"
-                        "%s",
-                        collector.total_engines,
-                        collector.total_used_memory,
-                        collector.total_overhead,
-                        collector.info);
-
-    sdsfree(collector.info);
-    return info;
+    infoEmitBeginSection(e, "Scripting Engines");
+    infoEmitFieldLL(e, "engines_count", collector.count);
+    infoEmitMetricULL(e, "engines_total_used_memory", collector.total_used_memory, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+    infoEmitMetricULL(e, "engines_total_memory_overhead", collector.total_overhead, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+    for (int i = 0; i < collector.count; i++) {
+        scriptingEngineInfoRecord *rec = &collector.records[i];
+        char key[32];
+        snprintf(key, sizeof(key), "engine_%d", i);
+        infoEmitBeginDict(e, key);
+        infoEmitDictStr(e, "name", rec->name);
+        infoEmitDictStr(e, "module", rec->module_name);
+        infoEmitDictLL(e, "abi_version", (long long)rec->abi_version);
+        infoEmitDictMetricLL(e, "used_memory", (long long)rec->used_memory, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitDictMetricLL(e, "memory_overhead", (long long)rec->memory_overhead, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitEndDict(e);
+    }
+    zfree(collector.records);
 }
 
 /* Create a dictionary with unique section names to be used by genValkeyInfoString.
@@ -6157,48 +6164,54 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             supervised = "no";
         }
 
-        if (sections++) info = sdscat(info, "\r\n");
-
         if (call_uname) {
             /* Uname can be slow and is always the same output. Cache it. */
             uname(&name);
             call_uname = 0;
         }
 
-        info = sdscatfmt(
-            info,
-            "# Server\r\n" FMTARGS(
-                "redis_version:%s\r\n", REDIS_VERSION,
-                "server_name:%s\r\n", SERVER_NAME,
-                "valkey_version:%s\r\n", VALKEY_VERSION,
-                "valkey_release_stage:%s\r\n", VALKEY_RELEASE_STAGE,
-                "redis_git_sha1:%s\r\n", serverGitSHA1(),
-                "redis_git_dirty:%i\r\n", strtol(serverGitDirty(), NULL, 10) > 0,
-                "redis_build_id:%s\r\n", serverBuildIdString(),
-                "%s_mode:", (server.extended_redis_compat ? "redis" : "server"),
-                "%s\r\n", mode,
-                "os:%s", name.sysname,
-                " %s", name.release,
-                " %s\r\n", name.machine,
-                "arch_bits:%i\r\n", server.arch_bits,
-                "monotonic_clock:%s\r\n", monotonicInfoString(),
-                "multiplexing_api:%s\r\n", aeGetApiName(),
-                "gcc_version:%s\r\n", GNUC_VERSION_STR,
-                "process_id:%I\r\n", (int64_t)getpid(),
-                "process_supervised:%s\r\n", supervised,
-                "run_id:%s\r\n", server.runid,
-                "tcp_port:%i\r\n", server.port ? server.port : server.tls_port,
-                "server_time_usec:%I\r\n", (int64_t)server.ustime,
-                "uptime_in_seconds:%I\r\n", (int64_t)uptime,
-                "uptime_in_days:%I\r\n", (int64_t)(uptime / (3600 * 24)),
-                "hz:%i\r\n", server.hz,
-                "configured_hz:%i\r\n", server.hz,
-                "clients_hz:%i\r\n", server.clients_hz,
-                "lru_clock:%u\r\n", (unsigned int)(server.unixtime & ((1 << LRULFU_BITS) - 1)),
-                "executable:%s\r\n", server.executable ? server.executable : "",
-                "config_file:%s\r\n", server.configfile ? server.configfile : "",
-                "io_threads_active:%i\r\n", server.active_io_threads_num > 1,
-                "availability_zone:%s\r\n", server.availability_zone));
+        /* Build the composite "os" value and the dynamic "<server|redis>_mode"
+         * key that the legacy multi-fragment sdscatfmt produced. Buffers are
+         * sized from the source fields so no truncation is possible. */
+        char server_mode_key[32];
+        snprintf(server_mode_key, sizeof(server_mode_key), "%s_mode",
+                 server.extended_redis_compat ? "redis" : "server");
+        char os_buf[sizeof(name.sysname) + sizeof(name.release) + sizeof(name.machine) + 3];
+        snprintf(os_buf, sizeof(os_buf), "%s %s %s", name.sysname, name.release, name.machine);
+
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Server");
+        infoEmitFieldStr(e, "redis_version", REDIS_VERSION);
+        infoEmitFieldStr(e, "server_name", SERVER_NAME);
+        infoEmitFieldStr(e, "valkey_version", VALKEY_VERSION);
+        infoEmitFieldStr(e, "valkey_release_stage", VALKEY_RELEASE_STAGE);
+        infoEmitFieldStr(e, "redis_git_sha1", serverGitSHA1());
+        infoEmitFieldLL(e, "redis_git_dirty", strtol(serverGitDirty(), NULL, 10) > 0);
+        infoEmitFieldStr(e, "redis_build_id", serverBuildIdString());
+        infoEmitFieldStr(e, server_mode_key, mode);
+        infoEmitFieldStr(e, "os", os_buf);
+        infoEmitFieldLL(e, "arch_bits", server.arch_bits);
+        infoEmitFieldStr(e, "monotonic_clock", monotonicInfoString());
+        infoEmitFieldStr(e, "multiplexing_api", aeGetApiName());
+        infoEmitFieldStr(e, "gcc_version", GNUC_VERSION_STR);
+        infoEmitFieldLL(e, "process_id", (int64_t)getpid());
+        infoEmitFieldStr(e, "process_supervised", supervised);
+        infoEmitFieldStr(e, "run_id", server.runid);
+        infoEmitFieldLL(e, "tcp_port", server.port ? server.port : server.tls_port);
+        infoEmitFieldLL(e, "server_time_usec", (int64_t)server.ustime);
+        infoEmitFieldLL(e, "uptime_in_seconds", (int64_t)uptime);
+        infoEmitFieldLL(e, "uptime_in_days", (int64_t)(uptime / (3600 * 24)));
+        infoEmitFieldLL(e, "hz", server.hz);
+        infoEmitFieldLL(e, "configured_hz", server.hz);
+        infoEmitFieldLL(e, "clients_hz", server.clients_hz);
+        infoEmitFieldULL(e, "lru_clock", (unsigned int)(server.unixtime & ((1 << LRULFU_BITS) - 1)));
+        infoEmitFieldStr(e, "executable", server.executable ? server.executable : "");
+        infoEmitFieldStr(e, "config_file", server.configfile ? server.configfile : "");
+        infoEmitFieldLL(e, "io_threads_active", server.active_io_threads_num > 1);
+        infoEmitFieldStr(e, "availability_zone", server.availability_zone);
+        info = infoEmitterTextResult(&te);
 
         /* Conditional properties */
         if (isShutdownInitiated()) {
@@ -6212,7 +6225,6 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
 
     /* TLS */
     if (all_sections || (dictFind(section_dict, "tls") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
         long long tls_server_seconds_remaining = 0;
         if (server.tls_server_cert_expire_time > 0) {
             tls_server_seconds_remaining = server.tls_server_cert_expire_time - (long long)server.unixtime;
@@ -6228,15 +6240,22 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             tls_ca_seconds_remaining = server.tls_ca_cert_expire_time - (long long)server.unixtime;
             if (tls_ca_seconds_remaining < 0) tls_ca_seconds_remaining = 0;
         }
-        info = sdscatprintf(
-            info,
-            "# TLS\r\n" FMTARGS(
-                "tls_server_cert_serial:%s\r\n", server.tls_server_cert_serial ? server.tls_server_cert_serial : "none",
-                "tls_server_cert_expires_in_seconds:%lld\r\n", tls_server_seconds_remaining,
-                "tls_client_cert_serial:%s\r\n", server.tls_client_cert_serial ? server.tls_client_cert_serial : "none",
-                "tls_client_cert_expires_in_seconds:%lld\r\n", tls_client_seconds_remaining,
-                "tls_ca_cert_serial:%s\r\n", server.tls_ca_cert_serial ? server.tls_ca_cert_serial : "none",
-                "tls_ca_cert_expires_in_seconds:%lld\r\n", tls_ca_seconds_remaining));
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "TLS");
+        infoEmitFieldStr(e, "tls_server_cert_serial",
+                         server.tls_server_cert_serial ? server.tls_server_cert_serial : "none");
+        infoEmitMetricLL(e, "tls_server_cert_expires_in_seconds", tls_server_seconds_remaining, INFO_KIND_GAUGE,
+                         INFO_UNIT_SECONDS);
+        infoEmitFieldStr(e, "tls_client_cert_serial",
+                         server.tls_client_cert_serial ? server.tls_client_cert_serial : "none");
+        infoEmitMetricLL(e, "tls_client_cert_expires_in_seconds", tls_client_seconds_remaining, INFO_KIND_GAUGE,
+                         INFO_UNIT_SECONDS);
+        infoEmitFieldStr(e, "tls_ca_cert_serial", server.tls_ca_cert_serial ? server.tls_ca_cert_serial : "none");
+        infoEmitMetricLL(e, "tls_ca_cert_expires_in_seconds", tls_ca_seconds_remaining, INFO_KIND_GAUGE,
+                         INFO_UNIT_SECONDS);
+        info = infoEmitterTextResult(&te);
     }
 
     /* Clients */
@@ -6260,26 +6279,27 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             paused_reason = getPausedReason(purpose);
         }
 
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(
-            info,
-            "# Clients\r\n" FMTARGS(
-                "connected_clients:%lu\r\n", listLength(server.clients) - listLength(server.replicas),
-                "cluster_connections:%lu\r\n", getClusterConnectionsCount(),
-                "maxclients:%u\r\n", server.maxclients,
-                "client_recent_max_input_buffer:%zu\r\n", maxin,
-                "client_recent_max_output_buffer:%zu\r\n", maxout,
-                "blocked_clients:%d\r\n", server.blocked_clients,
-                "tracking_clients:%d\r\n", server.tracking_clients,
-                "pubsub_clients:%d\r\n", server.pubsub_clients,
-                "watching_clients:%d\r\n", server.watching_clients,
-                "clients_in_timeout_table:%llu\r\n", (unsigned long long)raxSize(server.clients_timeout_table),
-                "total_watched_keys:%lu\r\n", watched_keys,
-                "total_blocking_keys:%lu\r\n", blocking_keys,
-                "total_blocking_keys_on_nokey:%lu\r\n", blocking_keys_on_nokey,
-                "paused_reason:%s\r\n", paused_reason,
-                "paused_actions:%s\r\n", paused_actions,
-                "paused_timeout_milliseconds:%lld\r\n", paused_timeout));
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Clients");
+        infoEmitFieldULL(e, "connected_clients", listLength(server.clients) - listLength(server.replicas));
+        infoEmitFieldULL(e, "cluster_connections", getClusterConnectionsCount());
+        infoEmitFieldULL(e, "maxclients", server.maxclients);
+        infoEmitMetricULL(e, "client_recent_max_input_buffer", maxin, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "client_recent_max_output_buffer", maxout, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldLL(e, "blocked_clients", server.blocked_clients);
+        infoEmitFieldLL(e, "tracking_clients", server.tracking_clients);
+        infoEmitFieldLL(e, "pubsub_clients", server.pubsub_clients);
+        infoEmitFieldLL(e, "watching_clients", server.watching_clients);
+        infoEmitFieldULL(e, "clients_in_timeout_table", (unsigned long long)raxSize(server.clients_timeout_table));
+        infoEmitFieldULL(e, "total_watched_keys", watched_keys);
+        infoEmitFieldULL(e, "total_blocking_keys", blocking_keys);
+        infoEmitFieldULL(e, "total_blocking_keys_on_nokey", blocking_keys_on_nokey);
+        infoEmitFieldStr(e, "paused_reason", paused_reason);
+        infoEmitFieldStr(e, "paused_actions", paused_actions);
+        infoEmitMetricLL(e, "paused_timeout_milliseconds", paused_timeout, INFO_KIND_GAUGE, INFO_UNIT_MILLISECONDS);
+        info = infoEmitterTextResult(&te);
     }
 
     /* Memory */
@@ -6314,76 +6334,90 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         bytesToHuman(used_memory_rss_hmem, sizeof(used_memory_rss_hmem), server.cron_malloc_stats.process_rss);
         bytesToHuman(maxmemory_hmem, sizeof(maxmemory_hmem), server.maxmemory);
 
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(
-            info,
-            "# Memory\r\n" FMTARGS(
-                "used_memory:%zu\r\n", zmalloc_used,
-                "used_memory_human:%s\r\n", hmem,
-                "used_memory_rss:%zu\r\n", server.cron_malloc_stats.process_rss,
-                "used_memory_rss_human:%s\r\n", used_memory_rss_hmem,
-                "used_memory_peak:%zu\r\n", server.stat_peak_memory,
-                "used_memory_peak_human:%s\r\n", peak_hmem,
-                "used_memory_peak_perc:%.2f%%\r\n", mh->peak_perc,
-                "used_memory_overhead:%zu\r\n", mh->overhead_total,
-                "used_memory_startup:%zu\r\n", mh->startup_allocated,
-                "used_memory_dataset:%zu\r\n", mh->dataset,
-                "used_memory_dataset_perc:%.2f%%\r\n", mh->dataset_perc,
-                "allocator_allocated:%zu\r\n", server.cron_malloc_stats.allocator_allocated,
-                "allocator_active:%zu\r\n", server.cron_malloc_stats.allocator_active,
-                "allocator_resident:%zu\r\n", server.cron_malloc_stats.allocator_resident,
-                "allocator_muzzy:%zu\r\n", server.cron_malloc_stats.allocator_muzzy,
-                "total_system_memory:%lu\r\n", (unsigned long)total_system_mem,
-                "total_system_memory_human:%s\r\n", total_system_hmem,
-                "used_memory_lua:%lld\r\n", memory_lua, /* deprecated, renamed to used_memory_vm_eval */
-                "used_memory_vm_eval:%lld\r\n", memory_lua,
-                "used_memory_lua_human:%s\r\n", used_memory_lua_hmem, /* deprecated */
-                "used_memory_scripts_eval:%lld\r\n", (long long)mh->lua_caches,
-                "number_of_cached_scripts:%zu\r\n", dictSize(evalScriptsDict()),
-                "number_of_functions:%lu\r\n", functionsNum(),
-                "number_of_libraries:%lu\r\n", functionsLibNum(),
-                "used_memory_vm_functions:%lld\r\n", memory_functions,
-                "used_memory_vm_total:%lld\r\n", memory_functions + memory_lua,
-                "used_memory_vm_total_human:%s\r\n", used_memory_vm_total_hmem,
-                "used_memory_functions:%lld\r\n", (long long)mh->functions_caches,
-                "used_memory_scripts:%lld\r\n", (long long)mh->lua_caches + (long long)mh->functions_caches,
-                "used_memory_scripts_human:%s\r\n", used_memory_scripts_hmem,
-                "maxmemory:%lld\r\n", server.maxmemory,
-                "maxmemory_human:%s\r\n", maxmemory_hmem,
-                "maxmemory_policy:%s\r\n", evict_policy,
-                "allocator_frag_ratio:%.2f\r\n", mh->allocator_frag,
-                "allocator_frag_bytes:%zu\r\n", mh->allocator_frag_bytes,
-                "allocator_rss_ratio:%.2f\r\n", mh->allocator_rss,
-                "allocator_rss_bytes:%zd\r\n", mh->allocator_rss_bytes,
-                "rss_overhead_ratio:%.2f\r\n", mh->rss_extra,
-                "rss_overhead_bytes:%zd\r\n", mh->rss_extra_bytes,
-                /* The next field (mem_fragmentation_ratio) is the total RSS
-                 * overhead, including fragmentation, but not just it. This field
-                 * (and the next one) is named like that just for backward
-                 * compatibility. */
-                "mem_fragmentation_ratio:%.2f\r\n", mh->total_frag,
-                "mem_fragmentation_bytes:%zd\r\n", mh->total_frag_bytes,
-                "mem_not_counted_for_evict:%zu\r\n", freeMemoryGetNotCountedMemory(),
-                "mem_replication_backlog:%zu\r\n", mh->repl_backlog,
-                "mem_total_replication_buffers:%zu\r\n", server.repl_buffer_mem + server.pending_repl_data.mem,
-                "mem_replicas_repl_buffer:%zu\r\n", server.pending_repl_data.mem,
-                "mem_clients_slaves:%zu\r\n", mh->clients_replicas,
-                "mem_clients_normal:%zu\r\n", mh->clients_normal,
-                "mem_cluster_links:%zu\r\n", mh->cluster_links,
-                "mem_cluster_slot_import:%zu\r\n", mh->cluster_slot_import,
-                "mem_cluster_slot_export:%zu\r\n", mh->cluster_slot_export,
-                "mem_aof_buffer:%zu\r\n", mh->aof_buffer,
-                "mem_allocator:%s\r\n", ZMALLOC_LIB,
-                "mem_overhead_db_hashtable_rehashing:%zu\r\n", mh->overhead_db_hashtable_rehashing,
-                "active_defrag_running:%d\r\n", server.active_defrag_cpu_percent,
-                "lazyfree_pending_objects:%zu\r\n", lazyfreeGetPendingObjectsCount(),
-                "lazyfreed_objects:%zu\r\n", lazyfreeGetFreedObjectsCount()));
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Memory");
+        infoEmitMetricULL(e, "used_memory", zmalloc_used, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldStr(e, "used_memory_human", hmem);
+        infoEmitMetricULL(e, "used_memory_rss", server.cron_malloc_stats.process_rss, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldStr(e, "used_memory_rss_human", used_memory_rss_hmem);
+        infoEmitMetricULL(e, "used_memory_peak", server.stat_peak_memory, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldStr(e, "used_memory_peak_human", peak_hmem);
+        infoEmitMetricDouble(e, "used_memory_peak_perc", mh->peak_perc, 2, INFO_KIND_GAUGE, INFO_UNIT_PERCENT);
+        infoEmitMetricULL(e, "used_memory_overhead", mh->overhead_total, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "used_memory_startup", mh->startup_allocated, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "used_memory_dataset", mh->dataset, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricDouble(e, "used_memory_dataset_perc", mh->dataset_perc, 2, INFO_KIND_GAUGE, INFO_UNIT_PERCENT);
+        infoEmitMetricULL(e, "allocator_allocated", server.cron_malloc_stats.allocator_allocated, INFO_KIND_GAUGE,
+                          INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "allocator_active", server.cron_malloc_stats.allocator_active, INFO_KIND_GAUGE,
+                          INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "allocator_resident", server.cron_malloc_stats.allocator_resident, INFO_KIND_GAUGE,
+                          INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "allocator_muzzy", server.cron_malloc_stats.allocator_muzzy, INFO_KIND_GAUGE,
+                          INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "total_system_memory", (unsigned long)total_system_mem, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldStr(e, "total_system_memory_human", total_system_hmem);
+        infoEmitMetricLL(e, "used_memory_lua", memory_lua, INFO_KIND_GAUGE,
+                         INFO_UNIT_BYTES); /* deprecated, renamed to used_memory_vm_eval */
+        infoEmitMetricLL(e, "used_memory_vm_eval", memory_lua, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldStr(e, "used_memory_lua_human", used_memory_lua_hmem); /* deprecated */
+        infoEmitMetricLL(e, "used_memory_scripts_eval", (long long)mh->lua_caches, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldULL(e, "number_of_cached_scripts", dictSize(evalScriptsDict()));
+        infoEmitFieldULL(e, "number_of_functions", functionsNum());
+        infoEmitFieldULL(e, "number_of_libraries", functionsLibNum());
+        infoEmitMetricLL(e, "used_memory_vm_functions", memory_functions, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricLL(e, "used_memory_vm_total", memory_functions + memory_lua, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldStr(e, "used_memory_vm_total_human", used_memory_vm_total_hmem);
+        infoEmitMetricLL(e, "used_memory_functions", (long long)mh->functions_caches, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricLL(e, "used_memory_scripts", (long long)mh->lua_caches + (long long)mh->functions_caches,
+                         INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldStr(e, "used_memory_scripts_human", used_memory_scripts_hmem);
+        infoEmitMetricLL(e, "maxmemory", server.maxmemory, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldStr(e, "maxmemory_human", maxmemory_hmem);
+        infoEmitFieldStr(e, "maxmemory_policy", evict_policy);
+        infoEmitFieldDouble(e, "allocator_frag_ratio", mh->allocator_frag, 2);
+        /* Legacy used %zu on an ssize_t field; reinterpret at size_t width
+         * first so 32-bit output matches byte-for-byte. */
+        infoEmitMetricULL(e, "allocator_frag_bytes", (unsigned long long)(size_t)mh->allocator_frag_bytes,
+                          INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldDouble(e, "allocator_rss_ratio", mh->allocator_rss, 2);
+        infoEmitMetricLL(e, "allocator_rss_bytes", mh->allocator_rss_bytes, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldDouble(e, "rss_overhead_ratio", mh->rss_extra, 2);
+        /* Legacy used %zd on a size_t field; reinterpret at ssize_t width
+         * first so 32-bit output matches byte-for-byte. */
+        infoEmitMetricLL(e, "rss_overhead_bytes", (long long)(ssize_t)mh->rss_extra_bytes, INFO_KIND_GAUGE,
+                         INFO_UNIT_BYTES);
+        /* The next field (mem_fragmentation_ratio) is the total RSS overhead,
+         * including fragmentation, but not just it. This field (and the next
+         * one) is named like that just for backward compatibility. */
+        infoEmitFieldDouble(e, "mem_fragmentation_ratio", mh->total_frag, 2);
+        infoEmitMetricLL(e, "mem_fragmentation_bytes", mh->total_frag_bytes, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "mem_not_counted_for_evict", freeMemoryGetNotCountedMemory(), INFO_KIND_GAUGE,
+                          INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "mem_replication_backlog", mh->repl_backlog, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "mem_total_replication_buffers", server.repl_buffer_mem + server.pending_repl_data.mem,
+                          INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "mem_replicas_repl_buffer", server.pending_repl_data.mem, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "mem_clients_slaves", mh->clients_replicas, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "mem_clients_normal", mh->clients_normal, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "mem_cluster_links", mh->cluster_links, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "mem_cluster_slot_import", mh->cluster_slot_import, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "mem_cluster_slot_export", mh->cluster_slot_export, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "mem_aof_buffer", mh->aof_buffer, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldStr(e, "mem_allocator", ZMALLOC_LIB);
+        infoEmitMetricULL(e, "mem_overhead_db_hashtable_rehashing", mh->overhead_db_hashtable_rehashing,
+                          INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldLL(e, "active_defrag_running", server.active_defrag_cpu_percent);
+        infoEmitFieldULL(e, "lazyfree_pending_objects", lazyfreeGetPendingObjectsCount());
+        infoEmitFieldULL(e, "lazyfreed_objects", lazyfreeGetFreedObjectsCount());
+        info = infoEmitterTextResult(&te);
         freeMemoryOverheadData(mh);
     }
 
     /* Persistence */
     if (all_sections || (dictFind(section_dict, "persistence") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
         double fork_perc = 0;
         if (server.stat_module_progress) {
             fork_perc = server.stat_module_progress * 100;
@@ -6392,51 +6426,61 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         }
         int aof_bio_fsync_status = atomic_load_explicit(&server.aof_bio_fsync_status, memory_order_relaxed);
 
-        info = sdscatprintf(
-            info,
-            "# Persistence\r\n" FMTARGS(
-                "loading:%d\r\n", (int)(server.loading && !server.async_loading),
-                "async_loading:%d\r\n", (int)server.async_loading,
-                "current_cow_peak:%zu\r\n", server.stat_current_cow_peak,
-                "current_cow_size:%zu\r\n", server.stat_current_cow_bytes,
-                "current_cow_size_age:%lu\r\n", (server.stat_current_cow_updated ? (unsigned long)elapsedMs(server.stat_current_cow_updated) / 1000 : 0),
-                "current_fork_perc:%.2f\r\n", fork_perc,
-                "current_save_keys_processed:%zu\r\n", server.stat_current_save_keys_processed,
-                "current_save_keys_total:%zu\r\n", server.stat_current_save_keys_total,
-                "rdb_changes_since_last_save:%lld\r\n", server.dirty,
-                "rdb_bgsave_in_progress:%d\r\n", server.child_type == CHILD_TYPE_RDB,
-                "rdb_last_save_time:%jd\r\n", (intmax_t)server.lastsave,
-                "rdb_last_bgsave_status:%s\r\n", (server.lastbgsave_status == C_OK) ? "ok" : "err",
-                "rdb_last_bgsave_time_sec:%jd\r\n", (intmax_t)server.rdb_save_time_last,
-                "rdb_current_bgsave_time_sec:%jd\r\n", (intmax_t)((server.child_type != CHILD_TYPE_RDB) ? -1 : time(NULL) - server.rdb_save_time_start),
-                "rdb_saves:%lld\r\n", server.stat_rdb_saves,
-                "rdb_last_cow_size:%zu\r\n", server.stat_rdb_cow_bytes,
-                "rdb_last_load_keys_expired:%lld\r\n", server.rdb_last_load_keys_expired,
-                "rdb_last_load_keys_loaded:%lld\r\n", server.rdb_last_load_keys_loaded,
-                "aof_enabled:%d\r\n", server.aof_state != AOF_OFF,
-                "aof_rewrite_in_progress:%d\r\n", server.child_type == CHILD_TYPE_AOF,
-                "aof_rewrite_scheduled:%d\r\n", server.aof_rewrite_scheduled,
-                "aof_last_rewrite_time_sec:%jd\r\n", (intmax_t)server.aof_rewrite_time_last,
-                "aof_current_rewrite_time_sec:%jd\r\n", (intmax_t)((server.child_type != CHILD_TYPE_AOF) ? -1 : time(NULL) - server.aof_rewrite_time_start),
-                "aof_last_bgrewrite_status:%s\r\n", (server.aof_lastbgrewrite_status == C_OK ? "ok" : "err"),
-                "aof_rewrites:%lld\r\n", server.stat_aof_rewrites,
-                "aof_rewrites_consecutive_failures:%lld\r\n", server.stat_aofrw_consecutive_failures,
-                "aof_last_write_status:%s\r\n", (server.aof_last_write_status == C_OK && aof_bio_fsync_status == C_OK) ? "ok" : "err",
-                "aof_last_cow_size:%zu\r\n", server.stat_aof_cow_bytes,
-                "module_fork_in_progress:%d\r\n", server.child_type == CHILD_TYPE_MODULE,
-                "module_fork_last_cow_size:%zu\r\n", server.stat_module_cow_bytes,
-                "slot_migration_fork_in_progress:%d\r\n", server.child_type == CHILD_TYPE_SLOT_MIGRATION));
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Persistence");
+        infoEmitFieldLL(e, "loading", (int)(server.loading && !server.async_loading));
+        infoEmitFieldLL(e, "async_loading", (int)server.async_loading);
+        infoEmitMetricULL(e, "current_cow_peak", server.stat_current_cow_peak, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "current_cow_size", server.stat_current_cow_bytes, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitMetricULL(e, "current_cow_size_age",
+                          (server.stat_current_cow_updated ? (unsigned long)elapsedMs(server.stat_current_cow_updated) / 1000 : 0),
+                          INFO_KIND_GAUGE, INFO_UNIT_SECONDS);
+        infoEmitFieldDouble(e, "current_fork_perc", fork_perc, 2);
+        infoEmitFieldULL(e, "current_save_keys_processed", server.stat_current_save_keys_processed);
+        infoEmitFieldULL(e, "current_save_keys_total", server.stat_current_save_keys_total);
+        infoEmitFieldLL(e, "rdb_changes_since_last_save", server.dirty);
+        infoEmitFieldLL(e, "rdb_bgsave_in_progress", server.child_type == CHILD_TYPE_RDB);
+        infoEmitFieldLL(e, "rdb_last_save_time", (long long)server.lastsave);
+        infoEmitFieldStr(e, "rdb_last_bgsave_status", (server.lastbgsave_status == C_OK) ? "ok" : "err");
+        infoEmitMetricLL(e, "rdb_last_bgsave_time_sec", (long long)server.rdb_save_time_last, INFO_KIND_GAUGE,
+                         INFO_UNIT_SECONDS);
+        infoEmitMetricLL(e, "rdb_current_bgsave_time_sec",
+                         (long long)((server.child_type != CHILD_TYPE_RDB) ? -1 : time(NULL) - server.rdb_save_time_start),
+                         INFO_KIND_GAUGE, INFO_UNIT_SECONDS);
+        infoEmitCounterLL(e, "rdb_saves", server.stat_rdb_saves);
+        infoEmitMetricULL(e, "rdb_last_cow_size", server.stat_rdb_cow_bytes, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitCounterLL(e, "rdb_last_load_keys_expired", server.rdb_last_load_keys_expired);
+        infoEmitCounterLL(e, "rdb_last_load_keys_loaded", server.rdb_last_load_keys_loaded);
+        infoEmitFieldLL(e, "aof_enabled", server.aof_state != AOF_OFF);
+        infoEmitFieldLL(e, "aof_rewrite_in_progress", server.child_type == CHILD_TYPE_AOF);
+        infoEmitFieldLL(e, "aof_rewrite_scheduled", server.aof_rewrite_scheduled);
+        infoEmitMetricLL(e, "aof_last_rewrite_time_sec", (long long)server.aof_rewrite_time_last, INFO_KIND_GAUGE,
+                         INFO_UNIT_SECONDS);
+        infoEmitMetricLL(e, "aof_current_rewrite_time_sec",
+                         (long long)((server.child_type != CHILD_TYPE_AOF) ? -1 : time(NULL) - server.aof_rewrite_time_start),
+                         INFO_KIND_GAUGE, INFO_UNIT_SECONDS);
+        infoEmitFieldStr(e, "aof_last_bgrewrite_status", (server.aof_lastbgrewrite_status == C_OK ? "ok" : "err"));
+        infoEmitCounterLL(e, "aof_rewrites", server.stat_aof_rewrites);
+        infoEmitFieldLL(e, "aof_rewrites_consecutive_failures", server.stat_aofrw_consecutive_failures);
+        infoEmitFieldStr(e, "aof_last_write_status",
+                         (server.aof_last_write_status == C_OK && aof_bio_fsync_status == C_OK) ? "ok" : "err");
+        infoEmitMetricULL(e, "aof_last_cow_size", server.stat_aof_cow_bytes, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldLL(e, "module_fork_in_progress", server.child_type == CHILD_TYPE_MODULE);
+        infoEmitMetricULL(e, "module_fork_last_cow_size", server.stat_module_cow_bytes, INFO_KIND_GAUGE,
+                          INFO_UNIT_BYTES);
+        infoEmitFieldLL(e, "slot_migration_fork_in_progress", server.child_type == CHILD_TYPE_SLOT_MIGRATION);
 
         if (server.aof_enabled) {
-            info = sdscatprintf(
-                info,
-                FMTARGS(
-                    "aof_current_size:%lld\r\n", (long long)server.aof_current_size,
-                    "aof_base_size:%lld\r\n", (long long)server.aof_rewrite_base_size,
-                    "aof_pending_rewrite:%d\r\n", server.aof_rewrite_scheduled,
-                    "aof_buffer_length:%zu\r\n", sdslen(server.aof_buf),
-                    "aof_pending_bio_fsync:%lu\r\n", bioPendingJobsOfType(BIO_AOF_FSYNC),
-                    "aof_delayed_fsync:%lu\r\n", server.aof_delayed_fsync));
+            infoEmitMetricLL(e, "aof_current_size", (long long)server.aof_current_size, INFO_KIND_GAUGE,
+                             INFO_UNIT_BYTES);
+            infoEmitMetricLL(e, "aof_base_size", (long long)server.aof_rewrite_base_size, INFO_KIND_GAUGE,
+                             INFO_UNIT_BYTES);
+            infoEmitFieldLL(e, "aof_pending_rewrite", server.aof_rewrite_scheduled);
+            infoEmitMetricULL(e, "aof_buffer_length", sdslen(server.aof_buf), INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+            infoEmitFieldULL(e, "aof_pending_bio_fsync", bioPendingJobsOfType(BIO_AOF_FSYNC));
+            infoEmitCounterULL(e, "aof_delayed_fsync", server.aof_delayed_fsync);
         }
 
         if (server.loading) {
@@ -6463,16 +6507,17 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 eta = (elapsed * remaining_bytes) / (server.loading_loaded_bytes + 1);
             }
 
-            info = sdscatprintf(
-                info,
-                FMTARGS(
-                    "loading_start_time:%jd\r\n", (intmax_t)server.loading_start_time,
-                    "loading_total_bytes:%llu\r\n", (unsigned long long)server.loading_total_bytes,
-                    "loading_rdb_used_mem:%llu\r\n", (unsigned long long)server.loading_rdb_used_mem,
-                    "loading_loaded_bytes:%llu\r\n", (unsigned long long)server.loading_loaded_bytes,
-                    "loading_loaded_perc:%.2f\r\n", perc,
-                    "loading_eta_seconds:%jd\r\n", (intmax_t)eta));
+            infoEmitFieldLL(e, "loading_start_time", (long long)server.loading_start_time);
+            infoEmitMetricULL(e, "loading_total_bytes", (unsigned long long)server.loading_total_bytes, INFO_KIND_GAUGE,
+                              INFO_UNIT_BYTES);
+            infoEmitMetricULL(e, "loading_rdb_used_mem", (unsigned long long)server.loading_rdb_used_mem,
+                              INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+            infoEmitMetricULL(e, "loading_loaded_bytes", (unsigned long long)server.loading_loaded_bytes,
+                              INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+            infoEmitFieldDouble(e, "loading_loaded_perc", perc, 2);
+            infoEmitMetricLL(e, "loading_eta_seconds", (long long)eta, INFO_KIND_GAUGE, INFO_UNIT_SECONDS);
         }
+        info = infoEmitterTextResult(&te);
     }
 
     /* Stats */
@@ -6482,87 +6527,118 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         ustime_t current_active_defrag_time =
             server.stat_last_active_defrag_time ? (ustime_t)elapsedUs(server.stat_last_active_defrag_time) : 0;
 
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(
-            info,
-            "# Stats\r\n" FMTARGS(
-                "total_connections_received:%lld\r\n", server.stat_numconnections,
-                "total_commands_processed:%lld\r\n", server.stat_numcommands,
-                "instantaneous_ops_per_sec:%lld\r\n", getInstantaneousMetric(STATS_METRIC_COMMAND),
-                "total_net_input_bytes:%lld\r\n", server.stat_net_input_bytes + server.stat_net_repl_input_bytes + server.bio_stat_net_repl_input_bytes + server.stat_net_cluster_slot_import_bytes,
-                "total_net_output_bytes:%lld\r\n", server.stat_net_output_bytes + server.stat_net_repl_output_bytes + server.stat_net_cluster_slot_export_bytes,
-                "total_net_repl_input_bytes:%lld\r\n", server.stat_net_repl_input_bytes + server.bio_stat_net_repl_input_bytes,
-                "total_net_repl_output_bytes:%lld\r\n", server.stat_net_repl_output_bytes,
-                "total_net_cluster_slot_import_bytes:%lld\r\n", server.stat_net_cluster_slot_import_bytes,
-                "total_net_cluster_slot_export_bytes:%lld\r\n", server.stat_net_cluster_slot_export_bytes,
-                "instantaneous_input_kbps:%.2f\r\n", (float)getInstantaneousMetric(STATS_METRIC_NET_INPUT) / 1024,
-                "instantaneous_output_kbps:%.2f\r\n", (float)getInstantaneousMetric(STATS_METRIC_NET_OUTPUT) / 1024,
-                "instantaneous_input_repl_kbps:%.2f\r\n", (float)getInstantaneousMetric(STATS_METRIC_NET_INPUT_REPLICATION) / 1024,
-                "instantaneous_output_repl_kbps:%.2f\r\n", (float)getInstantaneousMetric(STATS_METRIC_NET_OUTPUT_REPLICATION) / 1024,
-                "rejected_connections:%lld\r\n", server.stat_rejected_conn,
-                "sync_full:%lld\r\n", server.stat_sync_full,
-                "sync_partial_ok:%lld\r\n", server.stat_sync_partial_ok,
-                "sync_partial_err:%lld\r\n", server.stat_sync_partial_err,
-                "expired_keys:%lld\r\n", server.stat_expiredkeys,
-                "expired_fields:%lld\r\n", server.stat_expiredfields,
-                "expired_stale_perc:%.2f\r\n", server.stat_expired_keys_stale_perc * 100,
-                "expired_keys_with_volatile_items_stale_perc:%.2f\r\n", server.stat_expired_keys_with_vola_stale_perc * 100,
-                "expired_time_cap_reached_count:%lld\r\n", server.stat_expired_time_cap_reached_count,
-                "expire_cycle_cpu_milliseconds:%lld\r\n", server.stat_expire_cycle_time_used / 1000,
-                "evicted_keys:%lld\r\n", server.stat_evictedkeys,
-                "evicted_clients:%lld\r\n", server.stat_evictedclients,
-                "evicted_scripts:%lld\r\n", server.stat_evictedscripts,
-                "total_eviction_exceeded_time:%lld\r\n", (server.stat_total_eviction_exceeded_time + current_eviction_exceeded_time) / 1000,
-                "current_eviction_exceeded_time:%lld\r\n", current_eviction_exceeded_time / 1000,
-                "keyspace_hits:%lld\r\n", server.stat_keyspace_hits,
-                "keyspace_misses:%lld\r\n", server.stat_keyspace_misses,
-                "pubsub_channels:%llu\r\n", kvstoreSize(server.pubsub_channels),
-                "pubsub_patterns:%zu\r\n", dictSize(server.pubsub_patterns),
-                "pubsubshard_channels:%llu\r\n", kvstoreSize(server.pubsubshard_channels),
-                "latest_fork_usec:%lld\r\n", server.stat_fork_time,
-                "total_forks:%lld\r\n", server.stat_total_forks,
-                "migrate_cached_sockets:%zu\r\n", dictSize(server.migrate_cached_sockets),
-                "slave_expires_tracked_keys:%zu\r\n", getReplicaKeyWithExpireCount(),
-                "active_defrag_hits:%lld\r\n", server.stat_active_defrag_hits,
-                "active_defrag_misses:%lld\r\n", server.stat_active_defrag_misses,
-                "active_defrag_key_hits:%lld\r\n", server.stat_active_defrag_key_hits,
-                "active_defrag_key_misses:%lld\r\n", server.stat_active_defrag_key_misses,
-                "total_active_defrag_time:%lld\r\n", (server.stat_total_active_defrag_time + current_active_defrag_time) / 1000,
-                "current_active_defrag_time:%lld\r\n", current_active_defrag_time / 1000,
-                "tracking_total_keys:%lld\r\n", (unsigned long long)trackingGetTotalKeys(),
-                "tracking_total_items:%lld\r\n", (unsigned long long)trackingGetTotalItems(),
-                "tracking_total_prefixes:%lld\r\n", (unsigned long long)trackingGetTotalPrefixes(),
-                "unexpected_error_replies:%lld\r\n", server.stat_unexpected_error_replies,
-                "total_error_replies:%lld\r\n", server.stat_total_error_replies,
-                "dump_payload_sanitizations:%lld\r\n", server.stat_dump_payload_sanitizations,
-                "total_reads_processed:%lld\r\n", server.stat_total_reads_processed,
-                "total_writes_processed:%lld\r\n", server.stat_total_writes_processed,
-                "io_threaded_reads_processed:%lld\r\n", server.stat_io_reads_processed,
-                "io_threaded_writes_processed:%lld\r\n", server.stat_io_writes_processed,
-                "io_threaded_freed_objects:%lld\r\n", server.stat_io_freed_objects,
-                "io_threaded_accept_processed:%lld\r\n", server.stat_io_accept_offloaded,
-                "io_threaded_poll_processed:%lld\r\n", server.stat_poll_processed_by_io_threads,
-                "io_threaded_total_prefetch_batches:%lld\r\n", server.stat_total_prefetch_batches,
-                "io_threaded_total_prefetch_entries:%lld\r\n", server.stat_total_prefetch_entries,
-                "client_query_buffer_limit_disconnections:%lld\r\n", server.stat_client_qbuf_limit_disconnections,
-                "client_output_buffer_limit_disconnections:%lld\r\n", server.stat_client_outbuf_limit_disconnections,
-                "reply_buffer_shrinks:%lld\r\n", server.stat_reply_buffer_shrinks,
-                "reply_buffer_expands:%lld\r\n", server.stat_reply_buffer_expands,
-                "eventloop_cycles:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_EL].cnt,
-                "eventloop_duration_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_EL].sum,
-                "eventloop_duration_cmd_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_CMD].sum,
-                "instantaneous_eventloop_cycles_per_sec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_CYCLE),
-                "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION)));
-        info = genValkeyInfoStringACLStats(info);
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Stats");
+        infoEmitCounterLL(e, "total_connections_received", server.stat_numconnections);
+        infoEmitCounterLL(e, "total_commands_processed", server.stat_numcommands);
+        infoEmitFieldLL(e, "instantaneous_ops_per_sec", getInstantaneousMetric(STATS_METRIC_COMMAND));
+        infoEmitMetricLL(e, "total_net_input_bytes",
+                         server.stat_net_input_bytes + server.stat_net_repl_input_bytes +
+                             server.bio_stat_net_repl_input_bytes + server.stat_net_cluster_slot_import_bytes,
+                         INFO_KIND_COUNTER, INFO_UNIT_BYTES);
+        infoEmitMetricLL(e, "total_net_output_bytes",
+                         server.stat_net_output_bytes + server.stat_net_repl_output_bytes +
+                             server.stat_net_cluster_slot_export_bytes,
+                         INFO_KIND_COUNTER, INFO_UNIT_BYTES);
+        infoEmitMetricLL(e, "total_net_repl_input_bytes",
+                         server.stat_net_repl_input_bytes + server.bio_stat_net_repl_input_bytes, INFO_KIND_COUNTER,
+                         INFO_UNIT_BYTES);
+        infoEmitMetricLL(e, "total_net_repl_output_bytes", server.stat_net_repl_output_bytes, INFO_KIND_COUNTER,
+                         INFO_UNIT_BYTES);
+        infoEmitMetricLL(e, "total_net_cluster_slot_import_bytes", server.stat_net_cluster_slot_import_bytes,
+                         INFO_KIND_COUNTER, INFO_UNIT_BYTES);
+        infoEmitMetricLL(e, "total_net_cluster_slot_export_bytes", server.stat_net_cluster_slot_export_bytes,
+                         INFO_KIND_COUNTER, INFO_UNIT_BYTES);
+        infoEmitFieldDouble(e, "instantaneous_input_kbps", (float)getInstantaneousMetric(STATS_METRIC_NET_INPUT) / 1024,
+                            2);
+        infoEmitFieldDouble(e, "instantaneous_output_kbps",
+                            (float)getInstantaneousMetric(STATS_METRIC_NET_OUTPUT) / 1024, 2);
+        infoEmitFieldDouble(e, "instantaneous_input_repl_kbps",
+                            (float)getInstantaneousMetric(STATS_METRIC_NET_INPUT_REPLICATION) / 1024, 2);
+        infoEmitFieldDouble(e, "instantaneous_output_repl_kbps",
+                            (float)getInstantaneousMetric(STATS_METRIC_NET_OUTPUT_REPLICATION) / 1024, 2);
+        infoEmitCounterLL(e, "rejected_connections", server.stat_rejected_conn);
+        infoEmitCounterLL(e, "sync_full", server.stat_sync_full);
+        infoEmitCounterLL(e, "sync_partial_ok", server.stat_sync_partial_ok);
+        infoEmitCounterLL(e, "sync_partial_err", server.stat_sync_partial_err);
+        infoEmitCounterLL(e, "expired_keys", server.stat_expiredkeys);
+        infoEmitCounterLL(e, "expired_fields", server.stat_expiredfields);
+        infoEmitFieldDouble(e, "expired_stale_perc", server.stat_expired_keys_stale_perc * 100, 2);
+        infoEmitFieldDouble(e, "expired_keys_with_volatile_items_stale_perc",
+                            server.stat_expired_keys_with_vola_stale_perc * 100, 2);
+        infoEmitCounterLL(e, "expired_time_cap_reached_count", server.stat_expired_time_cap_reached_count);
+        infoEmitMetricLL(e, "expire_cycle_cpu_milliseconds", server.stat_expire_cycle_time_used / 1000,
+                         INFO_KIND_COUNTER, INFO_UNIT_MILLISECONDS);
+        infoEmitCounterLL(e, "evicted_keys", server.stat_evictedkeys);
+        infoEmitCounterLL(e, "evicted_clients", server.stat_evictedclients);
+        infoEmitCounterLL(e, "evicted_scripts", server.stat_evictedscripts);
+        infoEmitMetricLL(e, "total_eviction_exceeded_time",
+                         (server.stat_total_eviction_exceeded_time + current_eviction_exceeded_time) / 1000,
+                         INFO_KIND_COUNTER, INFO_UNIT_MILLISECONDS);
+        infoEmitMetricLL(e, "current_eviction_exceeded_time", current_eviction_exceeded_time / 1000, INFO_KIND_GAUGE,
+                         INFO_UNIT_MILLISECONDS);
+        infoEmitCounterLL(e, "keyspace_hits", server.stat_keyspace_hits);
+        infoEmitCounterLL(e, "keyspace_misses", server.stat_keyspace_misses);
+        infoEmitFieldULL(e, "pubsub_channels", kvstoreSize(server.pubsub_channels));
+        infoEmitFieldULL(e, "pubsub_patterns", dictSize(server.pubsub_patterns));
+        infoEmitFieldULL(e, "pubsubshard_channels", kvstoreSize(server.pubsubshard_channels));
+        infoEmitMetricLL(e, "latest_fork_usec", server.stat_fork_time, INFO_KIND_GAUGE, INFO_UNIT_MICROSECONDS);
+        infoEmitCounterLL(e, "total_forks", server.stat_total_forks);
+        infoEmitFieldULL(e, "migrate_cached_sockets", dictSize(server.migrate_cached_sockets));
+        infoEmitFieldULL(e, "slave_expires_tracked_keys", getReplicaKeyWithExpireCount());
+        infoEmitCounterLL(e, "active_defrag_hits", server.stat_active_defrag_hits);
+        infoEmitCounterLL(e, "active_defrag_misses", server.stat_active_defrag_misses);
+        infoEmitCounterLL(e, "active_defrag_key_hits", server.stat_active_defrag_key_hits);
+        infoEmitCounterLL(e, "active_defrag_key_misses", server.stat_active_defrag_key_misses);
+        infoEmitMetricLL(e, "total_active_defrag_time",
+                         (server.stat_total_active_defrag_time + current_active_defrag_time) / 1000, INFO_KIND_COUNTER,
+                         INFO_UNIT_MILLISECONDS);
+        infoEmitMetricLL(e, "current_active_defrag_time", current_active_defrag_time / 1000, INFO_KIND_GAUGE,
+                         INFO_UNIT_MILLISECONDS);
+        /* These print an unsigned count through the historical %lld specifier;
+         * reinterpret the same bits as signed to preserve byte-for-byte output. */
+        infoEmitFieldLL(e, "tracking_total_keys", (long long)(unsigned long long)trackingGetTotalKeys());
+        infoEmitFieldLL(e, "tracking_total_items", (long long)(unsigned long long)trackingGetTotalItems());
+        infoEmitFieldLL(e, "tracking_total_prefixes", (long long)(unsigned long long)trackingGetTotalPrefixes());
+        infoEmitCounterLL(e, "unexpected_error_replies", server.stat_unexpected_error_replies);
+        infoEmitCounterLL(e, "total_error_replies", server.stat_total_error_replies);
+        infoEmitCounterLL(e, "dump_payload_sanitizations", server.stat_dump_payload_sanitizations);
+        infoEmitCounterLL(e, "total_reads_processed", server.stat_total_reads_processed);
+        infoEmitCounterLL(e, "total_writes_processed", server.stat_total_writes_processed);
+        infoEmitCounterLL(e, "io_threaded_reads_processed", server.stat_io_reads_processed);
+        infoEmitCounterLL(e, "io_threaded_writes_processed", server.stat_io_writes_processed);
+        infoEmitCounterLL(e, "io_threaded_freed_objects", server.stat_io_freed_objects);
+        infoEmitCounterLL(e, "io_threaded_accept_processed", server.stat_io_accept_offloaded);
+        infoEmitCounterLL(e, "io_threaded_poll_processed", server.stat_poll_processed_by_io_threads);
+        infoEmitCounterLL(e, "io_threaded_total_prefetch_batches", server.stat_total_prefetch_batches);
+        infoEmitCounterLL(e, "io_threaded_total_prefetch_entries", server.stat_total_prefetch_entries);
+        infoEmitCounterLL(e, "client_query_buffer_limit_disconnections", server.stat_client_qbuf_limit_disconnections);
+        infoEmitCounterLL(e, "client_output_buffer_limit_disconnections",
+                          server.stat_client_outbuf_limit_disconnections);
+        infoEmitCounterLL(e, "reply_buffer_shrinks", server.stat_reply_buffer_shrinks);
+        infoEmitCounterLL(e, "reply_buffer_expands", server.stat_reply_buffer_expands);
+        infoEmitCounterULL(e, "eventloop_cycles", server.duration_stats[EL_DURATION_TYPE_EL].cnt);
+        infoEmitMetricULL(e, "eventloop_duration_sum", server.duration_stats[EL_DURATION_TYPE_EL].sum,
+                          INFO_KIND_COUNTER, INFO_UNIT_MICROSECONDS);
+        infoEmitMetricULL(e, "eventloop_duration_cmd_sum", server.duration_stats[EL_DURATION_TYPE_CMD].sum,
+                          INFO_KIND_COUNTER, INFO_UNIT_MICROSECONDS);
+        infoEmitFieldULL(e, "instantaneous_eventloop_cycles_per_sec",
+                         (unsigned long long)getInstantaneousMetric(STATS_METRIC_EL_CYCLE));
+        infoEmitFieldULL(e, "instantaneous_eventloop_duration_usec",
+                         (unsigned long long)getInstantaneousMetric(STATS_METRIC_EL_DURATION));
+        genValkeyInfoStringACLStats(e);
+        info = infoEmitterTextResult(&te);
     }
 
     /* Replication */
     if (all_sections || (dictFind(section_dict, "replication") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(info,
-                            "# Replication\r\n"
-                            "role:%s\r\n",
-                            server.primary_host == NULL ? "master" : "slave");
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Replication");
+        infoEmitFieldStr(e, "role", server.primary_host == NULL ? "master" : "slave");
         if (server.primary_host) {
             long long replica_repl_offset = 1;
             long long replica_read_repl_offset = 1;
@@ -6575,23 +6651,25 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 replica_read_repl_offset = server.cached_primary->repl_data->read_reploff;
             }
 
-            info = sdscatprintf(
-                info,
-                FMTARGS(
-                    "master_host:%s\r\n", server.primary_host,
-                    "master_port:%d\r\n", server.primary_port,
-                    "master_link_status:%s\r\n", (server.repl_state == REPL_STATE_CONNECTED) ? "up" : "down",
-                    "master_last_io_seconds_ago:%d\r\n", server.primary ? ((int)(server.unixtime - server.primary->last_interaction)) : -1,
-                    "master_sync_in_progress:%d\r\n", server.repl_state == REPL_STATE_TRANSFER,
-                    "slave_read_repl_offset:%lld\r\n", replica_read_repl_offset,
-                    "slave_repl_offset:%lld\r\n", replica_repl_offset,
-                    "replicas_repl_buffer_size:%zu\r\n", server.pending_repl_data.len,
-                    "replicas_repl_buffer_peak:%zu\r\n", server.pending_repl_data.peak));
+            infoEmitFieldStr(e, "master_host", server.primary_host);
+            infoEmitFieldLL(e, "master_port", server.primary_port);
+            infoEmitFieldStr(e, "master_link_status", (server.repl_state == REPL_STATE_CONNECTED) ? "up" : "down");
+            infoEmitMetricLL(e, "master_last_io_seconds_ago",
+                             server.primary ? ((int)(server.unixtime - server.primary->last_interaction)) : -1,
+                             INFO_KIND_GAUGE, INFO_UNIT_SECONDS);
+            infoEmitFieldLL(e, "master_sync_in_progress", server.repl_state == REPL_STATE_TRANSFER);
+            infoEmitFieldLL(e, "slave_read_repl_offset", replica_read_repl_offset);
+            infoEmitFieldLL(e, "slave_repl_offset", replica_repl_offset);
+            infoEmitMetricULL(e, "replicas_repl_buffer_size", server.pending_repl_data.len, INFO_KIND_GAUGE,
+                              INFO_UNIT_BYTES);
+            infoEmitMetricULL(e, "replicas_repl_buffer_peak", server.pending_repl_data.peak, INFO_KIND_GAUGE,
+                              INFO_UNIT_BYTES);
 
             if (server.repl_state == REPL_STATE_TRANSFER) {
                 off_t repl_transfer_size_stat;
                 off_t repl_transfer_read_stat;
-                if (atomic_load_explicit(&server.replica_bio_disk_save_state, memory_order_acquire) != REPL_BIO_DISK_SAVE_STATE_NONE) {
+                if (atomic_load_explicit(&server.replica_bio_disk_save_state, memory_order_acquire) !=
+                    REPL_BIO_DISK_SAVE_STATE_NONE) {
                     repl_transfer_size_stat = server.bio_repl_transfer_size;
                     repl_transfer_read_stat = server.bio_repl_transfer_read;
                 } else {
@@ -6602,34 +6680,35 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 if (repl_transfer_size_stat) {
                     perc = ((double)repl_transfer_read_stat / repl_transfer_size_stat) * 100;
                 }
-                info = sdscatprintf(
-                    info,
-                    FMTARGS(
-                        "master_sync_total_bytes:%lld\r\n", (long long)repl_transfer_size_stat,
-                        "master_sync_read_bytes:%lld\r\n", (long long)repl_transfer_read_stat,
-                        "master_sync_left_bytes:%lld\r\n", (long long)(repl_transfer_size_stat - repl_transfer_read_stat),
-                        "master_sync_perc:%.2f\r\n", perc,
-                        "master_sync_last_io_seconds_ago:%d\r\n", (int)(server.unixtime - server.repl_transfer_lastio)));
+                infoEmitMetricLL(e, "master_sync_total_bytes", (long long)repl_transfer_size_stat, INFO_KIND_GAUGE,
+                                 INFO_UNIT_BYTES);
+                infoEmitMetricLL(e, "master_sync_read_bytes", (long long)repl_transfer_read_stat, INFO_KIND_GAUGE,
+                                 INFO_UNIT_BYTES);
+                infoEmitMetricLL(e, "master_sync_left_bytes",
+                                 (long long)(repl_transfer_size_stat - repl_transfer_read_stat), INFO_KIND_GAUGE,
+                                 INFO_UNIT_BYTES);
+                infoEmitFieldDouble(e, "master_sync_perc", perc, 2);
+                infoEmitMetricLL(e, "master_sync_last_io_seconds_ago",
+                                 (int)(server.unixtime - server.repl_transfer_lastio), INFO_KIND_GAUGE,
+                                 INFO_UNIT_SECONDS);
             }
 
             if (server.repl_state != REPL_STATE_CONNECTED) {
-                info = sdscatprintf(info, "master_link_down_since_seconds:%jd\r\n",
-                                    server.repl_down_since ? (intmax_t)(server.unixtime - server.repl_down_since) : -1);
+                infoEmitMetricLL(e, "master_link_down_since_seconds",
+                                 server.repl_down_since ? (long long)(server.unixtime - server.repl_down_since) : -1,
+                                 INFO_KIND_GAUGE, INFO_UNIT_SECONDS);
             }
-            info = sdscatprintf(
-                info,
-                FMTARGS(
-                    "slave_priority:%d\r\n", server.replica_priority,
-                    "slave_read_only:%d\r\n", server.repl_replica_ro,
-                    "replica_announced:%d\r\n", server.replica_announced));
+            infoEmitFieldLL(e, "slave_priority", server.replica_priority);
+            infoEmitFieldLL(e, "slave_read_only", server.repl_replica_ro);
+            infoEmitFieldLL(e, "replica_announced", server.replica_announced);
         }
 
-        info = sdscatprintf(info, "connected_slaves:%lu\r\n", listLength(server.replicas));
+        infoEmitFieldULL(e, "connected_slaves", listLength(server.replicas));
 
         /* If min-replicas-to-write is active, write the number of replicas
          * currently considered 'good'. */
         if (server.repl_min_replicas_to_write && server.repl_min_replicas_max_lag) {
-            info = sdscatprintf(info, "min_slaves_good_slaves:%d\r\n", server.repl_good_replicas_count);
+            infoEmitFieldLL(e, "min_slaves_good_slaves", server.repl_good_replicas_count);
         }
 
         if (listLength(server.replicas)) {
@@ -6650,142 +6729,169 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 }
                 const char *state = replstateToString(replica->repl_data->repl_state);
                 if (state[0] == '\0') continue;
-                if (replica->repl_data->repl_state == REPLICA_STATE_ONLINE) lag = time(NULL) - replica->repl_data->repl_ack_time;
+                if (replica->repl_data->repl_state == REPLICA_STATE_ONLINE)
+                    lag = time(NULL) - replica->repl_data->repl_ack_time;
 
-                info = sdscatprintf(info,
-                                    "slave%d:ip=%s,port=%d,state=%s,"
-                                    "offset=%lld,lag=%ld,type=%s\r\n",
-                                    replica_id, replica_ip, replica->repl_data->replica_listening_port, state,
-                                    replica->repl_data->repl_ack_off, lag,
-                                    replica->flag.repl_rdb_channel                                ? "rdb-channel"
-                                    : replica->repl_data->repl_state == REPLICA_STATE_BG_RDB_LOAD ? "main-channel"
-                                                                                                  : "replica");
+                /* Composite per-replica line: slaveN:ip=..,port=..,.. */
+                char replica_key[32];
+                snprintf(replica_key, sizeof(replica_key), "slave%d", replica_id);
+                infoEmitBeginDict(e, replica_key);
+                infoEmitDictStr(e, "ip", replica_ip);
+                infoEmitDictLL(e, "port", replica->repl_data->replica_listening_port);
+                infoEmitDictStr(e, "state", state);
+                infoEmitDictLL(e, "offset", replica->repl_data->repl_ack_off);
+                infoEmitDictLL(e, "lag", lag);
+                infoEmitDictStr(e, "type",
+                                replica->flag.repl_rdb_channel                                ? "rdb-channel"
+                                : replica->repl_data->repl_state == REPLICA_STATE_BG_RDB_LOAD ? "main-channel"
+                                                                                              : "replica");
+                infoEmitEndDict(e);
                 replica_id++;
             }
         }
-        info = sdscatprintf(
-            info,
-            FMTARGS(
-                "replicas_waiting_psync:%llu\r\n", (unsigned long long)raxSize(server.replicas_waiting_psync),
-                "master_failover_state:%s\r\n", getFailoverStateString(),
-                "master_replid:%s\r\n", server.replid,
-                "master_replid2:%s\r\n", server.replid2,
-                "master_repl_offset:%lld\r\n", server.primary_repl_offset,
-                "second_repl_offset:%lld\r\n", server.second_replid_offset,
-                "repl_backlog_active:%d\r\n", server.repl_backlog != NULL,
-                "repl_backlog_size:%lld\r\n", server.repl_backlog_size,
-                "repl_backlog_first_byte_offset:%lld\r\n", server.repl_backlog ? server.repl_backlog->offset : 0,
-                "repl_backlog_histlen:%lld\r\n", server.repl_backlog ? server.repl_backlog->histlen : 0));
+        infoEmitFieldULL(e, "replicas_waiting_psync", (unsigned long long)raxSize(server.replicas_waiting_psync));
+        infoEmitFieldStr(e, "master_failover_state", getFailoverStateString());
+        infoEmitFieldStr(e, "master_replid", server.replid);
+        infoEmitFieldStr(e, "master_replid2", server.replid2);
+        infoEmitFieldLL(e, "master_repl_offset", server.primary_repl_offset);
+        infoEmitFieldLL(e, "second_repl_offset", server.second_replid_offset);
+        infoEmitFieldLL(e, "repl_backlog_active", server.repl_backlog != NULL);
+        infoEmitMetricLL(e, "repl_backlog_size", server.repl_backlog_size, INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        infoEmitFieldLL(e, "repl_backlog_first_byte_offset", server.repl_backlog ? server.repl_backlog->offset : 0);
+        infoEmitMetricLL(e, "repl_backlog_histlen", server.repl_backlog ? server.repl_backlog->histlen : 0,
+                         INFO_KIND_GAUGE, INFO_UNIT_BYTES);
+        info = infoEmitterTextResult(&te);
     }
 
     /* CPU */
     if (all_sections || (dictFind(section_dict, "cpu") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
-
         struct rusage self_ru, c_ru;
         getrusage(RUSAGE_SELF, &self_ru);
         getrusage(RUSAGE_CHILDREN, &c_ru);
-        info = sdscatprintf(info,
-                            "# CPU\r\n"
-                            "used_cpu_sys:%ld.%06ld\r\n"
-                            "used_cpu_user:%ld.%06ld\r\n"
-                            "used_cpu_sys_children:%ld.%06ld\r\n"
-                            "used_cpu_user_children:%ld.%06ld\r\n",
-                            (long)self_ru.ru_stime.tv_sec, (long)self_ru.ru_stime.tv_usec,
-                            (long)self_ru.ru_utime.tv_sec, (long)self_ru.ru_utime.tv_usec, (long)c_ru.ru_stime.tv_sec,
-                            (long)c_ru.ru_stime.tv_usec, (long)c_ru.ru_utime.tv_sec, (long)c_ru.ru_utime.tv_usec);
+
+        /* Emit via the info emitter's text backend. field_usec takes the total
+         * microseconds and renders "sec.usec", reproducing the legacy
+         * "%ld.%06ld" / "%lld.%06lld" formatting byte-for-byte. begin_section
+         * owns the inter-section separator via the shared counter. */
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "CPU");
+        infoEmitFieldUsec(e, "used_cpu_sys", (long long)self_ru.ru_stime.tv_sec * 1000000 + self_ru.ru_stime.tv_usec);
+        infoEmitFieldUsec(e, "used_cpu_user", (long long)self_ru.ru_utime.tv_sec * 1000000 + self_ru.ru_utime.tv_usec);
+        infoEmitFieldUsec(e, "used_cpu_sys_children", (long long)c_ru.ru_stime.tv_sec * 1000000 + c_ru.ru_stime.tv_usec);
+        infoEmitFieldUsec(e, "used_cpu_user_children",
+                          (long long)c_ru.ru_utime.tv_sec * 1000000 + c_ru.ru_utime.tv_usec);
 #ifdef RUSAGE_THREAD
         struct rusage m_ru;
         getrusage(RUSAGE_THREAD, &m_ru);
-        info = sdscatprintf(info,
-                            "used_cpu_sys_main_thread:%ld.%06ld\r\n"
-                            "used_cpu_user_main_thread:%ld.%06ld\r\n",
-                            (long)m_ru.ru_stime.tv_sec, (long)m_ru.ru_stime.tv_usec, (long)m_ru.ru_utime.tv_sec,
-                            (long)m_ru.ru_utime.tv_usec);
+        infoEmitFieldUsec(e, "used_cpu_sys_main_thread",
+                          (long long)m_ru.ru_stime.tv_sec * 1000000 + m_ru.ru_stime.tv_usec);
+        infoEmitFieldUsec(e, "used_cpu_user_main_thread",
+                          (long long)m_ru.ru_utime.tv_sec * 1000000 + m_ru.ru_utime.tv_usec);
 #endif /* RUSAGE_THREAD */
-        long long active_seconds = server.stat_active_time / 1000000;
-        ustime_t active_microseconds = server.stat_active_time % 1000000;
-        info = sdscatprintf(info,
-                            "used_active_time_main_thread:%lld.%06lld\r\n",
-                            active_seconds, active_microseconds);
+        infoEmitFieldUsec(e, "used_active_time_main_thread", server.stat_active_time);
         for (int i = 1; i < server.io_threads_num; i++) {
-            ustime_t used_active_time_io_thread = getIOThreadActiveTimeMicroseconds(i);
-            info = sdscatprintf(info,
-                                "used_active_time_io_thread_%d:%lld.%06lld\r\n",
-                                i,
-                                used_active_time_io_thread / 1000000,
-                                used_active_time_io_thread % 1000000);
+            char key[64];
+            snprintf(key, sizeof(key), "used_active_time_io_thread_%d", i);
+            infoEmitFieldUsec(e, key, getIOThreadActiveTimeMicroseconds(i));
         }
+        info = infoEmitterTextResult(&te);
     }
 
     /* Modules */
     if (all_sections || (dictFind(section_dict, "module_list") != NULL) ||
         (dictFind(section_dict, "modules") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(info, "# Modules\r\n");
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitBeginSection(&te.e, "Modules");
+        info = infoEmitterTextResult(&te);
+        /* Module-provided fields are still built by the module INFO callbacks
+         * (VM_InfoAddField*); routing that API through the emitter is a
+         * follow-up. The section header is emitted via the emitter above. */
         info = genModulesInfoString(info);
     }
 
     /* Command statistics */
     if (all_sections || (dictFind(section_dict, "commandstats") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(info, "# Commandstats\r\n");
-        info = genValkeyInfoStringCommandStats(info, server.commands);
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Commandstats");
+        genValkeyInfoStringCommandStats(e, server.commands);
+        info = infoEmitterTextResult(&te);
     }
 
     /* Error statistics */
     if (all_sections || (dictFind(section_dict, "errorstats") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscat(info, "# Errorstats\r\n");
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Errorstats");
         raxIterator ri;
         raxStart(&ri, server.errors);
         raxSeek(&ri, "^", NULL, 0);
-        struct serverError *e;
+        struct serverError *err;
         while (raxNext(&ri)) {
             char *tmpsafe;
-            e = (struct serverError *)ri.data;
-            info = sdscatprintf(info, "errorstat_%.*s:count=%lld\r\n", (int)ri.key_len,
-                                getSafeInfoString((char *)ri.key, ri.key_len, &tmpsafe), e->count);
+            err = (struct serverError *)ri.data;
+            sds key = sdscatprintf(sdsempty(), "errorstat_%.*s", (int)ri.key_len,
+                                   getSafeInfoString((char *)ri.key, ri.key_len, &tmpsafe));
             if (tmpsafe != NULL) zfree(tmpsafe);
+            infoEmitBeginDict(e, key);
+            sdsfree(key);
+            infoEmitDictCounterLL(e, "count", err->count);
+            infoEmitEndDict(e);
         }
         raxStop(&ri);
+        info = infoEmitterTextResult(&te);
     }
 
     /* Latency by percentile distribution per command */
     if (all_sections || (dictFind(section_dict, "latencystats") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(info, "# Latencystats\r\n");
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Latencystats");
         if (server.latency_tracking_enabled) {
-            info = genValkeyInfoStringLatencyStats(info, server.commands);
+            genValkeyInfoStringLatencyStats(e, server.commands);
         }
+        info = infoEmitterTextResult(&te);
     }
 
     /* Cluster */
     if (all_sections || (dictFind(section_dict, "cluster") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(info,
-                            "# Cluster\r\n"
-                            "cluster_enabled:%d\r\n",
-                            server.cluster_enabled);
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Cluster");
+        infoEmitFieldLL(e, "cluster_enabled", server.cluster_enabled);
+        info = infoEmitterTextResult(&te);
     }
 
     /* Cluster Info */
     if (all_sections || (dictFind(section_dict, "cluster_info") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(info, "# Cluster Info\r\n");
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitBeginSection(&te.e, "Cluster Info");
+        info = infoEmitterTextResult(&te);
         if (server.cluster_enabled) info = genClusterInfoString(info);
     }
 
     /* Scripting engines */
     if (all_sections || (dictFind(section_dict, "scriptingengines") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
-        info = genValkeyInfoStringScriptingEngines(info);
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        genValkeyInfoStringScriptingEngines(&te.e);
+        info = infoEmitterTextResult(&te);
     }
 
     /* Key space */
     if (all_sections || (dictFind(section_dict, "keyspace") != NULL)) {
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(info, "# Keyspace\r\n");
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Keyspace");
         for (j = 0; j < server.dbnum; j++) {
             serverDb *db = server.db[j];
             if (db == NULL) continue;
@@ -6796,10 +6902,17 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             keysvitems = kvstoreSize(db->keys_with_volatile_items);
 
             if (keys || vkeys) {
-                info = sdscatprintf(info, "db%d:keys=%lld,expires=%lld,avg_ttl=%lld,keys_with_volatile_items=%lld\r\n", j, keys, vkeys,
-                                    db->expiry[KEYS].avg_ttl, keysvitems);
+                char key[32];
+                snprintf(key, sizeof(key), "db%d", j);
+                infoEmitBeginDict(e, key);
+                infoEmitDictLL(e, "keys", keys);
+                infoEmitDictLL(e, "expires", vkeys);
+                infoEmitDictLL(e, "avg_ttl", db->expiry[KEYS].avg_ttl);
+                infoEmitDictLL(e, "keys_with_volatile_items", keysvitems);
+                infoEmitEndDict(e);
             }
         }
+        info = infoEmitterTextResult(&te);
     }
 
     /* Get info from modules.
@@ -6815,16 +6928,20 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
     }
 
     if (dictFind(section_dict, "debug") != NULL) {
-        if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(
-            info,
-            "# Debug\r\n" FMTARGS(
-                "eventloop_duration_aof_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_AOF].sum,
-                "eventloop_duration_cron_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_CRON].sum,
-                "eventloop_duration_max:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_EL].max,
-                "eventloop_cmd_per_cycle_max:%lld\r\n", server.el_cmd_cnt_max,
-                "io_threaded_reads_pending:%lld\r\n", server.stat_io_reads_pending,
-                "io_threaded_writes_pending:%lld\r\n", server.stat_io_writes_pending));
+        infoEmitterText te;
+        infoEmitterTextInit(&te, info, &sections);
+        infoEmitter *e = &te.e;
+        infoEmitBeginSection(e, "Debug");
+        infoEmitMetricULL(e, "eventloop_duration_aof_sum", server.duration_stats[EL_DURATION_TYPE_AOF].sum,
+                          INFO_KIND_COUNTER, INFO_UNIT_MICROSECONDS);
+        infoEmitMetricULL(e, "eventloop_duration_cron_sum", server.duration_stats[EL_DURATION_TYPE_CRON].sum,
+                          INFO_KIND_COUNTER, INFO_UNIT_MICROSECONDS);
+        infoEmitMetricULL(e, "eventloop_duration_max", server.duration_stats[EL_DURATION_TYPE_EL].max, INFO_KIND_GAUGE,
+                          INFO_UNIT_MICROSECONDS);
+        infoEmitFieldLL(e, "eventloop_cmd_per_cycle_max", server.el_cmd_cnt_max);
+        infoEmitFieldLL(e, "io_threaded_reads_pending", server.stat_io_reads_pending);
+        infoEmitFieldLL(e, "io_threaded_writes_pending", server.stat_io_writes_pending);
+        info = infoEmitterTextResult(&te);
     }
 
     return info;

--- a/src/server.h
+++ b/src/server.h
@@ -3368,7 +3368,8 @@ void ACLFreeUserAndKillClients(user *u);
 void addACLLogEntry(client *c, int reason, int context, int argpos, sds username, sds object);
 sds getAclErrorMessage(int acl_res, user *user, struct serverCommand *cmd, sds errored_val, int verbose);
 void ACLUpdateDefaultUserPassword(sds password);
-sds genValkeyInfoStringACLStats(sds info);
+typedef struct infoEmitter infoEmitter;
+void genValkeyInfoStringACLStats(infoEmitter *e);
 void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void);
 
 /* Sorted sets data type */

--- a/src/server.h
+++ b/src/server.h
@@ -4265,6 +4265,8 @@ const char *getSafeInfoString(const char *s, size_t len, char **tmp);
 dict *genInfoSectionDict(robj **argv, int argc, char **defaults, int *out_all, int *out_everything);
 void releaseInfoSectionDict(dict *sec);
 sds genValkeyInfoString(dict *section_dict, int all_sections, int everything);
+void genValkeyInfoToEmitter(infoEmitter *e, int *section_counter, dict *section_dict, int all_sections, int everything);
+void modulesCollectInfoToEmitter(infoEmitter *e, dict *sections_dict, int for_crash_report);
 sds genModulesInfoString(sds info);
 void applyWatchdogPeriod(void);
 void watchdogScheduleSignal(int period);

--- a/src/unit/test_info_emitter.cpp
+++ b/src/unit/test_info_emitter.cpp
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* Unit tests for the info emitter text backend (src/info_emitter.c).
+ *
+ * Two levels of coverage:
+ *   1. Per field-kind checks that the text backend renders each typed field
+ *      exactly as the legacy INFO formatting does.
+ *   2. A byte-for-byte parity test that reconstructs the CPU section using the
+ *      *original* inline format strings and asserts the emitter produces the
+ *      identical bytes for the same fixed inputs. This guards the pilot
+ *      conversion of the CPU section in genValkeyInfoString(). */
+
+#include "generated_wrappers.hpp"
+
+#include <functional>
+#include <string>
+
+extern "C" {
+#include "fmacros.h"
+#include "info_emitter.h"
+#include "sds.h"
+}
+
+namespace {
+
+/* Run `fn` against a fresh text emitter and return the accumulated bytes.
+ * The section counter starts at 0, so begin_section emits no leading separator
+ * (matches the "first section" case: output starts directly with "# ..."). */
+std::string emit(const std::function<void(infoEmitter *)> &fn) {
+    infoEmitterText te;
+    int sections = 0;
+    infoEmitterTextInit(&te, sdsempty(), &sections);
+    fn(&te.e);
+    sds s = infoEmitterTextResult(&te);
+    std::string out(s, sdslen(s));
+    sdsfree(s);
+    return out;
+}
+
+} // namespace
+
+class InfoEmitterTextTest : public ::testing::Test {};
+
+TEST_F(InfoEmitterTextTest, BeginSection) {
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitBeginSection(e, "CPU"); }), "# CPU\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, FieldLL) {
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldLL(e, "connected_clients", 42); }), "connected_clients:42\r\n");
+    /* Negative and boundary values render with the same digits as %lld/%ld/%d. */
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldLL(e, "k", -1); }), "k:-1\r\n");
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldLL(e, "k", -9223372036854775807LL - 1); }),
+              "k:-9223372036854775808\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, FieldULL) {
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldULL(e, "used_memory", 1002384ULL); }), "used_memory:1002384\r\n");
+    /* Full unsigned 64-bit range (matches %llu / %lu / %zu digits). */
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldULL(e, "k", 18446744073709551615ULL); }),
+              "k:18446744073709551615\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, FieldDoublePrecision) {
+    /* mem_fragmentation_ratio uses %.2f. */
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldDouble(e, "ratio", 1.5, 2); }), "ratio:1.50\r\n");
+    /* CPU-style precision uses %.6f. */
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldDouble(e, "x", 0.1, 6); }), "x:0.100000\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, PercentUnitAppendsSign) {
+    /* INFO_UNIT_PERCENT reproduces the legacy "%.2f%%" (trailing literal '%'). */
+    EXPECT_EQ(emit([](infoEmitter *e) {
+                  infoEmitMetricDouble(e, "used_memory_peak_perc", 3.14, 2, INFO_KIND_GAUGE, INFO_UNIT_PERCENT);
+              }),
+              "used_memory_peak_perc:3.14%\r\n");
+    /* A non-percent double with the same value has no trailing '%'. */
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldDouble(e, "x", 3.14, 2); }), "x:3.14\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, MetadataIgnoredByTextForIntegers) {
+    /* kind/unit are for structured backends; the text backend renders the same
+     * integer regardless of counter-vs-gauge or unit. */
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitCounterLL(e, "k", 42); }), "k:42\r\n");
+    EXPECT_EQ(emit([](infoEmitter *e) {
+                  infoEmitMetricLL(e, "k", 42, INFO_KIND_COUNTER, INFO_UNIT_BYTES);
+              }),
+              "k:42\r\n");
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldLL(e, "k", 42); }), "k:42\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, FieldStr) {
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldStr(e, "role", "master"); }), "role:master\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, FieldUsec) {
+    /* Total microseconds render as "sec.usec" with 6-digit zero-padded frac,
+     * matching the legacy "%ld.%06ld" / "%lld.%06lld" formatting. */
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldUsec(e, "used_cpu_sys", 1234567); }), "used_cpu_sys:1.234567\r\n");
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldUsec(e, "k", 999999); }), "k:0.999999\r\n");
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldUsec(e, "k", 60000000); }), "k:60.000000\r\n");
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldUsec(e, "k", 0); }), "k:0.000000\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, DictComposite) {
+    /* Keyspace-style composite line: key:sub1=v1,sub2=v2\r\n */
+    EXPECT_EQ(emit([](infoEmitter *e) {
+                  infoEmitBeginDict(e, "db0");
+                  infoEmitDictLL(e, "keys", 50);
+                  infoEmitDictLL(e, "expires", 0);
+                  infoEmitDictLL(e, "avg_ttl", 0);
+                  infoEmitEndDict(e);
+              }),
+              "db0:keys=50,expires=0,avg_ttl=0\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, DictSingleField) {
+    EXPECT_EQ(emit([](infoEmitter *e) {
+                  infoEmitBeginDict(e, "d");
+                  infoEmitDictStr(e, "name", "x");
+                  infoEmitEndDict(e);
+              }),
+              "d:name=x\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, Raw) {
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitRaw(e, "custom:%d\r\n", 7); }), "custom:7\r\n");
+}
+
+/* Byte-for-byte parity: rebuild the CPU section with the exact legacy format
+ * strings for a fixed set of inputs, then produce the same section through the
+ * emitter, and assert the two byte streams are identical. */
+TEST_F(InfoEmitterTextTest, CpuSectionByteParity) {
+    /* Fixed, deterministic inputs (seconds, microseconds). */
+    const long sys_s = 12, sys_us = 345678;
+    const long usr_s = 7, usr_us = 1;
+    const long csys_s = 0, csys_us = 0;
+    const long cusr_s = 100, cusr_us = 999999;
+    const long msys_s = 3, msys_us = 14;
+    const long musr_s = 2, musr_us = 718281;
+    const long long active = 5000123; /* used_active_time_main_thread */
+    const long long io1 = 250000, io2 = 61000000;
+
+    /* --- Legacy formatting (copied from the pre-refactor genValkeyInfoString) --- */
+    sds legacy = sdsempty();
+    legacy = sdscatprintf(legacy,
+                          "# CPU\r\n"
+                          "used_cpu_sys:%ld.%06ld\r\n"
+                          "used_cpu_user:%ld.%06ld\r\n"
+                          "used_cpu_sys_children:%ld.%06ld\r\n"
+                          "used_cpu_user_children:%ld.%06ld\r\n",
+                          sys_s, sys_us, usr_s, usr_us, csys_s, csys_us, cusr_s, cusr_us);
+    legacy = sdscatprintf(legacy,
+                          "used_cpu_sys_main_thread:%ld.%06ld\r\n"
+                          "used_cpu_user_main_thread:%ld.%06ld\r\n",
+                          msys_s, msys_us, musr_s, musr_us);
+    legacy = sdscatprintf(legacy, "used_active_time_main_thread:%lld.%06lld\r\n", active / 1000000, active % 1000000);
+    legacy = sdscatprintf(legacy, "used_active_time_io_thread_%d:%lld.%06lld\r\n", 1, io1 / 1000000, io1 % 1000000);
+    legacy = sdscatprintf(legacy, "used_active_time_io_thread_%d:%lld.%06lld\r\n", 2, io2 / 1000000, io2 % 1000000);
+    std::string expected(legacy, sdslen(legacy));
+    sdsfree(legacy);
+
+    /* --- Emitter formatting (mirrors the refactored CPU section) --- */
+    std::string actual = emit([&](infoEmitter *e) {
+        infoEmitBeginSection(e, "CPU");
+        infoEmitFieldUsec(e, "used_cpu_sys", (long long)sys_s * 1000000 + sys_us);
+        infoEmitFieldUsec(e, "used_cpu_user", (long long)usr_s * 1000000 + usr_us);
+        infoEmitFieldUsec(e, "used_cpu_sys_children", (long long)csys_s * 1000000 + csys_us);
+        infoEmitFieldUsec(e, "used_cpu_user_children", (long long)cusr_s * 1000000 + cusr_us);
+        infoEmitFieldUsec(e, "used_cpu_sys_main_thread", (long long)msys_s * 1000000 + msys_us);
+        infoEmitFieldUsec(e, "used_cpu_user_main_thread", (long long)musr_s * 1000000 + musr_us);
+        infoEmitFieldUsec(e, "used_active_time_main_thread", active);
+        for (int i = 1; i <= 2; i++) {
+            char key[64];
+            snprintf(key, sizeof(key), "used_active_time_io_thread_%d", i);
+            infoEmitFieldUsec(e, key, i == 1 ? io1 : io2);
+        }
+    });
+
+    EXPECT_EQ(actual, expected);
+}
+
+/* Stats-section parity for the %.2f fields whose legacy argument is a
+ * "(float)value / 1024" expression (instantaneous_*_kbps) or a "double * 100"
+ * expression (expired_stale_perc). The float case is the subtle one: the value
+ * is computed in float precision, then widened to double for %.2f. field_double
+ * takes a double, so the same widening yields identical bytes. */
+TEST_F(InfoEmitterTextTest, StatsFloat2fParity) {
+    /* kbps: (float)metric / 1024, rendered with %.2f. Pick values that exercise
+     * rounding at the 2nd decimal. */
+    const long long metrics[] = {0, 1500, 1048576, 123456789};
+    for (long long m : metrics) {
+        float kbps = (float)m / 1024;
+        sds legacy = sdscatprintf(sdsempty(), "instantaneous_input_kbps:%.2f\r\n", (double)kbps);
+        std::string expected(legacy, sdslen(legacy));
+        sdsfree(legacy);
+        std::string actual =
+            emit([&](infoEmitter *e) { infoEmitFieldDouble(e, "instantaneous_input_kbps", (double)kbps, 2); });
+        EXPECT_EQ(actual, expected) << "kbps mismatch for metric=" << m;
+    }
+
+    /* percentage: double * 100, rendered with %.2f. */
+    const double percs[] = {0.0, 0.5, 0.123456, 1.0};
+    for (double p : percs) {
+        double v = p * 100;
+        sds legacy = sdscatprintf(sdsempty(), "expired_stale_perc:%.2f\r\n", v);
+        std::string expected(legacy, sdslen(legacy));
+        sdsfree(legacy);
+        std::string actual = emit([&](infoEmitter *e) { infoEmitFieldDouble(e, "expired_stale_perc", v, 2); });
+        EXPECT_EQ(actual, expected) << "perc mismatch for p=" << p;
+    }
+}
+
+/* begin_section owns the inter-section "\r\n" separator: none before the first
+ * section, one before each subsequent section, matching the legacy
+ * "if (sections++) sdscat("\r\n")" behavior. The counter is shared with any
+ * legacy inline sections still present during migration. */
+TEST_F(InfoEmitterTextTest, SectionSeparatorOwnedByEmitter) {
+    infoEmitterText te;
+    int sections = 0;
+    infoEmitterTextInit(&te, sdsempty(), &sections);
+    infoEmitBeginSection(&te.e, "Alpha");
+    infoEmitFieldLL(&te.e, "a", 1);
+    infoEmitBeginSection(&te.e, "Beta");
+    infoEmitFieldLL(&te.e, "b", 2);
+    sds s = infoEmitterTextResult(&te);
+    std::string out(s, sdslen(s));
+    sdsfree(s);
+    EXPECT_EQ(out, "# Alpha\r\na:1\r\n\r\n# Beta\r\nb:2\r\n");
+    EXPECT_EQ(sections, 2);
+}
+
+/* When the caller starts the counter above zero (a prior legacy section already
+ * emitted), the first emitter section is correctly separated too. */
+TEST_F(InfoEmitterTextTest, SectionSeparatorRespectsPriorSections) {
+    infoEmitterText te;
+    int sections = 1; /* Pretend a legacy inline section ran first. */
+    infoEmitterTextInit(&te, sdsempty(), &sections);
+    infoEmitBeginSection(&te.e, "CPU");
+    sds s = infoEmitterTextResult(&te);
+    std::string out(s, sdslen(s));
+    sdsfree(s);
+    EXPECT_EQ(out, "\r\n# CPU\r\n");
+    EXPECT_EQ(sections, 2);
+}
+
+/* Cluster-section parity: single cluster_enabled field via field_ll. */
+TEST_F(InfoEmitterTextTest, ClusterSectionParity) {
+    for (int enabled = 0; enabled <= 1; enabled++) {
+        sds legacy = sdscatprintf(sdsempty(), "# Cluster\r\ncluster_enabled:%d\r\n", enabled);
+        std::string expected(legacy, sdslen(legacy));
+        sdsfree(legacy);
+        std::string actual = emit([&](infoEmitter *e) {
+            infoEmitBeginSection(e, "Cluster");
+            infoEmitFieldLL(e, "cluster_enabled", enabled);
+        });
+        EXPECT_EQ(actual, expected);
+    }
+}

--- a/src/unit/test_info_emitter.cpp
+++ b/src/unit/test_info_emitter.cpp
@@ -126,6 +126,57 @@ TEST_F(InfoEmitterTextTest, DictSingleField) {
               "d:name=x\r\n");
 }
 
+TEST_F(InfoEmitterTextTest, DictULL) {
+    /* Unsigned dict values (module VM_InfoAddFieldULongLong in a dict). */
+    EXPECT_EQ(emit([](infoEmitter *e) {
+                  infoEmitBeginDict(e, "d");
+                  infoEmitDictULL(e, "u", 18446744073709551614ULL);
+                  infoEmitEndDict(e);
+              }),
+              "d:u=18446744073709551614\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, DoubleFullPrecision) {
+    /* prec == INFO_PREC_FULL renders "%.17g" (module VM_InfoAddFieldDouble). */
+    EXPECT_EQ(emit([](infoEmitter *e) { infoEmitFieldDouble(e, "val", 3.3, INFO_PREC_FULL); }),
+              "val:3.2999999999999998\r\n");
+    EXPECT_EQ(emit([](infoEmitter *e) {
+                  infoEmitBeginDict(e, "d");
+                  infoEmitDictDouble(e, "x", 3.3, INFO_PREC_FULL);
+                  infoEmitEndDict(e);
+              }),
+              "d:x=3.2999999999999998\r\n");
+}
+
+TEST_F(InfoEmitterTextTest, StrnPreservesLength) {
+    /* field_strn/dict_strn use an explicit length (matching sds %S), so values
+     * with embedded NULs are reproduced in full rather than truncated. */
+    std::string val("ab\0cd", 5);
+    EXPECT_EQ(emit([&](infoEmitter *e) { infoEmitFieldStrn(e, "k", val.data(), val.size()); }),
+              std::string("k:ab\0cd\r\n", 9));
+    EXPECT_EQ(emit([&](infoEmitter *e) {
+                  infoEmitBeginDict(e, "d");
+                  infoEmitDictStrn(e, "s", val.data(), val.size());
+                  infoEmitEndDict(e);
+              }),
+              std::string("d:s=ab\0cd\r\n", 11));
+}
+
+TEST_F(InfoEmitterTextTest, BufferGrowExactBytes) {
+    /* Force the reply sds to grow well past SDS_MAX_PREALLOC (via a large value)
+     * and across thousands of fields, exercising the ie_reserve ->
+     * sdsMakeRoomFor realloc path, then assert the output is exactly correct. */
+    std::string big(200000, 'x'); /* single 200KB field value */
+    std::string out = emit([&](infoEmitter *e) {
+        infoEmitBeginSection(e, "Big");
+        infoEmitFieldStrn(e, "blob", big.data(), big.size());
+        for (long long i = 0; i < 5000; i++) infoEmitFieldLL(e, "n", i);
+    });
+    std::string expected = "# Big\r\nblob:" + big + "\r\n";
+    for (long long i = 0; i < 5000; i++) expected += "n:" + std::to_string(i) + "\r\n";
+    EXPECT_EQ(out, expected);
+}
+
 TEST_F(InfoEmitterTextTest, Raw) {
     EXPECT_EQ(emit([](infoEmitter *e) { infoEmitRaw(e, "custom:%d\r\n", 7); }), "custom:7\r\n");
 }


### PR DESCRIPTION
Part of #4078.

## What

Step 1 of adding OpenTelemetry (OTLP) metrics export (see #4078): decouple
`INFO` field generation from text formatting by introducing an **info emitter**
abstraction, so the same generation code can target the text `INFO` output today
and structured backends (OTLP metrics) in the future — without generating the
`INFO` string and parsing it back.

This is a **refactor with no functional change**: the `INFO` wire format is
unchanged (byte-for-byte).

## Commits

1. `refactor(info)` — introduce the emitter + text backend and convert every
   section of `genValkeyInfoString()` and its helpers.
2. `fix(info)` — request exactly the field size from `sdsMakeRoomFor` so the
   INFO reply buffer isn't over-allocated (see Performance/Testing).
3. `refactor(module)` — route the module INFO callback API through the emitter
   too, so module-provided fields also reach structured backends as typed values.

## Details

- New `src/info_emitter.{c,h}`: a backend vtable over "emit a section / emit a
  typed field" plus a **text backend**. Field kinds cover int/uint/
  double-with-precision/string/duration/dict and carry per-field metadata —
  `kind` (gauge vs counter) and `unit` (bytes/seconds/ms/us/percent) — so future
  structured backends get correct semantics without name heuristics. The text
  backend ignores metadata except `PERCENT` (to reproduce `%.2f%%`) and a
  full-precision `%.17g` mode used by the module API.
- All sections of `genValkeyInfoString()` and its helpers (commandstats,
  errorstats, latencystats, aclstats, scripting engines) emit through the
  interface. The inter-section separator is owned by the emitter, keeping call
  sites format-agnostic.
- The module INFO callback API (`VM_InfoAddSection` / `VM_InfoAddField*` /
  `VM_InfoBeginDictField` / `VM_InfoEndDictField`) now emits through the emitter
  via `modulesCollectInfo()`. The public module API and its output are unchanged.

## Backward compatibility

`INFO` output is **byte-for-byte identical**, for both core sections and
module-provided sections. Verified by diffing `INFO everything` from an
unmodified build against this build — identical after normalizing inherently
non-deterministic values (timestamps, memory, random ids, git sha) and the
process-nondeterministic hashtable iteration order of the
Commandstats/Latencystats sections. The `tests/unit/moduleapi/infotest`
integration suite passes (exercises the full module INFO API, including dict and
unsafe fields).

## Performance

The text backend writes fields directly into the `sds` buffer using
`ll2string`/`ull2string` (no per-field `vsnprintf`, single copy), so `INFO`
generation is **faster** than the previous batched `sdscatprintf`
implementation — roughly +5–10% on `INFO everything` (CPU-pinned, interleaved).
The command hot path (SET/GET) is not on the emitter path and is unaffected
(measured identical).

The `fix(info)` commit addresses a subtlety found by the `maxmemory` tests: the
INFO reply buffer is live memory while INFO is being generated, so
over-allocating it inflated the reported `used_memory`. Requesting exactly the
field size (and relying on sds's own greedy doubling) matches the legacy
allocation footprint; `tests/unit/maxmemory` passes.

## Testing

- `src/unit/test_info_emitter.cpp` (GoogleTest): each field kind, the percent
  suffix, full-precision doubles, unsigned dict fields, the section separator,
  metadata-ignored-by-text, and byte-parity of representative sections.
- Full unit-test suite passes; `tests/unit/maxmemory` and
  `tests/unit/moduleapi/infotest` pass; `clang-format-18` clean.
- Byte-for-byte `INFO everything` parity vs an unmodified build (core + modules).
