### PR TITLE
Fix out-of-bounds read in vsnprintf_async_signal_safe on a trailing '%'

### DIFF
--- a/src/unit/test_util.cpp
+++ b/src/unit/test_util.cpp
@@ -7,6 +7,7 @@
 #include "generated_wrappers.hpp"
 
 #include <climits>
+#include <cstdarg>
 #include <cstring>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -346,4 +347,41 @@ TEST_F(UtilTest, TestWritePointerWithPadding) {
     for (size_t i = ptr_size; i < sizeof(buf); i++) {
         ASSERT_EQ(buf[i], 0u);
     }
+}
+
+/* A forwarder without the printf format attribute, so we can exercise
+ * malformed format strings (such as a trailing '%') without tripping
+ * -Wformat. */
+static int callSnprintfAsyncSignalSafe(char *out, size_t n, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int r = vsnprintf_async_signal_safe(out, n, fmt, ap);
+    va_end(ap);
+    return r;
+}
+
+TEST_F(UtilTest, TestSnprintfAsyncSignalSafe) {
+    char out[64];
+
+    /* Ordinary formatting still works. */
+    ASSERT_EQ(callSnprintfAsyncSignalSafe(out, sizeof(out), "%d", (int)42), 2);
+    ASSERT_STREQ(out, "42");
+
+    ASSERT_EQ(callSnprintfAsyncSignalSafe(out, sizeof(out), "x%sy", "hi"), 4);
+    ASSERT_STREQ(out, "xhiy");
+
+    /* A trailing '%' is malformed. It must be handled safely and must not
+     * read past the end of the format string. */
+    ASSERT_EQ(callSnprintfAsyncSignalSafe(out, sizeof(out), "%"), 0);
+    ASSERT_STREQ(out, "");
+
+    ASSERT_EQ(callSnprintfAsyncSignalSafe(out, sizeof(out), "abc%"), 3);
+    ASSERT_STREQ(out, "abc");
+
+    /* Same for a length modifier with no conversion at the end. */
+    ASSERT_EQ(callSnprintfAsyncSignalSafe(out, sizeof(out), "%l"), 0);
+    ASSERT_STREQ(out, "");
+
+    ASSERT_EQ(callSnprintfAsyncSignalSafe(out, sizeof(out), "%ll"), 0);
+    ASSERT_STREQ(out, "");
 }

--- a/src/util.c
+++ b/src/util.c
@@ -1529,6 +1529,11 @@ int vsnprintf_async_signal_safe(char *to, size_t size, const char *format, va_li
 
         format = check_longlong_async_signal_safe(format, &have_longlong);
 
+        /* A malformed trailing conversion (e.g. "%", "%l" or "%ll" at the end
+         * of the format) leaves us on the terminating NUL. Stop here, otherwise
+         * the loop's ++format would step past the end of the string. */
+        if (*format == '\0') break;
+
         switch (*format) {
         case 'd':
         case 'i':


### PR DESCRIPTION
## Problem

`vsnprintf_async_signal_safe()` reads one or more bytes past the end of the
format string when the format ends with a lone conversion introducer — `"%"`,
`"%l"` or `"%ll"`.

After skipping `%` (and any `l`/`ll` length modifier), the code lands on the
terminating NUL. The `switch` on the conversion specifier has no case for
`'\0'` and no `default`, so it falls through, and the enclosing
`for (; *format; ++format)` loop then advances `format` **past** the NUL,
reading out of bounds on the next `*format` test.

This function backs `serverLogFromHandler()` (the async-signal-safe logger used
from signal handlers), so it should stay robust against malformed format
strings rather than read out of bounds.

## Fix

Stop processing when the conversion introducer is immediately followed by the
end of the format string:

```c
format = check_longlong_async_signal_safe(format, &have_longlong);

/* A malformed trailing conversion (e.g. "%", "%l" or "%ll" at the end
 * of the format) leaves us on the terminating NUL. Stop here, otherwise
 * the loop's ++format would step past the end of the string. */
if (*format == '\0') break;
```

Well-formed conversions are unaffected: their specifier character is never the
NUL, so the guard never triggers for them.

## Tests

Added `TestSnprintfAsyncSignalSafe` in `src/unit/test_util.cpp` (there was no
existing coverage for these functions). It checks ordinary formatting (`%d`,
`%s`) plus the trailing-`%`, `%l` and `%ll` cases.

Verified the out-of-bounds read against the current code by extracting the
function into a standalone harness built with `-fsanitize=address`:

```
==...==ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 1
    'f1' ... <== Memory access ... overflows this variable
SUMMARY: AddressSanitizer: stack-buffer-overflow ... in vsnprintf_async_signal_safe
```

With the fix, all cases pass with no sanitizer error.
