### PR TITLE
Prevent forgotten nodes from rejoining the cluster via MEET

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3960,6 +3960,15 @@ int clusterProcessPacket(clusterLink *link) {
 
     /* Initial processing of PING and MEET requests replying with a PONG. */
     if (type == CLUSTERMSG_TYPE_PING || type == CLUSTERMSG_TYPE_MEET) {
+        if (type == CLUSTERMSG_TYPE_MEET && !sender && clusterBlacklistExists(msg->sender, CLUSTER_NAMELEN)) {
+            /* The sender was removed with CLUSTER FORGET and is still in the
+             * blacklist. Ignore its MEET packet before any side effects, or
+             * it would add itself back to the cluster. */
+            serverLog(LL_NOTICE, "Ignoring MEET packet from blacklisted node %.40s", msg->sender);
+            freeClusterLink(link);
+            return 0;
+        }
+
         /* We use incoming MEET messages in order to set the address
          * for 'myself', since only other cluster nodes will send us
          * MEET messages on handshakes, when the cluster joins, or
@@ -3983,14 +3992,6 @@ int clusterProcessPacket(clusterLink *link) {
 
         if (type == CLUSTERMSG_TYPE_MEET) {
             if (!sender) {
-                if (clusterBlacklistExists(msg->sender, CLUSTER_NAMELEN)) {
-                    /* The sender was removed with CLUSTER FORGET and is still
-                     * in the blacklist. Ignore its MEET packet, or it would
-                     * add itself back to the cluster. */
-                    serverLog(LL_NOTICE, "Ignoring MEET packet from blacklisted node %.40s", msg->sender);
-                    freeClusterLink(link);
-                    return 0;
-                }
                 if (!link->node) {
                     char ip[NET_IP_STR_LEN] = {0};
                     if (nodeIp2String(ip, link, msg->myip) != C_OK) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1829,6 +1829,8 @@ void setClusterNodeToInboundClusterLink(clusterNode *node, clusterLink *link) {
     serverAssert(!node->inbound_link);
     node->inbound_link = link;
     link->node = node;
+    /* The node knows us now, so the MEET retry budget starts over. */
+    node->meet_attempts = 0;
     if (server.verbosity <= LL_VERBOSE) {
         char ip[NET_IP_STR_LEN];
         int port;
@@ -1955,6 +1957,7 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     node->outbound_link_attempt_time = 0;
     node->data_received = 0;
     node->meet_sent = 0;
+    node->meet_attempts = 0;
     node->fail_time = 0;
     node->link = NULL;
     node->inbound_link = NULL;
@@ -3980,6 +3983,14 @@ int clusterProcessPacket(clusterLink *link) {
 
         if (type == CLUSTERMSG_TYPE_MEET) {
             if (!sender) {
+                if (clusterBlacklistExists(msg->sender, CLUSTER_NAMELEN)) {
+                    /* The sender was removed with CLUSTER FORGET and is still
+                     * in the blacklist. Ignore its MEET packet, or it would
+                     * add itself back to the cluster. */
+                    serverLog(LL_NOTICE, "Ignoring MEET packet from blacklisted node %.40s", msg->sender);
+                    freeClusterLink(link);
+                    return 0;
+                }
                 if (!link->node) {
                     char ip[NET_IP_STR_LEN] = {0};
                     if (nodeIp2String(ip, link, msg->myip) != C_OK) {
@@ -4547,9 +4558,20 @@ void clusterLinkConnectHandler(connection *conn) {
      *
      * If the node is flagged as MEET, we send a MEET message instead
      * of a PING one, to force the receiver to add us in its node
-     * table. */
+     * table. For a known node (not in handshake) the MEET retry budget
+     * applies: a node that keeps refusing our MEET packets has probably
+     * deliberately forgotten us, so we stop insisting (see #2788). */
+    int send_meet = nodeInMeetState(node);
+    if (send_meet && !nodeInHandshake(node)) {
+        if (node->meet_attempts >= CLUSTER_MEET_MAX_ATTEMPTS) {
+            node->flags &= ~CLUSTER_NODE_MEET;
+            send_meet = 0;
+        } else {
+            node->meet_attempts++;
+        }
+    }
     mstime_t old_ping_sent = node->ping_sent;
-    clusterSendPing(link, nodeInMeetState(node) ? CLUSTERMSG_TYPE_MEET : CLUSTERMSG_TYPE_PING);
+    clusterSendPing(link, send_meet ? CLUSTERMSG_TYPE_MEET : CLUSTERMSG_TYPE_PING);
     if (old_ping_sent) {
         /* If there was an active ping before the link was
          * disconnected, we want to restore the ping time, otherwise
@@ -6068,11 +6090,17 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, long 
          * This probably means this node does not know us yet, whereas we know it.
          * So we send it a MEET packet to do a handshake with it and correct the inconsistent cluster view.
          * We make sure to not re-send a MEET packet more than once every handshake timeout period, so as to
-         * leave the other node time to complete the handshake. */
-        node->flags |= CLUSTER_NODE_MEET;
-        serverLog(LL_NOTICE, "Sending MEET packet to node %.40s (%s) because there is no inbound link for it",
-                  node->name, humanNodename(node));
-        clusterSendPing(node->link, CLUSTERMSG_TYPE_MEET);
+         * leave the other node time to complete the handshake.
+         * The number of attempts is bounded: a node that keeps refusing our MEET
+         * packets has probably removed us with CLUSTER FORGET, and insisting
+         * forever would reintroduce us after its blacklist expired (see #2788). */
+        if (node->meet_attempts < CLUSTER_MEET_MAX_ATTEMPTS) {
+            node->meet_attempts++;
+            node->flags |= CLUSTER_NODE_MEET;
+            serverLog(LL_NOTICE, "Sending MEET packet to node %.40s (%s) because there is no inbound link for it",
+                      node->name, humanNodename(node));
+            clusterSendPing(node->link, CLUSTERMSG_TYPE_MEET);
+        }
     }
 
     if (node->link == NULL) {

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -10,6 +10,8 @@
 #define CLUSTER_FAIL_UNDO_TIME_MULT 2        /* Undo fail if primary is back. */
 #define CLUSTER_MF_PAUSE_MULT 2              /* Primary pause manual failover mult. */
 #define CLUSTER_REPLICA_MIGRATION_DELAY 5000 /* Delay for replica migration. */
+#define CLUSTER_MEET_MAX_ATTEMPTS 5          /* Max MEET packets sent to a known node
+                                                that has no inbound link to us. */
 
 /* Reasons why a replica is not able to failover. */
 #define CLUSTER_CANT_FAILOVER_NONE 0
@@ -393,6 +395,8 @@ struct _clusterNode {
     mstime_t pong_received;                 /* Unix time we received the pong */
     mstime_t data_received;                 /* Unix time we received any data */
     mstime_t meet_sent;                     /* Unix time we sent latest meet packet */
+    int meet_attempts;                      /* Number of MEET packets sent to this known node since
+                                               we last had an inbound link from it */
     mstime_t fail_time;                     /* Unix time when FAIL flag was set */
     mstime_t orphaned_time;                 /* Starting time of orphaned primary condition */
     mstime_t outbound_link_attempt_time;    /* Unix time we last tried to establish an outgoing link */

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -10,8 +10,7 @@
 #define CLUSTER_FAIL_UNDO_TIME_MULT 2        /* Undo fail if primary is back. */
 #define CLUSTER_MF_PAUSE_MULT 2              /* Primary pause manual failover mult. */
 #define CLUSTER_REPLICA_MIGRATION_DELAY 5000 /* Delay for replica migration. */
-#define CLUSTER_MEET_MAX_ATTEMPTS 5          /* Max MEET packets sent to a known node
-                                                that has no inbound link to us. */
+#define CLUSTER_MEET_MAX_ATTEMPTS 5          /* Max MEETs sent to a known node with no inbound link to us. */
 
 /* Reasons why a replica is not able to failover. */
 #define CLUSTER_CANT_FAILOVER_NONE 0

--- a/tests/unit/cluster/forget.tcl
+++ b/tests/unit/cluster/forget.tcl
@@ -26,5 +26,10 @@ start_cluster 2 1 {tags {external:skip cluster} overrides {cluster-node-timeout 
             assert {[cluster_get_node_by_id 0 $forgotten_id] eq {}}
             assert {[cluster_get_node_by_id 1 $forgotten_id] eq {}}
         }
+
+        # The node stayed out because its MEET packets were refused,
+        # not because it never tried.
+        verify_log_message 0 "*Ignoring MEET packet from blacklisted node $forgotten_id*" 0
+        verify_log_message -1 "*Ignoring MEET packet from blacklisted node $forgotten_id*" 0
     }
 }

--- a/tests/unit/cluster/forget.tcl
+++ b/tests/unit/cluster/forget.tcl
@@ -1,0 +1,30 @@
+# Tests that a node removed with CLUSTER FORGET stays removed.
+# Since the no-inbound-link MEET retry (#1307), a forgotten node that is
+# still running keeps sending MEET packets to the cluster and used to
+# reintroduce itself once the blacklist TTL expired (#2788).
+
+start_cluster 2 1 {tags {external:skip cluster} overrides {cluster-node-timeout 1000}} {
+    test "FORGET-ed node does not reintroduce itself via MEET" {
+        set forgotten_id [dict get [get_myself 2] id]
+
+        # Use a short blacklist TTL so the test observes behavior past its
+        # expiration, when the forgotten node used to be re-accepted.
+        R 0 CONFIG SET cluster-blacklist-ttl 8
+        R 1 CONFIG SET cluster-blacklist-ttl 8
+
+        R 0 CLUSTER FORGET $forgotten_id
+        R 1 CLUSTER FORGET $forgotten_id
+        assert {[cluster_get_node_by_id 0 $forgotten_id] eq {}}
+        assert {[cluster_get_node_by_id 1 $forgotten_id] eq {}}
+
+        # Node 2 still knows the cluster and has outbound links but no
+        # inbound links, so it will try to MEET its way back in. Poll well
+        # past several handshake timeouts and the blacklist expiration; the
+        # node must stay forgotten the whole time.
+        for {set i 0} {$i < 30} {incr i} {
+            after 500
+            assert {[cluster_get_node_by_id 0 $forgotten_id] eq {}}
+            assert {[cluster_get_node_by_id 1 $forgotten_id] eq {}}
+        }
+    }
+}


### PR DESCRIPTION
Since #1307, a node with an outbound link but no inbound link re-sends MEET packets every handshake timeout, forever. A node removed with CLUSTER FORGET still knows the whole cluster and is exactly in that state, so it kept re-meeting its way back in once the blacklist TTL expired. On 8.0 the forgotten node stayed out.

Two changes:

- A MEET packet from an unknown sender whose claimed node ID is in the FORGET blacklist is now ignored, the same trust rule the gossip section already applies. Previously MEET was accepted unconditionally, so a forgotten node could even get back in during the ban window.
- The automatic no-inbound-link MEET from #1307 now has a bounded retry budget per node (5 attempts, reset whenever an inbound link from that node is established, i.e. the peer accepted us). A peer that keeps refusing our MEETs has deliberately forgotten us, so we stop insisting instead of retrying until its ban expires. Handshake-state MEETs (CLUSTER MEET, new joins) are not budgeted, and the reliable-MEET retries from #1520 are unaffected.

With this, the forgotten node exhausts its attempts inside the ban window and stays out permanently, matching 8.0. Following @madolson's comment that a briefly disconnected node should not get MEET packets forever, and @bandalgomsu's suggestion of tying the retry behavior to the blacklist window.

One caveat to be upfront about: if cluster-node-timeout exceeds cluster-blacklist-ttl, the first automatic MEET happens after the ban has already expired and is accepted. Since cluster-blacklist-ttl is configurable, operators with large node timeouts can raise it above the node timeout. If preferred, I can clamp the effective blacklist TTL to at least the handshake timeout so this holds in all configurations.

Added a regression test that forgets a running replica and verifies it stays out well past the blacklist expiration; it fails on unstable without this change. The cluster suite passes (1704 tests) including the #1307 reliable-meet coverage.

Fixes #2788.