### PR TITLE
Handle previously unchecked pthread_mutex_* and fclose return values  (#3852)

### DIFF
--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -388,8 +388,10 @@ static void createIOThread(int id) {
     spscInit(&io_private_inbox[id], IO_SPSC_QUEUE_SIZE);
 
     pthread_t tid;
-    pthread_mutex_init(&io_threads_mutex[id], NULL);
-    pthread_mutex_lock(&io_threads_mutex[id]); /* Thread will be stopped. */
+    int ret = pthread_mutex_init(&io_threads_mutex[id], NULL);
+    serverAssert(ret == 0);
+    ret = pthread_mutex_lock(&io_threads_mutex[id]); /* Thread will be stopped. */
+    serverAssert(ret == 0);
     int err = pthread_create(&tid, NULL, IOThreadMain, (void *)(long)id);
     if (err) {
         serverLog(LL_WARNING, "Fatal: Can't initialize IO thread, pthread_create failed with: %s", strerror(err));

--- a/src/logreqres.c
+++ b/src/logreqres.c
@@ -271,7 +271,7 @@ size_t reqresAppendResponse(client *c) {
     FILE *fp = fopen(server.req_res_logfile, "a");
     serverAssert(fp);
     fwrite(c->reqres.buf, c->reqres.used, 1, fp);
-    fclose(fp);
+    if (fclose(fp)) serverLog(LL_WARNING, "Failed to close req/res log file: %s", strerror(errno));
 
     return ret;
 }

--- a/src/mutexqueue.c
+++ b/src/mutexqueue.c
@@ -24,8 +24,9 @@ mutexQueue *mutexQueueCreate(void) {
     mutexQueue *mq;
     mq = zmalloc(sizeof(*mq));
 
-    pthread_mutex_init(&mq->mutex, NULL);
-    pthread_cond_init(&mq->notify_cv, NULL);
+    int ret = pthread_mutex_init(&mq->mutex, NULL);
+    assert(ret == 0);
+    assert(pthread_cond_init(&mq->notify_cv, NULL) == 0);
     mq->priority_fifo = fifoCreate();
     mq->normal_fifo = fifoCreate();
     return mq;


### PR DESCRIPTION
## Summary

Fixes [#3852](https://github.com/valkey-io/valkey/issues/3852).

This PR adds handling for previously ignored return values at the call sites identified in the issue, while following the existing error-handling conventions already used throughout the Valkey codebase.

### Changes

* `src/mutexqueue.c`

  * Check the return value of `pthread_mutex_init()` using the file's existing `assert(...)` style.

* `src/io_threads.c`

  * Check the return values of both `pthread_mutex_init()` and `pthread_mutex_lock()` in `createIOThread()` using the file's existing `serverAssert(...)` style.
  * The adjacent `pthread_mutex_init()` is included as it is the same class of unchecked return-value issue immediately preceding the `pthread_mutex_lock()` call.

* `src/logreqres.c`

  * Log `fclose()` failures with `serverLog(LL_WARNING, ...)` instead of silently ignoring them, matching the existing handling pattern used in other file-writing paths.

## Rationale

The implementation intentionally follows existing Valkey conventions rather than introducing new error-handling behavior:

* Mutex initialization and locking failures are treated as invariant violations using the project's existing assertion mechanisms.
* `fclose()` failures in this debug logging path are reported via a warning log instead of terminating the server, consistent with similar I/O paths elsewhere in the codebase.

## Validation

* Built successfully on the current `unstable` branch.
* Successful execution paths remain unchanged; only previously ignored error returns are now handled.
