### PR TITLE
Avoid refreshing daylight-saving info on every event-loop wakeup

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1806,6 +1806,9 @@ void whileBlockedCron(void) {
 
     defragWhileBlocked();
 
+    /* serverCron() doesn't run while blocked, so refresh the cached daylight-saving info here. */
+    updateCachedTime(1);
+
     /* Update memory stats during loading (excluding blocked scripts) */
     if (server.loading) cronUpdateMemoryStats();
 

--- a/src/server.c
+++ b/src/server.c
@@ -1570,6 +1570,11 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
 
     cronUpdateMemoryStats();
 
+    /* Refresh the cached daylight-saving info periodically every 1 second.
+     * This is only used to render log timestamps, so it doesn't need to be
+     * updated on every event-loop wakeup. */
+    run_with_period(1000) updateCachedTime(1);
+
     /* We received a SIGTERM or SIGINT, shutting down here in a safe way, as it is
      * not ok doing so inside the signal handler. */
     if (server.shutdown_asap && !isShutdownInitiated()) {
@@ -2071,8 +2076,9 @@ void afterSleep(struct aeEventLoop *eventLoop, int numevents) {
         server.el_cmd_cnt_start = server.stat_numcommands;
     }
 
-    /* Update the time cache. */
-    updateCachedTime(1);
+    /* Update the time cache. Skip the (relatively expensive) daylight-saving
+     * refresh here since afterSleep() runs on every event-loop wakeup. */
+    updateCachedTime(0);
 
     /* Update command time snapshot in case it'll be required without a command
      * e.g. somehow used by module timers. Don't update it while yielding to a


### PR DESCRIPTION
afterSleep() runs on every event-loop wakeup and called updateCachedTime(1), which invokes localtime_r() to refresh the cached daylight-saving flag (server.daylight_active). That flag is only used to render log timestamps and changes at most twice a year, so refreshing it per wakeup is overhead we could avoid. 

Fix

- afterSleep() now uses updateCachedTime(0) — no localtime_r() invocation.
- serverCron() refreshes the daylight-saving info once per second
-  whileBlockedCron() also refreshes it, since serverCron() doesn't fire during RDB/AOF loading or busy scripts