### PR TITLE
Coalesce small bulk replies into a single buffer append

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1499,8 +1499,28 @@ void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     _addReplyToBufferOrList(c, "\r\n", 2);
 }
 
+/* Max payload size for coalescing a bulk string reply ($<len>\r\n<data>\r\n)
+ * into a single buffer append. Chosen to keep the stack buffer small while
+ * covering the common case of short elements in aggregate replies. */
+#define BULK_COALESCE_MAX_SIZE 512
+
 void addWritePreparedReplyBulkCBuffer(writePreparedClient *wpc, const void *p, size_t len) {
     client *c = (client *)wpc;
+    if (len <= BULK_COALESCE_MAX_SIZE) {
+        /* Assemble the full bulk reply on the stack so the per-element
+         * bookkeeping in _addReplyToBufferOrList is paid once instead of
+         * three times. */
+        char buf[BULK_COALESCE_MAX_SIZE + LONG_STR_SIZE + 5];
+        buf[0] = '$';
+        size_t hdr = 1 + ll2string(buf + 1, LONG_STR_SIZE + 1, len);
+        buf[hdr] = '\r';
+        buf[hdr + 1] = '\n';
+        memcpy(buf + hdr + 2, p, len);
+        buf[hdr + 2 + len] = '\r';
+        buf[hdr + 3 + len] = '\n';
+        _addReplyToBufferOrList(c, buf, hdr + len + 4);
+        return;
+    }
     _addReplyLongLongWithPrefix(c, len, '$');
     _addReplyToBufferOrList(c, p, len);
     _addReplyToBufferOrList(c, "\r\n", 2);


### PR DESCRIPTION
Fixes #4113

# PR 3 — branch `perf/bulk-reply-coalescing`

**Title:** Coalesce small bulk replies into a single buffer append

## Description

### Problem

`addWritePreparedReplyBulkCBuffer()` emits every bulk string as three separate
calls into the reply machinery: the `$<len>\r\n` header, the payload, and the
trailing `\r\n`. Each `_addReplyToBufferOrList()` call re-runs the per-append
bookkeeping — client-type derivation (`getClientType`), copy-avoidance
evaluation (`isCopyAvoidPreferred`), reqres offset tracking, and the
buffer-vs-list dispatch.

For commands that emit many small elements (LRANGE, HGETALL, SMEMBERS, ZRANGE),
that bookkeeping dominates. Profiling `LRANGE_100` shows the reply chain at ~9%
of total cycles, with `getClientType` alone at ~2%.

### Fix

For payloads up to 512 bytes, assemble the complete RESP frame
`$<len>\r\n<payload>\r\n` in a stack buffer and append it with a single
`_addReplyToBufferOrList()` call — paying the bookkeeping once instead of three
times. Larger payloads keep the previous three-call path, to bound stack usage
and because the relative bookkeeping cost is negligible for them.

### Benchmarks

valkey-benchmark, LRANGE_100 (100-element lists), pipeline 8, 50 clients,
single-threaded, pinned cores:

| Metric | Before | After |
|---|---|---|
| rps | 95.8k | 114.0k (+19%) |
| p50 | 4.01 ms | 3.24 ms |

SET/GET unaffected.

### Testing

- `./runtest --single unit/type/list --single unit/protocol --single unit/type/string` — 437 pass

## Review notes / anticipated questions

- **Copy-avoidance interaction:** this helper is the plain-copy variant.
  Zero-copy bulk string references (`BULK_STR_REF`) are emitted by `addReplyBulk`
  via `_addBulkStrRefToBufferOrList`, a different path this PR does not touch, so
  there is no double-emit or conflict with `min-io-threads-copy-avoid`.
- **512B threshold:** chosen to keep the stack buffer small
  (`512 + LONG_STR_SIZE + 5` bytes) while covering the common short-element case.
  Happy to make it a named constant tunable if reviewers prefer; it is already a
  `#define BULK_COALESCE_MAX_SIZE`.
- Only the write-prepared CBuffer variant is changed. The same transformation
  could later be applied to `addReplyBulkCBuffer` (the non-write-prepared entry
  point) but that is left out to keep this PR minimal.