### PR TITLE
Remove per-iteration overhead from the IO thread main loop

### DIFF
--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -279,6 +279,23 @@ void cleanupThreadResources(void *dummy) {
     freeSharedQueryBuf();
 }
 
+/* CPU pause hint for the polling loop: reduces pipeline and cache pressure
+ * while spinning on shared queue state, giving the producer (main thread)
+ * better access to the contended cache lines. */
+#if defined(__x86_64__) || defined(__i386__)
+#define ioThreadCpuRelax() __builtin_ia32_pause()
+#elif defined(__aarch64__) || defined(__arm__)
+#define ioThreadCpuRelax() __asm__ __volatile__("yield")
+#else
+#define ioThreadCpuRelax() ((void)0)
+#endif
+
+/* How many consecutive empty polls before an IO thread visits its park gate
+ * (io_threads_mutex). The gate is uncontended unless the main thread wants to
+ * suspend this thread, so visiting it rarely only delays suspension by
+ * microseconds while removing a mutex lock/unlock pair from every empty poll. */
+#define IO_THREAD_PARK_CHECK_MASK 0x3FF /* every 1024 empty polls */
+
 static void *IOThreadMain(void *myid) {
     /* The ID is the thread ID number (from 1 to server.io_threads_num-1). ID 0 is the main thread. */
     long id = (long)myid;
@@ -292,22 +309,18 @@ static void *IOThreadMain(void *myid) {
 
     thread_id = (int)id;
     void *batch_jobs[BATCH_SIZE];
-    int processed = 0;
-    monotime work_start_time = 0;
+    unsigned long idle_polls = 0;
     while (1) {
-        /* Cancellation point so that pthread_cancel() from main thread is honored. */
-        pthread_testcancel();
         size_t batch_count = 0;
-        monotime prev_work_start_time = work_start_time;
-        work_start_time = getMonotonicUs();
-        if (processed != 0) {
-            atomic_fetch_add_explicit(&used_active_time_io_thread[id],
-                                      work_start_time - prev_work_start_time,
-                                      memory_order_relaxed);
-        }
-        processed = 0;
+        int processed = 0;
+        /* Timestamps are taken only around actual work: on the first
+         * successful dequeue and after processing. Empty polls stay free of
+         * clock reads. */
+        monotime work_start_time = 0;
+
         /* PRIORITY 1: Drain Private SPSC Queue (Batch Processing) */
         while ((batch_count = spscDequeueBatch(&io_private_inbox[id], batch_jobs, BATCH_SIZE)) > 0) {
+            if (!work_start_time) work_start_time = getMonotonicUs();
             for (size_t i = 0; i < batch_count; i++) {
                 void *data;
                 int type;
@@ -331,6 +344,7 @@ static void *IOThreadMain(void *myid) {
          * Only checked after SPSC is drained. */
         void *tagged_job = spmcDequeue(&io_shared_inbox);
         if (tagged_job) {
+            if (!work_start_time) work_start_time = getMonotonicUs();
             void *data;
             int type;
             untagJob(tagged_job, &data, &type);
@@ -358,17 +372,25 @@ static void *IOThreadMain(void *myid) {
         }
 
         if (processed) {
+            idle_polls = 0;
             atomic_fetch_add_explicit(&io_jobs_finished, processed, memory_order_release);
-        }
-
-        /* If both queues were empty (no processing done), wait for signal. */
-        if (processed == 0) {
+            atomic_fetch_add_explicit(&used_active_time_io_thread[id],
+                                      getMonotonicUs() - work_start_time,
+                                      memory_order_relaxed);
+        } else {
+            /* Cancellation point so that pthread_cancel() from main thread is
+             * honored. A thread with a continuously busy queue reaches this
+             * point too, since the main thread stops feeding the queues
+             * before cancelling (drain on reconfigure, or process shutdown). */
+            pthread_testcancel();
             if (unlikely(pending_io_responses)) {
                 flushPendingIOResponses(0);
-            } else {
+            } else if ((++idle_polls & IO_THREAD_PARK_CHECK_MASK) == 0) {
                 /* If it is locked. We should block until main thread unlocks it. */
                 pthread_mutex_lock(&io_threads_mutex[id]);
                 pthread_mutex_unlock(&io_threads_mutex[id]);
+            } else {
+                ioThreadCpuRelax();
             }
         }
     }


### PR DESCRIPTION
Fixes #4114

## Problem

`IOThreadMain()` paid three costs on every loop iteration, including every empty poll of a hot queue:

1. `pthread_testcancel()` — per iteration.
2. `getMonotonicUs()` — per iteration, for the active-time metric.
3. On every empty poll, a lock/unlock pair on the park-gate mutex `io_threads_mutex[id]`, ping-ponging that cache line.

Under `io-threads 8` with pipelined load, >11% of an IO thread's cycles go to `pthread_mutex_lock/unlock`, plus ~2.9% `getMonotonicUs` and ~1.4% `pthread_testcancel`.

## Fix (semantics preserved)

- Timestamp only around real work — empty polls take no clock reads.
- Move `pthread_testcancel()` to the empty-poll path (cancellation is always preceded by the queues draining, so a cancelled thread still reaches it).
- Spin-then-park: visit the park-gate mutex once per 1024 empty polls, `_mm_pause()`/`yield` otherwise. Post-load spin-down decay is unchanged.

## Metric change (worth a look)

`used_active_time_io_thread` (in `INFO`) previously accumulated wall time between loop iterations, counting empty-poll spinning as active time. It now measures time spent processing jobs, so it reads **lower** at the same throughput. It doesn't feed the scale-up/down policy (that uses SPMC queue depth), so behavior is unaffected — happy to split this into its own commit if preferred.

## Benchmarks

Dedicated client+server pairs, IRQs pinned, 30M-request steady-state runs, io-threads 16:

| workload | x86 c7i (SMT) | Graviton3 (no SMT) |
|---|---|---|
| XADD | +3.8% | ~0 |
| GET | +3.7% | +3.1% |

The throughput effect is a consistent low single digit; the primary benefit is efficiency — the removed per-empty-poll work lowers CPU and cache misses in the over-provisioned regime. Additive with #4107. (An earlier revision quoted +18%/+15-25% from short runs that measured connection ramp rather than steady state; corrected here.)

## Testing

`./runtest --single unit/io-threads` passes. Spin-down decay verified equal to baseline.

`IO_THREAD_PARK_CHECK_MASK` (1024) trades suspension latency for mutex traffic and can be tuned.
