### PR TITLE
Add static_assert to guard node flags fit in uint16_t

### DIFF
--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -69,7 +69,7 @@ typedef struct clusterLink {
                                                                                    * myself will gossip this flag to other replica in the   \
                                                                                    * shard so that the replicas can make a better ranking   \
                                                                                    * decisions to help with the failover. */
-#define CLUSTER_NODE_MAX CLUSTER_NODE_MY_PRIMARY_FAIL                         /* Max bit for CLUSTER_NODE_* flag, update while adding a new flag. */
+#define CLUSTER_NODE_MAX CLUSTER_NODE_MY_PRIMARY_FAIL                             /* Max bit for CLUSTER_NODE_* flag, update while adding a new flag. */
 
 /* Ensure cluster node flags never silently grew beyond 16 bits.
  * The flags in clusterMsg and clusterMsgDataGossip are uint16_t. */

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -69,6 +69,11 @@ typedef struct clusterLink {
                                                                                    * myself will gossip this flag to other replica in the   \
                                                                                    * shard so that the replicas can make a better ranking   \
                                                                                    * decisions to help with the failover. */
+#define CLUSTER_NODE_HIGHEST CLUSTER_NODE_MY_PRIMARY_FAIL                         /* Highest flag, bump when adding a flag. */
+
+/* Ensure cluster node flags never silently grow beyond 16 bits.
+ * The flags in clusterMsgHeader and clusterMsgDataGossip are uint16_t. */
+static_assert(CLUSTER_NODE_HIGHEST <= UINT16_MAX, "cluster node flags must fit in 16 bits");
 
 #define CLUSTER_NODE_NULL_NAME                                                                                         \
     "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000" \

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -69,11 +69,11 @@ typedef struct clusterLink {
                                                                                    * myself will gossip this flag to other replica in the   \
                                                                                    * shard so that the replicas can make a better ranking   \
                                                                                    * decisions to help with the failover. */
-#define CLUSTER_NODE_HIGHEST CLUSTER_NODE_MY_PRIMARY_FAIL                         /* Highest flag, bump when adding a flag. */
+#define CLUSTER_NODE_MAX CLUSTER_NODE_MY_PRIMARY_FAIL                         /* Max bit for CLUSTER_NODE_* flag, update while adding a new flag. */
 
-/* Ensure cluster node flags never silently grow beyond 16 bits.
+/* Ensure cluster node flags never silently grew beyond 16 bits.
  * The flags in clusterMsg and clusterMsgDataGossip are uint16_t. */
-static_assert(CLUSTER_NODE_HIGHEST <= UINT16_MAX, "cluster node flags must fit in 16 bits");
+static_assert(CLUSTER_NODE_MAX <= UINT16_MAX, "cluster node flags must fit in 16 bits");
 
 #define CLUSTER_NODE_NULL_NAME                                                                                         \
     "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000" \

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -72,7 +72,7 @@ typedef struct clusterLink {
 #define CLUSTER_NODE_HIGHEST CLUSTER_NODE_MY_PRIMARY_FAIL                         /* Highest flag, bump when adding a flag. */
 
 /* Ensure cluster node flags never silently grow beyond 16 bits.
- * The flags in clusterMsgHeader and clusterMsgDataGossip are uint16_t. */
+ * The flags in clusterMsg and clusterMsgDataGossip are uint16_t. */
 static_assert(CLUSTER_NODE_HIGHEST <= UINT16_MAX, "cluster node flags must fit in 16 bits");
 
 #define CLUSTER_NODE_NULL_NAME                                                                                         \


### PR DESCRIPTION
Introduce CLUSTER_NODE_MAX to track the highest node
flag and add a static_assert ensuring cluster node flags
never exceed 16 bits, since they are stored as uint16_t
in clusterMsgHeader and clusterMsgDataGossip.