### PR TITLE
Fix false sharing in per-thread memory usage counters

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -93,7 +93,6 @@ void zlibc_free(void *ptr) {
 
 #define thread_local _Thread_local
 
-#define PADDING_ELEMENT_NUM (CACHE_LINE_SIZE / sizeof(size_t) - 1)
 #define MAX_THREADS_NUM (IO_THREADS_MAX_NUM + 3 + 1)
 /* A thread-local storage which keep the current thread's index in the used_memory_thread array. */
 static thread_local int thread_index = -1;
@@ -103,14 +102,22 @@ static thread_local int thread_index = -1;
  * the reader will see the inconsistency memory on non x86 architecture potentially.
  * For the ARM and PowerPC platform, we can solve this issue by make the memory aligned.
  * For the other architecture, lets fall back to the atomic operation to keep safe. */
+/* Each thread's counter lives on its own cache line. Without this, adjacent
+ * threads' counters share a cache line and every allocation's counter update
+ * causes false sharing across all allocating threads (and with the main
+ * thread, which sums these counters in zmalloc_used_memory() after every
+ * command). */
 #if defined(__i386__) || defined(__x86_64__) || defined(__amd64__) || defined(__POWERPC__) || defined(__arm__) || \
     defined(__arm64__)
-static __attribute__((aligned(CACHE_LINE_SIZE))) size_t used_memory_thread_padded[MAX_THREADS_NUM + PADDING_ELEMENT_NUM];
-static size_t *used_memory_thread = &used_memory_thread_padded[PADDING_ELEMENT_NUM];
+typedef struct {
+    __attribute__((aligned(CACHE_LINE_SIZE))) size_t value;
+} used_memory_entry;
 #else
-static __attribute__((aligned(CACHE_LINE_SIZE))) _Atomic size_t used_memory_thread_padded[MAX_THREADS_NUM + PADDING_ELEMENT_NUM];
-static _Atomic size_t *used_memory_thread = &used_memory_thread_padded[PADDING_ELEMENT_NUM];
+typedef struct {
+    __attribute__((aligned(CACHE_LINE_SIZE))) _Atomic size_t value;
+} used_memory_entry;
 #endif
+static used_memory_entry used_memory_thread[MAX_THREADS_NUM];
 static atomic_int total_active_threads = 0;
 /* This is a simple protection. It's used only if some modules create a lot of threads. */
 static atomic_size_t used_memory_for_additional_threads = 0;
@@ -125,7 +132,7 @@ static inline void update_zmalloc_stat_alloc(size_t size) {
     if (unlikely(thread_index >= MAX_THREADS_NUM)) {
         atomic_fetch_add_explicit(&used_memory_for_additional_threads, size, memory_order_relaxed);
     } else {
-        used_memory_thread[thread_index] += size;
+        used_memory_thread[thread_index].value += size;
     }
 }
 
@@ -134,7 +141,7 @@ static inline void update_zmalloc_stat_free(size_t size) {
     if (unlikely(thread_index >= MAX_THREADS_NUM)) {
         atomic_fetch_sub_explicit(&used_memory_for_additional_threads, size, memory_order_relaxed);
     } else {
-        used_memory_thread[thread_index] -= size;
+        used_memory_thread[thread_index].value -= size;
     }
 }
 
@@ -524,7 +531,7 @@ size_t zmalloc_used_memory(void) {
         threads_num = MAX_THREADS_NUM;
     }
     for (int i = 0; i < threads_num; i++) {
-        um += used_memory_thread[i];
+        um += used_memory_thread[i].value;
     }
     return um;
 }


### PR DESCRIPTION
Fixes #4111

## Problem

`used_memory_thread[]` in `zmalloc.c` is an array of plain `size_t` with only the array *start* cache-line aligned, so counters for 8 adjacent threads share one 64-byte line. Every `zmalloc`/`zfree` writes its counter (invalidating the line for other threads), and the main thread sums all counters in `zmalloc_used_memory()` after every command. With I/O threads doing allocator work, this line is a continuous false-sharing hot spot.

## Fix

Give each per-thread counter its own cache line (align the struct to `CACHE_LINE_SIZE`). Cost: ~16KB static memory, zero per-op cost. This reverses the layout chosen in #1179; the tradeoff is one cache line fetched per *active* thread in the aggregation loop (which iterates `total_active_threads`, not `MAX_THREADS_NUM`) versus eliminating cross-thread invalidations on every allocation.

## Benchmarks

Dedicated client+server pairs, server pinned 0-15, NIC IRQs pinned off those cores, 30M-request steady-state runs, io-threads 16:

| workload | x86 c7i (SMT) | Graviton3 (no SMT) |
|---|---|---|
| XADD | +17.5% | ~0 |
| GET | +9.8% | +3.0% |

The #1179 regression did not reproduce on either arch. The throughput win is concentrated where hyperthread siblings share L1/L2 (SMT x86); on physical cores it's mostly neutral. Architecture-independent evidence: `zmalloc_used_memory` is 5-9% of main-thread self-time (halved by the fix), and cache misses drop 25-45% under the io=16 XADD load.

## Testing

`./runtest --single unit/info --single unit/maxmemory` passes; full build with jemalloc + LTO.

Note: `_Atomic` fallback for non-x86/ARM/POWER is unchanged — this only changes layout, not the memory model.
