### PR TITLE
Make serverObject (robj) opaque

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1903,7 +1903,7 @@ cleanup:
 int rioWriteBulkObject(rio *r, robj *obj) {
     /* Avoid using getDecodedObject to help copy-on-write (we are often
      * in a child process when this function is called). */
-    if (obj->encoding == OBJ_ENCODING_INT) {
+    if (objectGetEncoding(obj) == OBJ_ENCODING_INT) {
         return rioWriteBulkLongLong(r, (long)objectGetVal(obj));
     } else if (sdsEncodedObject(obj)) {
         return rioWriteBulkString(r, objectGetVal(obj), sdslen(objectGetVal(obj)));
@@ -2356,11 +2356,11 @@ int rewriteSelectDbRio(rio *aof, int db_num) {
 int rewriteObjectRio(rio *aof, robj *o, int db_num) {
     size_t aof_bytes_before_key = aof->processed_bytes;
     sds keystr;
-    robj key;
+    robjStatic key_buf;
     long long expiretime;
 
     keystr = objectGetKey(o);
-    initStaticStringObject(key, keystr);
+    robj *key = initStaticStringObject(&key_buf, keystr);
 
     expiretime = objectGetExpire(o);
 
@@ -2370,20 +2370,20 @@ int rewriteObjectRio(rio *aof, robj *o, int db_num) {
         char cmd[] = "*3\r\n$3\r\nSET\r\n";
         if (rioWrite(aof, cmd, sizeof(cmd) - 1) == 0) return C_ERR;
         /* Key and value */
-        if (rioWriteBulkObject(aof, &key) == 0) return C_ERR;
+        if (rioWriteBulkObject(aof, key) == 0) return C_ERR;
         if (rioWriteBulkObject(aof, o) == 0) return C_ERR;
     } else if (objectGetType(o) == OBJ_LIST) {
-        if (rewriteListObject(aof, &key, o) == 0) return C_ERR;
+        if (rewriteListObject(aof, key, o) == 0) return C_ERR;
     } else if (objectGetType(o) == OBJ_SET) {
-        if (rewriteSetObject(aof, &key, o) == 0) return C_ERR;
+        if (rewriteSetObject(aof, key, o) == 0) return C_ERR;
     } else if (objectGetType(o) == OBJ_ZSET) {
-        if (rewriteSortedSetObject(aof, &key, o) == 0) return C_ERR;
+        if (rewriteSortedSetObject(aof, key, o) == 0) return C_ERR;
     } else if (objectGetType(o) == OBJ_HASH) {
-        if (rewriteHashObject(aof, &key, o) == 0) return C_ERR;
+        if (rewriteHashObject(aof, key, o) == 0) return C_ERR;
     } else if (objectGetType(o) == OBJ_STREAM) {
-        if (rewriteStreamObject(aof, &key, o) == 0) return C_ERR;
+        if (rewriteStreamObject(aof, key, o) == 0) return C_ERR;
     } else if (objectGetType(o) == OBJ_MODULE) {
-        if (rewriteModuleObject(aof, &key, o, db_num) == 0) return C_ERR;
+        if (rewriteModuleObject(aof, key, o, db_num) == 0) return C_ERR;
     } else {
         serverPanic("Unknown object type");
     }
@@ -2398,7 +2398,7 @@ int rewriteObjectRio(rio *aof, robj *o, int db_num) {
     if (expiretime != -1) {
         char cmd[] = "*3\r\n$9\r\nPEXPIREAT\r\n";
         if (rioWrite(aof, cmd, sizeof(cmd) - 1) == 0) return C_ERR;
-        if (rioWriteBulkObject(aof, &key) == 0) return C_ERR;
+        if (rioWriteBulkObject(aof, key) == 0) return C_ERR;
         if (rioWriteBulkLongLong(aof, expiretime) == 0) return C_ERR;
     }
 

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -668,7 +668,7 @@ robj *lookupStringForBitCommand(client *c, uint64_t maxbit, int *dirty) {
  * If the source object is NULL the function is guaranteed to return NULL
  * and set 'len' to 0. */
 unsigned char *getObjectReadOnlyString(robj *o, long *len, char *llbuf) {
-    serverAssert(!o || o->type == OBJ_STRING);
+    serverAssert(!o || objectGetType(o) == OBJ_STRING);
     unsigned char *p = NULL;
 
     /* Set the 'p' pointer to the string, that can be just a stack allocated

--- a/src/commandlog.c
+++ b/src/commandlog.c
@@ -46,14 +46,14 @@ static commandlogEntry *commandlogCreateEntry(client *c, robj **argv, int argc, 
             if (clientCommandArgShouldBeRedacted(c, j)) {
                 ce->argv[j] = shared.redacted;
                 /* Trim too long strings as well... */
-            } else if (argv[j]->type == OBJ_STRING && sdsEncodedObject(argv[j]) &&
+            } else if (objectGetType(argv[j]) == OBJ_STRING && sdsEncodedObject(argv[j]) &&
                        sdslen(objectGetVal(argv[j])) > COMMANDLOG_ENTRY_MAX_STRING) {
                 sds s = sdsnewlen(objectGetVal(argv[j]), COMMANDLOG_ENTRY_MAX_STRING);
 
                 s = sdscatprintf(s, "... (%lu more bytes)",
                                  (unsigned long)sdslen(objectGetVal(argv[j])) - COMMANDLOG_ENTRY_MAX_STRING);
                 ce->argv[j] = createObject(OBJ_STRING, s);
-            } else if (argv[j]->refcount == OBJ_SHARED_REFCOUNT) {
+            } else if (objectGetRefcount(argv[j]) == OBJ_SHARED_REFCOUNT) {
                 ce->argv[j] = argv[j];
             } else {
                 /* Here we need to duplicate the string objects composing the

--- a/src/db.c
+++ b/src/db.c
@@ -110,8 +110,8 @@ robj *lookupKey(serverDb *db, robj *key, int flags) {
             flags |= LOOKUP_NOTOUCH;
         if (!hasActiveChildProcess() && !(flags & LOOKUP_NOTOUCH)) {
             /* Shared objects can't be stored in the database. */
-            serverAssert(val->refcount != OBJ_SHARED_REFCOUNT);
-            val->lru = lrulfu_touch(val->lru);
+            serverAssert(objectGetRefcount(val) != OBJ_SHARED_REFCOUNT);
+            objectSetLRU(val, lrulfu_touch(objectGetLRU(val)));
         }
 
         if (!(flags & (LOOKUP_NOSTATS | LOOKUP_WRITE))) server.stat_keyspace_hits++;
@@ -220,7 +220,7 @@ static void dbAddInternal(serverDb *db, robj *key, robj **valref, int update_if_
     dbTrackKeyWithVolatileItems(db, val);
     initObjectLRUOrLFU(val);
     kvstoreHashtableAdd(db->keys, dict_index, val);
-    signalKeyAsReady(db, key, val->type);
+    signalKeyAsReady(db, key, objectGetType(val));
     notifyKeyspaceEvent(NOTIFY_NEW, "new", key, db->id);
     *valref = val;
 }
@@ -335,24 +335,24 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
          * callback of the module. */
         moduleNotifyKeyUnlink(key, old, db->id, DB_FLAG_KEY_OVERWRITE);
         /* We want to try to unblock any module clients or clients using a blocking XREADGROUP */
-        signalDeletedKeyAsReady(db, key, old->type);
+        signalDeletedKeyAsReady(db, key, objectGetType(old));
         decrRefCount(old);
         /* Because of VM_StringDMA, old may be changed, so we need get old again */
         old = *oldref;
     }
 
-    if ((old->refcount == 1 && old->encoding != OBJ_ENCODING_EMBSTR) &&
-        (val->refcount == 1 && val->encoding != OBJ_ENCODING_EMBSTR)) {
-        /* Keep old object in the database. Just swap it's ptr, type and
+    if ((objectGetRefcount(old) == 1 && objectGetEncoding(old) != OBJ_ENCODING_EMBSTR) &&
+        (objectGetRefcount(val) == 1 && objectGetEncoding(val) != OBJ_ENCODING_EMBSTR)) {
+        /* Keep old object in the database. Just swap its ptr, type and
          * encoding with the content of val. */
-        int tmp_type = old->type;
-        int tmp_encoding = old->encoding;
+        int tmp_type = objectGetType(old);
+        int tmp_encoding = objectGetEncoding(old);
         void *tmp_ptr = objectGetVal(old);
-        old->type = val->type;
-        old->encoding = val->encoding;
+        objectSetType(old, objectGetType(val));
+        objectSetEncoding(old, objectGetEncoding(val));
         objectSetVal(old, objectGetVal(val));
-        val->type = tmp_type;
-        val->encoding = tmp_encoding;
+        objectSetType(val, tmp_type);
+        objectSetEncoding(val, tmp_encoding);
         objectSetVal(val, tmp_ptr);
         /* Set new to old to keep the old object. Set old to val to be freed below. */
         new = old;
@@ -373,11 +373,11 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
     }
 
     /* If overwriting a hash object, un-track it from the volatile items tracking if it contains volatile items.*/
-    if (old->type == OBJ_HASH && hashTypeHasVolatileFields(old)) {
+    if (objectGetType(old) == OBJ_HASH && hashTypeHasVolatileFields(old)) {
         /* Some commands create a new value (with NO key) and use setKey to change the value of an existing key.
          * In this case the old can be replaced with the provided value and be left without a key
          * however it is still a hashObject with optional volatile items and we need to untrack it. */
-        dbUntrackKeyWithVolatileItems(db, old->hasembkey ? old : new);
+        dbUntrackKeyWithVolatileItems(db, objectHasEmbeddedKey(old) ? old : new);
     }
     /* If the new object is a hash with volatile items we need to track it again */
     dbTrackKeyWithVolatileItems(db, new);
@@ -483,7 +483,7 @@ int dbGenericDeleteWithDictIndex(serverDb *db, robj *key, int async, int flags, 
         /* Tells the module that the key has been unlinked from the database. */
         moduleNotifyKeyUnlink(key, val, db->id, flags);
         /* We want to try to unblock any module clients or clients using a blocking XREADGROUP */
-        signalDeletedKeyAsReady(db, key, val->type);
+        signalDeletedKeyAsReady(db, key, objectGetType(val));
         /* Match the incrRefCount above. */
         decrRefCount(val);
         /* Because of dbUnshareStringValue, the val in de may change. */
@@ -584,7 +584,7 @@ int dbDelete(serverDb *db, robj *key) {
  */
 robj *dbUnshareStringValue(serverDb *db, robj *key, robj *o) {
     serverAssert(objectGetType(o) == OBJ_STRING);
-    if (o->refcount != 1 || o->encoding != OBJ_ENCODING_RAW) {
+    if (objectGetRefcount(o) != 1 || objectGetEncoding(o) != OBJ_ENCODING_RAW) {
         robj *decoded = getDecodedObject(o);
         o = createRawStringObject(objectGetVal(decoded), sdslen(objectGetVal(decoded)));
         decrRefCount(decoded);
@@ -993,8 +993,8 @@ typedef struct {
 
 /* Helper function to compare key type in scan commands */
 int objectTypeCompare(robj *o, long long target) {
-    if (o->type != OBJ_MODULE) {
-        if (o->type != target)
+    if (objectGetType(o) != OBJ_MODULE) {
+        if (objectGetType(o) != target)
             return 0;
         else
             return 1;
@@ -1035,9 +1035,9 @@ void keysScanCallback(void *privdata, void *entry, int didx) {
 
     /* Handle and skip expired key. */
     if (objectIsExpired(obj)) {
-        robj kobj;
-        initStaticStringObject(kobj, key);
-        if (expireIfNeededWithDictIndex(data->db, &kobj, obj, 0, didx) != KEY_VALID) {
+        robjStatic kobj_buf;
+        robj *kobj = initStaticStringObject(&kobj_buf, key);
+        if (expireIfNeededWithDictIndex(data->db, kobj, obj, 0, didx) != KEY_VALID) {
             return;
         }
     }
@@ -1061,9 +1061,9 @@ void hashtableScanCallback(void *privdata, void *entry) {
     serverAssert(o != NULL);
 
     /* get key, value */
-    if (o->type == OBJ_SET) {
+    if (objectGetType(o) == OBJ_SET) {
         key = (sds)entry;
-    } else if (o->type == OBJ_ZSET) {
+    } else if (objectGetType(o) == OBJ_ZSET) {
         zskiplistNode *node = (zskiplistNode *)entry;
         key = zslGetNodeElement(node);
         /* zset data is copied after filtering by key */
@@ -1085,7 +1085,7 @@ void hashtableScanCallback(void *privdata, void *entry) {
 
     /* zset data must be copied. Do this after filtering to avoid unneeded
      * allocations. */
-    if (o->type == OBJ_ZSET) {
+    if (objectGetType(o) == OBJ_ZSET) {
         /* zset data is copied */
         zskiplistNode *node = (zskiplistNode *)entry;
         key = sdsdup(zslGetNodeElement(node));
@@ -1138,13 +1138,13 @@ char *getObjectTypeName(robj *o) {
         return "none";
     }
 
-    serverAssert(o->type >= 0 && o->type < OBJ_TYPE_MAX);
+    serverAssert(objectGetType(o) >= 0 && objectGetType(o) < OBJ_TYPE_MAX);
 
-    if (o->type == OBJ_MODULE) {
+    if (objectGetType(o) == OBJ_MODULE) {
         moduleValue *mv = objectGetVal(o);
         return mv->type->name;
     } else {
-        return obj_type_name[o->type];
+        return obj_type_name[objectGetType(o)];
     }
 }
 
@@ -1184,14 +1184,14 @@ int parseScanOptionsOrReply(client *c, robj *o, int start_idx, bool allow_slot, 
             }
             i += 2;
         } else if (!strcasecmp(opt, "novalues")) {
-            if (!o || o->type != OBJ_HASH) {
+            if (!o || objectGetType(o) != OBJ_HASH) {
                 addReplyError(c, "NOVALUES option can only be used in HSCAN");
                 return C_ERR;
             }
             opts->only_keys = 1;
             i++;
         } else if (!strcasecmp(opt, "noscores")) {
-            if (!o || o->type != OBJ_ZSET) {
+            if (!o || objectGetType(o) != OBJ_ZSET) {
                 addReplyError(c, "NOSCORES option can only be used in ZSCAN");
                 return C_ERR;
             }
@@ -1230,7 +1230,7 @@ void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor
 
     /* Object must be NULL (to iterate keys names), or the type of the object
      * must be Set, Sorted Set, or Hash. */
-    serverAssert(o == NULL || o->type == OBJ_SET || objectGetType(o) == OBJ_HASH || o->type == OBJ_ZSET);
+    serverAssert(o == NULL || objectGetType(o) == OBJ_SET || objectGetType(o) == OBJ_HASH || objectGetType(o) == OBJ_ZSET);
 
     /* Iterate the collection.
      *
@@ -1248,13 +1248,13 @@ void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor
     void (*free_callback)(sds) = sdsfree;
     if (o == NULL) {
         free_callback = NULL;
-    } else if (o->type == OBJ_SET && o->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetType(o) == OBJ_SET && objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         ht = objectGetVal(o);
         free_callback = NULL;
-    } else if (objectGetType(o) == OBJ_HASH && o->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetType(o) == OBJ_HASH && objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         ht = objectGetVal(o);
         free_callback = NULL;
-    } else if (o->type == OBJ_ZSET && o->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetType(o) == OBJ_ZSET && objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(o);
         ht = zs->ht;
         /* scanning ZSET allocates temporary strings even though it's a dict */
@@ -1312,7 +1312,7 @@ void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor
                 cursor = hashtableScan(ht, cursor, hashtableScanCallback, &data);
             }
         } while (cursor && maxiterations-- && data.sampled < opts->count);
-    } else if (o->type == OBJ_SET) {
+    } else if (objectGetType(o) == OBJ_SET) {
         char *str;
         char buf[LONG_STR_SIZE];
         size_t len;
@@ -1331,7 +1331,7 @@ void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor
         }
         setTypeReleaseIterator(si);
         cursor = 0;
-    } else if ((objectGetType(o) == OBJ_HASH || o->type == OBJ_ZSET) && o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if ((objectGetType(o) == OBJ_HASH || objectGetType(o) == OBJ_ZSET) && objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         unsigned char *p = lpFirst(objectGetVal(o));
         unsigned char *str;
         int64_t len;
@@ -1674,7 +1674,7 @@ void copyCommand(client *c) {
 
     /* Duplicate object according to object's type. */
     robj *newobj;
-    switch (o->type) {
+    switch (objectGetType(o)) {
     case OBJ_STRING: newobj = dupStringObject(o); break;
     case OBJ_LIST: newobj = listTypeDup(o); break;
     case OBJ_SET: newobj = setTypeDup(o); break;
@@ -1714,7 +1714,7 @@ void scanDatabaseForReadyKeys(serverDb *db) {
         robj *key = dictGetKey(de);
         robj *value = dbFind(db, objectGetVal(key));
         if (value) {
-            signalKeyAsReady(db, key, value->type);
+            signalKeyAsReady(db, key, objectGetType(value));
         }
     }
     dictReleaseIterator(di);
@@ -1733,14 +1733,14 @@ void scanDatabaseForDeletedKeys(serverDb *emptied, serverDb *replaced_with) {
 
         robj *value = dbFind(emptied, objectGetVal(key));
         if (value) {
-            original_type = value->type;
+            original_type = objectGetType(value);
             existed = 1;
         }
 
         if (replaced_with) {
             value = dbFind(replaced_with, objectGetVal(key));
             if (value) {
-                curr_type = value->type;
+                curr_type = objectGetType(value);
                 exists = 1;
             }
         }
@@ -2169,7 +2169,7 @@ static keyStatus expireIfNeededWithDictIndex(serverDb *db, robj *key, robj *val,
         return KEY_EXPIRED;
 
     /* The key needs to be converted from static to heap before deleted */
-    int static_key = key->refcount == OBJ_STATIC_REFCOUNT;
+    int static_key = objectGetRefcount(key) == OBJ_STATIC_REFCOUNT;
     if (static_key) {
         key = createStringObject(objectGetVal(key), sdslen(objectGetVal(key)));
     }

--- a/src/debug.c
+++ b/src/debug.c
@@ -665,10 +665,10 @@ void debugCommand(client *c) {
             addReplyErrorObject(c, shared.nokeyerr);
             return;
         }
-        strenc = strEncoding(val->encoding);
+        strenc = strEncoding(objectGetEncoding(val));
 
         char extra[138] = {0};
-        if (val->encoding == OBJ_ENCODING_QUICKLIST) {
+        if (objectGetEncoding(val) == OBJ_ENCODING_QUICKLIST) {
             char *nextra = extra;
             int remaining = sizeof(extra);
             quicklist *ql = objectGetVal(val);
@@ -703,13 +703,13 @@ void debugCommand(client *c) {
         }
 
         sds s = sdsempty();
-        s = sdscatprintf(s, "Value at:%p refcount:%d encoding:%s", (void *)val, val->refcount, strenc);
+        s = sdscatprintf(s, "Value at:%p refcount:%d encoding:%s", (void *)val, objectGetRefcount(val), strenc);
         if (!fast) s = sdscatprintf(s, " serializedlength:%zu", rdbSavedObjectLen(val, c->argv[2], c->db->id));
         /* Either lru or lfu field could work correctly which depends on server.maxmemory_policy. */
         if (lrulfu_isUsingLFU()) {
-            s = sdscatprintf(s, " lfu_freq:%u lfu_access_time_minutes:%u", objectGetLFUFrequency(val), val->lru >> 8);
+            s = sdscatprintf(s, " lfu_freq:%u lfu_access_time_minutes:%u", objectGetLFUFrequency(val), objectGetLRU(val) >> 8);
         } else {
-            s = sdscatprintf(s, " lru:%d lru_seconds_idle:%u", val->lru, lru_getIdleSecs(val->lru));
+            s = sdscatprintf(s, " lru:%d lru_seconds_idle:%u", objectGetLRU(val), lru_getIdleSecs(objectGetLRU(val)));
         }
         s = sdscatprintf(s, "%s", extra);
         addReplyStatusLength(c, s, sdslen(s));
@@ -724,13 +724,13 @@ void debugCommand(client *c) {
         }
         key = objectGetKey(val);
 
-        if (val->type != OBJ_STRING || !sdsEncodedObject(val)) {
+        if (objectGetType(val) != OBJ_STRING || !sdsEncodedObject(val)) {
             addReplyError(c, "Not an sds encoded string.");
         } else {
             /* Report the complete robj allocation size as the key's allocation
              * size. Report 0 as allocation size for embedded values. */
             size_t obj_alloc = zmalloc_usable_size(val);
-            size_t val_alloc = val->encoding == OBJ_ENCODING_RAW ? sdsAllocSize(objectGetVal(val)) : 0;
+            size_t val_alloc = objectGetEncoding(val) == OBJ_ENCODING_RAW ? sdsAllocSize(objectGetVal(val)) : 0;
             addReplyStatusFormat(c,
                                  "key_sds_len:%lld key_sds_avail:%lld obj_alloc:%lld "
                                  "val_sds_len:%lld val_sds_avail:%lld val_alloc:%lld",
@@ -928,7 +928,7 @@ void debugCommand(client *c) {
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "structsize") && c->argc == 2) {
         sds sizes = sdsempty();
         sizes = sdscatprintf(sizes, "bits:%d ", (sizeof(void *) == 8) ? 64 : 32);
-        sizes = sdscatprintf(sizes, "robj:%d ", (int)sizeof(robj));
+        sizes = sdscatprintf(sizes, "robj:%d ", (int)objectGetStructSize());
         sizes = sdscatprintf(sizes, "dictentry:%d ", (int)dictEntryMemUsage(NULL));
         sizes = sdscatprintf(sizes, "sdshdr5:%d ", (int)sizeof(struct sdshdr5));
         sizes = sdscatprintf(sizes, "sdshdr8:%d ", (int)sizeof(struct sdshdr8));
@@ -1154,7 +1154,7 @@ void _serverAssertPrintClientInfo(const client *c) {
             continue;
         }
         sds repr = getArgvReprString(c->argv[j]);
-        serverLog(LL_WARNING, "client->argv[%d] = %s (refcount: %d)", j, repr, c->argv[j]->refcount);
+        serverLog(LL_WARNING, "client->argv[%d] = %s (refcount: %d)", j, repr, objectGetRefcount(c->argv[j]));
         sdsfree(repr);
         if (!strcasecmp(objectGetVal(c->argv[j]), "auth") || !strcasecmp(objectGetVal(c->argv[j]), "auth2")) {
             break;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -38,7 +38,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "server.h"
+#include "object_internals.h"
 #include "hashtable.h"
 #include "eval.h"
 #include "script.h"

--- a/src/functions.c
+++ b/src/functions.c
@@ -287,8 +287,8 @@ void functionsAddEngineStats(sds engine_name) {
 static int functionLibCreateFunction(compiledFunction *function,
                                      functionLibInfo *li,
                                      sds *err) {
-    serverAssert(function->name->type == OBJ_STRING);
-    serverAssert(function->desc == NULL || function->desc->type == OBJ_STRING);
+    serverAssert(objectGetType(function->name) == OBJ_STRING);
+    serverAssert(function->desc == NULL || objectGetType(function->desc) == OBJ_STRING);
 
     if (functionsVerifyName(objectGetVal(function->name)) != C_OK) {
         *err = sdsnew("Function names can only contain letters, numbers, or "

--- a/src/geo.c
+++ b/src/geo.c
@@ -274,7 +274,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
     /* That's: min <= val < max */
     zrangespec range = {.min = min, .max = max, .minex = 0, .maxex = 1};
     size_t origincount = ga->used;
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         unsigned char *vstr = NULL;
@@ -305,7 +305,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
             if (ga->used && limit && ga->used >= limit) break;
             zzlNext(zl, &eptr, &sptr);
         }
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -6,6 +6,7 @@
 
 #include "io_threads.h"
 #include "cluster_migrateslots.h"
+#include "object_internals.h"
 #include "queues.h"
 #include <sys/resource.h>
 
@@ -618,7 +619,7 @@ void ioThreadFreeArgv(robj **argv) {
         /* The main-thread set the refcount to 0 to indicate that this is the last argument to free */
         if (objectGetRefcount(o) == 0) {
             last_arg = 1;
-            o->refcount = 1;
+            objectSetRefcount(o, 1);
         }
 
         decrRefCount(o);
@@ -652,7 +653,7 @@ int tryOffloadFreeArgvToIOThreads(client *c, int argc, robj **argv) {
 
     /* Prepare the argv */
     for (int j = 0; j < argc; j++) {
-        if (argv[j]->refcount > 1) {
+        if (objectGetRefcount(argv[j]) > 1) {
             decrRefCount(argv[j]);
             /* Set argv[j] to NULL to avoid double free */
             argv[j] = NULL;
@@ -670,7 +671,7 @@ int tryOffloadFreeArgvToIOThreads(client *c, int argc, robj **argv) {
     /* We set the refcount of the last arg to free to 0 to indicate that
      * this is the last argument to free. With this approach, we don't need to
      * send the argc to the IO thread and we can send just the argv ptr. */
-    argv[last_arg_to_free]->refcount = 0;
+    objectSetRefcount(argv[last_arg_to_free], 0);
     void *job = tagJob(argv, JOB_REQ_FREE_ARGV);
     /* We pass false to enqueue the job without committing the queue index immediately.
      * This allows us to batch multiple free jobs together and
@@ -691,9 +692,9 @@ int tryOffloadFreeObjToIOThreads(robj *obj) {
         return C_ERR;
     }
 
-    if (obj->refcount > 1) return C_ERR;
+    if (objectGetRefcount(obj) > 1) return C_ERR;
 
-    if (obj->encoding != OBJ_ENCODING_RAW || obj->type != OBJ_STRING) return C_ERR;
+    if (objectGetEncoding(obj) != OBJ_ENCODING_RAW || objectGetType(obj) != OBJ_STRING) return C_ERR;
 
     void *job = tagJob(obj, JOB_REQ_FREE_OBJ);
     if (unlikely(spmcEnqueue(&io_shared_inbox, job) == false)) return C_ERR;

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -135,19 +135,19 @@ void lazyfreeResetStats(void) {
  * For lists the function returns the number of elements in the quicklist
  * representing the list. */
 size_t lazyfreeGetFreeEffort(robj *key, robj *obj, int dbid) {
-    if (obj->type == OBJ_LIST && obj->encoding == OBJ_ENCODING_QUICKLIST) {
+    if (objectGetType(obj) == OBJ_LIST && objectGetEncoding(obj) == OBJ_ENCODING_QUICKLIST) {
         quicklist *ql = objectGetVal(obj);
         return ql->len;
-    } else if (obj->type == OBJ_SET && obj->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetType(obj) == OBJ_SET && objectGetEncoding(obj) == OBJ_ENCODING_HASHTABLE) {
         hashtable *ht = objectGetVal(obj);
         return hashtableSize(ht);
-    } else if (obj->type == OBJ_ZSET && obj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetType(obj) == OBJ_ZSET && objectGetEncoding(obj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(obj);
         return zslGetLength(zs->zsl);
-    } else if (obj->type == OBJ_HASH && obj->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetType(obj) == OBJ_HASH && objectGetEncoding(obj) == OBJ_ENCODING_HASHTABLE) {
         hashtable *ht = objectGetVal(obj);
         return hashtableSize(ht);
-    } else if (obj->type == OBJ_STREAM) {
+    } else if (objectGetType(obj) == OBJ_STREAM) {
         size_t effort = 0;
         stream *s = objectGetVal(obj);
 
@@ -171,7 +171,7 @@ size_t lazyfreeGetFreeEffort(robj *key, robj *obj, int dbid) {
             raxStop(&ri);
         }
         return effort;
-    } else if (obj->type == OBJ_MODULE) {
+    } else if (objectGetType(obj) == OBJ_MODULE) {
         size_t effort = moduleGetFreeEffort(key, obj, dbid);
         /* If the module's free_effort returns 0, we will use asynchronous free
          * memory by default. */
@@ -195,7 +195,7 @@ void freeObjAsync(robj *key, robj *obj, int dbid) {
      * possible. This rarely happens, however sometimes the implementation
      * of parts of the server core may call incrRefCount() to protect
      * objects, and then call dbDelete(). */
-    if (free_effort > LAZYFREE_THRESHOLD && obj->refcount == 1) {
+    if (free_effort > LAZYFREE_THRESHOLD && objectGetRefcount(obj) == 1) {
         atomic_fetch_add_explicit(&lazyfree_objects, 1, memory_order_relaxed);
         bioCreateLazyFreeJob(lazyfreeFreeObject, 1, obj);
     } else {

--- a/src/logreqres.c
+++ b/src/logreqres.c
@@ -197,7 +197,7 @@ size_t reqresAppendRequest(client *c) {
     for (int i = 0; i < argc; i++) {
         if (sdsEncodedObject(argv[i])) {
             ret += reqresAppendArg(c, objectGetVal(argv[i]), sdslen(objectGetVal(argv[i])));
-        } else if (argv[i]->encoding == OBJ_ENCODING_INT) {
+        } else if (objectGetEncoding(argv[i]) == OBJ_ENCODING_INT) {
             char buf[LONG_STR_SIZE];
             size_t len = ll2string(buf, sizeof(buf), (long)objectGetVal(argv[i]));
             ret += reqresAppendArg(c, buf, len);

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -137,7 +137,7 @@ static void prefetchValue(KeyPrefetchInfo *info) {
     void *entry;
     if (hashtableIncrementalFindGetResult(&info->hashtab_state, &entry)) {
         robj *val = entry;
-        if (val->encoding == OBJ_ENCODING_RAW && val->type == OBJ_STRING) {
+        if (objectGetEncoding(val) == OBJ_ENCODING_RAW && objectGetType(val) == OBJ_STRING) {
             valkey_prefetch(objectGetVal(val));
         }
     }
@@ -194,7 +194,7 @@ static void prefetchCommands(void) {
         client *c = batch->clients[i];
         if (!c || c->argc <= 1) continue;
         for (int j = 1; j < c->argc; j++) {
-            if (c->argv[j]->encoding == OBJ_ENCODING_RAW) {
+            if (objectGetEncoding(c->argv[j]) == OBJ_ENCODING_RAW) {
                 valkey_prefetch(objectGetVal(c->argv[j]));
             }
         }

--- a/src/module.c
+++ b/src/module.c
@@ -1060,7 +1060,7 @@ void ValkeyModuleCommandDispatcher(client *c) {
     for (int i = 0; i < c->argc; i++) {
         /* Only do the work if the module took ownership of the object:
          * in that case the refcount is no longer 1. */
-        if (c->argv[i]->refcount > 1) trimStringObjectIfNeeded(c->argv[i], 0);
+        if (objectGetRefcount(c->argv[i]) > 1) trimStringObjectIfNeeded(c->argv[i], 0);
     }
 }
 
@@ -2968,7 +2968,7 @@ void VM_RetainString(ValkeyModuleCtx *ctx, ValkeyModuleString *str) {
  * This API is not thread safe, access to these retained strings (if they originated
  * from a client command arguments) must be done with GIL locked. */
 ValkeyModuleString *VM_HoldString(ValkeyModuleCtx *ctx, ValkeyModuleString *str) {
-    if (str->refcount == OBJ_STATIC_REFCOUNT) {
+    if (objectGetRefcount(str) == OBJ_STATIC_REFCOUNT) {
         return VM_CreateStringFromString(ctx, str);
     }
 
@@ -3081,20 +3081,20 @@ int VM_StringCompare(const ValkeyModuleString *a, const ValkeyModuleString *b) {
 /* Return the (possibly modified in encoding) input 'str' object if
  * the string is unshared, otherwise NULL is returned. */
 static ValkeyModuleString *moduleAssertUnsharedString(ValkeyModuleString *str) {
-    if (str->refcount != 1) {
+    if (objectGetRefcount(str) != 1) {
         serverLog(LL_WARNING, "Module attempted to use an in-place string modify operation "
                               "with a string referenced multiple times. Please check the code "
                               "for API usage correctness.");
         return NULL;
     }
-    if (str->encoding == OBJ_ENCODING_EMBSTR) {
+    if (objectGetEncoding(str) == OBJ_ENCODING_EMBSTR) {
         /* Note: here we "leak" the additional allocation that was
          * used in order to store the embedded string in the object. */
         objectUnembedVal(str);
-    } else if (str->encoding == OBJ_ENCODING_INT) {
+    } else if (objectGetEncoding(str) == OBJ_ENCODING_INT) {
         /* Convert the string from integer to raw encoding. */
         objectSetVal(str, sdsfromlonglong((long)objectGetVal(str)));
-        str->encoding = OBJ_ENCODING_RAW;
+        objectSetEncoding(str, OBJ_ENCODING_RAW);
     }
     return str;
 }
@@ -6376,7 +6376,7 @@ robj **moduleCreateArgvFromUserFormat(const char *cmdname, const char *fmt, int 
             argv[argc++] = createStringObject(cstr, strlen(cstr));
         } else if (*p == 's') {
             robj *obj = va_arg(ap, void *);
-            if (obj->refcount == OBJ_STATIC_REFCOUNT)
+            if (objectGetRefcount(obj) == OBJ_STATIC_REFCOUNT)
                 obj = createStringObject(objectGetVal(obj), sdslen(objectGetVal(obj)));
             else
                 incrRefCount(obj);
@@ -11733,7 +11733,7 @@ void moduleFireCommandResultEvent(client *c,
     int needs_decode = 0;
 
     for (int i = 0; i < argc; i++) {
-        if (argv[i]->encoding == OBJ_ENCODING_INT) {
+        if (objectGetEncoding(argv[i]) == OBJ_ENCODING_INT) {
             needs_decode = 1;
             break;
         }
@@ -11809,7 +11809,7 @@ void moduleFireCommandACLRejectedEvent(client *c, uint64_t subevent, int errpos)
     if ((subevent == VALKEYMODULE_ACL_LOG_KEY || subevent == VALKEYMODULE_ACL_LOG_CHANNEL) &&
         errpos >= 0 && errpos < c->argc) {
         robj *key_obj = c->argv[errpos];
-        if (key_obj->encoding == OBJ_ENCODING_INT) {
+        if (objectGetEncoding(key_obj) == OBJ_ENCODING_INT) {
             ll2string(int_key_buf, sizeof(int_key_buf), (long)objectGetVal(key_obj));
             rejection_context = int_key_buf;
         } else {
@@ -11854,8 +11854,8 @@ size_t VM_MallocUsableSize(void *ptr) {
 /* Same as VM_MallocSize, except it works on ValkeyModuleString pointers.
  */
 size_t VM_MallocSizeString(ValkeyModuleString *str) {
-    serverAssert(str->type == OBJ_STRING);
-    return sizeof(*str) + getStringObjectSdsUsedMemory(str);
+    serverAssert(objectGetType(str) == OBJ_STRING);
+    return objectGetStructSize() + getStringObjectSdsUsedMemory(str);
 }
 
 /* Same as VM_MallocSize, except it works on ValkeyModuleDict pointers.
@@ -12954,7 +12954,7 @@ void moduleNotifyKeyUnlink(robj *key, robj *val, int dbid, int flags) {
     KeyInfo info = {dbid, key, val, VALKEYMODULE_READ};
     moduleFireServerEvent(VALKEYMODULE_EVENT_KEY, subevent, &info);
 
-    if (val->type == OBJ_MODULE) {
+    if (objectGetType(val) == OBJ_MODULE) {
         moduleValue *mv = objectGetVal(val);
         moduleType *mt = mv->type;
         /* We prefer to use the enhanced version. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -170,7 +170,7 @@ typedef enum {
 /* Return the amount of memory used by the sds string at object->ptr
  * for a string object. This includes internal fragmentation. */
 size_t getStringObjectSdsUsedMemory(robj *o) {
-    serverAssertWithInfo(NULL, o, o->type == OBJ_STRING);
+    serverAssertWithInfo(NULL, o, objectGetType(o) == OBJ_STRING);
     if (objectGetEncoding(o) != OBJ_ENCODING_INT) {
         return sdsAllocSize(objectGetVal(o));
     }
@@ -180,13 +180,13 @@ size_t getStringObjectSdsUsedMemory(robj *o) {
 /* Return the total memory used by a string object, including the robj
  * structure and the sds string overhead (internal fragmentation). */
 size_t getStringObjectMemory(robj *o) {
-    return sizeof(robj) + getStringObjectSdsUsedMemory(o);
+    return objectGetStructSize() + getStringObjectSdsUsedMemory(o);
 }
 
 /* Return the length of a string object.
  * This does NOT include internal fragmentation or sds unused space. */
 size_t getStringObjectLen(robj *o) {
-    serverAssertWithInfo(NULL, o, o->type == OBJ_STRING);
+    serverAssertWithInfo(NULL, o, objectGetType(o) == OBJ_STRING);
     switch (objectGetEncoding(o)) {
     case OBJ_ENCODING_RAW: return sdslen(objectGetVal(o));
     case OBJ_ENCODING_EMBSTR: return sdslen(objectGetVal(o));
@@ -270,8 +270,8 @@ static int isCopyAvoidPreferred(client *c, robj *obj) {
     if (type != CLIENT_TYPE_NORMAL && type != CLIENT_TYPE_PUBSUB) return 0;
 
     if (obj) {
-        if (obj->encoding != OBJ_ENCODING_RAW) return 0;
-        if (obj->refcount == OBJ_STATIC_REFCOUNT) return 0;
+        if (objectGetEncoding(obj) != OBJ_ENCODING_RAW) return 0;
+        if (objectGetRefcount(obj) == OBJ_STATIC_REFCOUNT) return 0;
     }
 
     /* Copy avoidance is preferred for any string size starting certain number of I/O threads  */
@@ -795,7 +795,7 @@ void addReply(client *c, robj *obj) {
 
     if (sdsEncodedObject(obj)) {
         _addReplyToBufferOrList(c, objectGetVal(obj), sdslen(objectGetVal(obj)));
-    } else if (obj->encoding == OBJ_ENCODING_INT) {
+    } else if (objectGetEncoding(obj) == OBJ_ENCODING_INT) {
         /* For integer encoded strings we just convert it into a string
          * using our optimized function, and attach the resulting string
          * to the output buffer. */
@@ -1502,7 +1502,7 @@ void addReplyBulk(client *c, robj *obj) {
         /* If copy avoidance allowed, then we explicitly maintain net_output_bytes_curr_cmd.
          * We determine per-reply if tracking is enabled by checking the config in the main thread. */
         if (server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1) {
-            serverAssert(obj->encoding == OBJ_ENCODING_RAW);
+            serverAssert(objectGetEncoding(obj) == OBJ_ENCODING_RAW);
             size_t str_len = sdslen(objectGetVal(obj));
             uint32_t num_len = digits10(str_len);
             /* RESP encodes bulk strings as $<length>\r\n<data>\r\n */
@@ -4199,7 +4199,7 @@ static void prefetchCommandQueueKeys(client *c) {
             robj *val = entry;
             /* TODO? Prefetch all types and encodings except OBJ_ENCODING_EMBSTR
              * and OBJ_ENCODING_INT. */
-            if (val->encoding == OBJ_ENCODING_RAW && val->type == OBJ_STRING) {
+            if (objectGetEncoding(val) == OBJ_ENCODING_RAW && objectGetType(val) == OBJ_STRING) {
                 valkey_prefetch(objectGetVal(val));
             }
         }

--- a/src/object.c
+++ b/src/object.c
@@ -29,7 +29,7 @@
  */
 
 #include "hashtable.h"
-#include "server.h"
+#include "object_internals.h"
 #include "serverassert.h"
 #include "functions.h"
 #include "intset.h" /* Compact integer set structure */
@@ -71,12 +71,36 @@ unsigned int objectGetRefcount(const robj *o) {
     return o->refcount;
 }
 
+void objectSetRefcount(robj *o, unsigned int refcount) {
+    o->refcount = refcount;
+}
+
 unsigned int objectGetLRU(const robj *o) {
     return o->lru;
 }
 
 void objectSetLRU(robj *o, unsigned int lru) {
     o->lru = lru;
+}
+
+robj *initStaticStringObject(robjStatic *buf, void *ptr) {
+    robj *o = (robj *)buf;
+    o->refcount = OBJ_STATIC_REFCOUNT;
+    o->type = OBJ_STRING;
+    o->encoding = OBJ_ENCODING_RAW;
+    o->hasexpire = 0;
+    o->hasembkey = 0;
+    o->hasembval = 0;
+    o->val_ptr = ptr;
+    return o;
+}
+
+size_t objectGetStructSize(void) {
+    return sizeof(robj);
+}
+
+int objectHasEmbeddedKey(const robj *o) {
+    return o->hasembkey;
 }
 
 /* ===================== Creation and parsing of objects ==================== */

--- a/src/object_internals.h
+++ b/src/object_internals.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* object_internals.h - Internal definition of struct serverObject.
+ *
+ * This header should ONLY be included by files that need direct access to
+ * serverObject fields (object.c, defrag.c, etc.). All other code should use
+ * the accessor functions declared in server.h.
+ *
+ * This separation enforces opacity: code that doesn't include this header
+ * cannot access robj fields directly, preventing accidental coupling. */
+
+#ifndef OBJECT_INTERNALS_H
+#define OBJECT_INTERNALS_H
+
+#include "server.h"
+
+/* The serverObject struct is variable in size. It has several static fields that are always present,
+ * followed by several optional variable-sized fields. The static fields are `type` through `refcount`
+ * in the struct-defined order:
+ *
+ *    +------+----------+-----+-----------+-----------+-----------+----------+----
+ *    | type | encoding | lru | hasexpire | hasembkey | hasembval | refcount | ...
+ *    +------+----------+-----+-----------+-----------+-----------+----------+----
+ *
+ * The optional variable-sized embedded data has 2 possible layouts. If value is embedded (hasembval == 1)
+ *  the `val_ptr` pointer is not used - instead the val data is embedded:
+ *
+ *    +------+----------+-----+------------+----------+--------+-----------------+---------+------------+
+ *    | type | encoding | lru | has* flags | refcount | expire | key_header_size | key sds | value data |
+ *    +------+----------+-----+------------+----------+--------+-----------------+---------+------------+
+ *                                                      ^        ^                 ^         ^
+ *                                                      |        |                 |         |
+ *                                                      |        |                 |         +--- present because hasembval == 1
+ *                                                      |        |                 |
+ *                                                      |        +-----------------+--- present if hasembkey == 1
+ *                                                      |
+ *                                                      +--- present if hasexpire == 1
+ *
+ * Otherwise value is not embedded and we use the `val_ptr` pointer:
+ *
+ *    +------+----------+-----+------------+----------+---------+--------+-----------------+---------+
+ *    | type | encoding | lru | has* flags | refcount | val_ptr | expire | key_header_size | key sds |
+ *    +------+----------+-----+------------+----------+---------+--------+-----------------+---------+
+ *                                                      ^         ^        ^                 ^
+ *                                                      |         |        |                 |
+ *                                                      |         |        +-----------------+--- present if hasembkey == 1
+ *                                                      |         |
+ *                                                      |         +--- present if hasexpire == 1
+ *                                                      |
+ *                                                      +--- present because hasembval == 0
+ */
+
+struct serverObject {
+    unsigned type : 4;
+    unsigned encoding : 4;
+    unsigned lru : LRULFU_BITS;
+    unsigned hasexpire : 1;
+    unsigned hasembkey : 1;
+    unsigned hasembval : 1;
+    unsigned refcount : OBJ_REFCOUNT_BITS;
+    void *val_ptr; /* Not always present. Use objectGetVal(obj) and
+                    * objectSetVal(obj, val) instead. */
+};
+static_assert(sizeof(struct serverObject) <= 8 + sizeof(void *), "unexpected size - verify struct is packed correctly");
+static_assert(sizeof(struct serverObject) == sizeof(robjStatic), "robjStatic size must match struct serverObject");
+
+/* Internal-only accessor for setting refcount directly.
+ * Normal code should use incrRefCount()/decrRefCount(). */
+void objectSetRefcount(robj *o, unsigned int refcount);
+
+#endif /* OBJECT_INTERNALS_H */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -552,7 +552,7 @@ ssize_t rdbSaveLongLongAsStringObject(rio *rdb, long long value) {
 ssize_t rdbSaveStringObject(rio *rdb, robj *obj) {
     /* Avoid to decode the object, then encode it again, if the
      * object is already integer encoded. */
-    if (obj->encoding == OBJ_ENCODING_INT) {
+    if (objectGetEncoding(obj) == OBJ_ENCODING_INT) {
         return rdbSaveLongLongAsStringObject(rdb, (long)objectGetVal(obj));
     } else {
         serverAssertWithInfo(NULL, obj, sdsEncodedObject(obj));
@@ -1436,13 +1436,13 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, int rdbver, long *key_counte
             sdsfree(slot_info);
         }
         sds keystr = objectGetKey(o);
-        robj key;
+        robjStatic key_buf;
         long long expire;
         size_t rdb_bytes_before_key = rdb->processed_bytes;
 
-        initStaticStringObject(key, keystr);
+        robj *key = initStaticStringObject(&key_buf, keystr);
         expire = objectGetExpire(o);
-        if ((res = rdbSaveKeyValuePair(rdb, &key, o, expire, dbid, rdbver)) < 0) goto werr;
+        if ((res = rdbSaveKeyValuePair(rdb, key, o, expire, dbid, rdbver)) < 0) goto werr;
         written += res;
 
         /* In fork child process, we can try to release memory back to the
@@ -2245,13 +2245,13 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 itemexpiry != EXPIRY_NONE && itemexpiry < now) {
                 /* Emit HDEL to replicas. */
                 if ((rdbflags & RDBFLAGS_FEED_REPL) && server.repl_backlog) {
-                    robj keyobj, fieldobj;
-                    initStaticStringObject(keyobj, key);
-                    initStaticStringObject(fieldobj, field);
+                    robjStatic keyobj_buf, fieldobj_buf;
+                    robj *keyobj = initStaticStringObject(&keyobj_buf, key);
+                    robj *fieldobj = initStaticStringObject(&fieldobj_buf, field);
                     robj *argv[3];
                     argv[0] = shared.hdel;
-                    argv[1] = &keyobj;
-                    argv[2] = &fieldobj;
+                    argv[1] = keyobj;
+                    argv[2] = fieldobj;
                     replicationFeedReplicas(dbid, argv, 3);
                 }
                 sdsfree(field);
@@ -2928,9 +2928,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
             return NULL;
         }
         ValkeyModuleIO io;
-        robj keyobj;
-        initStaticStringObject(keyobj, key);
-        moduleInitIOContext(&io, mt, rdb, &keyobj, dbid);
+        robjStatic keyobj_buf;
+        robj *keyobj = initStaticStringObject(&keyobj_buf, key);
+        moduleInitIOContext(&io, mt, rdb, keyobj, dbid);
         /* Call the rdb_load method of the module providing the 10 bit
          * encoding version in the lower 10 bits of the module ID. */
         void *ptr = mt->rdb_load(&io, moduleid & 1023);
@@ -3520,19 +3520,19 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                  * and now this path only works when rebooting,
                  * so we don't have replicas yet. */
                 serverAssert(server.repl_backlog != NULL && listLength(server.replicas) == 0);
-                robj keyobj;
-                initStaticStringObject(keyobj, key);
+                robjStatic keyobj_buf;
+                robj *keyobj = initStaticStringObject(&keyobj_buf, key);
                 robj *argv[2];
                 argv[0] = server.lazyfree_lazy_expire ? shared.unlink : shared.del;
-                argv[1] = &keyobj;
+                argv[1] = keyobj;
                 replicationFeedReplicas(dbid, argv, 2);
             }
             sdsfree(key);
             decrRefCount(val);
             server.rdb_last_load_keys_expired++;
         } else {
-            robj keyobj;
-            initStaticStringObject(keyobj, key);
+            robjStatic keyobj_buf;
+            robj *keyobj = initStaticStringObject(&keyobj_buf, key);
 
             /* Add the new object in the hash table */
             int added = dbAddRDBLoad(db, key, &val);
@@ -3542,7 +3542,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                     /* This flag is useful for DEBUG RELOAD special modes.
                      * When it's set we allow new keys to replace the current
                      * keys with the same name. */
-                    dbSyncDelete(db, &keyobj);
+                    dbSyncDelete(db, keyobj);
                     added = dbAddRDBLoad(db, key, &val);
                     serverAssert(added);
                 } else {
@@ -3557,14 +3557,14 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
 
             /* Set the expire time if needed */
             if (expiretime != -1) {
-                val = setExpire(NULL, db, &keyobj, expiretime);
+                val = setExpire(NULL, db, keyobj, expiretime);
             }
 
             /* Set usage information (for eviction). */
             objectSetLRUOrLFU(val, lfu_freq, lru_idle);
 
             /* call key space notification on key loaded for modules only */
-            moduleNotifyKeyspaceEvent(NOTIFY_LOADED, "loaded", &keyobj, db->id);
+            moduleNotifyKeyspaceEvent(NOTIFY_LOADED, "loaded", keyobj, db->id);
 
             /* Release key (sds), dictEntry stores a copy of it in embedded data */
             sdsfree(key);

--- a/src/replication.c
+++ b/src/replication.c
@@ -634,7 +634,7 @@ void replicationFeedReplicas(int dictid, robj **argv, int argc) {
 
     for (int j = 0; j < argc; j++) {
         robj *o = argv[j];
-        if (o->encoding == OBJ_ENCODING_INT) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_INT) {
             char aux[LONG_STR_SIZE];
             size_t dlen = ll2string(aux, sizeof(aux), (long)objectGetVal(o));
             frame = catReplicationBulkLen(frame, dlen);
@@ -745,7 +745,7 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     for (j = 0; j < argc; j++) {
         if (clientCommandArgShouldBeRedacted(c, j)) {
             cmdrepr = sdscatrepr(cmdrepr, (char *)objectGetVal(shared.redacted), sdslen(objectGetVal(shared.redacted)));
-        } else if (argv[j]->encoding == OBJ_ENCODING_INT) {
+        } else if (objectGetEncoding(argv[j]) == OBJ_ENCODING_INT) {
             cmdrepr = sdscatprintf(cmdrepr, "\"%ld\"", (long)objectGetVal(argv[j]));
         } else {
             cmdrepr = sdscatrepr(cmdrepr, (char *)objectGetVal(argv[j]), sdslen(objectGetVal(argv[j])));

--- a/src/server.c
+++ b/src/server.c
@@ -475,17 +475,17 @@ int dictEncObjKeyCompare(const void *key1, const void *key2) {
     robj *o1 = (robj *)key1, *o2 = (robj *)key2;
     int cmp;
 
-    if (o1->encoding == OBJ_ENCODING_INT && o2->encoding == OBJ_ENCODING_INT) return objectGetVal(o1) == objectGetVal(o2);
+    if (objectGetEncoding(o1) == OBJ_ENCODING_INT && objectGetEncoding(o2) == OBJ_ENCODING_INT) return objectGetVal(o1) == objectGetVal(o2);
 
     /* Due to OBJ_STATIC_REFCOUNT, we avoid calling getDecodedObject() without
      * good reasons, because it would incrRefCount() the object, which
      * is invalid. So we check to make sure dictFind() works with static
      * objects as well. */
-    if (o1->refcount != OBJ_STATIC_REFCOUNT) o1 = getDecodedObject(o1);
-    if (o2->refcount != OBJ_STATIC_REFCOUNT) o2 = getDecodedObject(o2);
+    if (objectGetRefcount(o1) != OBJ_STATIC_REFCOUNT) o1 = getDecodedObject(o1);
+    if (objectGetRefcount(o2) != OBJ_STATIC_REFCOUNT) o2 = getDecodedObject(o2);
     cmp = dictSdsKeyCompare(objectGetVal(o1), objectGetVal(o2));
-    if (o1->refcount != OBJ_STATIC_REFCOUNT) decrRefCount(o1);
-    if (o2->refcount != OBJ_STATIC_REFCOUNT) decrRefCount(o2);
+    if (objectGetRefcount(o1) != OBJ_STATIC_REFCOUNT) decrRefCount(o1);
+    if (objectGetRefcount(o2) != OBJ_STATIC_REFCOUNT) decrRefCount(o2);
     return cmp;
 }
 
@@ -648,8 +648,8 @@ const void *hashtableObjectGetKey(const void *entry) {
 /* Prefetch the value if it's not embedded. */
 void hashtableObjectPrefetchValue(const void *entry) {
     const robj *obj = entry;
-    if (obj->encoding != OBJ_ENCODING_EMBSTR &&
-        obj->encoding != OBJ_ENCODING_INT) {
+    if (objectGetEncoding(obj) != OBJ_ENCODING_EMBSTR &&
+        objectGetEncoding(obj) != OBJ_ENCODING_INT) {
         valkey_prefetch(objectGetVal(obj));
     }
 }
@@ -2273,7 +2273,7 @@ void createSharedObjects(void) {
 
     for (j = 0; j < OBJ_SHARED_INTEGERS; j++) {
         shared.integers[j] = makeObjectShared(createObject(OBJ_STRING, (void *)(long)j));
-        shared.integers[j]->encoding = OBJ_ENCODING_INT;
+        objectSetEncoding(shared.integers[j], OBJ_ENCODING_INT);
     }
     for (j = 0; j < OBJ_SHARED_BULKHDR_LEN; j++) {
         shared.mbulkhdr[j] = createSharedStringFromSds(sdscatprintf(sdsempty(), "*%d\r\n", j));
@@ -3537,11 +3537,10 @@ struct serverCommand *lookupCommandBySdsLogic(hashtable *commands, sds s) {
     }
 
     serverAssert(argc > 0); /* Avoid warning `-Wmaybe-uninitialized` in lookupCommandLogic() */
-    robj objects[argc];
+    robjStatic objects[argc];
     robj *argv[argc];
     for (j = 0; j < argc; j++) {
-        initStaticStringObject(objects[j], strings[j]);
-        argv[j] = &objects[j];
+        argv[j] = initStaticStringObject(&objects[j], strings[j]);
     }
 
     struct serverCommand *cmd = lookupCommandLogic(commands, argv, argc, 1);
@@ -3928,14 +3927,14 @@ void call(client *c, int flags) {
      * modifications. */
     robj **debug_argv_clone = NULL;
     int debug_argc_clone = 0;
-    int *debug_argv_refcount = NULL;
+    unsigned int *debug_argv_refcount = NULL;
     if (c->flag.argv_borrowed && server.enable_debug_assert) {
         debug_argc_clone = c->original_argv ? c->original_argc : c->argc;
         debug_argv_clone = zmalloc(sizeof(robj *) * debug_argc_clone);
-        debug_argv_refcount = zmalloc(sizeof(int) * debug_argc_clone);
+        debug_argv_refcount = zmalloc(sizeof(unsigned int) * debug_argc_clone);
         for (int i = 0; i < debug_argc_clone; i++) {
             debug_argv_clone[i] = c->original_argv ? c->original_argv[i] : c->argv[i];
-            debug_argv_refcount[i] = c->original_argv ? c->original_argv[i]->refcount : c->argv[i]->refcount;
+            debug_argv_refcount[i] = c->original_argv ? objectGetRefcount(c->original_argv[i]) : objectGetRefcount(c->argv[i]);
         }
     }
 
@@ -3954,11 +3953,11 @@ void call(client *c, int flags) {
                 serverLog(LL_WARNING, "Debug: command %s modified argv[%d]", c->cmd->current_name, i);
             }
             serverAssert(debug_argv_clone[i] == argv[i]);
-            if (argv[i]->refcount < debug_argv_refcount[i]) {
-                serverLog(LL_WARNING, "Debug: command %s modified argv[%d] refcount, original value: %d, new value: %d",
-                          c->cmd->current_name, i, debug_argv_refcount[i], argv[i]->refcount);
+            if (objectGetRefcount(argv[i]) < debug_argv_refcount[i]) {
+                serverLog(LL_WARNING, "Debug: command %s modified argv[%d] refcount, original value: %u, new value: %u",
+                          c->cmd->current_name, i, debug_argv_refcount[i], objectGetRefcount(argv[i]));
             }
-            serverAssert(argv[i]->refcount >= debug_argv_refcount[i]);
+            serverAssert(objectGetRefcount(argv[i]) >= debug_argv_refcount[i]);
         }
         zfree(debug_argv_clone);
         zfree(debug_argv_refcount);

--- a/src/server.h
+++ b/src/server.h
@@ -776,74 +776,28 @@ typedef struct ValkeyModuleType moduleType;
 #define OBJ_STATIC_REFCOUNT ((1 << OBJ_REFCOUNT_BITS) - 2) /* Object allocated in the stack. */
 #define OBJ_FIRST_SPECIAL_REFCOUNT OBJ_STATIC_REFCOUNT
 
-/* The serverObject struct is variable in size. It has several static fields that are always present,
- * followed by several optional variable-sized fields. The static fields are `type` through `refcount`
- * in the struct-defined order:
- *
- *    +------+----------+-----+-----------+-----------+-----------+----------+----
- *    | type | encoding | lru | hasexpire | hasembkey | hasembval | refcount | ...
- *    +------+----------+-----+-----------+-----------+-----------+----------+----
- *
- * The optional variable-sized embedded data has 2 possible layouts. If value is embedded (hasembval == 1)
- *  the `val_ptr` pointer is not used - instead the val data is embedded:
- *
- *    +------+----------+-----+------------+----------+--------+-----------------+---------+------------+
- *    | type | encoding | lru | has* flags | refcount | expire | key_header_size | key sds | value data |
- *    +------+----------+-----+------------+----------+--------+-----------------+---------+------------+
- *                                                      ^        ^                 ^         ^
- *                                                      |        |                 |         |
- *                                                      |        |                 |         +--- present because hasembval == 1
- *                                                      |        |                 |
- *                                                      |        +-----------------+--- present if hasembkey == 1
- *                                                      |
- *                                                      +--- present if hasexpire == 1
- *
- * Otherwise value is not embedded and we use the `val_ptr` pointer:
- *
- *    +------+----------+-----+------------+----------+---------+--------+-----------------+---------+
- *    | type | encoding | lru | has* flags | refcount | val_ptr | expire | key_header_size | key sds |
- *    +------+----------+-----+------------+----------+---------+--------+-----------------+---------+
- *                                                      ^         ^        ^                 ^
- *                                                      |         |        |                 |
- *                                                      |         |        +-----------------+--- present if hasembkey == 1
- *                                                      |         |
- *                                                      |         +--- present if hasexpire == 1
- *                                                      |
- *                                                      +--- present because hasembval == 0
- */
+/* The serverObject struct definition is in object_internals.h.
+ * Only files that need direct field access should include it.
+ * All other code should use the accessor functions below. */
 
-struct serverObject {
-    unsigned type : 4;
-    unsigned encoding : 4;
-    unsigned lru : LRULFU_BITS;
-    unsigned hasexpire : 1;
-    unsigned hasembkey : 1;
-    unsigned hasembval : 1;
-    unsigned refcount : OBJ_REFCOUNT_BITS;
-    void *val_ptr; /* Not always present. Use objectGetVal(obj) and
-                    * objectSetVal(obj, val) instead. */
-};
-static_assert(sizeof(struct serverObject) <= 8 + sizeof(void *), "unexpected size - verify struct is packed correctly");
+/* Opaque stack-allocatable robj. Use initStaticStringObject() to initialize.
+ * 8 bytes bitfields + sizeof(void*) for val_ptr. */
+#define ROBJ_STATIC_SIZE (8 + sizeof(void *))
+typedef union {
+    void *_align; /* ensure pointer alignment */
+    char _opaque[ROBJ_STATIC_SIZE];
+} robjStatic;
 
 /* The string name for an object's type as listed above
  * Native types are checked against the OBJ_STRING, OBJ_LIST, OBJ_* defines,
  * and Module types have their registered name returned. */
 char *getObjectTypeName(robj *);
 
-/* Macro used to initialize an Object allocated on the stack.
- * Note that this macro is taken near the structure definition to make sure
- * we'll update it when the structure is changed, to avoid bugs like
- * bug #85 introduced exactly in this way. */
-#define initStaticStringObject(_var, _ptr)   \
-    do {                                     \
-        _var.refcount = OBJ_STATIC_REFCOUNT; \
-        _var.type = OBJ_STRING;              \
-        _var.encoding = OBJ_ENCODING_RAW;    \
-        _var.hasexpire = 0;                  \
-        _var.hasembkey = 0;                  \
-        _var.hasembval = 0;                  \
-        _var.val_ptr = _ptr;                 \
-    } while (0)
+/* Initialize a stack-allocated robjStatic as a static raw string and return
+ * a pointer usable as robj*. The cast through robjStatic is aliasing-safe
+ * because initStaticStringObject writes the memory through the correct type
+ * internally (struct serverObject* in object.c). */
+robj *initStaticStringObject(robjStatic *buf, void *ptr);
 
 struct evictionPoolEntry; /* Defined in evict.c */
 
@@ -3205,6 +3159,8 @@ void objectSetEncoding(robj *o, int encoding);
 unsigned int objectGetRefcount(const robj *o);
 unsigned int objectGetLRU(const robj *o);
 void objectSetLRU(robj *o, unsigned int lru);
+size_t objectGetStructSize(void);
+int objectHasEmbeddedKey(const robj *o);
 
 /* Synchronous I/O with timeout */
 ssize_t syncWrite(int fd, char *ptr, ssize_t size, long long timeout);

--- a/src/sort.c
+++ b/src/sort.c
@@ -297,7 +297,7 @@ void sortCommandGeneric(client *c, int readonly) {
 
     /* Lookup the key to sort. It must be of the right types */
     sortval = lookupKeyRead(c->db, c->argv[1]);
-    if (sortval && sortval->type != OBJ_SET && sortval->type != OBJ_LIST && sortval->type != OBJ_ZSET) {
+    if (sortval && objectGetType(sortval) != OBJ_SET && objectGetType(sortval) != OBJ_LIST && objectGetType(sortval) != OBJ_ZSET) {
         listRelease(operations);
         addReplyErrorObject(c, shared.wrongtypeerr);
         return;
@@ -317,7 +317,7 @@ void sortCommandGeneric(client *c, int readonly) {
      * The other types (list, sorted set) will retain their native order
      * even if no sort order is requested, so they remain stable across
      * scripting and replication. */
-    if (dontsort && sortval->type == OBJ_SET && (storekey || c->flag.script)) {
+    if (dontsort && objectGetType(sortval) == OBJ_SET && (storekey || c->flag.script)) {
         /* Force ALPHA sorting */
         dontsort = 0;
         alpha = 1;
@@ -325,10 +325,10 @@ void sortCommandGeneric(client *c, int readonly) {
     }
 
     /* Destructively convert encoded sorted sets for SORT. */
-    if (sortval->type == OBJ_ZSET) zsetConvert(sortval, OBJ_ENCODING_SKIPLIST);
+    if (objectGetType(sortval) == OBJ_ZSET) zsetConvert(sortval, OBJ_ENCODING_SKIPLIST);
 
     /* Obtain the length of the object to sort. */
-    switch (sortval->type) {
+    switch (objectGetType(sortval)) {
     case OBJ_LIST: vectorlen = listTypeLength(sortval); break;
     case OBJ_SET: vectorlen = setTypeSize(sortval); break;
     case OBJ_ZSET: vectorlen = hashtableSize(((zset *)objectGetVal(sortval))->ht); break;
@@ -356,7 +356,7 @@ void sortCommandGeneric(client *c, int readonly) {
      * the number of elements to fetch, we also optimize to just load the
      * range we are interested in and allocating a vector that is big enough
      * for the selected range length. */
-    if ((sortval->type == OBJ_ZSET || sortval->type == OBJ_LIST) && dontsort && (start != 0 || end != vectorlen - 1)) {
+    if ((objectGetType(sortval) == OBJ_ZSET || objectGetType(sortval) == OBJ_LIST) && dontsort && (start != 0 || end != vectorlen - 1)) {
         vectorlen = end - start + 1;
     }
 
@@ -364,7 +364,7 @@ void sortCommandGeneric(client *c, int readonly) {
     vector = zmalloc(sizeof(serverSortObject) * vectorlen);
     j = 0;
 
-    if (sortval->type == OBJ_LIST && dontsort) {
+    if (objectGetType(sortval) == OBJ_LIST && dontsort) {
         /* Special handling for a list, if 'dontsort' is true.
          * This makes sure we return elements in the list original
          * ordering, accordingly to DESC / ASC options.
@@ -388,7 +388,7 @@ void sortCommandGeneric(client *c, int readonly) {
             end -= start;
             start = 0;
         }
-    } else if (sortval->type == OBJ_LIST) {
+    } else if (objectGetType(sortval) == OBJ_LIST) {
         listTypeIterator *li = listTypeInitIterator(sortval, 0, LIST_TAIL);
         listTypeEntry entry;
         while (listTypeNext(li, &entry)) {
@@ -398,7 +398,7 @@ void sortCommandGeneric(client *c, int readonly) {
             j++;
         }
         listTypeReleaseIterator(li);
-    } else if (sortval->type == OBJ_SET) {
+    } else if (objectGetType(sortval) == OBJ_SET) {
         setTypeIterator *si = setTypeInitIterator(sortval);
         sds sdsele;
         while ((sdsele = setTypeNextObject(si)) != NULL) {
@@ -408,7 +408,7 @@ void sortCommandGeneric(client *c, int readonly) {
             j++;
         }
         setTypeReleaseIterator(si);
-    } else if (sortval->type == OBJ_ZSET && dontsort) {
+    } else if (objectGetType(sortval) == OBJ_ZSET && dontsort) {
         /* Special handling for a sorted set, if 'dontsort' is true.
          * This makes sure we return elements in the sorted set original
          * ordering, accordingly to DESC / ASC options.
@@ -446,7 +446,7 @@ void sortCommandGeneric(client *c, int readonly) {
         /* Fix start/end: output code is not aware of this optimization. */
         end -= start;
         start = 0;
-    } else if (sortval->type == OBJ_ZSET) {
+    } else if (objectGetType(sortval) == OBJ_ZSET) {
         hashtable *ht = ((zset *)objectGetVal(sortval))->ht;
         hashtableIterator iter;
         hashtableInitIterator(&iter, ht, 0);
@@ -488,7 +488,7 @@ void sortCommandGeneric(client *c, int readonly) {
                     if (eptr[0] != '\0' || errno == ERANGE || errno == EINVAL || isnan(vector[j].u.score)) {
                         int_conversion_error = 1;
                     }
-                } else if (byval->encoding == OBJ_ENCODING_INT) {
+                } else if (objectGetEncoding(byval) == OBJ_ENCODING_INT) {
                     /* Don't need to decode the object if it's
                      * integer-encoded (the only encoding supported) so
                      * far. We can just cast it */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -169,7 +169,7 @@ void hashTypeTryConversion(robj *o, robj **argv, int start, int end) {
     int i;
     size_t sum = 0;
 
-    if (o->encoding != OBJ_ENCODING_LISTPACK) return;
+    if (objectGetEncoding(o) != OBJ_ENCODING_LISTPACK) return;
 
     /* We guess that most of the values in the input are unique, so
      * if there are enough arguments we create a pre-sized hash, which
@@ -626,7 +626,7 @@ unsigned long hashTypeLength(const robj *o) {
 
 void hashTypeInitIterator(robj *subject, hashTypeIterator *hi) {
     hi->subject = subject;
-    hi->encoding = subject->encoding;
+    hi->encoding = objectGetEncoding(subject);
     hi->volatile_items_iter = false;
 
     if (hi->encoding == OBJ_ENCODING_LISTPACK) {
@@ -641,7 +641,7 @@ void hashTypeInitIterator(robj *subject, hashTypeIterator *hi) {
 
 void hashTypeInitVolatileIterator(robj *subject, hashTypeIterator *hi) {
     hi->subject = subject;
-    hi->encoding = subject->encoding;
+    hi->encoding = objectGetEncoding(subject);
     hi->volatile_items_iter = true;
 
     if (hi->encoding == OBJ_ENCODING_LISTPACK) {
@@ -833,12 +833,12 @@ robj *hashTypeDup(robj *o) {
         unsigned char *new_zl = zmalloc(sz);
         memcpy(new_zl, zl, sz);
         hobj = createObject(OBJ_HASH, new_zl);
-        hobj->encoding = OBJ_ENCODING_LISTPACK;
+        objectSetEncoding(hobj, OBJ_ENCODING_LISTPACK);
     } else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         hashtable *ht = hashtableCreate(&hashHashtableType);
         hashtableExpand(ht, hashtableSize((const hashtable *)objectGetVal(o)));
         hobj = createObject(OBJ_HASH, ht);
-        hobj->encoding = OBJ_ENCODING_HASHTABLE;
+        objectSetEncoding(hobj, OBJ_ENCODING_HASHTABLE);
 
         hashTypeInitIterator(o, &hi);
         while (hashTypeNext(&hi) != C_ERR) {
@@ -882,7 +882,7 @@ void hashReplyFromListpackEntry(client *c, listpackEntry *e) {
  * Return C_OK otherwise. */
 static int hashTypeRandomElement(robj *hashobj, unsigned long hashsize, listpackEntry *field, listpackEntry *val) {
     int rc = C_OK;
-    if (hashobj->encoding == OBJ_ENCODING_HASHTABLE) {
+    if (objectGetEncoding(hashobj) == OBJ_ENCODING_HASHTABLE) {
         void *e = NULL;
         int maxtries = 100;
         hashTypeIgnoreTTL(hashobj, true);
@@ -905,7 +905,7 @@ static int hashTypeRandomElement(robj *hashobj, unsigned long hashsize, listpack
             }
         }
         hashTypeIgnoreTTL(hashobj, false);
-    } else if (hashobj->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(hashobj) == OBJ_ENCODING_LISTPACK) {
         lpRandomPair(objectGetVal(hashobj), hashsize, field, val);
     } else {
         serverPanic("Unknown hash encoding");
@@ -1130,7 +1130,7 @@ void hdelCommand(client *c) {
     if ((o = lookupKeyWriteOrReply(c, c->argv[1], shared.czero)) == NULL || checkType(c, o, OBJ_HASH)) return;
 
     bool hash_volatile_items = hashTypeHasVolatileFields(o);
-    if (o->encoding == OBJ_ENCODING_HASHTABLE) hashtablePauseAutoShrink(objectGetVal(o));
+    if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) hashtablePauseAutoShrink(objectGetVal(o));
     for (j = 2; j < c->argc; j++) {
         if (hashTypeDelete(o, objectGetVal(c->argv[j]))) {
             deleted++;
@@ -1142,7 +1142,7 @@ void hdelCommand(client *c) {
             }
         }
     }
-    if (!keyremoved && o->encoding == OBJ_ENCODING_HASHTABLE) hashtableResumeAutoShrink(objectGetVal(o));
+    if (!keyremoved && objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) hashtableResumeAutoShrink(objectGetVal(o));
     if (deleted) {
         if (!keyremoved && hash_volatile_items != hashTypeHasVolatileFields(o)) {
             dbUpdateObjectWithVolatileItemsTracking(c->db, o);
@@ -1181,7 +1181,7 @@ void hgetdelCommand(client *c) {
     if (checkType(c, o, OBJ_HASH)) return;
 
     bool hash_volatile_items = hashTypeHasVolatileFields(o);
-    if (o && o->encoding == OBJ_ENCODING_HASHTABLE) hashtablePauseAutoShrink(objectGetVal(o));
+    if (o && objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) hashtablePauseAutoShrink(objectGetVal(o));
 
     initDeferredReplyBuffer(c);
 
@@ -1202,7 +1202,7 @@ void hgetdelCommand(client *c) {
             }
         }
     }
-    if (!keyremoved && o && o->encoding == OBJ_ENCODING_HASHTABLE) hashtableResumeAutoShrink(objectGetVal(o));
+    if (!keyremoved && o && objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) hashtableResumeAutoShrink(objectGetVal(o));
 
     if (deleted) {
         if (!keyremoved && hash_volatile_items != hashTypeHasVolatileFields(o)) {
@@ -2182,7 +2182,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
      * structures. This case is the only one that also needs to return the
      * elements in random order. */
     if (!uniq || count == 1) {
-        if (hash->encoding == OBJ_ENCODING_HASHTABLE) {
+        if (objectGetEncoding(hash) == OBJ_ENCODING_HASHTABLE) {
             while (count--) {
                 listpackEntry field, value;
 
@@ -2197,7 +2197,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
                 if (c->flag.close_asap) break;
                 reply_size++;
             }
-        } else if (hash->encoding == OBJ_ENCODING_LISTPACK) {
+        } else if (objectGetEncoding(hash) == OBJ_ENCODING_LISTPACK) {
             listpackEntry *fields, *vals = NULL;
             unsigned long limit, sample_count;
 
@@ -2244,7 +2244,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
      *
      * And it is inefficient to repeatedly pick one random element from a
      * listpack in CASE 4. So we use this instead. */
-    if (hash->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(hash) == OBJ_ENCODING_LISTPACK) {
         reply_size = count < size ? count : size;
         listpackEntry *fields, *vals = NULL;
         fields = zmalloc(sizeof(listpackEntry) * count);
@@ -2455,12 +2455,12 @@ static void defragHashTypeEntry(void *privdata, void *element_ref) {
 }
 
 size_t hashTypeScanDefrag(robj *ob, size_t cursor, void *(*defragAllocfn)(void *)) {
-    if (ob->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(ob) == OBJ_ENCODING_LISTPACK) {
         unsigned char *newzl;
         if ((newzl = activeDefragAlloc(objectGetVal(ob)))) objectSetVal(ob, newzl);
         return 0;
     }
-    serverAssert(ob->encoding == OBJ_ENCODING_HASHTABLE);
+    serverAssert(objectGetEncoding(ob) == OBJ_ENCODING_HASHTABLE);
     static struct volatileSetCursor {
         size_t cursor;
         bool is_vsetDefrag;

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -105,7 +105,7 @@ static void listTypeTryConvertQuicklist(robj *o, int shrinking, beforeConvertCB 
     objectSetVal(o, ql->head->entry);
     ql->head->entry = NULL;
     quicklistRelease(ql);
-    o->encoding = OBJ_ENCODING_LISTPACK;
+    objectSetEncoding(o, OBJ_ENCODING_LISTPACK);
 }
 
 /* Check if the list needs to be converted to appropriate encoding due to
@@ -154,18 +154,18 @@ void listTypeTryConversionAppend(robj *o, robj **argv, int start, int end, befor
  * There is no need for the caller to increment the refcount of 'value' as
  * the function takes care of it if needed. */
 void listTypePush(robj *subject, robj *value, int where) {
-    if (subject->encoding == OBJ_ENCODING_QUICKLIST) {
+    if (objectGetEncoding(subject) == OBJ_ENCODING_QUICKLIST) {
         int pos = (where == LIST_HEAD) ? QUICKLIST_HEAD : QUICKLIST_TAIL;
-        if (value->encoding == OBJ_ENCODING_INT) {
+        if (objectGetEncoding(value) == OBJ_ENCODING_INT) {
             char buf[32];
             ll2string(buf, 32, (long)objectGetVal(value));
             quicklistPush(objectGetVal(subject), buf, strlen(buf), pos);
         } else {
             quicklistPush(objectGetVal(subject), objectGetVal(value), sdslen(objectGetVal(value)), pos);
         }
-    } else if (subject->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(subject) == OBJ_ENCODING_LISTPACK) {
         unsigned char *new_val = NULL;
-        if (value->encoding == OBJ_ENCODING_INT) {
+        if (objectGetEncoding(value) == OBJ_ENCODING_INT) {
             new_val = (where == LIST_HEAD) ? lpPrependInteger(objectGetVal(subject), (long)objectGetVal(value))
                                            : lpAppendInteger(objectGetVal(subject), (long)objectGetVal(value));
         } else {
@@ -185,13 +185,13 @@ void *listPopSaver(unsigned char *data, size_t sz) {
 robj *listTypePop(robj *subject, int where) {
     robj *value = NULL;
 
-    if (subject->encoding == OBJ_ENCODING_QUICKLIST) {
+    if (objectGetEncoding(subject) == OBJ_ENCODING_QUICKLIST) {
         long long vlong;
         int ql_where = where == LIST_HEAD ? QUICKLIST_HEAD : QUICKLIST_TAIL;
         if (quicklistPopCustom(objectGetVal(subject), ql_where, (unsigned char **)&value, NULL, &vlong, listPopSaver)) {
             if (!value) value = createStringObjectFromLongLong(vlong);
         }
-    } else if (subject->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(subject) == OBJ_ENCODING_LISTPACK) {
         unsigned char *p;
         unsigned char *vstr;
         int64_t vlen;
@@ -210,9 +210,9 @@ robj *listTypePop(robj *subject, int where) {
 }
 
 unsigned long listTypeLength(const robj *subject) {
-    if (subject->encoding == OBJ_ENCODING_QUICKLIST) {
+    if (objectGetEncoding(subject) == OBJ_ENCODING_QUICKLIST) {
         return quicklistCount(objectGetVal(subject));
-    } else if (subject->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(subject) == OBJ_ENCODING_LISTPACK) {
         return lpLength(objectGetVal(subject));
     } else {
         serverPanic("Unknown list encoding");
@@ -223,7 +223,7 @@ unsigned long listTypeLength(const robj *subject) {
 listTypeIterator *listTypeInitIterator(robj *subject, long index, unsigned char direction) {
     listTypeIterator *li = zmalloc(sizeof(listTypeIterator));
     li->subject = subject;
-    li->encoding = subject->encoding;
+    li->encoding = objectGetEncoding(subject);
     li->direction = direction;
     li->iter = NULL;
     /* LIST_HEAD means start at TAIL and move *towards* head.
@@ -268,7 +268,7 @@ void listTypeReleaseIterator(listTypeIterator *li) {
  * entry is in fact an entry, 0 otherwise. */
 int listTypeNext(listTypeIterator *li, listTypeEntry *entry) {
     /* Protect from converting when iterating */
-    serverAssert(li->subject->encoding == li->encoding);
+    serverAssert(objectGetEncoding(li->subject) == li->encoding);
 
     entry->li = li;
     if (li->encoding == OBJ_ENCODING_QUICKLIST) {
@@ -433,22 +433,22 @@ void listTypeDelete(listTypeIterator *iter, listTypeEntry *entry) {
 robj *listTypeDup(robj *o) {
     robj *lobj;
 
-    serverAssert(o->type == OBJ_LIST);
+    serverAssert(objectGetType(o) == OBJ_LIST);
 
-    switch (o->encoding) {
+    switch (objectGetEncoding(o)) {
     case OBJ_ENCODING_LISTPACK: lobj = createObject(OBJ_LIST, lpDup(objectGetVal(o))); break;
     case OBJ_ENCODING_QUICKLIST: lobj = createObject(OBJ_LIST, quicklistDup(objectGetVal(o))); break;
     default: serverPanic("Unknown list encoding"); break;
     }
-    lobj->encoding = o->encoding;
+    objectSetEncoding(lobj, objectGetEncoding(o));
     return lobj;
 }
 
 /* Delete a range of elements from the list. */
 void listTypeDelRange(robj *subject, long start, long count) {
-    if (subject->encoding == OBJ_ENCODING_QUICKLIST) {
+    if (objectGetEncoding(subject) == OBJ_ENCODING_QUICKLIST) {
         quicklistDelRange(objectGetVal(subject), start, count);
-    } else if (subject->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(subject) == OBJ_ENCODING_LISTPACK) {
         objectSetVal(subject, lpDeleteRange(objectGetVal(subject), start, count));
     } else {
         serverPanic("Unknown list encoding");

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -63,8 +63,8 @@ robj *setTypeCreate(sds value, size_t size_hint) {
 /* Check if the existing set should be converted to another encoding based off the
  * the size hint. */
 void setTypeMaybeConvert(robj *set, size_t size_hint) {
-    if ((set->encoding == OBJ_ENCODING_LISTPACK && size_hint > server.set_max_listpack_entries) ||
-        (set->encoding == OBJ_ENCODING_INTSET && size_hint > server.set_max_intset_entries)) {
+    if ((objectGetEncoding(set) == OBJ_ENCODING_LISTPACK && size_hint > server.set_max_listpack_entries) ||
+        (objectGetEncoding(set) == OBJ_ENCODING_INTSET && size_hint > server.set_max_intset_entries)) {
         setTypeConvertAndExpand(set, OBJ_ENCODING_HASHTABLE, size_hint, 1);
     }
 }
@@ -79,7 +79,7 @@ static size_t intsetMaxEntries(void) {
 
 /* Converts intset to HT if it contains too many entries. */
 static void maybeConvertIntset(robj *subject) {
-    serverAssert(subject->encoding == OBJ_ENCODING_INTSET);
+    serverAssert(objectGetEncoding(subject) == OBJ_ENCODING_INTSET);
     if (intsetLen(objectGetVal(subject)) > intsetMaxEntries()) setTypeConvert(subject, OBJ_ENCODING_HASHTABLE);
 }
 
@@ -87,8 +87,8 @@ static void maybeConvertIntset(robj *subject) {
  * an intset. No conversion happens if the set contains too many entries for an
  * intset. */
 static void maybeConvertToIntset(robj *set) {
-    if (set->encoding == OBJ_ENCODING_INTSET) return;  /* already intset */
-    if (setTypeSize(set) > intsetMaxEntries()) return; /* can't use intset */
+    if (objectGetEncoding(set) == OBJ_ENCODING_INTSET) return; /* already intset */
+    if (setTypeSize(set) > intsetMaxEntries()) return;         /* can't use intset */
     intset *is = intsetNew();
     char *str;
     size_t len;
@@ -107,7 +107,7 @@ static void maybeConvertToIntset(robj *set) {
     setTypeReleaseIterator(si);
     freeSetObject(set); /* frees the internals but not robj itself */
     objectSetVal(set, is);
-    set->encoding = OBJ_ENCODING_INTSET;
+    objectSetEncoding(set, OBJ_ENCODING_INTSET);
 }
 
 /* Add the specified sds value into a set.
@@ -127,7 +127,7 @@ int setTypeAdd(robj *subject, sds value) {
 int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sds) {
     char tmpbuf[LONG_STR_SIZE];
     if (!str) {
-        if (set->encoding == OBJ_ENCODING_INTSET) {
+        if (objectGetEncoding(set) == OBJ_ENCODING_INTSET) {
             uint8_t success = 0;
             objectSetVal(set, intsetAdd(objectGetVal(set), llval, &success));
             if (success) maybeConvertIntset(set);
@@ -140,7 +140,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
     }
 
     serverAssert(str);
-    if (set->encoding == OBJ_ENCODING_HASHTABLE) {
+    if (objectGetEncoding(set) == OBJ_ENCODING_HASHTABLE) {
         /* Avoid duping the string if it is an sds string. */
         sds sdsval = str_is_sds ? (sds)str : sdsnewlen(str, len);
         hashtable *ht = objectGetVal(set);
@@ -155,7 +155,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
             sdsfree(sdsval);
             return 0;
         }
-    } else if (set->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(set) == OBJ_ENCODING_LISTPACK) {
         unsigned char *lp = objectGetVal(set);
         unsigned char *p = lpFirst(lp);
         if (p != NULL) p = lpFind(lp, p, (unsigned char *)str, len, 0);
@@ -178,7 +178,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
             }
             return 1;
         }
-    } else if (set->encoding == OBJ_ENCODING_INTSET) {
+    } else if (objectGetEncoding(set) == OBJ_ENCODING_INTSET) {
         long long value;
         if (string2ll(str, len, &value)) {
             uint8_t success = 0;
@@ -239,7 +239,7 @@ int setTypeRemove(robj *setobj, sds value) {
 int setTypeRemoveAux(robj *setobj, char *str, size_t len, int64_t llval, int str_is_sds) {
     char tmpbuf[LONG_STR_SIZE];
     if (!str) {
-        if (setobj->encoding == OBJ_ENCODING_INTSET) {
+        if (objectGetEncoding(setobj) == OBJ_ENCODING_INTSET) {
             int success;
             objectSetVal(setobj, intsetRemove(objectGetVal(setobj), llval, &success));
             return success;
@@ -249,12 +249,12 @@ int setTypeRemoveAux(robj *setobj, char *str, size_t len, int64_t llval, int str
         str_is_sds = 0;
     }
 
-    if (setobj->encoding == OBJ_ENCODING_HASHTABLE) {
+    if (objectGetEncoding(setobj) == OBJ_ENCODING_HASHTABLE) {
         sds sdsval = str_is_sds ? (sds)str : sdsnewlen(str, len);
         int deleted = hashtableDelete(objectGetVal(setobj), sdsval);
         if (sdsval != str) sdsfree(sdsval); /* free temp copy */
         return deleted;
-    } else if (setobj->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(setobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *lp = objectGetVal(setobj);
         unsigned char *p = lpFirst(lp);
         if (p == NULL) return 0;
@@ -264,7 +264,7 @@ int setTypeRemoveAux(robj *setobj, char *str, size_t len, int64_t llval, int str
             objectSetVal(setobj, lp);
             return 1;
         }
-    } else if (setobj->encoding == OBJ_ENCODING_INTSET) {
+    } else if (objectGetEncoding(setobj) == OBJ_ENCODING_INTSET) {
         long long llval;
         if (string2ll(str, len, &llval)) {
             int success;
@@ -292,22 +292,22 @@ int setTypeIsMember(robj *subject, sds value) {
 int setTypeIsMemberAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sds) {
     char tmpbuf[LONG_STR_SIZE];
     if (!str) {
-        if (set->encoding == OBJ_ENCODING_INTSET) return intsetFind(objectGetVal(set), llval);
+        if (objectGetEncoding(set) == OBJ_ENCODING_INTSET) return intsetFind(objectGetVal(set), llval);
         len = ll2string(tmpbuf, sizeof tmpbuf, llval);
         str = tmpbuf;
         str_is_sds = 0;
     }
 
-    if (set->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(set) == OBJ_ENCODING_LISTPACK) {
         unsigned char *lp = objectGetVal(set);
         unsigned char *p = lpFirst(lp);
         return p && lpFind(lp, p, (unsigned char *)str, len, 0);
-    } else if (set->encoding == OBJ_ENCODING_INTSET) {
+    } else if (objectGetEncoding(set) == OBJ_ENCODING_INTSET) {
         long long llval;
         return string2ll(str, len, &llval) && intsetFind(objectGetVal(set), llval);
-    } else if (set->encoding == OBJ_ENCODING_HASHTABLE && str_is_sds) {
+    } else if (objectGetEncoding(set) == OBJ_ENCODING_HASHTABLE && str_is_sds) {
         return hashtableFind(objectGetVal(set), (sds)str, NULL);
-    } else if (set->encoding == OBJ_ENCODING_HASHTABLE) {
+    } else if (objectGetEncoding(set) == OBJ_ENCODING_HASHTABLE) {
         sds sdsval = sdsnewlen(str, len);
         int result = hashtableFind(objectGetVal(set), sdsval, NULL);
         sdsfree(sdsval);
@@ -320,7 +320,7 @@ int setTypeIsMemberAux(robj *set, char *str, size_t len, int64_t llval, int str_
 setTypeIterator *setTypeInitIterator(robj *subject) {
     setTypeIterator *si = zmalloc(sizeof(setTypeIterator));
     si->subject = subject;
-    si->encoding = subject->encoding;
+    si->encoding = objectGetEncoding(subject);
     if (si->encoding == OBJ_ENCODING_HASHTABLE) {
         si->hashtable_iterator = hashtableCreateIterator(objectGetVal(subject), 0);
     } else if (si->encoding == OBJ_ENCODING_INTSET) {
@@ -419,16 +419,16 @@ sds setTypeNextObject(setTypeIterator *si) {
  * Note that both the str, len and llele pointers should be passed and cannot
  * be NULL. If str is set to NULL, the value is an integer stored in llele. */
 int setTypeRandomElement(robj *setobj, char **str, size_t *len, int64_t *llele) {
-    if (setobj->encoding == OBJ_ENCODING_HASHTABLE) {
+    if (objectGetEncoding(setobj) == OBJ_ENCODING_HASHTABLE) {
         void *entry = NULL;
         hashtableFairRandomEntry(objectGetVal(setobj), &entry);
         *str = entry;
         *len = sdslen(*str);
         *llele = -123456789; /* Not needed. Defensive. */
-    } else if (setobj->encoding == OBJ_ENCODING_INTSET) {
+    } else if (objectGetEncoding(setobj) == OBJ_ENCODING_INTSET) {
         *llele = intsetRandom(objectGetVal(setobj));
         *str = NULL; /* Not needed. Defensive. */
-    } else if (setobj->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(setobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *lp = objectGetVal(setobj);
         int r = rand() % lpLength(lp);
         unsigned char *p = lpSeek(lp, r);
@@ -438,13 +438,13 @@ int setTypeRandomElement(robj *setobj, char **str, size_t *len, int64_t *llele) 
     } else {
         serverPanic("Unknown set encoding");
     }
-    return setobj->encoding;
+    return objectGetEncoding(setobj);
 }
 
 /* Pops a random element and returns it as an object. */
 robj *setTypePopRandom(robj *set) {
     robj *obj;
-    if (set->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(set) == OBJ_ENCODING_LISTPACK) {
         /* Find random and delete it without re-seeking the listpack. */
         unsigned int i = 0;
         unsigned char *p = lpNextRandom(objectGetVal(set), lpFirst(objectGetVal(set)), &i, 1, 0);
@@ -471,11 +471,11 @@ robj *setTypePopRandom(robj *set) {
 }
 
 unsigned long setTypeSize(const robj *subject) {
-    if (subject->encoding == OBJ_ENCODING_HASHTABLE) {
+    if (objectGetEncoding(subject) == OBJ_ENCODING_HASHTABLE) {
         return hashtableSize((const hashtable *)objectGetVal(subject));
-    } else if (subject->encoding == OBJ_ENCODING_INTSET) {
+    } else if (objectGetEncoding(subject) == OBJ_ENCODING_INTSET) {
         return intsetLen((const intset *)objectGetVal(subject));
-    } else if (subject->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(subject) == OBJ_ENCODING_LISTPACK) {
         return lpLength((unsigned char *)objectGetVal(subject));
     } else {
         serverPanic("Unknown set encoding");
@@ -495,7 +495,7 @@ void setTypeConvert(robj *setobj, int enc) {
  * C_OK. */
 int setTypeConvertAndExpand(robj *setobj, int enc, unsigned long cap, int panic) {
     setTypeIterator *si;
-    serverAssertWithInfo(NULL, setobj, setobj->type == OBJ_SET && setobj->encoding != enc);
+    serverAssertWithInfo(NULL, setobj, objectGetType(setobj) == OBJ_SET && objectGetEncoding(setobj) != enc);
 
     if (enc == OBJ_ENCODING_HASHTABLE) {
         hashtable *ht = hashtableCreate(&setHashtableType);
@@ -517,12 +517,12 @@ int setTypeConvertAndExpand(robj *setobj, int enc, unsigned long cap, int panic)
         setTypeReleaseIterator(si);
 
         freeSetObject(setobj); /* frees the internals but not setobj itself */
-        setobj->encoding = OBJ_ENCODING_HASHTABLE;
+        objectSetEncoding(setobj, OBJ_ENCODING_HASHTABLE);
         objectSetVal(setobj, ht);
     } else if (enc == OBJ_ENCODING_LISTPACK) {
         /* Preallocate the minimum two bytes per element (enc/value + backlen) */
         size_t estcap = cap * 2;
-        if (setobj->encoding == OBJ_ENCODING_INTSET && setTypeSize(setobj) > 0) {
+        if (objectGetEncoding(setobj) == OBJ_ENCODING_INTSET && setTypeSize(setobj) > 0) {
             /* If we're converting from intset, we have a better estimate. */
             size_t s1 = lpEstimateBytesRepeatedInteger(intsetMin(objectGetVal(setobj)), cap);
             size_t s2 = lpEstimateBytesRepeatedInteger(intsetMax(objectGetVal(setobj)), cap);
@@ -542,7 +542,7 @@ int setTypeConvertAndExpand(robj *setobj, int enc, unsigned long cap, int panic)
         setTypeReleaseIterator(si);
 
         freeSetObject(setobj); /* frees the internals but not setobj itself */
-        setobj->encoding = OBJ_ENCODING_LISTPACK;
+        objectSetEncoding(setobj, OBJ_ENCODING_LISTPACK);
         objectSetVal(setobj, lp);
     } else {
         serverPanic("Unsupported set conversion");
@@ -568,14 +568,14 @@ robj *setTypeDup(robj *o) {
         intset *newis = zmalloc(size);
         memcpy(newis, is, size);
         set = createObject(OBJ_SET, newis);
-        set->encoding = OBJ_ENCODING_INTSET;
+        objectSetEncoding(set, OBJ_ENCODING_INTSET);
     } else if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         unsigned char *lp = objectGetVal(o);
         size_t sz = lpBytes(lp);
         unsigned char *new_lp = zmalloc(sz);
         memcpy(new_lp, lp, sz);
         set = createObject(OBJ_SET, new_lp);
-        set->encoding = OBJ_ENCODING_LISTPACK;
+        objectSetEncoding(set, OBJ_ENCODING_LISTPACK);
     } else if (objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE) {
         set = createSetObject();
         hashtable *ht = objectGetVal(o);
@@ -625,7 +625,7 @@ void sremCommand(client *c) {
 
     if ((set = lookupKeyWriteOrReply(c, c->argv[1], shared.czero)) == NULL || checkType(c, set, OBJ_SET)) return;
 
-    if (set->encoding == OBJ_ENCODING_HASHTABLE) hashtablePauseAutoShrink(objectGetVal(set));
+    if (objectGetEncoding(set) == OBJ_ENCODING_HASHTABLE) hashtablePauseAutoShrink(objectGetVal(set));
     for (j = 2; j < c->argc; j++) {
         if (setTypeRemove(set, objectGetVal(c->argv[j]))) {
             deleted++;
@@ -636,7 +636,7 @@ void sremCommand(client *c) {
             }
         }
     }
-    if (!keyremoved && set->encoding == OBJ_ENCODING_HASHTABLE) hashtableResumeAutoShrink(objectGetVal(set));
+    if (!keyremoved && objectGetEncoding(set) == OBJ_ENCODING_HASHTABLE) hashtableResumeAutoShrink(objectGetVal(set));
 
     if (deleted) {
         signalModifiedKey(c, c->db, c->argv[1]);
@@ -816,7 +816,7 @@ void spopWithCountCommand(client *c) {
      * CASE 2: The number of elements to return is small compared to the
      * set size. We can just extract random elements and return them to
      * the set. */
-    if (remaining * SPOP_MOVE_STRATEGY_MUL > count && set->encoding == OBJ_ENCODING_LISTPACK) {
+    if (remaining * SPOP_MOVE_STRATEGY_MUL > count && objectGetEncoding(set) == OBJ_ENCODING_LISTPACK) {
         /* Specialized case for listpack. Traverse it only once. */
         unsigned char *lp = objectGetVal(set);
         unsigned char *p = lpFirst(lp);
@@ -877,7 +877,7 @@ void spopWithCountCommand(client *c) {
         robj *newset = NULL;
 
         /* Create a new set with just the remaining elements. */
-        if (set->encoding == OBJ_ENCODING_LISTPACK) {
+        if (objectGetEncoding(set) == OBJ_ENCODING_LISTPACK) {
             /* Specialized case for listpack. Traverse it only once. */
             newset = createSetListpackObject();
             unsigned char *lp = objectGetVal(set);
@@ -1038,7 +1038,7 @@ void srandmemberWithCountCommand(client *c) {
     if (!uniq || count == 1) {
         addReplyArrayLen(c, count);
 
-        if (set->encoding == OBJ_ENCODING_LISTPACK && count > 1) {
+        if (objectGetEncoding(set) == OBJ_ENCODING_LISTPACK && count > 1) {
             /* Specialized case for listpack, traversing it only once. */
             unsigned long limit, sample_count;
             limit = count > SRANDFIELD_RANDOM_SAMPLE_LIMIT ? SRANDFIELD_RANDOM_SAMPLE_LIMIT : count;
@@ -1099,7 +1099,7 @@ void srandmemberWithCountCommand(client *c) {
      *
      * And it is inefficient to repeatedly pick one random element from a
      * listpack in CASE 4. So we use this instead. */
-    if (set->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(set) == OBJ_ENCODING_LISTPACK) {
         unsigned char *lp = objectGetVal(set);
         unsigned char *p = lpFirst(lp);
         unsigned int i = 0;
@@ -1311,18 +1311,18 @@ void sinterGenericCommand(client *c,
     if (dstkey) {
         /* If we have a target key where to store the resulting set
          * create this key with an empty set inside */
-        if (sets[0]->encoding == OBJ_ENCODING_INTSET) {
+        if (objectGetEncoding(sets[0]) == OBJ_ENCODING_INTSET) {
             /* The first set is an intset, so the result is an intset too. The
              * elements are inserted in ascending order which is efficient in an
              * intset. */
             dstset = createIntsetObject();
-        } else if (sets[0]->encoding == OBJ_ENCODING_LISTPACK) {
+        } else if (objectGetEncoding(sets[0]) == OBJ_ENCODING_LISTPACK) {
             /* To avoid many reallocs, we estimate that the result is a listpack
              * of approximately the same size as the first set. Then we shrink
              * it or possibly convert it to intset in the end. */
             unsigned char *lp = lpNew(lpBytes(objectGetVal(sets[0])));
             dstset = createObject(OBJ_SET, lp);
-            dstset->encoding = OBJ_ENCODING_LISTPACK;
+            objectSetEncoding(dstset, OBJ_ENCODING_LISTPACK);
         } else {
             /* We start off with a listpack, since it's more efficient to append
              * to than an intset. Later we can convert it to intset or a
@@ -1361,7 +1361,7 @@ void sinterGenericCommand(client *c,
                 if (str && only_integers) {
                     /* It may be an integer although we got it as a string. */
                     if (encoding == OBJ_ENCODING_HASHTABLE && string2ll(str, len, (long long *)&intobj)) {
-                        if (dstset->encoding == OBJ_ENCODING_LISTPACK || dstset->encoding == OBJ_ENCODING_INTSET) {
+                        if (objectGetEncoding(dstset) == OBJ_ENCODING_LISTPACK || objectGetEncoding(dstset) == OBJ_ENCODING_INTSET) {
                             /* Adding it as an integer is more efficient. */
                             str = NULL;
                         }
@@ -1383,7 +1383,7 @@ void sinterGenericCommand(client *c,
          * is not an empty set. */
         if (setTypeSize(dstset) > 0) {
             if (only_integers) maybeConvertToIntset(dstset);
-            if (dstset->encoding == OBJ_ENCODING_LISTPACK) {
+            if (objectGetEncoding(dstset) == OBJ_ENCODING_LISTPACK) {
                 /* We allocated too much memory when we created it to avoid
                  * frequent reallocs. Therefore, we shrink it now. */
                 objectSetVal(dstset, lpShrinkToFit(objectGetVal(dstset)));
@@ -1483,7 +1483,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum, robj *dstke
          * the hashtable is more efficient when find and compare than the listpack. The corresponding
          * time complexity are O(1) vs O(n). */
         if (!dstkey && dstset_encoding == OBJ_ENCODING_INTSET &&
-            (setobj->encoding == OBJ_ENCODING_LISTPACK || setobj->encoding == OBJ_ENCODING_HASHTABLE)) {
+            (objectGetEncoding(setobj) == OBJ_ENCODING_LISTPACK || objectGetEncoding(setobj) == OBJ_ENCODING_HASHTABLE)) {
             dstset_encoding = OBJ_ENCODING_HASHTABLE;
         }
         sets[j] = setobj;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -163,7 +163,7 @@ robj *streamDup(robj *o) {
 
     serverAssert(objectGetType(o) == OBJ_STREAM);
 
-    switch (o->encoding) {
+    switch (objectGetEncoding(o)) {
     case OBJ_ENCODING_STREAM: sobj = createStreamObject(); break;
     default: serverPanic("Wrong encoding."); break;
     }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -536,7 +536,7 @@ void mgetCommand(client *c) {
         if (o == NULL) {
             addReplyNull(c);
         } else {
-            if (o->type != OBJ_STRING) {
+            if (objectGetType(o) != OBJ_STRING) {
                 addReplyNull(c);
             } else {
                 addReplyBulk(c, o);
@@ -710,7 +710,7 @@ void incrDecrCommand(client *c, long long incr) {
     }
     value += incr;
 
-    if (o && o->refcount == 1 && objectGetEncoding(o) == OBJ_ENCODING_INT &&
+    if (o && objectGetRefcount(o) == 1 && objectGetEncoding(o) == OBJ_ENCODING_INT &&
         value >= LONG_MIN && value <= LONG_MAX) {
         new = o;
         objectSetVal(o, (void *)((long)value));
@@ -848,8 +848,8 @@ void lcsCommand(client *c) {
 
     obja = lookupKeyRead(c->db, c->argv[1]);
     objb = lookupKeyRead(c->db, c->argv[2]);
-    if ((obja && obja->type != OBJ_STRING) ||
-        (objb && objb->type != OBJ_STRING)) {
+    if ((obja && objectGetType(obja) != OBJ_STRING) ||
+        (objb && objectGetType(objb) != OBJ_STRING)) {
         addReplyError(c,
                       "The specified keys must contain string values");
         /* Don't cleanup the objects, we need to do that

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -628,7 +628,7 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
      * by the "(" character, it's considered "open". For instance
      * ZRANGEBYSCORE zset (1.5 (2.5 will match min < x < max
      * ZRANGEBYSCORE zset 1.5 2.5 will instead match min <= x <= max */
-    if (min->encoding == OBJ_ENCODING_INT) {
+    if (objectGetEncoding(min) == OBJ_ENCODING_INT) {
         spec->min = (long)objectGetVal(min);
     } else {
         char *s = objectGetVal(min);
@@ -642,7 +642,7 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
         }
     }
-    if (max->encoding == OBJ_ENCODING_INT) {
+    if (objectGetEncoding(max) == OBJ_ENCODING_INT) {
         spec->max = (long)objectGetVal(max);
     } else {
         char *s = objectGetVal(max);
@@ -716,7 +716,7 @@ void zsetFreeLexRange(zlexrangespec *spec) {
 int zsetParseLexRange(robj *min, robj *max, zlexrangespec *spec) {
     /* The range can't be valid if objects are integer encoded.
      * Every item must start with ( or [. */
-    if (min->encoding == OBJ_ENCODING_INT || max->encoding == OBJ_ENCODING_INT) return C_ERR;
+    if (objectGetEncoding(min) == OBJ_ENCODING_INT || objectGetEncoding(max) == OBJ_ENCODING_INT) return C_ERR;
 
     spec->min = spec->max = NULL;
     if (zslParseLexRangeItem(min, &spec->min, &spec->minex) == C_ERR ||
@@ -1281,9 +1281,9 @@ unsigned char *zzlDeleteRangeByRank(unsigned char *zl, unsigned int start, unsig
 
 unsigned long zsetLength(const robj *zobj) {
     unsigned long length = 0;
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         length = zzlLength(objectGetVal(zobj));
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         length = zslGetLength(((const zset *)objectGetVal(zobj))->zsl);
     } else {
         serverPanic("Unknown sorted set encoding");
@@ -1313,7 +1313,7 @@ robj *zsetTypeCreate(size_t size_hint, size_t val_len_hint) {
 /* Check if the existing zset should be converted to another encoding based off the
  * the size hint. */
 void zsetTypeMaybeConvert(robj *zobj, size_t size_hint, size_t value_len_hint) {
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK &&
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK &&
         (size_hint > server.zset_max_listpack_entries || value_len_hint > server.zset_max_listpack_value)) {
         zsetConvertAndExpand(zobj, OBJ_ENCODING_SKIPLIST, size_hint);
     }
@@ -1333,8 +1333,8 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
     sds ele;
     double score;
 
-    if (zobj->encoding == encoding) return;
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == encoding) return;
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         unsigned char *vstr;
@@ -1372,8 +1372,8 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
 
         zfree(objectGetVal(zobj));
         objectSetVal(zobj, zs);
-        zobj->encoding = OBJ_ENCODING_SKIPLIST;
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+        objectSetEncoding(zobj, OBJ_ENCODING_SKIPLIST);
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         unsigned char *zl = lpNew(0);
 
         if (encoding != OBJ_ENCODING_LISTPACK) serverPanic("Unknown target encoding");
@@ -1395,7 +1395,7 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
 
         zfree(zs);
         objectSetVal(zobj, zl);
-        zobj->encoding = OBJ_ENCODING_LISTPACK;
+        objectSetEncoding(zobj, OBJ_ENCODING_LISTPACK);
     } else {
         serverPanic("Unknown sorted set encoding");
     }
@@ -1405,7 +1405,7 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
  * and if the number of elements and the maximum element size and total elements size
  * are within the expected ranges. */
 void zsetConvertToListpackIfNeeded(robj *zobj, size_t maxelelen, size_t totelelen) {
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) return;
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) return;
     zset *zset = objectGetVal(zobj);
 
     if (zslGetLength(zset->zsl) <= server.zset_max_listpack_entries &&
@@ -1421,9 +1421,9 @@ void zsetConvertToListpackIfNeeded(robj *zobj, size_t maxelelen, size_t totelele
 int zsetScore(robj *zobj, sds member, double *score) {
     if (!zobj || !member) return C_ERR;
 
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         if (zzlFind(objectGetVal(zobj), member, score) == NULL) return C_ERR;
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
         void *entry;
         if (!hashtableFind(zs->ht, member, &entry)) return C_ERR;
@@ -1497,7 +1497,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
     }
 
     /* Update the sorted set according to its encoding. */
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *eptr;
 
         if ((eptr = zzlFind(objectGetVal(zobj), ele, &curscore)) != NULL) {
@@ -1551,7 +1551,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 
     /* Note that the above block handling listpack would have either returned or
      * converted the key to skiplist. */
-    if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
 
         void **node_ref_in_hashtable = hashtableFindRef(zs->ht, ele);
@@ -1626,14 +1626,14 @@ static int zsetRemoveFromSkiplist(zset *zs, sds ele) {
 /* Delete the element 'ele' from the sorted set, returning 1 if the element
  * existed and was deleted, 0 otherwise (the element was not there). */
 int zsetDel(robj *zobj, sds ele) {
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *eptr;
 
         if ((eptr = zzlFind(objectGetVal(zobj), ele, NULL)) != NULL) {
             objectSetVal(zobj, zzlDelete(objectGetVal(zobj), eptr));
             return 1;
         }
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
         if (zsetRemoveFromSkiplist(zs, ele)) {
             return 1;
@@ -1661,7 +1661,7 @@ static long zsetRank(robj *zobj, sds ele, int reverse, double *output_score) {
 
     llen = zsetLength(zobj);
 
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
 
@@ -1686,7 +1686,7 @@ static long zsetRank(robj *zobj, sds ele, int reverse, double *output_score) {
         } else {
             return -1;
         }
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
 
         void *entry;
@@ -1725,7 +1725,7 @@ robj *zsetDup(robj *o) {
         unsigned char *new_zl = zmalloc(sz);
         memcpy(new_zl, zl, sz);
         zobj = createObject(OBJ_ZSET, new_zl);
-        zobj->encoding = OBJ_ENCODING_LISTPACK;
+        objectSetEncoding(zobj, OBJ_ENCODING_LISTPACK);
     } else if (objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST) {
         zobj = createZsetObject();
         zs = objectGetVal(o);
@@ -1774,7 +1774,7 @@ void zsetReplyFromListpackEntry(client *c, listpackEntry *e) {
  * The memory in `key` is not to be freed or modified by the caller.
  * 'score' can be NULL in which case it's not extracted. */
 static void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpackEntry *key, double *score) {
-    if (zsetobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    if (objectGetEncoding(zsetobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zsetobj);
         void *entry;
         hashtableFairRandomEntry(zs->ht, &entry);
@@ -1783,7 +1783,7 @@ static void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpac
         key->sval = (unsigned char *)ele;
         key->slen = sdslen(ele);
         if (score) *score = node->score;
-    } else if (zsetobj->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetEncoding(zsetobj) == OBJ_ENCODING_LISTPACK) {
         listpackEntry val;
         lpRandomPair(objectGetVal(zsetobj), zsetsize, key, &val);
         if (score) {
@@ -1953,7 +1953,7 @@ void zremCommand(client *c) {
 
     if ((zobj = lookupKeyWriteOrReply(c, key, shared.czero)) == NULL || checkType(c, zobj, OBJ_ZSET)) return;
 
-    if (zobj->encoding == OBJ_ENCODING_SKIPLIST) hashtablePauseAutoShrink(((zset *)objectGetVal(zobj))->ht);
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) hashtablePauseAutoShrink(((zset *)objectGetVal(zobj))->ht);
     for (j = 2; j < c->argc; j++) {
         if (zsetDel(zobj, objectGetVal(c->argv[j]))) deleted++;
         if (zsetLength(zobj) == 0) {
@@ -1962,7 +1962,7 @@ void zremCommand(client *c) {
             break;
         }
     }
-    if (!keyremoved && zobj->encoding == OBJ_ENCODING_SKIPLIST) hashtableResumeAutoShrink(((zset *)objectGetVal(zobj))->ht);
+    if (!keyremoved && objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) hashtableResumeAutoShrink(((zset *)objectGetVal(zobj))->ht);
 
     if (deleted) {
         notifyKeyspaceEvent(NOTIFY_ZSET, "zrem", key, c->db->id);
@@ -2033,7 +2033,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     }
 
     /* Step 3: Perform the range deletion operation. */
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         switch (rangetype) {
         case ZRANGE_AUTO:
         case ZRANGE_RANK: objectSetVal(zobj, zzlDeleteRangeByRank(objectGetVal(zobj), start + 1, end + 1, &deleted)); break;
@@ -2044,7 +2044,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
             dbDelete(c->db, key);
             keyremoved = 1;
         }
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
         hashtablePauseAutoShrink(zs->ht);
         switch (rangetype) {
@@ -2646,15 +2646,15 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
     for (i = 0, j = numkeysIndex + 1; i < setnum; i++, j++) {
         robj *obj = lookupKeyRead(c->db, c->argv[j]);
         if (obj != NULL) {
-            if (obj->type != OBJ_ZSET && obj->type != OBJ_SET) {
+            if (objectGetType(obj) != OBJ_ZSET && objectGetType(obj) != OBJ_SET) {
                 zfree(src);
                 addReplyErrorObject(c, shared.wrongtypeerr);
                 return;
             }
 
             src[i].subject = obj;
-            src[i].type = obj->type;
-            src[i].encoding = obj->encoding;
+            src[i].type = objectGetType(obj);
+            src[i].encoding = objectGetEncoding(obj);
         } else {
             src[i].subject = NULL;
         }
@@ -3127,7 +3127,7 @@ void genericZrangebyrankCommand(zrange_result_handler *handler,
     result_cardinality = rangelen;
 
     handler->beginResultEmission(handler, rangelen);
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         unsigned char *vstr;
@@ -3162,7 +3162,7 @@ void genericZrangebyrankCommand(zrange_result_handler *handler,
                 zzlNext(zl, &eptr, &sptr);
         }
 
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;
@@ -3230,7 +3230,7 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
         return;
     }
 
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         unsigned char *vstr;
@@ -3282,7 +3282,7 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
                 zzlNext(zl, &eptr, &sptr);
             }
         }
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;
@@ -3349,7 +3349,7 @@ void zcountCommand(client *c) {
     /* Lookup the sorted set */
     if ((zobj = lookupKeyReadOrReply(c, key, shared.czero)) == NULL || checkType(c, zobj, OBJ_ZSET)) return;
 
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         double score;
@@ -3380,7 +3380,7 @@ void zcountCommand(client *c) {
                 zzlNext(zl, &eptr, &sptr);
             }
         }
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *zn;
@@ -3426,7 +3426,7 @@ void zlexcountCommand(client *c) {
         return;
     }
 
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
 
@@ -3454,7 +3454,7 @@ void zlexcountCommand(client *c) {
                 zzlNext(zl, &eptr, &sptr);
             }
         }
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *zn;
@@ -3497,7 +3497,7 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
 
     handler->beginResultEmission(handler, -1);
 
-    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         unsigned char *vstr;
@@ -3551,7 +3551,7 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
                 zzlNext(zl, &eptr, &sptr);
             }
         }
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;
@@ -3945,7 +3945,7 @@ void genericZpopCommand(client *c,
 
     /* Remove the element. */
     do {
-        if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+        if (objectGetEncoding(zobj) == OBJ_ENCODING_LISTPACK) {
             unsigned char *zl = objectGetVal(zobj);
             unsigned char *eptr, *sptr;
             unsigned char *vstr;
@@ -3965,7 +3965,7 @@ void genericZpopCommand(client *c,
             sptr = lpNext(zl, eptr);
             serverAssertWithInfo(c, zobj, sptr != NULL);
             score = zzlGetScore(sptr);
-        } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+        } else if (objectGetEncoding(zobj) == OBJ_ENCODING_SKIPLIST) {
             zset *zs = objectGetVal(zobj);
             zskiplist *zsl = zs->zsl;
             zskiplistNode *zln;
@@ -4179,7 +4179,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
             addReplyArrayLen(c, count * 2);
         else
             addReplyArrayLen(c, count);
-        if (zsetobj->encoding == OBJ_ENCODING_SKIPLIST) {
+        if (objectGetEncoding(zsetobj) == OBJ_ENCODING_SKIPLIST) {
             zset *zs = objectGetVal(zsetobj);
             while (count--) {
                 void *entry;
@@ -4191,7 +4191,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
                 if (withscores) addReplyDouble(c, node->score);
                 if (c->flag.close_asap) break;
             }
-        } else if (zsetobj->encoding == OBJ_ENCODING_LISTPACK) {
+        } else if (objectGetEncoding(zsetobj) == OBJ_ENCODING_LISTPACK) {
             listpackEntry *keys, *vals = NULL;
             unsigned long limit, sample_count;
             limit = count > ZRANDMEMBER_RANDOM_SAMPLE_LIMIT ? ZRANDMEMBER_RANDOM_SAMPLE_LIMIT : count;
@@ -4213,8 +4213,8 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     zsetopsrc src;
     zsetopval zval;
     src.subject = zsetobj;
-    src.type = zsetobj->type;
-    src.encoding = zsetobj->encoding;
+    src.type = objectGetType(zsetobj);
+    src.encoding = objectGetEncoding(zsetobj);
     zuiInitIterator(&src);
     memset(&zval, 0, sizeof(zval));
 
@@ -4246,7 +4246,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
      *
      * And it is inefficient to repeatedly pick one random element from a
      * listpack in CASE 4. So we use this instead. */
-    if (zsetobj->encoding == OBJ_ENCODING_LISTPACK) {
+    if (objectGetEncoding(zsetobj) == OBJ_ENCODING_LISTPACK) {
         listpackEntry *keys, *vals = NULL;
         keys = zmalloc(sizeof(listpackEntry) * count);
         if (withscores) vals = zmalloc(sizeof(listpackEntry) * count);

--- a/src/unit/custom_matchers.hpp
+++ b/src/unit/custom_matchers.hpp
@@ -12,7 +12,7 @@
 
 // Matches an robj (which MUST contain an sds encoded string) to a char* string.
 MATCHER_P(robjEqualsStr, str, "robj string matcher") {
-    assert(arg->type == OBJ_STRING);
+    assert(objectGetType(arg) == OBJ_STRING);
     assert(sdsEncodedObject(arg));
     return strcmp(static_cast<const char *>(objectGetVal(arg)), str) == 0;
 }

--- a/src/unit/test_networking.cpp
+++ b/src/unit/test_networking.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 
 extern "C" {
+#include "object_internals.h"
 #include "server.h"
 
 /* Internal types from networking.c */

--- a/src/unit/test_object.cpp
+++ b/src/unit/test_object.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "generated_wrappers.hpp"
+#include "object_internals.h"
 
 #include <climits>
 #include <cmath>

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -251,7 +251,7 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
     UNUSED(keyobj);
     char buf[128];
 
-    rdbStats *stats = rdbstate.stats[o->type + dbid * OBJ_TYPE_MAX];
+    rdbStats *stats = rdbstate.stats[objectGetType(o) + dbid * OBJ_TYPE_MAX];
 
     stats->all_key_size += sdslen(objectGetVal(keyobj));
     stats->keys++;
@@ -263,9 +263,9 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
         stats->expires++;
 
     /* Save the key and associated value */
-    if (o->type == OBJ_STRING) {
+    if (objectGetType(o) == OBJ_STRING) {
         statsRecordSimple(stringObjectLen(o), 1, stats);
-    } else if (o->type == OBJ_LIST) {
+    } else if (objectGetType(o) == OBJ_LIST) {
         listTypeIterator *li = listTypeInitIterator(o, 0, LIST_TAIL);
         listTypeEntry entry;
         while (listTypeNext(li, &entry)) {
@@ -275,7 +275,7 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
         }
         listTypeReleaseIterator(li);
         statsRecordCount(listTypeLength(o), stats);
-    } else if (o->type == OBJ_SET) {
+    } else if (objectGetType(o) == OBJ_SET) {
         setTypeIterator *si = setTypeInitIterator(o);
         sds sdsele;
         while ((sdsele = setTypeNextObject(si)) != NULL) {
@@ -284,8 +284,8 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
         }
         setTypeReleaseIterator(si);
         statsRecordCount(setTypeSize(o), stats);
-    } else if (o->type == OBJ_ZSET) {
-        if (o->encoding == OBJ_ENCODING_LISTPACK) {
+    } else if (objectGetType(o) == OBJ_ZSET) {
+        if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
             unsigned char *zl = objectGetVal(o);
             unsigned char *eptr, *sptr;
             unsigned char *vstr;
@@ -317,7 +317,7 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
                 zzlNext(zl, &eptr, &sptr);
             }
             statsRecordCount(lpLength(objectGetVal(o)), stats);
-        } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
+        } else if (objectGetEncoding(o) == OBJ_ENCODING_SKIPLIST) {
             zset *zs = objectGetVal(o);
             hashtableIterator iter;
             hashtableInitIterator(&iter, zs->ht, 0);
@@ -338,7 +338,7 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
         } else {
             serverPanic("Unknown sorted set encoding");
         }
-    } else if (o->type == OBJ_HASH) {
+    } else if (objectGetType(o) == OBJ_HASH) {
         hashTypeIterator hi;
         hashTypeInitIterator(o, &hi);
         while (hashTypeNext(&hi) != C_ERR) {
@@ -356,7 +356,7 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
         }
         hashTypeResetIterator(&hi);
         statsRecordCount(hashTypeLength(o), stats);
-    } else if (o->type == OBJ_STREAM) {
+    } else if (objectGetType(o) == OBJ_STREAM) {
         streamIterator si;
         streamIteratorStart(&si, objectGetVal(o), NULL, NULL, 0);
         streamID id;
@@ -372,7 +372,7 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
         }
         streamIteratorStop(&si);
         statsRecordCount(streamLength(o), stats);
-    } else if (o->type == OBJ_MODULE) {
+    } else if (objectGetType(o) == OBJ_MODULE) {
         statsRecordCount(1, stats);
     } else {
         serverPanic("Unknown object type");


### PR DESCRIPTION
Moves `struct serverObject` out of `server.h` so the compiler enforces encapsulation. Code outside the implementation files can no longer access robj fields directly. Resolves #3017

## Changes

- New `object_internals.h` — contains the struct definition. Only included by `object.c`, `defrag.c`, and `io_threads.c` (files that genuinely need internal access).
- All remaining direct field accesses (`->type`, `->encoding`, `->refcount`, `->lru`) converted to existing accessor functions across ~25 files.
- New accessors: `objectHasEmbeddedKey()`, `objectGetStructSize()`.
- `objectSetRefcount()` made internal-only (normal code uses `incrRefCount`/`decrRefCount`).
- `initStaticStringObject` converted from macro to function; `robjStatic` type added for opaque stack allocation.

## How to review

The vast majority of this diff is mechanical `->field` → `objectGetField()`/`objectSetField()` substitution. The interesting parts are:

1. `server.h` — struct removal, new `robjStatic` type (~10 lines)
2. `object_internals.h` — new file, struct + internal declarations
3. `object.c` — new accessor implementations (~20 lines)
4. `db.c:338-356` — type/encoding swap rewritten with accessors
5. `rdb.c`, `aof.c`, `server.c` — `robjStatic` stack allocation pattern

Everything else is find-and-replace.