### PR TITLE
Deflake "Replica output bytes metric" with atomic stats capture

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -201,10 +201,12 @@ start_server {tags {"repl external:skip"}} {
             # assertion below doesn't race with it.
             wait_for_ofs_sync $A $B
 
-            # reset stats
+            # Reset stats and read them atomically so replication traffic can't
+            # arrive between the reset and the stats snapshot.
+            $A multi
             $A config resetstat
-            
-            set info [$A info stats]
+            $A info stats
+            set info [lindex [$A exec] 1]
             set replica_bytes_output [getInfoProperty $info "total_net_repl_output_bytes"]
             assert_equal $replica_bytes_output 0
             

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -196,7 +196,13 @@ start_server {tags {"repl external:skip"}} {
         }
         
         test {Replica output bytes metric} {
-            # reset stats 
+            # Disable periodic replication pings and drain any already-queued
+            # replication stream, so no ping (the 14-byte RESP *1\r\n$4\r\nping\r\n
+            # frame) can land between resetstat and the info read below and make
+            # total_net_repl_output_bytes non-zero (see #3930).
+            $A config set repl-ping-replica-period 3600
+            wait_for_ofs_sync $A $B
+
             $A config resetstat
             
             set info [$A info stats]


### PR DESCRIPTION
The test resets stats and asserts `total_net_repl_output_bytes` is 0. A periodic replication PING can otherwise land between `CONFIG RESETSTAT` and `INFO stats`, making the counter 14 (the serialized PING frame) instead of 0.

#4158 added a replication-stream drain and a longer propagation wait. This follow-up keeps those improvements and queues `CONFIG RESETSTAT` plus `INFO stats` atomically in `MULTI`/`EXEC`, so the zero-baseline check has no interleaving window. It does not mutate `repl-ping-replica-period`.

Validation:
- atomic probe: 100/100 passed
- `make -j2` passed
- `integration/replication`: 67/67 passed across four runs

Fixes #3930