### PR TITLE
Fix bitfield command did not replicate when only creating or resizing

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1304,11 +1304,6 @@ void bitfieldGeneric(client *c, int flags) {
             zfree(ops);
             return;
         }
-        /* Creating or growing the key is itself a modification, so count it once
-         * here. Otherwise a command whose ops all OVERFLOW FAIL would leave
-         * changes == 0 and the create/resize would never be propagated to
-         * replicas or the AOF, diverging the primary from its replicas. */
-        changes = dirty;
     }
 
     initDeferredReplyBuffer(c);
@@ -1350,7 +1345,7 @@ void bitfieldGeneric(client *c, int flags) {
                     addReplyLongLong(c, retval);
                     setSignedBitfield(objectGetVal(o), thisop->offset, thisop->bits, newval);
 
-                    if (oldval != newval) changes++;
+                    if (dirty || (oldval != newval)) changes++;
                 } else {
                     addReplyNull(c);
                 }
@@ -1380,7 +1375,7 @@ void bitfieldGeneric(client *c, int flags) {
                     addReplyLongLong(c, retval);
                     setUnsignedBitfield(objectGetVal(o), thisop->offset, thisop->bits, newval);
 
-                    if (oldval != newval) changes++;
+                    if (dirty || (oldval != newval)) changes++;
                 } else {
                     addReplyNull(c);
                 }
@@ -1417,6 +1412,13 @@ void bitfieldGeneric(client *c, int flags) {
             }
         }
     }
+
+    /* If the key was created or grown (dirty) but no operation counted a change
+     * -- e.g. every op hit OVERFLOW FAIL and the per-op check above was skipped
+     * -- the create/resize is still a modification that must be propagated to
+     * replicas and the AOF. Count it once here so the block below runs;
+     * otherwise the primary would diverge from its replicas. */
+    if (dirty && !changes) changes++;
 
     if (changes) {
         signalModifiedKey(c, c->db, c->argv[1]);

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1304,6 +1304,11 @@ void bitfieldGeneric(client *c, int flags) {
             zfree(ops);
             return;
         }
+        /* Creating or growing the key is itself a modification, so count it once
+         * here. Otherwise a command whose ops all OVERFLOW FAIL would leave
+         * changes == 0 and the create/resize would never be propagated to
+         * replicas or the AOF, diverging the primary from its replicas. */
+        changes = dirty;
     }
 
     initDeferredReplyBuffer(c);
@@ -1345,7 +1350,7 @@ void bitfieldGeneric(client *c, int flags) {
                     addReplyLongLong(c, retval);
                     setSignedBitfield(objectGetVal(o), thisop->offset, thisop->bits, newval);
 
-                    if (dirty || (oldval != newval)) changes++;
+                    if (oldval != newval) changes++;
                 } else {
                     addReplyNull(c);
                 }
@@ -1375,7 +1380,7 @@ void bitfieldGeneric(client *c, int flags) {
                     addReplyLongLong(c, retval);
                     setUnsignedBitfield(objectGetVal(o), thisop->offset, thisop->bits, newval);
 
-                    if (dirty || (oldval != newval)) changes++;
+                    if (oldval != newval) changes++;
                 } else {
                     addReplyNull(c);
                 }

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -259,5 +259,41 @@ start_server {tags {"repl external:skip"}} {
             catch {$slave bitfield_ro bits set u8 0 100 get u8 0} err
             assert_match {*ERR BITFIELD_RO only supports the GET subcommand*} $err
         }
+
+        test {BITFIELD OVERFLOW FAIL on new key creates key on primary but is not propagated} {
+            # u8 max is 255; SET u8 300 overflows. With OVERFLOW FAIL the write is
+            # skipped and nil is returned, but lookupStringForBitCommand has already
+            # created the (zero-padded) key on the primary.
+            assert_equal {{}} [$master bitfield k OVERFLOW FAIL SET u8 0 300]
+
+            # Key exists on the master...
+            assert_equal 1 [$master exists k]
+            wait_for_ofs_sync $master $slave
+            assert_equal 1 [$slave exists k]
+        }
+
+        test {BITFIELD OVERFLOW FAIL that resizes an existing key is propagated to the replica} {
+            # Pre-create a small (1-byte) string that is already replicated.
+            $master setbit k2 0 1
+            wait_for_ofs_sync $master $slave
+            assert_equal 1 [$slave exists k2]
+            assert_equal 1 [$slave strlen k2]
+
+            # SET u8 at offset 100 grows the (zero-padded) value before the
+            # overflow check runs. u8 max is 255; SET u8 300 overflows, so with
+            # OVERFLOW FAIL the write is skipped and nil is returned -- but the
+            # key has already been resized on the primary. The resize is itself a
+            # modification: it must bump the dirty counter and be replicated, or
+            # primary/replica sizes diverge.
+            assert_equal {{}} [$master bitfield k2 OVERFLOW FAIL SET u8 100 300]
+
+            set master_len [$master strlen k2]
+            assert {$master_len > 1}
+
+            # The resize must have been replicated, so the replica reports the
+            # same (grown) length.
+            wait_for_ofs_sync $master $slave
+            assert_equal $master_len [$slave strlen k2]
+        }
     }
 }

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -260,13 +260,14 @@ start_server {tags {"repl external:skip"}} {
             assert_match {*ERR BITFIELD_RO only supports the GET subcommand*} $err
         }
 
-        test {BITFIELD OVERFLOW FAIL on new key creates key on primary but is not propagated} {
+        test {BITFIELD OVERFLOW FAIL on new key creates key on primary and is propagated} {
             # u8 max is 255; SET u8 300 overflows. With OVERFLOW FAIL the write is
             # skipped and nil is returned, but lookupStringForBitCommand has already
-            # created the (zero-padded) key on the primary.
+            # created the (zero-padded) key on the primary. That create is a
+            # modification and must be propagated, or the replica never sees the key.
             assert_equal {{}} [$master bitfield k OVERFLOW FAIL SET u8 0 300]
 
-            # Key exists on the master...
+            # Key exists on the master and is replicated.
             assert_equal 1 [$master exists k]
             wait_for_ofs_sync $master $slave
             assert_equal 1 [$slave exists k]


### PR DESCRIPTION
## Problem

When a `BITFIELD` command creates or grows a key but every operation hits `OVERFLOW FAIL`, the create/resize is applied on the primary but never propagated to replicas or the AOF, leaving the primary and its replicas inconsistent.

## Reproduction

```
# on primary
> BITFIELD k OVERFLOW FAIL SET u8 0 300   # returns (nil); u8 max is 255
> EXISTS k                                # => 1 (key was created)
# on replica
> EXISTS k                                # => 0  (never received)
```

The same happens when an existing key is grown: `BITFIELD k2 OVERFLOW FAIL SET u8 100 300` resizes `k2` on the primary only, so `STRLEN k2` diverges between primary and replica.

## Fix

Count the create/resize as a change once, right after the lookup.
Added two replication tests in `tests/unit/bitfield.tcl`: one for creating a new key with `OVERFLOW FAIL`, one for resizing an existing key; both assert the key/size is replicated.
