### PR TITLE
Fixes RESP response splitting in the Lua shebang error path.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -397,7 +397,7 @@ static int evalRegisterNewScript(client *c, robj *body, char **sha) {
     char *engine_name = NULL;
     if (evalExtractShebangFlags(objectGetVal(body), &engine_name, &script_flags, &shebang_len, &err) == C_ERR) {
         if (c != NULL) {
-            addReplyErrorSds(c, err);
+            addReplyErrorSdsSafe(c, err);
         }
         if (engine_name) {
             zfree(engine_name);


### PR DESCRIPTION
The shebang flag error (eval.c) interpolates a token decoded by sdsnsplitargs() — which turns \r \n escapes into raw CR/LF — into the error reply via addReplyErrorSds(), which does not sanitize CR/LF (unlike addReplyErrorSdsSafe used elsewhere). This lets a client inject valid RESP frames into the reply stream.

Same class as GHSA-p876-p7q5-hv2m. Reported on the security list;
submitting as a routine fix per the maintainer's guidance.