### PR TITLE
Fix CLUSTER BUMPEPOCH getting stuck when a dead node holds a high configEpoch

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -90,7 +90,7 @@ void clusterDelNode(clusterNode *delnode);
 sds representClusterNodeFlags(sds ci, uint16_t flags);
 sds representSlotInfo(sds ci, uint16_t *slot_info_pairs, int slot_info_pairs_count);
 void clusterFreeNodesSlotsInfo(clusterNode *n);
-uint64_t clusterGetMaxEpoch(void);
+uint64_t clusterGetMaxEpoch(int filter);
 int clusterBumpConfigEpochWithoutConsensus(void);
 void moduleCallClusterReceivers(const char *sender_id,
                                 uint64_t module_id,
@@ -1026,7 +1026,7 @@ int clusterLoadConfig(char *filename) {
     /* Something that should never happen: currentEpoch smaller than
      * the max epoch found in the nodes configuration. However we handle this
      * as some form of protection against manual editing of critical files. */
-    uint64_t maxEpoch = clusterGetMaxEpoch();
+    uint64_t maxEpoch = clusterGetMaxEpoch(0);
     if (maxEpoch > server.cluster->currentEpoch) {
         server.cluster->currentEpoch = maxEpoch;
     }
@@ -2340,9 +2340,12 @@ void clusterRemoveNodeFromShard(clusterNode *node) {
  * CLUSTER config epoch handling
  * -------------------------------------------------------------------------- */
 
-/* Return the greatest configEpoch found in the cluster, or the current
- * epoch if greater than any node configEpoch. */
-uint64_t clusterGetMaxEpoch(void) {
+/* Return the greatest configEpoch found among the cluster nodes.
+ *
+ * All the nodes matching at least one of the node flags specified in
+ * "filter" are excluded from the scan, so using zero as a filter will
+ * include all the known nodes in the scan. */
+uint64_t clusterGetMaxEpoch(int filter) {
     uint64_t max = 0;
     dictIterator *di;
     dictEntry *de;
@@ -2350,10 +2353,10 @@ uint64_t clusterGetMaxEpoch(void) {
     di = dictGetSafeIterator(server.cluster->nodes);
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
+        if (node->flags & filter) continue;
         if (node->configEpoch > max) max = node->configEpoch;
     }
     dictReleaseIterator(di);
-    if (max < server.cluster->currentEpoch) max = server.cluster->currentEpoch;
     return max;
 }
 
@@ -2369,10 +2372,10 @@ uint64_t clusterGetMaxEpoch(void) {
  * otherwise C_ERR is returned (since the node has already the greatest
  * configuration around) and no operation is performed.
  *
- * This function bumps unless our configEpoch is already strictly greater
- * than every other node's. This handles the case where a dead/unreachable
- * node holds an abnormally high configEpoch that currentEpoch never caught
- * up with via PING/PONG.
+ * We bump unless our configEpoch is already strictly greater than every
+ * other known node's AND not behind currentEpoch: the former covers a
+ * dead/unreachable node holding an equal or abnormally high configEpoch,
+ * the latter realigns us to the top when currentEpoch ran ahead.
  *
  * Important note: this function violates the principle that config epochs
  * should be generated with consensus and should be unique across the cluster.
@@ -2392,17 +2395,8 @@ uint64_t clusterGetMaxEpoch(void) {
  * config epochs. However using this function may violate the "last failover
  * wins" rule, so should only be used with care. */
 int clusterBumpConfigEpochWithoutConsensus(void) {
-    uint64_t maxEpoch = 0;
-    dictIterator *di;
-    dictEntry *de;
-
     /* Find the highest configEpoch held by any node other than ourselves. */
-    di = dictGetSafeIterator(server.cluster->nodes);
-    while ((de = dictNext(di)) != NULL) {
-        clusterNode *node = dictGetVal(de);
-        if (node != myself && node->configEpoch > maxEpoch) maxEpoch = node->configEpoch;
-    }
-    dictReleaseIterator(di);
+    uint64_t maxEpoch = clusterGetMaxEpoch(CLUSTER_NODE_MYSELF);
 
     /* Something that should never happen: currentEpoch smaller than
      * the max epoch found in the nodes configuration. However we handle this
@@ -2413,8 +2407,14 @@ int clusterBumpConfigEpochWithoutConsensus(void) {
         server.cluster->currentEpoch = maxEpoch;
     }
 
-    /* Bump unless we are already strictly greater than every other node. */
-    if (myself->configEpoch == 0 || myself->configEpoch <= maxEpoch) {
+    /* Bump unless we are already strictly greater than every other node
+     * and not behind currentEpoch. */
+    if (myself->configEpoch == 0 ||
+        myself->configEpoch <= maxEpoch ||
+        myself->configEpoch < server.cluster->currentEpoch) {
+        /* currentEpoch is now at least maxEpoch, so incrementing it and
+         * adopting the result guarantees a configEpoch strictly greater
+         * than every other node in a single bump. */
         server.cluster->currentEpoch++;
         myself->configEpoch = server.cluster->currentEpoch;
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_FSYNC_CONFIG | CLUSTER_TODO_BROADCAST_ALL);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1026,8 +1026,9 @@ int clusterLoadConfig(char *filename) {
     /* Something that should never happen: currentEpoch smaller than
      * the max epoch found in the nodes configuration. However we handle this
      * as some form of protection against manual editing of critical files. */
-    if (clusterGetMaxEpoch() > server.cluster->currentEpoch) {
-        server.cluster->currentEpoch = clusterGetMaxEpoch();
+    uint64_t maxEpoch = clusterGetMaxEpoch();
+    if (maxEpoch > server.cluster->currentEpoch) {
+        server.cluster->currentEpoch = maxEpoch;
     }
     return C_OK;
 
@@ -2368,6 +2369,11 @@ uint64_t clusterGetMaxEpoch(void) {
  * otherwise C_ERR is returned (since the node has already the greatest
  * configuration around) and no operation is performed.
  *
+ * This function bumps unless our configEpoch is already strictly greater
+ * than every other node's. This handles the case where a dead/unreachable
+ * node holds an abnormally high configEpoch that currentEpoch never caught
+ * up with via PING/PONG.
+ *
  * Important note: this function violates the principle that config epochs
  * should be generated with consensus and should be unique across the cluster.
  * However the cluster uses this auto-generated new config epochs in two
@@ -2386,9 +2392,29 @@ uint64_t clusterGetMaxEpoch(void) {
  * config epochs. However using this function may violate the "last failover
  * wins" rule, so should only be used with care. */
 int clusterBumpConfigEpochWithoutConsensus(void) {
-    uint64_t maxEpoch = clusterGetMaxEpoch();
+    uint64_t maxEpoch = 0;
+    dictIterator *di;
+    dictEntry *de;
 
-    if (myself->configEpoch == 0 || myself->configEpoch != maxEpoch) {
+    /* Find the highest configEpoch held by any node other than ourselves. */
+    di = dictGetSafeIterator(server.cluster->nodes);
+    while ((de = dictNext(di)) != NULL) {
+        clusterNode *node = dictGetVal(de);
+        if (node != myself && node->configEpoch > maxEpoch) maxEpoch = node->configEpoch;
+    }
+    dictReleaseIterator(di);
+
+    /* Something that should never happen: currentEpoch smaller than
+     * the max epoch found in the nodes configuration. However we handle this
+     * as some form of protection against a stale, abnormally high configEpoch
+     * held by a dead/unreachable node that currentEpoch never caught up with
+     * via PING/PONG. */
+    if (maxEpoch > server.cluster->currentEpoch) {
+        server.cluster->currentEpoch = maxEpoch;
+    }
+
+    /* Bump unless we are already strictly greater than every other node. */
+    if (myself->configEpoch == 0 || myself->configEpoch <= maxEpoch) {
         server.cluster->currentEpoch++;
         myself->configEpoch = server.cluster->currentEpoch;
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_FSYNC_CONFIG | CLUSTER_TODO_BROADCAST_ALL);

--- a/tests/unit/cluster/bumpepoch-dead-node.tcl
+++ b/tests/unit/cluster/bumpepoch-dead-node.tcl
@@ -1,0 +1,100 @@
+proc cluster_nodes_conf_path {id} {
+    set dir [lindex [R $id config get dir] 1]
+    set conf [lindex [R $id config get cluster-config-file] 1]
+    return [file join $dir $conf]
+}
+
+proc read_file {path} {
+    set fd [open $path r]
+    set data [read $fd]
+    close $fd
+    return $data
+}
+
+proc write_file {path content} {
+    set fd [open $path w]
+    puts $fd $content
+    close $fd
+}
+
+test "CLUSTER BUMPEPOCH is not stuck on a tie with a dead node" {
+    start_cluster 1 0 {tags {external:skip cluster}} {
+        set R0_nodeid [R 0 CLUSTER MYID]
+        set R0_epoch [CI 0 cluster_my_epoch]
+        set dead_nodeid "0000000000000000000000000000000000000000"
+
+        # Shutdown R0.
+        set conf_path [cluster_nodes_conf_path 0]
+        catch {R 0 shutdown nosave}
+
+        # Modify R0's nodes.conf to inject a dead node that holds the same
+        # configEpoch as R0
+        set content [read_file $conf_path]
+        set lines [split $content "\n"]
+        set new_lines {}
+        foreach line $lines {
+            if {[string first $R0_nodeid $line] == 0} {
+                # We first write the original R0 line, then modify it and
+                # write it as the new dead node line.
+                lappend new_lines $line
+                regsub $R0_nodeid $line $dead_nodeid line
+                regsub {myself} $line {fail,noaddr} line
+                lappend new_lines $line
+            }
+        }
+        set new_content [join $new_lines "\n"]
+        write_file $conf_path $new_content
+
+        # Restart the R0, R0 and the dead node have the same epoch.
+        restart_server 0 true false
+        set R0_epoch [dict get [cluster_get_node_by_id 0 $R0_nodeid] config_epoch]
+        set dead_epoch [dict get [cluster_get_node_by_id 0 $dead_nodeid] config_epoch]
+        assert_equal $R0_epoch $dead_epoch
+
+        # Ensure the bump is successful even if they have the same epoch.
+        assert_equal [R 0 cluster bumpepoch] "BUMPED [expr $R0_epoch + 1]"
+    }
+}
+
+test "CLUSTER BUMPEPOCH jumps above a dead node with a very large configEpoch" {
+    start_cluster 1 0 {tags {external:skip cluster}} {
+        set R0_nodeid [R 0 CLUSTER MYID]
+        set R0_epoch [CI 0 cluster_my_epoch]
+        set dead_nodeid "0000000000000000000000000000000000000000"
+        set dead_epoch 999999
+        assert_morethan $dead_epoch $R0_epoch
+
+        # Shutdown R0.
+        set conf_path [cluster_nodes_conf_path 0]
+        catch {R 0 shutdown nosave}
+
+        # Modify R0's nodes.conf to inject a dead node with a very large
+        # configEpoch.
+        set content [read_file $conf_path]
+        set lines [split $content "\n"]
+        set new_lines {}
+        foreach line $lines {
+            if {[string first $R0_nodeid $line] == 0} {
+                # We first write the original R0 line, then modify it and
+                # write it as the new dead node line.
+                lappend new_lines $line
+                regsub $R0_nodeid $line $dead_nodeid line
+                regsub {myself} $line {fail,noaddr} line
+                regsub "$R0_epoch connected" $line "$dead_epoch connected" line
+                lappend new_lines $line
+            }
+        }
+        set new_content [join $new_lines "\n"]
+        write_file $conf_path $new_content
+
+        # Restart the R0
+        restart_server 0 true false
+
+        # When loading nodes.conf, currentEpoch is automatically set to the
+        # maximum epoch, so the bump will always succeed.
+        set current_epoch [CI 0 cluster_current_epoch]
+        set dead_epoch [dict get [cluster_get_node_by_id 0 $dead_nodeid] config_epoch]
+        assert_equal $dead_epoch $current_epoch
+        assert_equal [R 0 cluster bumpepoch] "BUMPED [expr $dead_epoch + 1]"
+    }
+}


### PR DESCRIPTION
clusterBumpConfigEpochWithoutConsensus() used clusterGetMaxEpoch() which
includes our own configEpoch in the max. When a dead/unreachable node
held an abnormally high configEpoch (e.g. due to bit flips from network
corruption) that currentEpoch never caught up with via PING/PONG, two
problems occurred:

1) If the dead node's configEpoch tied with ours, the condition
   `myself->configEpoch != maxEpoch` was false, so we returned C_ERR
   and never bumped.

2) If the dead node's configEpoch was far higher, we only incremented
   currentEpoch by 1 each call, requiring thousands of BUMPEPOCH calls
   to overtake it.

Fix by computing the max configEpoch excluding ourselves, then aligning
currentEpoch to that value before the increment. This guarantees a
single CLUSTER BUMPEPOCH always produces an epoch strictly greater than
any node's configEpoch.