### PR TITLE
Fix racy remaining_repl_size assertion in slot migration test

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -2518,9 +2518,14 @@ start_cluster 3 0 {tags {logreqres:skip external:skip cluster} overrides {cluste
         # With slot-migration-max-failover-repl-bytes -1, the source (R2) should proceed
         # to pause writes regardless of the large remaining_repl_size.
         R 2 DEBUG SLOTMIGRATION PREVENT-PAUSE 0
-        wait_for_log_messages -2 {"*Pausing writes*"} 0 1000 10
-        set pattern "*Pausing writes (remaining_repl_size is $remaining_repl_size) to allow slot migration*"
-        verify_log_message -2 $pattern 0
+        # The logged remaining_repl_size is racy: the migration cron appends
+        # SYNCSLOTS ACKs to the same job->client buffer and R0 is paused so it
+        # never drains. Assert a lower bound against the snapshot.
+        set log_line [lindex [wait_for_log_messages -2 {"*Pausing writes*"} 0 1000 10] 0]
+        if {![regexp {remaining_repl_size is (\d+)} $log_line _ actual_repl_size]} {
+            fail "could not parse remaining_repl_size from log line: $log_line"
+        }
+        assert_morethan_equal $actual_repl_size $remaining_repl_size
 
         # Resume R0 and wait for R0 to finish the migration.
         resume_process [srv 0 pid]


### PR DESCRIPTION
In the "slot-migration-max-failover-repl-bytes -1" test, the
"Pausing writes" log line was matched with the exact
remaining_repl_size captured earlier via a snapshot. The test
is flaky, the logs:
```
expected pattern found in srv -2 log file:
*Pausing writes (remaining_repl_size is 49152936) to allow slot migration*

but instead got:
Pausing writes (remaining_repl_size is 49169328) to allow slot migration
```

The value is racy: the migration cron appends a SYNCSLOTS ACK
to the same job->client reply list, and reply_bytes only grows
when a new reply-list node is allocated (R0 is paused, so the
buffer never drains).

Replace the exact match with a lower-bound assertion against the
snapshot. Closes #4013. The test was introduced in #3443.