### PR TITLE
Skip commandlog bookkeeping when no threshold is crossed

### DIFF
--- a/src/commandlog.c
+++ b/src/commandlog.c
@@ -104,10 +104,12 @@ void commandlogInit(void) {
  * configured max length. */
 static void commandlogPushEntryIfNeeded(client *c, robj **argv, int argc, long long value, int type) {
     if (server.commandlog[type].threshold < 0 || server.commandlog[type].max_len == 0) return; /* The corresponding commandlog disabled */
-    if (value >= server.commandlog[type].threshold)
-        listAddNodeHead(server.commandlog[type].entries, commandlogCreateEntry(c, argv, argc, value, type));
+    if (value < server.commandlog[type].threshold) return;
+    listAddNodeHead(server.commandlog[type].entries, commandlogCreateEntry(c, argv, argc, value, type));
 
-    /* Remove old entries if needed. */
+    /* Remove old entries if needed. The list can only exceed max_len right
+     * after a push, so trimming here keeps the invariant without touching
+     * the list on the fast path. */
     while (listLength(server.commandlog[type].entries) > server.commandlog[type].max_len) listDelNode(server.commandlog[type].entries, listLast(server.commandlog[type].entries));
 }
 
@@ -144,10 +146,25 @@ static void commandlogGetReply(client *c, int type, long count) {
 }
 
 /* Log the last command a client executed into the commandlog. */
+/* Returns 1 if the given value would be logged into the command log of the
+ * given type. Kept inline and branch-light for the per-command fast path. */
+static inline int commandlogWouldLog(long long value, int type) {
+    return server.commandlog[type].threshold >= 0 && server.commandlog[type].max_len != 0 &&
+           value >= server.commandlog[type].threshold;
+}
+
 void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd) {
     /* Some commands may contain sensitive data that should not be available in the commandlog.
      */
     if (cmd->flags & CMD_SKIP_COMMANDLOG) return;
+
+    /* Fast path: on a healthy server virtually no command crosses any of the
+     * thresholds, so bail out before touching the argv/original_argv and
+     * script state below. */
+    if (!commandlogWouldLog(c->duration, COMMANDLOG_TYPE_SLOW) &&
+        !commandlogWouldLog(c->net_input_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REQUEST) &&
+        !commandlogWouldLog(c->net_output_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REPLY))
+        return;
 
     /* If command argument vector was rewritten, use the original
      * arguments. */


### PR DESCRIPTION
Fixes #4112

# PR 2 — branch `perf/commandlog-fast-path`

**Title:** Skip commandlog bookkeeping when no threshold is crossed

## Description

### Problem

`commandlogPushCurrentCommand()` runs after every command and unconditionally
called `commandlogPushEntryIfNeeded()` three times (SLOW / LARGE_REQUEST /
LARGE_REPLY). Each call ran the trim loop
`while (listLength(entries) > max_len) ...` even when nothing was pushed, reading
the lengths of three separate lists — three dependent loads of cold list heads
per command.

On a healthy server no command crosses any threshold, so this is pure overhead.
Profiling a pipelined SET workload with default config shows ~1.8% of total
cycles in `commandlogPushCurrentCommand` + `commandlogPushEntryIfNeeded`.

### Fix

- Add a branch-light `commandlogWouldLog()` check at the top of
  `commandlogPushCurrentCommand()` that returns before touching
  `argv`/`original_argv` or script state when none of the three thresholds is
  crossed.
- Move the trim loop in `commandlogPushEntryIfNeeded()` behind the push. The
  list can only exceed `max_len` immediately after a push, so trimming there
  preserves the invariant.

### Behavior change (minor)

Shrinking `*-max-len` via `CONFIG SET` now takes effect on the next command that
*pushes* an entry of that type, rather than the next command of any kind. This
matches how the reset path already behaves and is not observable except via a
deliberate CONFIG-SET-then-COMMANDLOG-LEN sequence with no intervening logged
command.

### Benchmarks

valkey-benchmark, SET d=64, pipeline 8, 50 clients, single-threaded, pinned
cores:

| Metric | Before | After |
|---|---|---|
| SET rps | 395k | 408k (+3.4%) |
| SET p50 | 0.940 ms | 0.924 ms |

GET is unaffected (its reply path does not reach the slow branches).

### Testing

- `./runtest --single unit/commandlog --single unit/slowlog` — 43 pass

## Review notes / anticipated questions

- The `CONFIG SET max_len` timing change is the only semantic difference; called
  out above and in the commit message so reviewers don't have to discover it.
- `commandlogWouldLog()` duplicates the guard in `commandlogPushEntryIfNeeded()`
  intentionally — the early-out must be cheap and self-contained; the per-type
  function keeps its own guard for correctness when called directly.