### PR TITLE
perf: Drop redundant per-command peak-memory sampling in `call()`

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4100,11 +4100,6 @@ void call(client *c, int flags) {
         server.stat_numcommands++;
     }
 
-    /* Record peak memory after each command and before the eviction that runs
-     * before the next command. */
-    size_t zmalloc_used = zmalloc_used_memory();
-    if (zmalloc_used > server.stat_peak_memory) server.stat_peak_memory = zmalloc_used;
-
     /* Do some maintenance job and cleanup */
     afterCommand(c);
 


### PR DESCRIPTION
Part of #4117

`call()` reads `zmalloc_used_memory()` and updates `server.stat_peak_memory` after every command. That update is redundant — `stat_peak_memory` is already maintained in `beforeSleep()` (once per event-loop iteration), in `cronUpdateMemoryStats()` (once per `serverCron` tick), and corrected on read in the `INFO memory` path. Removing the per-command read leaves peak tracking at event-loop granularity, consistent with the existing note in `INFO` that peak is updated "from time to time by `serverCron()`" and corrected if the instantaneous value is larger.

On a GET-heavy profile `zmalloc_used_memory` is ~4.7% of on-CPU samples — pure per-command overhead the event loop already captures at batch boundaries.

## Results

Graviton 4 (c8g.metal), non-PGO, `GET` 16B / io-threads 9 / pipeline 10, 10 reps, baseline = branch base:

| | throughput | main-thread instr/req |
|---|---|---|
| baseline | 3.281M rps (CV 0.45%) | 3136 |
| this PR | 3.434M rps (CV 0.37%) | 3075 (−1.95%) |

**+4.66% throughput.** All 10 candidate reps (3.408–3.449M) sit above baseline's full range (3.251–3.301M) — non-overlapping distributions — and the main-thread instruction drop confirms the mechanism.
