### PR TITLE
Cluster Bus v2 -  Decentralized Failure Detector

### DIFF
--- a/design-docs/cluster-raft.md
+++ b/design-docs/cluster-raft.md
@@ -529,7 +529,8 @@ replicas and checks their health via two paths:
 2. *Disconnected replica (not in `server.replicas`)*: a crash causes
    immediate TCP RST and client removal. The primary tracks the first
    observation time (`repl_unconnected_since`) and proposes NODE_FAIL
-   after `max(REPL_CONNECT_GRACE_PERIOD_MS - (5 seconds), server.node_timeout)`. The grace period allows a healthy replica time to complete its replication handshake after a FAILOVER when replicas connect to the new primary.
+   after `max(REPL_CONNECT_GRACE_PERIOD_MS - (5 seconds), server.node_timeout)`.
+   The grace period allows a healthy replica time to complete its replication handshake after a FAILOVER when replicas connect to the new primary.
 
 **Replica-side detection:** The replica checks `myself->replicaof`
 from cluster state and monitors replication health via

--- a/design-docs/cluster-raft.md
+++ b/design-docs/cluster-raft.md
@@ -172,22 +172,21 @@ NODE_INFO <node-id> <address-string> <flags>
     and SET_REPLICA_OF. Flags is "nofailover" or "noflags". No shard epoch required here
     as it does not create any mutations.
 
-NODE_FAIL <target-node-id> <proposer-node-id>
+NODE_FAIL <target-node-id> <proposer-node-id> <shard-epoch>
     Mark a node as failed. Proposed by a shard member via the
     replication-stream detector, or by the raft leader via AE_ACK
     for single-node shards and whole-shard-down fallback. The
-    proposer field enables apply-time validation (see Failure
-    Detection). No shard epoch as it does not change cluster
-    membership or leadership.
+    proposer is validated at propose time; the shard-epoch is
+    validated at apply time to reject entries made stale by a
+    concurrent shard change (see Failure Detection). Does not itself
+    bump the shard epoch.
 
-NODE_RECOVER <target-node-id> <proposer-node-id>
+NODE_RECOVER <target-node-id> <proposer-node-id> <shard-epoch>
     Clear the FAIL flag. Proposed by the primary when a FAIL'd
     replica reappears in server.replicas, by the raft leader when
     a single-node shard sends AE_ACK, or by a replica when its
     FAIL'd primary's replication link is restored (only when
-    failover is disabled). Apply-time validation mirrors NODE_FAIL:
-    proposer must be the leader, a non-replica recovering a replica,
-    or a replica recovering a non-replica.
+    failover is disabled). Validation mirrors NODE_FAIL.
 ```
 
 Ranges in SLOT_CHANGE use the same format as nodes.conf: `0-5460` or
@@ -474,14 +473,21 @@ complexity to the leader's replication logic.
 
 ## Failure Detection
 
-Two failure detectors work in conjunction: a centralized AE_ACK-based
-detector on the raft leader, and a decentralized replication-stream
-detector on shard members. The AE_ACK detector handles single-node
-shards and the whole-shard-down fallback. The replication-stream
-detector handles multi-node shards where the data-path is the
-authoritative health signal.
+There are two modes of failure detection, working in conjunction:
 
-### Centralized AE_ACK detector
+1. **Shard-level (replica ↔ primary):** shard members detect each
+   other via the replication stream (the data-path), which is the
+   authoritative health signal for a shard. Decentralized.
+
+2. **Cluster-level (leader → whole shard):** the raft leader detects a
+   shard via AE_ACK when no member of that shard is responsive.
+
+The two modes are complementary: as long as *any* shard member is
+alive, mode 1 owns detection for that shard (it has the real data-path
+signal); mode 2 only fires when the whole shard has gone silent, where
+the leader's AE_ACK is the only remaining signal.
+
+### Cluster-level AE_ACK detector
 
 The raft leader tracks `last_ack_time` per peer, updated on every
 AE_ACK received. This serves two purposes:
@@ -490,21 +496,12 @@ AE_ACK received. This serves two purposes:
    majority of peers have not ACK'd within `cluster-node-timeout`,
    the leader steps down to prevent split-brain writes.
 
-2. **NODE_FAIL for single-node shards**: for shards with no replicas,
-   there is no replication stream to monitor. If a peer hasn't
-   responded within `cluster-node-timeout`, the leader proposes
-   NODE_FAIL. When the node comes back and sends AE_ACK, the leader
-   proposes NODE_RECOVER.
-
-**Whole-shard-down fallback:** When ALL members of a multi-node shard
-have timed out on the leader's AE_ACK tracking, no shard member is
-alive to propose NODE_FAIL via the replication-stream detector. In
-this case, the leader falls back to proposing NODE_FAIL via AE_ACK
-for each timed-out member. This only activates when no shard member
-is responsive — if any single member is still alive, it handles
-detection via the replication-stream paths below. This is needed as
-the raft leader has no other signal to represent node health of a
-shard in this scenario.
+2. **NODE_FAIL when a whole shard is silent**: if every member of a
+   shard has failed to ACK within `cluster-node-timeout`, no member is
+   alive to run the replication-stream detector, so the leader proposes
+   NODE_FAIL for each timed-out member. A single-node shard also
+   satisfies "every member is silent". When a node comes back and sends
+   AE_ACK, the leader proposes NODE_RECOVER.
 
 ### Why replication-stream-based detection is also needed
 
@@ -532,9 +529,7 @@ replicas and checks their health via two paths:
 2. *Disconnected replica (not in `server.replicas`)*: a crash causes
    immediate TCP RST and client removal. The primary tracks the first
    observation time (`repl_unconnected_since`) and proposes NODE_FAIL
-   after `REPL_CONNECT_GRACE_PERIOD_MS` (5 seconds). The grace period
-   allows a healthy replica time to complete its replication handshake
-   after a FAILOVER when replicas connect to the new primary.
+   after `max(REPL_CONNECT_GRACE_PERIOD_MS - (5 seconds), server.node_timeout)`. The grace period allows a healthy replica time to complete its replication handshake after a FAILOVER when replicas connect to the new primary.
 
 **Replica-side detection:** The replica checks `myself->replicaof`
 from cluster state and monitors replication health via
@@ -557,6 +552,21 @@ primary failed to do so (e.g., the primary itself crashed).
 - Replica-side: proposes NODE_RECOVER only when failover is disabled
   (`cluster-replica-no-failover`). Normally, a replica with a FAIL'd
   primary should failover, not recover.
+
+### NODE_FAIL / NODE_RECOVER validation
+
+A NODE_FAIL/NODE_RECOVER entry carries `<target> <proposer>
+<shard-epoch>` and is validated in two places:
+
+- **Propose time (leader):** the proposer must be legitimate — the raft
+  leader, or the target's actual primary/replica peer.
+  An already-FAIL'd proposer is a no-op. This check runs once,
+  during leader pre-validation.
+
+- **Apply time (NODE_FAIL only):** the shard epoch is re-checked (not
+  bumped). A concurrent FAILOVER bumps the epoch, so a stale `NODE_FAIL` carrying the old epoch is rejected. Without this, after a node R fails over node P, the stale `NODE_FAIL R` from the old primary P could mark the freshly promoted R as FAILED.
+
+- **Apply time (NODE_RECOVER):** no epoch check because clearing a FAIL flag is the safe direction as stale recovery is either a no-op or gets re-FAILed on the next detector tick. Epoch-gating it would only delay a legitimate recovery, an availability regression.
 
 ### Election timeout
 

--- a/design-docs/cluster-raft.md
+++ b/design-docs/cluster-raft.md
@@ -474,28 +474,60 @@ complexity to the leader's replication logic.
 
 ## Failure Detection
 
-NODE_FAIL represents **data-path health**, not raft-protocol health.
-A node marked FAIL continues to participate in raft (sends AE_ACK,
-votes in elections, applies log entries). The only operation that
-removes a node from raft participation is NODE_FORGET.
+Two failure detectors work in conjunction: a centralized AE_ACK-based
+detector on the raft leader, and a decentralized replication-stream
+detector on shard members. The AE_ACK detector handles single-node
+shards and the whole-shard-down fallback. The replication-stream
+detector handles multi-node shards where the data-path is the
+authoritative health signal.
 
-Failure detection uses two complementary mechanisms based on shard type:
+### Centralized AE_ACK detector
+
+The raft leader tracks `last_ack_time` per peer, updated on every
+AE_ACK received. This serves two purposes:
+
+1. **Quorum freshness** (`clusterRaftLeaderHasFreshQuorum()`): if a
+   majority of peers have not ACK'd within `cluster-node-timeout`,
+   the leader steps down to prevent split-brain writes.
+
+2. **NODE_FAIL for single-node shards**: for shards with no replicas,
+   there is no replication stream to monitor. If a peer hasn't
+   responded within `cluster-node-timeout`, the leader proposes
+   NODE_FAIL. When the node comes back and sends AE_ACK, the leader
+   proposes NODE_RECOVER.
+
+**Whole-shard-down fallback:** When ALL members of a multi-node shard
+have timed out on the leader's AE_ACK tracking, no shard member is
+alive to propose NODE_FAIL via the replication-stream detector. In
+this case, the leader falls back to proposing NODE_FAIL via AE_ACK
+for each timed-out member. This only activates when no shard member
+is responsive — if any single member is still alive, it handles
+detection via the replication-stream paths below. This is needed as
+the raft leader has no other signal to represent node health of a
+shard in this scenario.
+
+### Why replication-stream-based detection is also needed
+
+For shard nodes, the actual liveness signal is replication stream
+health. A primary and its replicas communicate via the replication
+connection — if that connection is healthy, the shard is serving
+traffic correctly regardless of whether the raft leader can reach
+those nodes. This allows shard nodes to operate independently from
+raft leader partitions and avoid false positives.
 
 ### Decentralized replication-stream detector
 
-For shards with a primary and one or more replicas, failure is detected
-via the data-path (replication stream) rather than the raft leader.
-This avoids false positives from asymmetric partitions where the raft
-leader can reach a node but the node's data-path is broken. Asymmetric
-timeouts between primary and replica ensure that in case of partition,
-the primary marks the replica FAIL first. This is more accurate than a
-centralized detector as it captures real replication health.
+For shards with a primary and one or more replicas, failure is
+detected via the data-path (replication stream). Asymmetric timeouts
+between primary and replica is set to avoid failovers in case of partition
+between primary and replica. This will also be later used as primaryship
+lease for sync replication.
 
 **Primary-side detection:** The primary iterates its cluster-state
 replicas and checks their health via two paths:
 
-1. *Connected replica (in `server.replicas`)*: checks `repl_ack_time`
-   freshness. Timeout = `cluster-node-timeout`.
+1. *Connected replica (in `server.replicas`, state ONLINE)*: checks
+   `repl_ack_time` freshness. Timeout = `cluster-node-timeout`.
 
 2. *Disconnected replica (not in `server.replicas`)*: a crash causes
    immediate TCP RST and client removal. The primary tracks the first
@@ -504,13 +536,13 @@ replicas and checks their health via two paths:
    allows a healthy replica time to complete its replication handshake
    after a FAILOVER when replicas connect to the new primary.
 
-**Replica-side detection:** The replica checks `myself->replicaof` from
-cluster state (the authoritative source for who the primary is) and
-monitors replication health via `server.primary->last_interaction`
-(link up but silent) or `server.repl_down_since` (link dropped).
-Timeout = `1.5 × cluster-node-timeout`. The asymmetric (longer) timeout
-ensures the primary proposes NODE_FAIL first; the replica only proposes
-if the primary failed to do so (e.g., the primary itself crashed).
+**Replica-side detection:** The replica checks `myself->replicaof`
+from cluster state and monitors replication health via
+`server.primary->last_interaction` (link up but silent) or
+`server.repl_down_since` (link dropped). Timeout = `1.5 ×
+cluster-node-timeout`. The asymmetric (longer) timeout ensures the
+primary proposes NODE_FAIL first; the replica only proposes if the
+primary failed to do so (e.g., the primary itself crashed).
 
 **Timeout summary:**
 
@@ -520,55 +552,11 @@ if the primary failed to do so (e.g., the primary itself crashed).
 | Replica: primary silent/down | 1.5 × node-timeout | Let primary propose first |
 
 **Recovery:**
-- Primary-side: proposes NODE_RECOVER when a FAIL'd replica reappears
-  in `server.replicas`.
+- Primary-side: proposes NODE_RECOVER when a FAIL'd replica is present
+  in `server.replicas` and `repl_ack_time` is fresh.
 - Replica-side: proposes NODE_RECOVER only when failover is disabled
   (`cluster-replica-no-failover`). Normally, a replica with a FAIL'd
-  primary should failover, not recover. The recovery path exists for
-  replicas that cannot failover — their only option to restore the
-  shard is to wait for the primary to come back.
-
-### Centralized AE_ACK detector
-
-For shards with a single node (no replicas), the raft leader monitors
-the node via AE_ACK. If a peer hasn't responded within
-`cluster-node-timeout`, the leader proposes NODE_FAIL. When the node
-comes back and sends AE_ACK, the leader proposes NODE_RECOVER.
-
-### Whole-shard-down fallback
-
-When ALL members of a multi-node shard have timed out on the raft
-leader's AE_ACK tracking, no shard member is alive to propose NODE_FAIL.
-In this case, the leader falls back to proposing NODE_FAIL via AE_ACK
-for each timed-out member. This only activates when no shard member is
-responsive — if any single member is still alive, it handles detection
-via the replication-stream paths above.
-
-When learner mode is implemented, nodes participating in raft protocol,
-single shard node and whole shard down fallback will use AE_ACK based detector.
-
-### NODE_FAIL apply-time validation
-
-The NODE_FAIL entry format is `NODE_FAIL <target-id> <proposer-id>`.
-At apply time, the entry is validated — the proposer must be either:
-
-- The raft leader (AE_ACK / whole-shard-down fallback), or
-- A non-replica proposing FAIL for a replica (primary detecting
-  replica failure), or
-- A replica proposing FAIL for a non-replica (replica detecting
-  primary failure).
-
-This ensures NODE_FAIL can only flow between a primary and its
-replica (or from the raft leader as a fallback). It prevents a
-stale/restarted node with outdated cluster state from marking a
-healthy shard member as FAIL.
-
-### Common behavior
-
-On apply, the FAIL flag is set on the node and slot coverage is
-rechecked, transitioning `cluster_state` to `fail` if a node with
-slots is down. A node that is itself marked FAIL does not run failure
-detection or recovery.
+  primary should failover, not recover.
 
 ### Election timeout
 

--- a/design-docs/cluster-raft.md
+++ b/design-docs/cluster-raft.md
@@ -172,13 +172,22 @@ NODE_INFO <node-id> <address-string> <flags>
     and SET_REPLICA_OF. Flags is "nofailover" or "noflags". No shard epoch required here
     as it does not create any mutations.
 
-NODE_FAIL <node-id>
-    Mark a node as failed. Proposed by the leader when a peer exceeds
-    the node timeout without responding to heartbeats. No shard epoch here as it does not change cluster membership or leadership.
+NODE_FAIL <target-node-id> <proposer-node-id>
+    Mark a node as failed. Proposed by a shard member via the
+    replication-stream detector, or by the raft leader via AE_ACK
+    for single-node shards and whole-shard-down fallback. The
+    proposer field enables apply-time validation (see Failure
+    Detection). No shard epoch as it does not change cluster
+    membership or leadership.
 
-NODE_RECOVER <node-id>
-    Clear the FAIL flag. Proposed by the leader when it receives
-    AE_ACK from a previously failed node.
+NODE_RECOVER <target-node-id> <proposer-node-id>
+    Clear the FAIL flag. Proposed by the primary when a FAIL'd
+    replica reappears in server.replicas, by the raft leader when
+    a single-node shard sends AE_ACK, or by a replica when its
+    FAIL'd primary's replication link is restored (only when
+    failover is disabled). Apply-time validation mirrors NODE_FAIL:
+    proposer must be the leader, a non-replica recovering a replica,
+    or a replica recovering a non-replica.
 ```
 
 Ranges in SLOT_CHANGE use the same format as nodes.conf: `0-5460` or
@@ -465,16 +474,101 @@ complexity to the leader's replication logic.
 
 ## Failure Detection
 
-The leader tracks `last_ack_time` per peer, updated on every AE_ACK
-received. In the leader's cron, if a peer hasn't responded within
-`cluster-node-timeout`, the leader proposes a NODE_FAIL entry.
+NODE_FAIL represents **data-path health**, not raft-protocol health.
+A node marked FAIL continues to participate in raft (sends AE_ACK,
+votes in elections, applies log entries). The only operation that
+removes a node from raft participation is NODE_FORGET.
+
+Failure detection uses two complementary mechanisms based on shard type:
+
+### Decentralized replication-stream detector
+
+For shards with a primary and one or more replicas, failure is detected
+via the data-path (replication stream) rather than the raft leader.
+This avoids false positives from asymmetric partitions where the raft
+leader can reach a node but the node's data-path is broken. Asymmetric
+timeouts between primary and replica ensure that in case of partition,
+the primary marks the replica FAIL first. This is more accurate than a
+centralized detector as it captures real replication health.
+
+**Primary-side detection:** The primary iterates its cluster-state
+replicas and checks their health via two paths:
+
+1. *Connected replica (in `server.replicas`)*: checks `repl_ack_time`
+   freshness. Timeout = `cluster-node-timeout`.
+
+2. *Disconnected replica (not in `server.replicas`)*: a crash causes
+   immediate TCP RST and client removal. The primary tracks the first
+   observation time (`repl_unconnected_since`) and proposes NODE_FAIL
+   after `REPL_CONNECT_GRACE_PERIOD_MS` (5 seconds). The grace period
+   allows a healthy replica time to complete its replication handshake
+   after a FAILOVER when replicas connect to the new primary.
+
+**Replica-side detection:** The replica checks `myself->replicaof` from
+cluster state (the authoritative source for who the primary is) and
+monitors replication health via `server.primary->last_interaction`
+(link up but silent) or `server.repl_down_since` (link dropped).
+Timeout = `1.5 × cluster-node-timeout`. The asymmetric (longer) timeout
+ensures the primary proposes NODE_FAIL first; the replica only proposes
+if the primary failed to do so (e.g., the primary itself crashed).
+
+**Timeout summary:**
+
+| Path | Timeout | Rationale |
+|------|---------|-----------|
+| Primary: connected replica silent | cluster-node-timeout | Replica should ACK within this window |
+| Replica: primary silent/down | 1.5 × node-timeout | Let primary propose first |
+
+**Recovery:**
+- Primary-side: proposes NODE_RECOVER when a FAIL'd replica reappears
+  in `server.replicas`.
+- Replica-side: proposes NODE_RECOVER only when failover is disabled
+  (`cluster-replica-no-failover`). Normally, a replica with a FAIL'd
+  primary should failover, not recover. The recovery path exists for
+  replicas that cannot failover — their only option to restore the
+  shard is to wait for the primary to come back.
+
+### Centralized AE_ACK detector
+
+For shards with a single node (no replicas), the raft leader monitors
+the node via AE_ACK. If a peer hasn't responded within
+`cluster-node-timeout`, the leader proposes NODE_FAIL. When the node
+comes back and sends AE_ACK, the leader proposes NODE_RECOVER.
+
+### Whole-shard-down fallback
+
+When ALL members of a multi-node shard have timed out on the raft
+leader's AE_ACK tracking, no shard member is alive to propose NODE_FAIL.
+In this case, the leader falls back to proposing NODE_FAIL via AE_ACK
+for each timed-out member. This only activates when no shard member is
+responsive — if any single member is still alive, it handles detection
+via the replication-stream paths above.
+
+When learner mode is implemented, nodes participating in raft protocol,
+single shard node and whole shard down fallback will use AE_ACK based detector.
+
+### NODE_FAIL apply-time validation
+
+The NODE_FAIL entry format is `NODE_FAIL <target-id> <proposer-id>`.
+At apply time, the entry is validated — the proposer must be either:
+
+- The raft leader (AE_ACK / whole-shard-down fallback), or
+- A non-replica proposing FAIL for a replica (primary detecting
+  replica failure), or
+- A replica proposing FAIL for a non-replica (replica detecting
+  primary failure).
+
+This ensures NODE_FAIL can only flow between a primary and its
+replica (or from the raft leader as a fallback). It prevents a
+stale/restarted node with outdated cluster state from marking a
+healthy shard member as FAIL.
+
+### Common behavior
 
 On apply, the FAIL flag is set on the node and slot coverage is
 rechecked, transitioning `cluster_state` to `fail` if a node with
-slots is down.
-
-When a failed node comes back and sends AE_ACK, the leader proposes
-a NODE_RECOVER entry to clear the FAIL flag on all nodes.
+slots is down. A node that is itself marked FAIL does not run failure
+detection or recovery.
 
 ### Election timeout
 

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -2183,6 +2183,39 @@ static void clusterRaftInitLast(void) {
     }
 }
 
+/* Find a client in server.replicas matching the given cluster node ID.
+ * Returns the client if found, NULL otherwise. */
+static client *clusterRaftFindReplicaClient(clusterNode *node) {
+    listIter li;
+    listNode *ln;
+    listRewind(server.replicas, &li);
+    while ((ln = listNext(&li))) {
+        client *c = listNodeValue(ln);
+        if (c->repl_data->replica_nodeid && sdslen(c->repl_data->replica_nodeid) == CLUSTER_NAMELEN &&
+            memcmp(c->repl_data->replica_nodeid, node->name, CLUSTER_NAMELEN) == 0) {
+            return c;
+        }
+    }
+    return NULL;
+}
+
+/* Propose NODE_FAIL for a given node.
+ * Format: "NODE_FAIL <target-node-id> <proposer-node-id>" */
+static void clusterRaftProposeNodeFail(clusterNode *node, const char *reason) {
+    clusterNodeRaftData *rd = RAFT_NODE(node);
+    if (nodeFailed(node) || rd->pending_fail_change) return;
+
+    serverLog(LL_NOTICE, "%.40s %s, proposing NODE_FAIL.", node->name, reason);
+
+    sds entry = sdsnew("NODE_FAIL ");
+    entry = sdscatlen(entry, node->name, CLUSTER_NAMELEN);
+    entry = sdscatlen(entry, " ", 1);
+    entry = sdscatlen(entry, myself->name, CLUSTER_NAMELEN);
+    clusterRaftPropose(entry, NULL, NULL);
+    sdsfree(entry);
+    rd->pending_fail_change = 1;
+}
+
 /* Leader: periodically drop stale links to failed nodes so that
  * clusterConnectNodes can establish a fresh connection. This allows
  * the leader to detect recovery when the node comes back and sends
@@ -2269,38 +2302,13 @@ static void clusterRaftDetectFailures(mstime_t now) {
             if (!all_timed_out) continue;
         }
 
-        serverLog(LL_NOTICE, "Node %.40s not responding (AE_ACK), proposing NODE_FAIL.", node->name);
-
-        sds entry = sdsnew("NODE_FAIL ");
-        entry = sdscatlen(entry, node->name, CLUSTER_NAMELEN);
-        entry = sdscatlen(entry, " ", 1);
-        entry = sdscatlen(entry, myself->name, CLUSTER_NAMELEN);
-        clusterRaftPropose(entry, NULL, NULL);
-        sdsfree(entry);
-        rd->pending_fail_change = 1;
+        clusterRaftProposeNodeFail(node, "AE_ACK timeout");
     }
     dictReleaseIterator(di);
 }
 
-/* Propose NODE_FAIL for a given node via the replication stream failure
- * detector. Used by both primary-side and replica-side detection paths.
- * Format: "NODE_FAIL <target-node-id> <proposer-node-id>" */
-static void clusterRaftProposeReplStreamNodeFail(clusterNode *node) {
-    clusterNodeRaftData *rd = RAFT_NODE(node);
-    if (nodeFailed(node) || rd->pending_fail_change) return;
-
-    serverLog(LL_NOTICE,
-              "Replication stream timeout: proposing NODE_FAIL for %.40s.",
-              node->name);
-
-    sds entry = sdsnew("NODE_FAIL ");
-    entry = sdscatlen(entry, node->name, CLUSTER_NAMELEN);
-    entry = sdscatlen(entry, " ", 1);
-    entry = sdscatlen(entry, myself->name, CLUSTER_NAMELEN);
-    clusterRaftPropose(entry, NULL, NULL);
-    sdsfree(entry);
-    rd->pending_fail_change = 1;
-}
+/* Find a client in server.replicas matching the given cluster node ID.
+ * Returns the client if found, NULL otherwise. */
 
 /* Detect failures via the replication stream. Active only in raft mode.
  *
@@ -2325,20 +2333,7 @@ static void clusterRaftDetectReplStreamFailures(mstime_t now) {
             if (!node || nodeFailed(node)) continue;
             if (RAFT_NODE(node)->pending_fail_change) continue;
 
-            /* Find matching client in server.replicas. */
-            client *replica_client = NULL;
-            listIter li2;
-            listNode *ln2;
-            listRewind(server.replicas, &li2);
-            while ((ln2 = listNext(&li2))) {
-                client *c = listNodeValue(ln2);
-                if (c->repl_data->replica_nodeid &&
-                    sdslen(c->repl_data->replica_nodeid) == CLUSTER_NAMELEN &&
-                    memcmp(c->repl_data->replica_nodeid, node->name, CLUSTER_NAMELEN) == 0) {
-                    replica_client = c;
-                    break;
-                }
-            }
+            client *replica_client = clusterRaftFindReplicaClient(node);
 
             if (replica_client) {
                 /* Replica is connected — reset disconnect tracker. */
@@ -2348,7 +2343,7 @@ static void clusterRaftDetectReplStreamFailures(mstime_t now) {
                 if (replica_client->repl_data->repl_state == REPLICA_STATE_ONLINE) {
                     time_t ack_age = server.unixtime - replica_client->repl_data->repl_ack_time;
                     if (ack_age > timeout_sec) {
-                        clusterRaftProposeReplStreamNodeFail(node);
+                        clusterRaftProposeNodeFail(node, "replication stream timeout");
                     }
                 }
             } else {
@@ -2359,7 +2354,7 @@ static void clusterRaftDetectReplStreamFailures(mstime_t now) {
                 if (rd->repl_unconnected_since == 0) {
                     rd->repl_unconnected_since = now;
                 } else if (now - rd->repl_unconnected_since > REPL_CONNECT_GRACE_PERIOD_MS) {
-                    clusterRaftProposeReplStreamNodeFail(node);
+                    clusterRaftProposeNodeFail(node, "replication stream timeout");
                 }
             }
         }
@@ -2385,7 +2380,7 @@ static void clusterRaftDetectReplStreamFailures(mstime_t now) {
         }
 
         if (should_propose) {
-            clusterRaftProposeReplStreamNodeFail(my_primary);
+            clusterRaftProposeNodeFail(my_primary, "replication stream timeout");
         }
     }
 
@@ -2428,20 +2423,7 @@ static void clusterRaftDetectReplStreamRecovery(mstime_t now) {
             if (!node || !nodeFailed(node)) continue;
             if (RAFT_NODE(node)->pending_fail_change) continue;
 
-            int found = 0;
-            listIter li;
-            listNode *ln;
-            listRewind(server.replicas, &li);
-            while ((ln = listNext(&li))) {
-                client *c = listNodeValue(ln);
-                if (c->repl_data->replica_nodeid &&
-                    sdslen(c->repl_data->replica_nodeid) == CLUSTER_NAMELEN &&
-                    memcmp(c->repl_data->replica_nodeid, node->name, CLUSTER_NAMELEN) == 0) {
-                    found = 1;
-                    break;
-                }
-            }
-            if (found) {
+            if (clusterRaftFindReplicaClient(node)) {
                 RAFT_NODE(node)->repl_unconnected_since = 0;
                 clusterRaftProposeReplStreamNodeRecover(node);
             }

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1339,8 +1339,10 @@ static int raftValidateFailRecoverEntry(sds data, clusterNode **target, clusterN
     }
     if (*target && *proposer) {
         int is_leader = (memcmp((*proposer)->name, rs->leader, CLUSTER_NAMELEN) == 0);
-        int primary_and_replica = (!nodeIsReplica(*proposer) && nodeIsReplica(*target));
-        int replica_and_primary = (nodeIsReplica(*proposer) && !nodeIsReplica(*target));
+        int same_shard = (memcmp((*proposer)->shard_id, (*target)->shard_id, CLUSTER_NAMELEN) == 0);
+        int primary_and_replica = (same_shard && !nodeIsReplica(*proposer) && nodeIsReplica(*target));
+        int replica_and_primary = (same_shard && nodeIsReplica(*proposer) && !nodeIsReplica(*target));
+        if (nodeFailed(*proposer)) return 0;
         if (!is_leader && !primary_and_replica && !replica_and_primary) return 0;
     }
     return 1;
@@ -1499,7 +1501,7 @@ static void raftLogApply(raftLogEntry *e) {
         clusterNode *proposer = NULL;
         int valid_proposer = raftValidateFailRecoverEntry(e->data, &node, &proposer);
         int applied = 0;
-        if (node && node != myself && valid_proposer) {
+        if (node && node != myself && !nodeFailed(node) && valid_proposer) {
             node->flags |= CLUSTER_NODE_FAIL;
             RAFT_NODE(node)->pending_fail_change = 0;
             rs->todo_update_slot_coverage = 1;
@@ -2231,15 +2233,21 @@ static void clusterRaftDetectFailures(mstime_t now) {
             continue;
 
         /* For multi-node shards, only act if ALL shard members have
-         * timed out. If any member is still alive, it will handle
-         * detection via the replication stream. */
+         * timed out. If any member is still alive (including myself),
+         * it will handle detection via the replication stream. */
         if (nodeIsReplica(node) || clusterNodeNumReplicas(node) > 0) {
             clusterNode *primary = nodeIsReplica(node) ? node->replicaof : node;
             if (!primary) continue;
             int all_timed_out = 1;
 
+            /* If the leader is itself in this shard, it's a responsive
+             * member — defer to replication-stream detection. */
+            if (memcmp(myself->shard_id, primary->shard_id, CLUSTER_NAMELEN) == 0) {
+                all_timed_out = 0;
+            }
+
             /* Check the primary (if it's not the node we're evaluating). */
-            if (primary != node && primary != myself && !nodeFailed(primary)) {
+            if (all_timed_out && primary != node && !nodeFailed(primary)) {
                 clusterNodeRaftData *prd = RAFT_NODE(primary);
                 if (!(prd->last_ack_time > 0 && now - prd->last_ack_time > node_timeout)) {
                     all_timed_out = 0;
@@ -2250,7 +2258,7 @@ static void clusterRaftDetectFailures(mstime_t now) {
                 int num_replicas = clusterNodeNumReplicas(primary);
                 for (int i = 0; i < num_replicas; i++) {
                     clusterNode *replica = clusterNodeGetReplica(primary, i);
-                    if (replica == node || replica == myself || nodeFailed(replica)) continue;
+                    if (replica == node || nodeFailed(replica)) continue;
                     clusterNodeRaftData *rrd = RAFT_NODE(replica);
                     if (!(rrd->last_ack_time > 0 && now - rrd->last_ack_time > node_timeout)) {
                         all_timed_out = 0;
@@ -2303,7 +2311,7 @@ static void clusterRaftProposeReplStreamNodeFail(clusterNode *node) {
  * proposes NODE_FAIL first; the replica only proposes if the primary failed
  * to do so (e.g., the primary itself crashed). */
 static void clusterRaftDetectReplStreamFailures(mstime_t now) {
-    if (server.loading || nodeFailed(myself)) return;
+    if (server.loading || nodeFailed(myself) || server.shutdown_flags) return;
 
     /* Primary side: iterate cluster-state replicas and check health.
      * If the replica has a client in server.replicas, check repl_ack_time.
@@ -2333,10 +2341,15 @@ static void clusterRaftDetectReplStreamFailures(mstime_t now) {
             }
 
             if (replica_client) {
-                /* Replica is connected — check replication ACK freshness. */
-                time_t ack_age = server.unixtime - replica_client->repl_data->repl_ack_time;
-                if (ack_age > timeout_sec) {
-                    clusterRaftProposeReplStreamNodeFail(node);
+                /* Replica is connected — reset disconnect tracker. */
+                RAFT_NODE(node)->repl_unconnected_since = 0;
+                /* Check replication ACK freshness. Skip replicas still in
+                 * full sync (repl_ack_time not yet initialized). */
+                if (replica_client->repl_data->repl_state == REPLICA_STATE_ONLINE) {
+                    time_t ack_age = server.unixtime - replica_client->repl_data->repl_ack_time;
+                    if (ack_age > timeout_sec) {
+                        clusterRaftProposeReplStreamNodeFail(node);
+                    }
                 }
             } else {
                 /* After FAILOVER, a healthy replica needs time to
@@ -3749,9 +3762,10 @@ static RaftProposalResult clusterRaftApplyFailover(sds data, int validate_only) 
         }
     }
 
-    /* Promote replica to primary. */
+    /* Promote replica to primary. Clear FAIL flag if set — the node is
+     * now the active primary serving slots. */
     clusterNodeRemoveReplica(primary, replica);
-    replica->flags &= ~CLUSTER_NODE_REPLICA;
+    replica->flags &= ~(CLUSTER_NODE_REPLICA | CLUSTER_NODE_FAIL);
     replica->flags |= CLUSTER_NODE_PRIMARY;
     replica->replicaof = NULL;
 

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -59,14 +59,12 @@ typedef enum {
 #define REPL_CONNECT_GRACE_PERIOD_MS 5000
 
 
-/* Primary-side timeout (seconds) for detecting a silent connected replica.
- * Uses cluster-node-timeout converted to seconds. */
+/* Primary-side timeout (seconds) for detecting replica failure. */
 static inline time_t raftPrimarySideTimeout(void) {
     return (time_t)(server.cluster_node_timeout / 1000);
 }
 
-/* Replica-side timeout (seconds) for detecting a silent/down primary.
- * 1.5× cluster-node-timeout to let the primary propose first. */
+/* Replica-side timeout (seconds) for detecting primary failure. */
 static inline time_t raftReplicaSideTimeout(void) {
     time_t t = (time_t)(server.cluster_node_timeout / 1000) * 3 / 2;
     return t < 1 ? 1 : t;
@@ -1343,6 +1341,8 @@ static int raftValidateFailRecoverEntry(sds data, clusterNode **target, clusterN
         int primary_and_replica = (same_shard && !nodeIsReplica(*proposer) && nodeIsReplica(*target));
         int replica_and_primary = (same_shard && nodeIsReplica(*proposer) && !nodeIsReplica(*target));
         if (nodeFailed(*proposer)) return 0;
+        /* Valid if: raft leader, or primary proposing for its replica,
+         * or replica proposing for its primary. */
         if (!is_leader && !primary_and_replica && !replica_and_primary) return 0;
     }
     return 1;
@@ -2219,10 +2219,7 @@ static void clusterRaftProposeNodeFail(clusterNode *node, const char *reason) {
 /* Leader: periodically drop stale links to failed nodes so that
  * clusterConnectNodes can establish a fresh connection. This allows
  * the leader to detect recovery when the node comes back and sends
- * an AE_ACK on the new link.
- *
- * Periodically drops stale links so clusterConnectNodes can establish
- * a fresh connection for recovery detection. */
+ * an AE_ACK on the new link. */
 static void clusterRaftRecycleFailedNodeLinks(mstime_t now) {
     mstime_t node_timeout = server.cluster_node_timeout;
 
@@ -2257,8 +2254,7 @@ static void clusterRaftDetectFailures(mstime_t now) {
     dictEntry *de;
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
-        if (node == myself) continue;
-        if (nodeFailed(node)) continue;
+        if (node == myself || nodeFailed(node)) continue;
 
         clusterNodeRaftData *rd = RAFT_NODE(node);
         if (rd->pending_fail_change) continue;
@@ -2270,7 +2266,9 @@ static void clusterRaftDetectFailures(mstime_t now) {
          * it will handle detection via the replication stream. */
         if (nodeIsReplica(node) || clusterNodeNumReplicas(node) > 0) {
             clusterNode *primary = nodeIsReplica(node) ? node->replicaof : node;
-            if (!primary) continue;
+            /* Orphaned replica with no primary — no replication stream
+             * exists to monitor it. */
+            if (!primary) goto propose_fail;
             int all_timed_out = 1;
 
             /* If the leader is itself in this shard, it's a responsive
@@ -2279,14 +2277,17 @@ static void clusterRaftDetectFailures(mstime_t now) {
                 all_timed_out = 0;
             }
 
-            /* Check the primary (if it's not the node we're evaluating). */
+            /* Check the primary: if it's still responsive, it can detect
+             * the failed replica via replication-stream — no need for
+             * AE_ACK fallback. */
             if (all_timed_out && primary != node && !nodeFailed(primary)) {
                 clusterNodeRaftData *prd = RAFT_NODE(primary);
                 if (!(prd->last_ack_time > 0 && now - prd->last_ack_time > node_timeout)) {
                     all_timed_out = 0;
                 }
             }
-            /* Check all replicas. */
+            /* Check all replicas: if any replica is still responsive,
+             * it can detect the failed primary via replication-stream. */
             if (all_timed_out) {
                 int num_replicas = clusterNodeNumReplicas(primary);
                 for (int i = 0; i < num_replicas; i++) {
@@ -2302,13 +2303,11 @@ static void clusterRaftDetectFailures(mstime_t now) {
             if (!all_timed_out) continue;
         }
 
+    propose_fail:
         clusterRaftProposeNodeFail(node, "AE_ACK timeout");
     }
     dictReleaseIterator(di);
 }
-
-/* Find a client in server.replicas matching the given cluster node ID.
- * Returns the client if found, NULL otherwise. */
 
 /* Detect failures via the replication stream. Active only in raft mode.
  *
@@ -2361,7 +2360,7 @@ static void clusterRaftDetectReplStreamFailures(mstime_t now) {
     }
 
     /* Replica side: check our primary from cluster state.
-     * Timeout = 1.5T to let the primary (or the raft leader) propose first. */
+     * Timeout = 1.5T to let the primary propose first. */
     if (nodeIsReplica(myself) && myself->replicaof &&
         !nodeFailed(myself->replicaof) &&
         !RAFT_NODE(myself->replicaof)->pending_fail_change) {
@@ -2406,16 +2405,11 @@ static void clusterRaftProposeReplStreamNodeRecover(clusterNode *node) {
     rd->pending_fail_change = 1;
 }
 
-/* Detect data-path recovery via the replication stream for multi-node shards.
- *
- * Primary side: a FAIL'd replica is now ACKing again within the timeout.
- * Replica side: primary marked FAIL but replication link is back and active. */
+/* Detect data-path recovery via the replication stream for multi-node shards. */
 static void clusterRaftDetectReplStreamRecovery(mstime_t now) {
     if (server.loading || nodeFailed(myself)) return;
 
-    /* Primary side: check if a FAIL marked replica has reconnected (appeared
-     * back in server.replicas). This is the inverse of the failure path:
-     * when the replica's client reappears, the data path is restored. */
+    /* Primary side: check if a FAIL marked replica is active again. */
     if (nodeIsPrimary(myself) && clusterNodeNumReplicas(myself) > 0) {
         int num_replicas = clusterNodeNumReplicas(myself);
         for (int i = 0; i < num_replicas; i++) {
@@ -2423,9 +2417,17 @@ static void clusterRaftDetectReplStreamRecovery(mstime_t now) {
             if (!node || !nodeFailed(node)) continue;
             if (RAFT_NODE(node)->pending_fail_change) continue;
 
-            if (clusterRaftFindReplicaClient(node)) {
+            client *replica_client = clusterRaftFindReplicaClient(node);
+            if (replica_client) {
                 RAFT_NODE(node)->repl_unconnected_since = 0;
-                clusterRaftProposeReplStreamNodeRecover(node);
+                /* Only propose recovery if the replica is ONLINE and
+                 * actively ACKing. */
+                if (replica_client->repl_data->repl_state == REPLICA_STATE_ONLINE) {
+                    time_t ack_age = server.unixtime - replica_client->repl_data->repl_ack_time;
+                    if (ack_age <= raftPrimarySideTimeout()) {
+                        clusterRaftProposeReplStreamNodeRecover(node);
+                    }
+                }
             }
         }
     }

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -393,6 +393,8 @@ static RaftProposalResult clusterRaftApplySlotChange(sds data, int validate_only
 static RaftProposalResult clusterRaftApplySetReplica(sds data, int validate_only);
 static RaftProposalResult clusterRaftApplyFailover(sds data, int validate_only);
 static RaftProposalResult clusterRaftApplyNodeForget(sds data, int validate_only);
+static RaftProposalResult clusterRaftValidateFailRecoverProposer(sds data);
+static void raftClearPendingFailChange(int type, sds data);
 static void raftLogApply(raftLogEntry *e);
 static raftLogEntry *raftLogCreate(uint64_t term, uint64_t index, uint8_t type, sds data);
 static void raftLogAppend(raftLogEntry *e);
@@ -847,6 +849,8 @@ static void clusterRaftPropose(sds entry, void *ctx, void (*callback)(void *ctx,
         RaftProposalResult pre_result = clusterRaftPreValidate(type, data);
         if (pre_result != RAFT_RESULT_OK) {
             if (callback) callback(ctx, raftProposalResultMsg(pre_result));
+            /* Let the detector re-evaluate a rejected NODE_FAIL/NODE_RECOVER. */
+            raftClearPendingFailChange(type, data);
             sdsfree(data);
             return;
         }
@@ -1098,6 +1102,10 @@ static RaftProposalResult clusterRaftPreValidate(int type, sds data) {
     case RAFT_ENTRY_NODE_FORGET:
         result = clusterRaftApplyNodeForget(data, 1);
         break;
+    case RAFT_ENTRY_NODE_FAIL:
+    case RAFT_ENTRY_NODE_RECOVER:
+        result = clusterRaftValidateFailRecoverProposer(data);
+        break;
     default:
         break;
     }
@@ -1313,6 +1321,8 @@ static void clusterRaftCompletePendingProposal(int type, sds data, RaftProposalR
                 return;
             }
             if (pp->callback) pp->callback(pp->ctx, raftProposalResultMsg(result));
+            /* On terminal rejection, free the detector to re-evaluate. */
+            if (result != RAFT_RESULT_OK) raftClearPendingFailChange(type, data);
             sdsfree(pp->data);
             zfree(pp);
             listDelNode(rs->pending_proposals, ln);
@@ -1321,31 +1331,57 @@ static void clusterRaftCompletePendingProposal(int type, sds data, RaftProposalR
     }
 }
 
-/* Parse a NODE_FAIL or NODE_RECOVER entry and validate the proposer.
- * Format: "<target-node-id> [<proposer-node-id>]"
- * Returns 1 if the proposer is valid, 0 otherwise.
- * Sets *target and *proposer to the looked-up nodes (may be NULL). */
-static int raftValidateFailRecoverEntry(sds data, clusterNode **target, clusterNode **proposer) {
-    clusterRaftState *rs = RAFT_STATE();
+/* Parse a NODE_FAIL or NODE_RECOVER entry.
+ * Format: "<target-node-id> <proposer-node-id> <shard-epoch>"
+ * Sets *target and *proposer to the looked-up nodes
+ * and *epoch to the entry's shard epoch (0 if absent). */
+static void raftParseFailRecoverEntry(sds data, clusterNode **target, clusterNode **proposer, uint64_t *epoch) {
     *target = NULL;
     *proposer = NULL;
-    if (sdslen(data) >= CLUSTER_NAMELEN) {
-        *target = clusterLookupNode(data, CLUSTER_NAMELEN);
-        if (sdslen(data) >= CLUSTER_NAMELEN * 2 + 1) {
-            *proposer = clusterLookupNode(data + CLUSTER_NAMELEN + 1, CLUSTER_NAMELEN);
-        }
-    }
-    if (*target && *proposer) {
-        int is_leader = (memcmp((*proposer)->name, rs->leader, CLUSTER_NAMELEN) == 0);
-        int same_shard = (memcmp((*proposer)->shard_id, (*target)->shard_id, CLUSTER_NAMELEN) == 0);
-        int primary_and_replica = (same_shard && !nodeIsReplica(*proposer) && nodeIsReplica(*target));
-        int replica_and_primary = (same_shard && nodeIsReplica(*proposer) && !nodeIsReplica(*target));
-        if (nodeFailed(*proposer)) return 0;
-        /* Valid if: raft leader, or primary proposing for its replica,
-         * or replica proposing for its primary. */
-        if (!is_leader && !primary_and_replica && !replica_and_primary) return 0;
-    }
-    return 1;
+    *epoch = 0;
+    int argc;
+    sds *argv = sdssplitlen(data, sdslen(data), " ", 1, &argc);
+    if (!argv) return;
+    if (argc >= 1 && sdslen(argv[0]) == CLUSTER_NAMELEN)
+        *target = clusterLookupNode(argv[0], CLUSTER_NAMELEN);
+    if (argc >= 2 && sdslen(argv[1]) == CLUSTER_NAMELEN)
+        *proposer = clusterLookupNode(argv[1], CLUSTER_NAMELEN);
+    if (argc >= 3)
+        *epoch = strtoull(argv[2], NULL, 10);
+    sdsfreesplitres(argv, argc);
+}
+
+/* Clear a target node's pending_fail_change flag from a NODE_FAIL/NODE_RECOVER
+ * entry's raw data. Used when such a proposal is rejected or expires so the
+ * detector is free to re-evaluate. No-op for other entry types. */
+static void raftClearPendingFailChange(int type, sds data) {
+    if (type != RAFT_ENTRY_NODE_FAIL && type != RAFT_ENTRY_NODE_RECOVER) return;
+    if (sdslen(data) < CLUSTER_NAMELEN) return;
+    clusterNode *target = clusterLookupNode(data, CLUSTER_NAMELEN);
+    if (target) RAFT_NODE(target)->pending_fail_change = 0;
+}
+
+/* Propose-time validation of a NODE_FAIL/NODE_RECOVER proposer. Runs on the
+ * leader (pre-validation) before the entry is appended. The proposer must be:
+ * the raft leader, or a primary proposing for its own replica, or a replica
+ * proposing for its own primary. This is validated at proposal time. */
+static RaftProposalResult clusterRaftValidateFailRecoverProposer(sds data) {
+    clusterRaftState *rs = RAFT_STATE();
+    clusterNode *target, *proposer;
+    uint64_t epoch;
+    raftParseFailRecoverEntry(data, &target, &proposer, &epoch);
+    if (!target || !proposer) return RAFT_RESULT_REJECTED;
+
+    /* The raft leader is always an authoritative proposer. */
+    if (memcmp(proposer->name, rs->leader, CLUSTER_NAMELEN) == 0) return RAFT_RESULT_OK;
+
+    /* A stale (already FAIL'd) proposer is not trusted. */
+    if (nodeFailed(proposer)) return RAFT_RESULT_REJECTED;
+
+    /* Otherwise the proposer must be in a live primary<->replica relationship
+     * with the target. */
+    if (target->replicaof == proposer || proposer->replicaof == target) return RAFT_RESULT_OK;
+    return RAFT_RESULT_REJECTED;
 }
 
 /* Apply a committed log entry. */
@@ -1499,9 +1535,11 @@ static void raftLogApply(raftLogEntry *e) {
     case RAFT_ENTRY_NODE_FAIL: {
         clusterNode *node = NULL;
         clusterNode *proposer = NULL;
-        int valid_proposer = raftValidateFailRecoverEntry(e->data, &node, &proposer);
+        uint64_t entry_epoch = 0;
+        raftParseFailRecoverEntry(e->data, &node, &proposer, &entry_epoch);
+        int valid_epoch = (node && clusterValidateShardEpoch(node->shard_id, entry_epoch));
         int applied = 0;
-        if (node && node != myself && !nodeFailed(node) && valid_proposer) {
+        if (node && node != myself && !nodeFailed(node) && valid_epoch) {
             node->flags |= CLUSTER_NODE_FAIL;
             RAFT_NODE(node)->pending_fail_change = 0;
             rs->todo_update_slot_coverage = 1;
@@ -1566,9 +1604,10 @@ static void raftLogApply(raftLogEntry *e) {
     case RAFT_ENTRY_NODE_RECOVER: {
         clusterNode *node = NULL;
         clusterNode *proposer = NULL;
-        int valid_proposer = raftValidateFailRecoverEntry(e->data, &node, &proposer);
+        uint64_t entry_epoch = 0;
+        raftParseFailRecoverEntry(e->data, &node, &proposer, &entry_epoch);
         int applied = 0;
-        if (node && valid_proposer) {
+        if (node) {
             node->flags &= ~CLUSTER_NODE_FAIL;
             RAFT_NODE(node)->pending_fail_change = 0;
             rs->todo_update_slot_coverage = 1;
@@ -1836,6 +1875,7 @@ static int clusterRaftProcessAppendEntriesResponse(clusterLink *link, int argc, 
         entry = sdscatlen(entry, node->name, CLUSTER_NAMELEN);
         entry = sdscatlen(entry, " ", 1);
         entry = sdscatlen(entry, myself->name, CLUSTER_NAMELEN);
+        entry = sdscatfmt(entry, " %U", (unsigned long long)clusterGetShardEpoch(node->shard_id));
         clusterRaftPropose(entry, NULL, NULL);
         sdsfree(entry);
         serverLog(LL_NOTICE, "Node %.40s is back (AE_ACK), proposing NODE_RECOVER.", node->name);
@@ -2200,7 +2240,7 @@ static client *clusterRaftFindReplicaClient(clusterNode *node) {
 }
 
 /* Propose NODE_FAIL for a given node.
- * Format: "NODE_FAIL <target-node-id> <proposer-node-id>" */
+ * Format: "NODE_FAIL <target-node-id> <proposer-node-id> <shard-epoch>" */
 static void clusterRaftProposeNodeFail(clusterNode *node, const char *reason) {
     clusterNodeRaftData *rd = RAFT_NODE(node);
     if (nodeFailed(node) || rd->pending_fail_change) return;
@@ -2211,6 +2251,7 @@ static void clusterRaftProposeNodeFail(clusterNode *node, const char *reason) {
     entry = sdscatlen(entry, node->name, CLUSTER_NAMELEN);
     entry = sdscatlen(entry, " ", 1);
     entry = sdscatlen(entry, myself->name, CLUSTER_NAMELEN);
+    entry = sdscatfmt(entry, " %U", (unsigned long long)clusterGetShardEpoch(node->shard_id));
     clusterRaftPropose(entry, NULL, NULL);
     sdsfree(entry);
     rd->pending_fail_change = 1;
@@ -2352,7 +2393,8 @@ static void clusterRaftDetectReplStreamFailures(mstime_t now) {
                 clusterNodeRaftData *rd = RAFT_NODE(node);
                 if (rd->repl_unconnected_since == 0) {
                     rd->repl_unconnected_since = now;
-                } else if (now - rd->repl_unconnected_since > REPL_CONNECT_GRACE_PERIOD_MS) {
+                } else if (now - rd->repl_unconnected_since > max(server.cluster_node_timeout,
+                                                                  REPL_CONNECT_GRACE_PERIOD_MS)) {
                     clusterRaftProposeNodeFail(node, "replication stream timeout");
                 }
             }
@@ -2400,6 +2442,7 @@ static void clusterRaftProposeReplStreamNodeRecover(clusterNode *node) {
     entry = sdscatlen(entry, node->name, CLUSTER_NAMELEN);
     entry = sdscatlen(entry, " ", 1);
     entry = sdscatlen(entry, myself->name, CLUSTER_NAMELEN);
+    entry = sdscatfmt(entry, " %U", (unsigned long long)clusterGetShardEpoch(node->shard_id));
     clusterRaftPropose(entry, NULL, NULL);
     sdsfree(entry);
     rd->pending_fail_change = 1;
@@ -2506,6 +2549,7 @@ static void clusterRaftRetryProposals(int include_pending) {
                 RaftProposalResult pre_result = clusterRaftPreValidate(pp->type, pp->data);
                 if (pre_result != RAFT_RESULT_OK) {
                     if (pp->callback) pp->callback(pp->ctx, raftProposalResultMsg(pre_result));
+                    raftClearPendingFailChange(pp->type, pp->data);
                     sdsfree(pp->data);
                     zfree(pp);
                     listDelNode(rs->pending_proposals, ln);
@@ -2571,10 +2615,7 @@ static void clusterRaftCron(void) {
                               raftEntryTypeName(pp->type), (long long)(now - pp->ctime));
                     if (pp->callback) pp->callback(pp->ctx, "-TIMEOUT Cluster consensus not reached in time");
                     /* Clear pending_fail_change so the detector can re-propose. */
-                    if (pp->type == RAFT_ENTRY_NODE_FAIL || pp->type == RAFT_ENTRY_NODE_RECOVER) {
-                        clusterNode *target = clusterLookupNode(pp->data, CLUSTER_NAMELEN);
-                        if (target) RAFT_NODE(target)->pending_fail_change = 0;
-                    }
+                    raftClearPendingFailChange(pp->type, pp->data);
                     sdsfree(pp->data);
                     zfree(pp);
                     listDelNode(rs->pending_proposals, eln);

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -53,6 +53,25 @@ typedef enum {
 #define GENERIC_PROPOSAL_REJECTION_MSG "proposal rejected by raft leader"
 #define STALE_SHARD_EPOCH_REJECTION_MSG "proposal rejected due to stale shard epoch"
 
+/* Grace period (ms) before proposing NODE_FAIL for a replica that is not in
+ * server.replicas. After a topology change (FAILOVER/SET_REPLICA_OF), a
+ * healthy replica needs time to establish its replication connection. */
+#define REPL_CONNECT_GRACE_PERIOD_MS 5000
+
+
+/* Primary-side timeout (seconds) for detecting a silent connected replica.
+ * Uses cluster-node-timeout converted to seconds. */
+static inline time_t raftPrimarySideTimeout(void) {
+    return (time_t)(server.cluster_node_timeout / 1000);
+}
+
+/* Replica-side timeout (seconds) for detecting a silent/down primary.
+ * 1.5× cluster-node-timeout to let the primary propose first. */
+static inline time_t raftReplicaSideTimeout(void) {
+    time_t t = (time_t)(server.cluster_node_timeout / 1000) * 3 / 2;
+    return t < 1 ? 1 : t;
+}
+
 /* Wire-protocol tokens used in REJECT proposal between leader -> follower. */
 #define REJECT_WIRE_CONFLICT "conflict" /* for stale shard epoch validation fail. */
 #define REJECT_WIRE_REJECTED "rejected" /* for any other validation fail. */
@@ -240,6 +259,7 @@ typedef struct {
     uint64_t next_index;
     uint64_t match_index;
     mstime_t last_ack_time;               /* Last time we received AE_ACK from this peer */
+    mstime_t repl_unconnected_since;      /* monotonicMs() when replica first seen missing from server.replicas (0 = connected or not tracked) */
     unsigned int pending_fail_change : 1; /* NODE_FAIL or NODE_RECOVER in flight */
 } clusterNodeRaftData;
 
@@ -1303,6 +1323,29 @@ static void clusterRaftCompletePendingProposal(int type, sds data, RaftProposalR
     }
 }
 
+/* Parse a NODE_FAIL or NODE_RECOVER entry and validate the proposer.
+ * Format: "<target-node-id> [<proposer-node-id>]"
+ * Returns 1 if the proposer is valid, 0 otherwise.
+ * Sets *target and *proposer to the looked-up nodes (may be NULL). */
+static int raftValidateFailRecoverEntry(sds data, clusterNode **target, clusterNode **proposer) {
+    clusterRaftState *rs = RAFT_STATE();
+    *target = NULL;
+    *proposer = NULL;
+    if (sdslen(data) >= CLUSTER_NAMELEN) {
+        *target = clusterLookupNode(data, CLUSTER_NAMELEN);
+        if (sdslen(data) >= CLUSTER_NAMELEN * 2 + 1) {
+            *proposer = clusterLookupNode(data + CLUSTER_NAMELEN + 1, CLUSTER_NAMELEN);
+        }
+    }
+    if (*target && *proposer) {
+        int is_leader = (memcmp((*proposer)->name, rs->leader, CLUSTER_NAMELEN) == 0);
+        int primary_and_replica = (!nodeIsReplica(*proposer) && nodeIsReplica(*target));
+        int replica_and_primary = (nodeIsReplica(*proposer) && !nodeIsReplica(*target));
+        if (!is_leader && !primary_and_replica && !replica_and_primary) return 0;
+    }
+    return 1;
+}
+
 /* Apply a committed log entry. */
 static void raftLogApply(raftLogEntry *e) {
     clusterRaftState *rs = RAFT_STATE();
@@ -1452,40 +1495,94 @@ static void raftLogApply(raftLogEntry *e) {
         break;
     }
     case RAFT_ENTRY_NODE_FAIL: {
-        clusterNode *node = clusterLookupNode(e->data, sdslen(e->data));
-        if (node && node != myself) {
+        clusterNode *node = NULL;
+        clusterNode *proposer = NULL;
+        int valid_proposer = raftValidateFailRecoverEntry(e->data, &node, &proposer);
+        int applied = 0;
+        if (node && node != myself && valid_proposer) {
             node->flags |= CLUSTER_NODE_FAIL;
             RAFT_NODE(node)->pending_fail_change = 0;
             rs->todo_update_slot_coverage = 1;
             rs->todo_invalidate_slots_cache = 1;
+            applied = 1;
+
+            /* Send REPL_OFFSETS to replicas of the failed primary so they
+             * can rank themselves for automatic failover. Sent at apply
+             * time so replicas have offset data before acting on NODE_FAIL. */
+            if (rs->role == RAFT_ROLE_LEADER &&
+                !nodeIsReplica(node) && clusterNodeNumReplicas(node) > 0) {
+                int num_replicas = clusterNodeNumReplicas(node);
+                sds hint = wireNewMsg("REPL_OFFSETS");
+                for (int r = 0; r < num_replicas; r++) {
+                    clusterNode *replica = clusterNodeGetReplica(node, r);
+                    long long roff = (replica == myself)
+                                         ? (nodeIsReplica(myself) ? replicationGetReplicaOffset()
+                                                                  : server.primary_repl_offset)
+                                         : replica->repl_offset;
+                    hint = sdscatlen(hint, " ", 1);
+                    hint = sdscatlen(hint, replica->name, CLUSTER_NAMELEN);
+                    hint = sdscatfmt(hint, " %I", roff);
+                }
+                hint = wireFinishMsg(hint);
+
+                size_t hint_len = sdslen(hint);
+                clusterMsgSendBlock *block = clusterAllocMsgSendBlock(hint_len);
+                memcpy(block->data, hint, hint_len);
+                sdsfree(hint);
+                for (int r = 0; r < num_replicas; r++) {
+                    clusterNode *replica = clusterNodeGetReplica(node, r);
+                    if (replica == myself) continue;
+                    clusterLink *link = replica->link;
+                    if (link) {
+                        clusterLinkSendBlock(link, block);
+                    } else {
+                        serverLog(LL_WARNING,
+                                  "No outbound link to replica %.40s for REPL_OFFSETS.",
+                                  replica->name);
+                    }
+                }
+                clusterMsgSendBlockDecrRefCount(block);
+            }
+        } else if (node) {
+            RAFT_NODE(node)->pending_fail_change = 0;
         }
-        serverLog(LL_NOTICE, "Applied NODE_FAIL %.40s (index %llu).",
-                  e->data, (unsigned long long)e->index);
+        serverLog(LL_NOTICE, "%s NODE_FAIL %.40s (index %llu).",
+                  applied ? "Applied" : "Skipped duplicate",
+                  node ? node->name : e->data,
+                  (unsigned long long)e->index);
 
         /* If the failed node is my primary, defer failover scheduling
          * to beforeSleep. This avoids acting on stale NODE_FAIL entries
          * when catching up on old log entries — a subsequent NODE_RECOVER
          * in the same batch will clear the flag. */
-        if (node && nodeIsReplica(myself) && myself->replicaof == node &&
-            !nodeCantFailover(myself)) {
+        if (applied && node && nodeIsReplica(myself) &&
+            myself->replicaof == node && !nodeCantFailover(myself)) {
             rs->todo_schedule_failover = 1;
         }
         break;
     }
     case RAFT_ENTRY_NODE_RECOVER: {
-        clusterNode *node = clusterLookupNode(e->data, sdslen(e->data));
-        if (node) {
+        clusterNode *node = NULL;
+        clusterNode *proposer = NULL;
+        int valid_proposer = raftValidateFailRecoverEntry(e->data, &node, &proposer);
+        int applied = 0;
+        if (node && valid_proposer) {
             node->flags &= ~CLUSTER_NODE_FAIL;
             RAFT_NODE(node)->pending_fail_change = 0;
             rs->todo_update_slot_coverage = 1;
             rs->todo_invalidate_slots_cache = 1;
+            applied = 1;
             /* Cancel deferred failover if the recovered node is my primary. */
             if (nodeIsReplica(myself) && myself->replicaof == node) {
                 rs->todo_schedule_failover = 0;
             }
+        } else if (node) {
+            RAFT_NODE(node)->pending_fail_change = 0;
         }
-        serverLog(LL_NOTICE, "Applied NODE_RECOVER %.40s (index %llu).",
-                  e->data, (unsigned long long)e->index);
+        serverLog(LL_NOTICE, "%s NODE_RECOVER %.40s (index %llu).",
+                  applied ? "Applied" : "Skipped",
+                  node ? node->name : e->data,
+                  (unsigned long long)e->index);
         break;
     }
     case RAFT_ENTRY_NODE_INFO: {
@@ -1723,14 +1820,23 @@ static int clusterRaftProcessAppendEntriesResponse(clusterLink *link, int argc, 
         clusterRaftBroadcastNodeOffset(node, follower_repl_offset);
     }
 
-    /* Propose NODE_RECOVER if the node is back. */
-    if (nodeFailed(node) && !rd->pending_fail_change) {
+    /* Propose NODE_RECOVER if the node is back, with a cooldown to
+     * prevent rapid FAIL/RECOVER flapping.
+     *
+     * For nodes in multi-node shards, skip leader-initiated recovery —
+     * the AE_ACK only proves control-plane connectivity, not data-path
+     * health. The shard members detect data-path recovery themselves
+     * via replication-stream signals. */
+    if (nodeFailed(node) && !rd->pending_fail_change &&
+        !nodeIsReplica(node) && clusterNodeNumReplicas(node) == 0) {
         rd->pending_fail_change = 1;
         sds entry = sdsnew("NODE_RECOVER ");
         entry = sdscatlen(entry, node->name, CLUSTER_NAMELEN);
+        entry = sdscatlen(entry, " ", 1);
+        entry = sdscatlen(entry, myself->name, CLUSTER_NAMELEN);
         clusterRaftPropose(entry, NULL, NULL);
         sdsfree(entry);
-        serverLog(LL_NOTICE, "Node %.40s is back, proposing NODE_RECOVER.", node->name);
+        serverLog(LL_NOTICE, "Node %.40s is back (AE_ACK), proposing NODE_RECOVER.", node->name);
     }
 
     if (success) {
@@ -2045,6 +2151,13 @@ static void clusterRaftInit(void) {
     rs->todo_update_slot_coverage = 1;
     rs->shard_epochs = dictCreate(&raftShardEpochDictType);
     server.cluster->size = 0; /* Incremented by NODE_JOIN apply */
+
+    /* Override ping period so that it is half of cluster timeout */
+    int ping_period = (int)(server.cluster_node_timeout / 2000);
+    if (ping_period < 1) ping_period = 1;
+    if (ping_period < server.repl_ping_replica_period) {
+        server.repl_ping_replica_period = ping_period;
+    }
 }
 
 static void clusterRaftInitLast(void) {
@@ -2068,82 +2181,274 @@ static void clusterRaftInitLast(void) {
     }
 }
 
-/* Leader: detect node failures and propose NODE_FAIL. */
+/* Leader: periodically drop stale links to failed nodes so that
+ * clusterConnectNodes can establish a fresh connection. This allows
+ * the leader to detect recovery when the node comes back and sends
+ * an AE_ACK on the new link.
+ *
+ * Periodically drops stale links so clusterConnectNodes can establish
+ * a fresh connection for recovery detection. */
+static void clusterRaftRecycleFailedNodeLinks(mstime_t now) {
+    mstime_t node_timeout = server.cluster_node_timeout;
+
+    dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
+    dictEntry *de;
+    while ((de = dictNext(di)) != NULL) {
+        clusterNode *node = dictGetVal(de);
+        if (node == myself || !nodeFailed(node)) continue;
+        clusterNodeRaftData *rd = RAFT_NODE(node);
+        if (node->link) {
+            if (rd->last_ack_time > 0 &&
+                now - rd->last_ack_time > node_timeout) {
+                freeClusterLink(node->link);
+                rd->last_ack_time = now;
+            }
+        }
+    }
+    dictReleaseIterator(di);
+}
+
+
+/* Leader: detect node failures via cluster bus (AE_ACK).
+ *
+ * - Single-node shards: always monitored here.
+ * - Multi-node shards: only propose NODE_FAIL when ALL members of the
+ *   shard have timed out (whole-shard-down). If any member is still
+ *   responsive, defer to the decentralized replication-stream detector. */
 static void clusterRaftDetectFailures(mstime_t now) {
     mstime_t node_timeout = server.cluster_node_timeout;
 
-    /* Check individual nodes. */
     dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
     dictEntry *de;
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
         if (node == myself) continue;
+        if (nodeFailed(node)) continue;
 
-        if (nodeFailed(node)) {
-            /* For failed nodes, drop stale links periodically so
-             * clusterConnectNodes can establish a fresh connection.
-             * This allows the leader to detect recovery via AE_ACK. */
-            if (node->link) {
-                clusterNodeRaftData *rd = RAFT_NODE(node);
-                if (rd->last_ack_time > 0 &&
-                    now - rd->last_ack_time > node_timeout) {
-                    freeClusterLink(node->link);
-                    rd->last_ack_time = now;
-                }
-            }
-            continue;
-        }
         clusterNodeRaftData *rd = RAFT_NODE(node);
         if (rd->pending_fail_change) continue;
-        if (rd->last_ack_time > 0 &&
-            now - rd->last_ack_time > node_timeout) {
-            serverLog(LL_NOTICE, "Node %.40s not responding, proposing NODE_FAIL.", node->name);
+        if (!(rd->last_ack_time > 0 && now - rd->last_ack_time > node_timeout))
+            continue;
 
-            /* If the failed node is a primary with replicas, send
-             * REPL_OFFSETS to each replica with all sibling offsets
-             * so they can rank themselves for automatic failover. */
-            if (!nodeIsReplica(node) && clusterNodeNumReplicas(node) > 0) {
-                int num_replicas = clusterNodeNumReplicas(node);
-                sds hint = wireNewMsg("REPL_OFFSETS");
-                for (int r = 0; r < num_replicas; r++) {
-                    clusterNode *replica = clusterNodeGetReplica(node, r);
-                    long long roff = (replica == myself)
-                                         ? (nodeIsReplica(myself) ? replicationGetReplicaOffset()
-                                                                  : server.primary_repl_offset)
-                                         : replica->repl_offset;
-                    hint = sdscatlen(hint, " ", 1);
-                    hint = sdscatlen(hint, replica->name, CLUSTER_NAMELEN);
-                    hint = sdscatfmt(hint, " %I", roff);
+        /* For multi-node shards, only act if ALL shard members have
+         * timed out. If any member is still alive, it will handle
+         * detection via the replication stream. */
+        if (nodeIsReplica(node) || clusterNodeNumReplicas(node) > 0) {
+            clusterNode *primary = nodeIsReplica(node) ? node->replicaof : node;
+            if (!primary) continue;
+            int all_timed_out = 1;
+
+            /* Check the primary (if it's not the node we're evaluating). */
+            if (primary != node && primary != myself && !nodeFailed(primary)) {
+                clusterNodeRaftData *prd = RAFT_NODE(primary);
+                if (!(prd->last_ack_time > 0 && now - prd->last_ack_time > node_timeout)) {
+                    all_timed_out = 0;
                 }
-                hint = wireFinishMsg(hint);
-
-                /* Build a send block and send to remote replicas. */
-                size_t hint_len = sdslen(hint);
-                clusterMsgSendBlock *block = clusterAllocMsgSendBlock(hint_len);
-                memcpy(block->data, hint, hint_len);
-                sdsfree(hint);
-                for (int r = 0; r < num_replicas; r++) {
-                    clusterNode *replica = clusterNodeGetReplica(node, r);
-                    if (replica == myself) continue;
-                    clusterLink *link = replica->link;
-                    if (link) {
-                        clusterLinkSendBlock(link, block);
-                    } else {
-                        serverLog(LL_WARNING, "No outbound link to replica %.40s for REPL_OFFSETS.",
-                                  replica->name);
+            }
+            /* Check all replicas. */
+            if (all_timed_out) {
+                int num_replicas = clusterNodeNumReplicas(primary);
+                for (int i = 0; i < num_replicas; i++) {
+                    clusterNode *replica = clusterNodeGetReplica(primary, i);
+                    if (replica == node || replica == myself || nodeFailed(replica)) continue;
+                    clusterNodeRaftData *rrd = RAFT_NODE(replica);
+                    if (!(rrd->last_ack_time > 0 && now - rrd->last_ack_time > node_timeout)) {
+                        all_timed_out = 0;
+                        break;
                     }
                 }
-                clusterMsgSendBlockDecrRefCount(block);
             }
-
-            sds entry = sdsnew("NODE_FAIL ");
-            entry = sdscatlen(entry, node->name, CLUSTER_NAMELEN);
-            clusterRaftPropose(entry, NULL, NULL);
-            sdsfree(entry);
-            rd->pending_fail_change = 1;
+            if (!all_timed_out) continue;
         }
+
+        serverLog(LL_NOTICE, "Node %.40s not responding (AE_ACK), proposing NODE_FAIL.", node->name);
+
+        sds entry = sdsnew("NODE_FAIL ");
+        entry = sdscatlen(entry, node->name, CLUSTER_NAMELEN);
+        entry = sdscatlen(entry, " ", 1);
+        entry = sdscatlen(entry, myself->name, CLUSTER_NAMELEN);
+        clusterRaftPropose(entry, NULL, NULL);
+        sdsfree(entry);
+        rd->pending_fail_change = 1;
     }
     dictReleaseIterator(di);
+}
+
+/* Propose NODE_FAIL for a given node via the replication stream failure
+ * detector. Used by both primary-side and replica-side detection paths.
+ * Format: "NODE_FAIL <target-node-id> <proposer-node-id>" */
+static void clusterRaftProposeReplStreamNodeFail(clusterNode *node) {
+    clusterNodeRaftData *rd = RAFT_NODE(node);
+    if (nodeFailed(node) || rd->pending_fail_change) return;
+
+    serverLog(LL_NOTICE,
+              "Replication stream timeout: proposing NODE_FAIL for %.40s.",
+              node->name);
+
+    sds entry = sdsnew("NODE_FAIL ");
+    entry = sdscatlen(entry, node->name, CLUSTER_NAMELEN);
+    entry = sdscatlen(entry, " ", 1);
+    entry = sdscatlen(entry, myself->name, CLUSTER_NAMELEN);
+    clusterRaftPropose(entry, NULL, NULL);
+    sdsfree(entry);
+    rd->pending_fail_change = 1;
+}
+
+/* Detect failures via the replication stream. Active only in raft mode.
+ *
+ * Primary side: monitors replica ACK timestamps. Timeout = cluster_node_timeout (T).
+ * Replica side: monitors primary's last_interaction. Timeout = 1.5T.
+ *
+ * The asymmetric timeout avoids races: the primary (often the raft leader)
+ * proposes NODE_FAIL first; the replica only proposes if the primary failed
+ * to do so (e.g., the primary itself crashed). */
+static void clusterRaftDetectReplStreamFailures(mstime_t now) {
+    if (server.loading || nodeFailed(myself)) return;
+
+    /* Primary side: iterate cluster-state replicas and check health.
+     * If the replica has a client in server.replicas, check repl_ack_time.
+     * If it does not (crash/disconnect), wait for grace period. */
+    if (nodeIsPrimary(myself) && clusterNodeNumReplicas(myself) > 0) {
+        int num_replicas = clusterNodeNumReplicas(myself);
+        time_t timeout_sec = raftPrimarySideTimeout();
+
+        for (int i = 0; i < num_replicas; i++) {
+            clusterNode *node = clusterNodeGetReplica(myself, i);
+            if (!node || nodeFailed(node)) continue;
+            if (RAFT_NODE(node)->pending_fail_change) continue;
+
+            /* Find matching client in server.replicas. */
+            client *replica_client = NULL;
+            listIter li2;
+            listNode *ln2;
+            listRewind(server.replicas, &li2);
+            while ((ln2 = listNext(&li2))) {
+                client *c = listNodeValue(ln2);
+                if (c->repl_data->replica_nodeid &&
+                    sdslen(c->repl_data->replica_nodeid) == CLUSTER_NAMELEN &&
+                    memcmp(c->repl_data->replica_nodeid, node->name, CLUSTER_NAMELEN) == 0) {
+                    replica_client = c;
+                    break;
+                }
+            }
+
+            if (replica_client) {
+                /* Replica is connected — check replication ACK freshness. */
+                time_t ack_age = server.unixtime - replica_client->repl_data->repl_ack_time;
+                if (ack_age > timeout_sec) {
+                    clusterRaftProposeReplStreamNodeFail(node);
+                }
+            } else {
+                /* After FAILOVER, a healthy replica needs time to
+                 * establish the replication connection. Wait for the grace
+                 * period before proposing NODE_FAIL. */
+                clusterNodeRaftData *rd = RAFT_NODE(node);
+                if (rd->repl_unconnected_since == 0) {
+                    rd->repl_unconnected_since = now;
+                } else if (now - rd->repl_unconnected_since > REPL_CONNECT_GRACE_PERIOD_MS) {
+                    clusterRaftProposeReplStreamNodeFail(node);
+                }
+            }
+        }
+    }
+
+    /* Replica side: check our primary from cluster state.
+     * Timeout = 1.5T to let the primary (or the raft leader) propose first. */
+    if (nodeIsReplica(myself) && myself->replicaof &&
+        !nodeFailed(myself->replicaof) &&
+        !RAFT_NODE(myself->replicaof)->pending_fail_change) {
+        clusterNode *my_primary = myself->replicaof;
+        time_t replica_timeout = raftReplicaSideTimeout();
+        int should_propose = 0;
+
+        if (server.repl_state == REPL_STATE_CONNECTED && server.primary) {
+            /* Connected but primary is silent. */
+            time_t primary_age = server.unixtime - server.primary->last_interaction;
+            if (primary_age > replica_timeout) should_propose = 1;
+        } else if (server.repl_down_since > 0) {
+            /* Link dropped and reconnection failing. */
+            time_t down_age = server.unixtime - server.repl_down_since;
+            if (down_age > replica_timeout) should_propose = 1;
+        }
+
+        if (should_propose) {
+            clusterRaftProposeReplStreamNodeFail(my_primary);
+        }
+    }
+
+    UNUSED(now);
+}
+
+/* Propose NODE_RECOVER for a given node via the replication stream
+ * detector. Used by both primary-side and replica-side recovery paths. */
+static void clusterRaftProposeReplStreamNodeRecover(clusterNode *node) {
+    clusterNodeRaftData *rd = RAFT_NODE(node);
+    if (!nodeFailed(node) || rd->pending_fail_change) return;
+
+    serverLog(LL_NOTICE,
+              "Replication stream recovered: proposing NODE_RECOVER for %.40s.",
+              node->name);
+
+    sds entry = sdsnew("NODE_RECOVER ");
+    entry = sdscatlen(entry, node->name, CLUSTER_NAMELEN);
+    entry = sdscatlen(entry, " ", 1);
+    entry = sdscatlen(entry, myself->name, CLUSTER_NAMELEN);
+    clusterRaftPropose(entry, NULL, NULL);
+    sdsfree(entry);
+    rd->pending_fail_change = 1;
+}
+
+/* Detect data-path recovery via the replication stream for multi-node shards.
+ *
+ * Primary side: a FAIL'd replica is now ACKing again within the timeout.
+ * Replica side: primary marked FAIL but replication link is back and active. */
+static void clusterRaftDetectReplStreamRecovery(mstime_t now) {
+    if (server.loading || nodeFailed(myself)) return;
+
+    /* Primary side: check if a FAIL marked replica has reconnected (appeared
+     * back in server.replicas). This is the inverse of the failure path:
+     * when the replica's client reappears, the data path is restored. */
+    if (nodeIsPrimary(myself) && clusterNodeNumReplicas(myself) > 0) {
+        int num_replicas = clusterNodeNumReplicas(myself);
+        for (int i = 0; i < num_replicas; i++) {
+            clusterNode *node = clusterNodeGetReplica(myself, i);
+            if (!node || !nodeFailed(node)) continue;
+            if (RAFT_NODE(node)->pending_fail_change) continue;
+
+            int found = 0;
+            listIter li;
+            listNode *ln;
+            listRewind(server.replicas, &li);
+            while ((ln = listNext(&li))) {
+                client *c = listNodeValue(ln);
+                if (c->repl_data->replica_nodeid &&
+                    sdslen(c->repl_data->replica_nodeid) == CLUSTER_NAMELEN &&
+                    memcmp(c->repl_data->replica_nodeid, node->name, CLUSTER_NAMELEN) == 0) {
+                    found = 1;
+                    break;
+                }
+            }
+            if (found) {
+                RAFT_NODE(node)->repl_unconnected_since = 0;
+                clusterRaftProposeReplStreamNodeRecover(node);
+            }
+        }
+    }
+
+    /* Replica side: if our primary is marked FAIL but replication is
+     * connected and active, propose recovery. Only when failover is
+     * disabled — otherwise the replica should failover, not recover. */
+    if (nodeIsReplica(myself) && myself->replicaof &&
+        nodeFailed(myself->replicaof) && nodeCantFailover(myself)) {
+        if (server.repl_state == REPL_STATE_CONNECTED && server.primary) {
+            time_t primary_age = server.unixtime - server.primary->last_interaction;
+            if (primary_age <= raftPrimarySideTimeout()) {
+                clusterRaftProposeReplStreamNodeRecover(myself->replicaof);
+            }
+        }
+    }
+
+    UNUSED(now);
 }
 
 /* Forward a pending proposal to the leader or append locally if we are
@@ -2268,6 +2573,11 @@ static void clusterRaftCron(void) {
                     serverLog(LL_NOTICE, "Expiring stale proposal %s after %lldms.",
                               raftEntryTypeName(pp->type), (long long)(now - pp->ctime));
                     if (pp->callback) pp->callback(pp->ctx, "-TIMEOUT Cluster consensus not reached in time");
+                    /* Clear pending_fail_change so the detector can re-propose. */
+                    if (pp->type == RAFT_ENTRY_NODE_FAIL || pp->type == RAFT_ENTRY_NODE_RECOVER) {
+                        clusterNode *target = clusterLookupNode(pp->data, CLUSTER_NAMELEN);
+                        if (target) RAFT_NODE(target)->pending_fail_change = 0;
+                    }
                     sdsfree(pp->data);
                     zfree(pp);
                     listDelNode(rs->pending_proposals, eln);
@@ -2328,7 +2638,13 @@ static void clusterRaftCron(void) {
             }
             myself->repl_offset = my_offset;
             clusterRaftDetectFailures(now);
+            clusterRaftRecycleFailedNodeLinks(now);
         }
+
+        /* Replication-stream failure/recovery detection runs on any node
+         * that is a data primary or replica, regardless of raft role. */
+        clusterRaftDetectReplStreamFailures(now);
+        clusterRaftDetectReplStreamRecovery(now);
     }
 
     /* Coordinated manual failover: check if replication caught up. */

--- a/src/config.c
+++ b/src/config.c
@@ -3267,6 +3267,22 @@ static int applyClientMaxMemoryUsage(const char **err) {
     return 1;
 }
 
+static int applyClusterNodeTimeout(const char **err) {
+    UNUSED(err);
+    if (server.cluster_protocol == CLUSTER_PROTOCOL_RAFT) {
+        int ping_period = (int)(server.cluster_node_timeout / 2000);
+        if (ping_period < 1) ping_period = 1;
+        if (ping_period < server.repl_ping_replica_period) {
+            serverLog(LL_NOTICE,
+                      "Raft mode: updating repl-ping-replica-period from %d to %d "
+                      "(half of cluster-node-timeout).",
+                      server.repl_ping_replica_period, ping_period);
+            server.repl_ping_replica_period = ping_period;
+        }
+    }
+    return 1;
+}
+
 #define HASH_SEED_MAX_LEN 256
 static int isValidDbHashSeed(sds val, const char **err) {
     if (sdslen(val) > HASH_SEED_MAX_LEN) {
@@ -3465,7 +3481,7 @@ standardConfig static_configs[] = {
 
     /* Long Long configs */
     createLongLongConfig("busy-reply-threshold", "lua-time-limit", MODIFIABLE_CONFIG, 0, LONG_MAX, server.busy_reply_threshold, 5000, INTEGER_CONFIG, NULL, NULL), /* milliseconds */
-    createLongLongConfig("cluster-node-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.cluster_node_timeout, 15000, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("cluster-node-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.cluster_node_timeout, 15000, INTEGER_CONFIG, NULL, applyClusterNodeTimeout),
     createLongLongConfig("cluster-ping-interval", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, LLONG_MAX, server.cluster_ping_interval, 0, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("commandlog-execution-slower-than", "slowlog-log-slower-than", MODIFIABLE_CONFIG, -1, LLONG_MAX, server.commandlog[COMMANDLOG_TYPE_SLOW].threshold, 10000, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("commandlog-request-larger-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.commandlog[COMMANDLOG_TYPE_LARGE_REQUEST].threshold, 1024 * 1024, MEMORY_CONFIG | SIGNED_MEMORY_CONFIG, NULL, NULL),

--- a/tests/unit/cluster/cluster-raft-failure-detector.tcl
+++ b/tests/unit/cluster/cluster-raft-failure-detector.tcl
@@ -1,0 +1,130 @@
+# Test raft failure detection paths.
+# Validates that the correct detector is used based on shard type:
+# - Single-node shard: AE_ACK-based detector (centralized, on the raft leader)
+# - Multi-node shard: replication-stream-based detector (decentralized)
+#
+# Uses 3 masters + 2 replicas: masters 0,1 have replicas (multi-node shards),
+# master 2 has no replica (single-node shard).
+
+start_cluster 3 2 {tags {external:skip cluster cluster-raft:only}} {
+
+    test "Cluster should start ok" {
+        wait_for_cluster_state ok
+    }
+
+    test "Identify topology: single-node shard and multi-node shard" {
+        # Find raft leader
+        set ::leader_idx -1
+        for {set j 0} {$j < 5} {incr j} {
+            if {[CI $j cluster_raft_role] eq "leader"} {
+                set ::leader_idx $j
+                break
+            }
+        }
+        assert {$::leader_idx != -1}
+
+        # Find a single-node primary (no replica) and a multi-node primary
+        # (has a replica). Prefer a non-leader for the multi-node primary,
+        # but accept the leader if it's the only option — the replica-side
+        # detector works regardless.
+        set ::single_node_primary -1
+        set ::multi_node_primary -1
+        set ::multi_node_replica -1
+
+        for {set j 0} {$j < 3} {incr j} {
+            set myid [dict get [cluster_get_myself $j] id]
+            set has_replica 0
+            for {set k 3} {$k < 5} {incr k} {
+                if {[dict get [cluster_get_myself $k] slaveof] eq $myid} {
+                    set has_replica 1
+                    if {$::multi_node_primary == -1 || $::multi_node_primary == $::leader_idx} {
+                        set ::multi_node_primary $j
+                        set ::multi_node_replica $k
+                    }
+                    break
+                }
+            }
+            if {!$has_replica} {
+                set ::single_node_primary $j
+            }
+        }
+        assert {$::single_node_primary != -1}
+        assert {$::multi_node_primary != -1}
+        assert {$::multi_node_replica != -1}
+        puts "Leader=#$::leader_idx, single-node-primary=#$::single_node_primary, multi-node-primary=#$::multi_node_primary, replica=#$::multi_node_replica"
+    }
+
+    test "Wait for multi-node replica to sync" {
+        wait_for_condition 1000 50 {
+            [s [expr -1*$::multi_node_replica] master_link_status] eq {up}
+        } else {
+            fail "Replica #$::multi_node_replica master link not up"
+        }
+    }
+
+    test "Single-node shard uses AE_ACK-based failure detection" {
+        # The raft leader monitors single-node shards via AE_ACK.
+        # Skip if the single-node primary is itself the raft leader.
+        if {$::single_node_primary == $::leader_idx} {
+            puts "SKIP: single-node primary is the raft leader"
+            return
+        }
+
+        set loglines [count_log_lines [expr -1*$::leader_idx]]
+        set single_id [R $::single_node_primary CLUSTER MYID]
+
+        pause_process [srv [expr -1*$::single_node_primary] pid]
+
+        # Wait for the AE_ACK-based detection log on the raft leader.
+        wait_for_log_messages [expr -1*$::leader_idx] \
+            {"*not responding (AE_ACK), proposing NODE_FAIL*"} \
+            $loglines 2000 50
+
+        # Verify NODE_FAIL is applied — node shows fail flag in CLUSTER NODES.
+        wait_for_condition 1000 50 {
+            [string match "*$single_id*fail*" [R $::leader_idx CLUSTER NODES]]
+        } else {
+            fail "NODE_FAIL not applied for single-node shard primary"
+        }
+
+        resume_process [srv [expr -1*$::single_node_primary] pid]
+
+        # Wait for recovery — fail flag cleared.
+        wait_for_condition 1000 50 {
+            ![string match "*$single_id*fail*" [R $::leader_idx CLUSTER NODES]]
+        } else {
+            fail "Single-node shard primary did not recover"
+        }
+    }
+
+    test "Multi-node shard uses replication-stream failure detection" {
+        # The shard members (primary or replica) detect failure via replication
+        # stream, NOT via AE_ACK on the leader. Kill the multi-node primary
+        # and verify the repl-stream detection log appears.
+        set loglines [count_log_lines [expr -1*$::multi_node_replica]]
+
+        pause_process [srv [expr -1*$::multi_node_primary] pid]
+
+        # Wait for the replication-stream detection log on the replica.
+        wait_for_log_messages [expr -1*$::multi_node_replica] \
+            {"*Replication stream timeout: proposing NODE_FAIL*"} \
+            $loglines 2000 50
+
+        # Verify failover completes.
+        wait_for_condition 1000 50 {
+            [s [expr -1*$::multi_node_replica] role] eq {master}
+        } else {
+            fail "Replica #$::multi_node_replica did not fail over"
+        }
+
+        resume_process [srv [expr -1*$::multi_node_primary] pid]
+
+        # Wait for old primary to become replica.
+        wait_for_condition 1000 50 {
+            [s [expr -1*$::multi_node_primary] role] eq {slave}
+        } else {
+            fail "Old primary #$::multi_node_primary did not become replica"
+        }
+    }
+
+} ;# start_cluster

--- a/tests/unit/cluster/cluster-raft-failure-detector.tcl
+++ b/tests/unit/cluster/cluster-raft-failure-detector.tcl
@@ -77,7 +77,7 @@ start_cluster 3 2 {tags {external:skip cluster cluster-raft:only}} {
 
         # Wait for the AE_ACK-based detection log on the raft leader.
         wait_for_log_messages [expr -1*$::leader_idx] \
-            {"*not responding (AE_ACK), proposing NODE_FAIL*"} \
+            {"*AE_ACK timeout, proposing NODE_FAIL*"} \
             $loglines 2000 50
 
         # Verify NODE_FAIL is applied — node shows fail flag in CLUSTER NODES.
@@ -107,7 +107,7 @@ start_cluster 3 2 {tags {external:skip cluster cluster-raft:only}} {
 
         # Wait for the replication-stream detection log on the replica.
         wait_for_log_messages [expr -1*$::multi_node_replica] \
-            {"*Replication stream timeout: proposing NODE_FAIL*"} \
+            {"*replication stream timeout, proposing NODE_FAIL*"} \
             $loglines 2000 50
 
         # Verify failover completes.

--- a/tests/unit/cluster/cluster-raft-failure-detector.tcl
+++ b/tests/unit/cluster/cluster-raft-failure-detector.tcl
@@ -127,4 +127,46 @@ start_cluster 3 2 {tags {external:skip cluster cluster-raft:only}} {
         }
     }
 
+    test "Whole-shard-down fallback uses AE_ACK-based detection" {
+        # Kill both primary and replica of a multi-node shard. The raft
+        # leader (outside the shard) should detect via AE_ACK fallback.
+        # Skip if leader is in the same shard as the multi-node pair.
+        if {$::leader_idx == $::multi_node_primary || $::leader_idx == $::multi_node_replica} {
+            puts "SKIP: leader is in the target shard"
+            return
+        }
+
+        set loglines [count_log_lines [expr -1*$::leader_idx]]
+        set primary_id [R $::multi_node_primary CLUSTER MYID]
+        set replica_id [R $::multi_node_replica CLUSTER MYID]
+
+        # Kill both shard members.
+        pause_process [srv [expr -1*$::multi_node_primary] pid]
+        pause_process [srv [expr -1*$::multi_node_replica] pid]
+
+        # Wait for the AE_ACK-based detection log on the raft leader.
+        wait_for_log_messages [expr -1*$::leader_idx] \
+            {"*AE_ACK timeout, proposing NODE_FAIL*"} \
+            $loglines 2000 50
+
+        # Verify both nodes are marked FAIL.
+        wait_for_condition 1000 50 {
+            [string match "*$primary_id*fail*" [R $::leader_idx CLUSTER NODES]] &&
+            [string match "*$replica_id*fail*" [R $::leader_idx CLUSTER NODES]]
+        } else {
+            fail "Whole-shard-down: not all members marked FAIL"
+        }
+
+        resume_process [srv [expr -1*$::multi_node_primary] pid]
+        resume_process [srv [expr -1*$::multi_node_replica] pid]
+
+        # Wait for recovery.
+        wait_for_condition 1000 50 {
+            ![string match "*$primary_id*fail*" [R $::leader_idx CLUSTER NODES]] &&
+            ![string match "*$replica_id*fail*" [R $::leader_idx CLUSTER NODES]]
+        } else {
+            fail "Whole-shard-down: members did not recover"
+        }
+    }
+
 } ;# start_cluster


### PR DESCRIPTION
Closes #3862 

Implements a decentralized failure detection mechanism for multi-node shard that uses the replication stream (data-path) rather than relying solely on the centralized AE_ACK-based detector on the raft leader. For multi-node shard, this provides reliable signal on the actual replication health.


The failure detector uses two complementary mechanisms (either of - Centralized or decentralized):
- **Shard-level (replica ↔ primary):** Primary and replica detect each other via the replication stream. The primary monitors repl_ack_time for connected replicas and tracks repl_unconnected_since for disconnected ones. The replica monitors last_interaction or repl_down_since for its primary. Asymmetric timeouts (T for primary, 1.5T for replica) ensure the primary proposes NODE_FAIL first.
- **Cluster-level (leader → whole shard):** the raft leader detects a shard via AE_ACK when no member of that shard is responsive.
 
In case where shard nodes can't reach each other but can be reached by raft leader, replica will get marked NODE_FAIL by the primary as this replica is of no use to primary.

**Testing**

```
./runtest --verbose --dump-logs --cluster-raft --single tests/unit/cluster/
```

```

Test Summary: 497 passed, 0 failed

\o/ All tests passed without errors!

Cleanup: may take some time... OK
```