### PR TITLE
Save cluster config when node address is updated via gossip

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2878,6 +2878,8 @@ int clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
                  * replicationSetPrimary and update the primary host. */
                 if (nodeIsReplica(myself) && myself->replicaof == node)
                     replicationSetPrimary(node->ip, getNodeDefaultReplicationPort(node), 0, false);
+
+                clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
             }
         } else if (!node) {
             /* If it's not in NOADDR state and we don't have it, we


### PR DESCRIPTION
A successful nodeUpdateAddressIfNeeded() call is normally followed
by the caller invoking clusterDoBeforeSleep to persist the change.
```
if (nodeUpdateAddressIfNeeded(sender, link, msg)) {
    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
}
```

But the gossip section path did not and the updates are nof relected
in nodes.conf in a timely manner.