### PR TITLE
Validate node ID when decoding open slots RDB aux field

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -8533,7 +8533,7 @@ int clusterDecodeOpenSlotsAuxField(int rdbflags, sds s) {
 
         /* Reject an invalid node ID instead of creating an illegal node. */
         if (verifyClusterNodeId(node_name, CLUSTER_NAMELEN) != C_OK) return C_ERR;
-        
+
         /* Ensure the delimiter is found. */
         if (*s != ',') return C_ERR;
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -8537,7 +8537,6 @@ int clusterDecodeOpenSlotsAuxField(int rdbflags, sds s) {
         /* Ensure the delimiter is found. */
         if (*s != ',') return C_ERR;
 
-
         /* Move to the next slot */
         s++;
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -8531,11 +8531,12 @@ int clusterDecodeOpenSlotsAuxField(int rdbflags, sds s) {
             node_name[k++] = *s++;
         }
 
-        /* Ensure the node name is of the correct length */
-        if (k != CLUSTER_NAMELEN || *s != ',') return C_ERR;
-
         /* Reject an invalid node ID instead of creating an illegal node. */
         if (verifyClusterNodeId(node_name, CLUSTER_NAMELEN) != C_OK) return C_ERR;
+        
+        /* Ensure the delimiter is found. */
+        if (*s != ',') return C_ERR;
+
 
         /* Move to the next slot */
         s++;

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -8534,6 +8534,9 @@ int clusterDecodeOpenSlotsAuxField(int rdbflags, sds s) {
         /* Ensure the node name is of the correct length */
         if (k != CLUSTER_NAMELEN || *s != ',') return C_ERR;
 
+        /* Reject an invalid node ID instead of creating an illegal node. */
+        if (verifyClusterNodeId(node_name, CLUSTER_NAMELEN) != C_OK) return C_ERR;
+
         /* Move to the next slot */
         s++;
 


### PR DESCRIPTION
clusterLookupNode() returns NULL for both unknown and invalid node IDs,
so a malformed-but-correct-length nodename was treated as "not found" and
a new illegal node got created.

Validate with verifyClusterNodeId() and reject the field on failure.
The aux field is normally trusted (it comes from a full sync), so this
hardens the security posture further.