### PR TITLE
Wait past the HEXPIREAT deadline in the non-existing fields negative test

### DIFF
--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -3474,10 +3474,12 @@ start_server {tags {"hashexpire external:skip"}} {
             
             # Try to expire non-existing fields
             r $command myhash [get_short_expire_value $command] FIELDS 2 f3 f4
-            
-            
-            # Wait to ensure no active expiry occurs
-            after 1500
+
+
+            # Wait past the TTL deadline to ensure no active expiry occurs.
+            # The HEXPIREAT/HPEXPIREAT deadline can be up to 2s away, so the
+            # wait must exceed that or this assertion passes vacuously.
+            after 2500
             assert [check_myhash_and_expired_subkeys r myhash 2 $initial_expired 0]
         }
 


### PR DESCRIPTION
Follow-up to #4157, which fixed the HGETEX EXAT notification flake (#4088) by moving the HEXPIREAT/HPEXPIREAT test deadline to now + 2 seconds.

The negative test "$command active expiry with non-existing fields" was not updated with it. It waits a fixed 1500ms and then asserts that no active expiry happened — but the wait only proves something if it exceeds the TTL deadline. With the deadline now up to 2s away (depending on subsecond phase when the command runs), the 1500ms wait exceeds it only about half the time, so for the AT variants the assertion frequently passes vacuously and would miss a regression where the command wrongly registered an expiry on non-existing fields.

Bump the wait to 2500ms so it always outlasts the deadline. hashexpire passes locally; the four non-existing-fields cases now take ~2.5s each.