### PR TITLE
Retry PSYNC on -BUSY error instead of downgrading to SYNC

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -518,6 +518,8 @@ void debugCommand(client *c) {
             "    Enable or disable the reply buffer resize cron job",
             "PAUSE-AFTER-FORK <0|1>",
             "    Stop the server's main process after fork.",
+            "PAUSE-BEFORE-PSYNC <0|1>",
+            "    Stop the server's main process before sending PSYNC.",
             "DELAY-RDB-CLIENT-FREE-SECONDS <seconds>",
             "    Grace period in seconds for replica main channel to establish psync.",
             "DICT-RESIZING <0|1>",
@@ -1063,11 +1065,8 @@ void debugCommand(client *c) {
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "pause-after-fork") && c->argc == 3) {
         server.debug_pause_after_fork = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(objectGetVal(c->argv[1]), "repl-pause-before-psync") && c->argc == 3) {
-        server.debug_repl_pause_before_psync = atoi(objectGetVal(c->argv[2]));
-        addReply(c, shared.ok);
-    } else if (!strcasecmp(objectGetVal(c->argv[1]), "repl-pause-before-sync") && c->argc == 3) {
-        server.debug_repl_pause_before_sync = atoi(objectGetVal(c->argv[2]));
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "pause-before-psync") && c->argc == 3) {
+        server.debug_pause_before_psync = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "delay-rdb-client-free-seconds") && c->argc == 3) {
         server.wait_before_rdb_client_free = atoi(objectGetVal(c->argv[2]));

--- a/src/debug.c
+++ b/src/debug.c
@@ -1063,6 +1063,12 @@ void debugCommand(client *c) {
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "pause-after-fork") && c->argc == 3) {
         server.debug_pause_after_fork = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "repl-pause-before-psync") && c->argc == 3) {
+        server.debug_repl_pause_before_psync = atoi(objectGetVal(c->argv[2]));
+        addReply(c, shared.ok);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "repl-pause-before-sync") && c->argc == 3) {
+        server.debug_repl_pause_before_sync = atoi(objectGetVal(c->argv[2]));
+        addReply(c, shared.ok);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "delay-rdb-client-free-seconds") && c->argc == 3) {
         server.wait_before_rdb_client_free = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);

--- a/src/replication.c
+++ b/src/replication.c
@@ -3701,7 +3701,12 @@ int replicaProcessPsyncReply(connection *conn) {
      * Return PSYNC_NOT_SUPPORTED on errors we don't understand, otherwise
      * return PSYNC_TRY_LATER if we believe this is a transient error. */
 
-    if (!strncmp(reply, "-NOMASTERLINK", 13) || !strncmp(reply, "-LOADING", 8)) {
+    /* The primary replied with a transient error: it cannot serve a PSYNC
+     * right now, but will be able to in the future. Retry PSYNC later instead
+     * of falling back to the legacy SYNC command, because a SYNC full resync
+     * does not carry the +FULLRESYNC offset baseline, which would leave the
+     * replica in pre_psync mode (no ACKs, breaking WAIT / psync / failover). */
+    if (!strncmp(reply, "-NOMASTERLINK", 13) || !strncmp(reply, "-LOADING", 8) || !strncmp(reply, "-BUSY", 5) ) {
         serverLog(LL_NOTICE,
                   "Primary is currently unable to PSYNC "
                   "but should be in the future: %s",
@@ -4049,11 +4054,11 @@ int syncWithPrimaryHandleSendPsyncState(connection *conn) {
     /* Debug hook: pause the replica right before it sends PSYNC to its
      * primary, so a test can put the primary into a transient (e.g. BUSY)
      * state and deterministically reproduce the PSYNC -> SYNC downgrade race. */
-    if (server.debug_repl_pause_before_psync) {
-        server.debug_repl_pause_before_psync = 0;
-        serverLog(LL_NOTICE, "Debug: pausing replica before sending PSYNC");
+    if (server.debug_pause_before_psync) {
+        server.debug_pause_before_psync = 0;
         debugPauseProcess();
     }
+
     if (replicaSendPsyncCommand(conn) == PSYNC_WRITE_ERROR) {
         sds err = sdsnew("Write error sending the PSYNC command.");
         abortFailover(err);
@@ -4317,16 +4322,7 @@ void syncWithPrimary(connection *conn) {
      * and the server.primary_replid and primary_initial_offset are
      * already populated. */
     if (psync_result == PSYNC_NOT_SUPPORTED) {
-        /* Debug hook: pause the replica right before falling back to the
-         * legacy SYNC command, so a test can take the primary out of its
-         * transient (e.g. BUSY) state first and observe the resulting
-         * pre_psync (no initial offset) replica. */
         serverLog(LL_NOTICE, "Retrying with SYNC...");
-        if (server.debug_repl_pause_before_sync) {
-            server.debug_repl_pause_before_sync = 0;
-            serverLog(LL_NOTICE, "Debug: pausing replica before sending SYNC");
-            debugPauseProcess();
-        }
         if (connSyncWrite(conn, "SYNC\r\n", 6, server.repl_syncio_timeout * 1000) == -1) {
             serverLog(LL_WARNING, "I/O error writing to PRIMARY: %s", connGetLastError(conn));
             syncWithPrimaryHandleError(&conn);

--- a/src/replication.c
+++ b/src/replication.c
@@ -4046,6 +4046,14 @@ int syncWithPrimaryHandleReceiveNodeIDReplyState(connection *conn) {
 }
 
 int syncWithPrimaryHandleSendPsyncState(connection *conn) {
+    /* Debug hook: pause the replica right before it sends PSYNC to its
+     * primary, so a test can put the primary into a transient (e.g. BUSY)
+     * state and deterministically reproduce the PSYNC -> SYNC downgrade race. */
+    if (server.debug_repl_pause_before_psync) {
+        server.debug_repl_pause_before_psync = 0;
+        serverLog(LL_NOTICE, "Debug: pausing replica before sending PSYNC");
+        debugPauseProcess();
+    }
     if (replicaSendPsyncCommand(conn) == PSYNC_WRITE_ERROR) {
         sds err = sdsnew("Write error sending the PSYNC command.");
         abortFailover(err);
@@ -4309,7 +4317,16 @@ void syncWithPrimary(connection *conn) {
      * and the server.primary_replid and primary_initial_offset are
      * already populated. */
     if (psync_result == PSYNC_NOT_SUPPORTED) {
+        /* Debug hook: pause the replica right before falling back to the
+         * legacy SYNC command, so a test can take the primary out of its
+         * transient (e.g. BUSY) state first and observe the resulting
+         * pre_psync (no initial offset) replica. */
         serverLog(LL_NOTICE, "Retrying with SYNC...");
+        if (server.debug_repl_pause_before_sync) {
+            server.debug_repl_pause_before_sync = 0;
+            serverLog(LL_NOTICE, "Debug: pausing replica before sending SYNC");
+            debugPauseProcess();
+        }
         if (connSyncWrite(conn, "SYNC\r\n", 6, server.repl_syncio_timeout * 1000) == -1) {
             serverLog(LL_WARNING, "I/O error writing to PRIMARY: %s", connGetLastError(conn));
             syncWithPrimaryHandleError(&conn);

--- a/src/replication.c
+++ b/src/replication.c
@@ -3706,7 +3706,7 @@ int replicaProcessPsyncReply(connection *conn) {
      * of falling back to the legacy SYNC command, because a SYNC full resync
      * does not carry the +FULLRESYNC offset baseline, which would leave the
      * replica in pre_psync mode (no ACKs, breaking WAIT / psync / failover). */
-    if (!strncmp(reply, "-NOMASTERLINK", 13) || !strncmp(reply, "-LOADING", 8) || !strncmp(reply, "-BUSY", 5) ) {
+    if (!strncmp(reply, "-NOMASTERLINK", 13) || !strncmp(reply, "-LOADING", 8) || !strncmp(reply, "-BUSY", 5)) {
         serverLog(LL_NOTICE,
                   "Primary is currently unable to PSYNC "
                   "but should be in the future: %s",

--- a/src/server.c
+++ b/src/server.c
@@ -2980,6 +2980,7 @@ void initServer(void) {
     server.client_mem_usage_buckets = NULL;
     server.debug_client_enforce_reply_list = 0;
     server.debug_force_free_primary_async = 0;
+    server.debug_pause_before_psync = 0;
     resetReplicationBuffer();
 
     /* Make sure the locale is set on startup based on the config file. */
@@ -3025,8 +3026,6 @@ void initServer(void) {
     server.in_exec = 0;
     server.busy_module_yield_flags = BUSY_MODULE_YIELD_NONE;
     server.busy_module_yield_reply = NULL;
-    server.debug_repl_pause_before_psync = 0;
-    server.debug_repl_pause_before_sync = 0;
     server.client_pause_in_transaction = 0;
     server.child_pid = -1;
     server.child_type = CHILD_TYPE_NONE;

--- a/src/server.c
+++ b/src/server.c
@@ -3025,6 +3025,8 @@ void initServer(void) {
     server.in_exec = 0;
     server.busy_module_yield_flags = BUSY_MODULE_YIELD_NONE;
     server.busy_module_yield_reply = NULL;
+    server.debug_repl_pause_before_psync = 0;
+    server.debug_repl_pause_before_sync = 0;
     server.client_pause_in_transaction = 0;
     server.child_pid = -1;
     server.child_type = CHILD_TYPE_NONE;

--- a/src/server.h
+++ b/src/server.h
@@ -2141,6 +2141,11 @@ struct valkeyServer {
                                                  * to establish psync. */
     int debug_pause_after_fork;                 /* Debug param that pauses the main process
                                                  * after a replication fork() (for bgsave). */
+    int debug_repl_pause_before_psync;          /* Replica pauses (SIGSTOP) right before
+                                                 * sending PSYNC to its primary. */
+    int debug_repl_pause_before_sync;           /* Replica pauses (SIGSTOP) right before
+                                                 * falling back to the legacy SYNC command
+                                                 * after a failed PSYNC. */
     size_t repl_buffer_mem;                     /* The memory of replication buffer. */
     list *repl_buffer_blocks;                   /* Replication buffers blocks list
                                                  * (serving replica clients and repl backlog) */

--- a/src/server.h
+++ b/src/server.h
@@ -2141,11 +2141,8 @@ struct valkeyServer {
                                                  * to establish psync. */
     int debug_pause_after_fork;                 /* Debug param that pauses the main process
                                                  * after a replication fork() (for bgsave). */
-    int debug_repl_pause_before_psync;          /* Replica pauses (SIGSTOP) right before
+    int debug_pause_before_psync;               /* Replica pauses (SIGSTOP) right before
                                                  * sending PSYNC to its primary. */
-    int debug_repl_pause_before_sync;           /* Replica pauses (SIGSTOP) right before
-                                                 * falling back to the legacy SYNC command
-                                                 * after a failed PSYNC. */
     size_t repl_buffer_mem;                     /* The memory of replication buffer. */
     list *repl_buffer_blocks;                   /* Replication buffers blocks list
                                                  * (serving replica clients and repl backlog) */

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -5,20 +5,10 @@ proc log_file_matches {log pattern} {
     string match $pattern $content
 }
 
-# Wait until the process enters a paused state.
-proc wait_process_paused idx {
-    set pid [srv $idx pid]
-    wait_for_condition 50 1000 {
-        [string match "T*" [exec ps -o state= -p $pid]]
-    } else {
-        fail "Process $pid didn't stop, current state is [exec ps -o state= -p $pid]"
-    }
-}
-
 # Wait until the process enters a paused state, then resume the process.
 proc wait_and_resume_process idx {
     set pid [srv $idx pid]
-    wait_process_paused $idx
+    wait_process_paused $pid
     resume_process $pid
 }
 
@@ -836,7 +826,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             set loglines [lindex $res 1]
         }
         # Waiting for the primary to enter the paused state, that is, make sure that bgsave is triggered.
-        wait_process_paused -1
+        wait_process_paused [srv -1 pid]
         wait_for_log_messages 0 {"*Done loading RDB*"} $replica_loglines 5000 10
         $replica replicaof no one
         # Resume the primary and make sure the sync is dropped.

--- a/tests/integration/replication-busy-psync.tcl
+++ b/tests/integration/replication-busy-psync.tcl
@@ -1,0 +1,67 @@
+start_server {tags {"replication" "external:skip"}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+    set primary_rd [valkey_deferring_client]
+
+    start_server {} {
+        set replica1 [srv 0 client]
+        $replica1 replicaof $primary_host $primary_port
+        wait_for_sync $replica1
+
+        $primary set key [string repeat A [expr 1024*1024]]
+        wait_for_ofs_sync $primary $replica1
+
+        start_server {} {
+            set replica2 [srv 0 client]
+            set replica2_pid [srv 0 pid]
+
+            # Arm both pause points so we control the handshake precisely.
+            $replica2 debug repl-pause-before-psync 1
+            $replica2 debug repl-pause-before-sync 1
+
+            # Start replication. The replica will pause (SIGSTOP) right before
+            # sending PSYNC, before the primary is busy.
+            $replica2 replicaof $primary_host $primary_port
+
+            # Wait until the replica process is actually stopped.
+            wait_process_paused $replica2_pid
+
+            # Put the primary into a BUSY state.
+            $primary config set busy-reply-threshold 10
+            $primary_rd eval {local a = 1 while true do a = a + 1 end} 0
+            $primary_rd flush
+            wait_for_condition 50 100 {
+                [catch {$primary ping} e] == 1 && [string match {BUSY*} $e]
+            } else {
+                fail "Primary did not enter $busy_kind BUSY"
+            }
+
+            # Resume the replica: it sends PSYNC and receives -BUSY.
+            resume_process $replica2_pid
+            wait_for_log_messages 0 {"*Retrying with SYNC*"} 0 10 1000
+
+            # Wait until the replica process is actually stopped.
+            wait_process_paused $replica2_pid
+
+            # Take the primary out of the BUSY state.
+            $primary script kill
+
+            # Resume the replica: it sends SYNC
+            resume_process $replica2_pid
+            wait_for_sync $replica2
+
+            puts "primary offset: [status $primary master_repl_offset]"
+            puts "replica1 offset: [status $replica1 master_repl_offset]"
+            puts "replica2 offset: [status $replica2 master_repl_offset]"
+
+            $primary set key [string repeat A [expr 1024*1024]]
+
+            puts "after a set"
+            puts "primary offset: [status $primary master_repl_offset]"
+            puts "replica1 offset: [status $replica1 master_repl_offset]"
+            puts "replica2 offset: [status $replica2 master_repl_offset]"
+        }
+    }
+    $primary_rd close
+}

--- a/tests/integration/replication-busy-psync.tcl
+++ b/tests/integration/replication-busy-psync.tcl
@@ -5,10 +5,12 @@ start_server {tags {"replication" "external:skip"}} {
     set primary_rd [valkey_deferring_client]
 
     start_server {} {
+        # replica1 is a normal replica, so that we have the backlog.
         set replica1 [srv 0 client]
         $replica1 replicaof $primary_host $primary_port
         wait_for_sync $replica1
 
+        # Adding some data and keep offset growing.
         $primary set key [string repeat A [expr 1024*1024]]
         wait_for_ofs_sync $primary $replica1
 
@@ -16,9 +18,8 @@ start_server {tags {"replication" "external:skip"}} {
             set replica2 [srv 0 client]
             set replica2_pid [srv 0 pid]
 
-            # Arm both pause points so we control the handshake precisely.
-            $replica2 debug repl-pause-before-psync 1
-            $replica2 debug repl-pause-before-sync 1
+            # Arm the pause point so we control the handshake precisely.
+            $replica2 debug pause-before-psync 1
 
             # Start replication. The replica will pause (SIGSTOP) right before
             # sending PSYNC, before the primary is busy.
@@ -34,33 +35,28 @@ start_server {tags {"replication" "external:skip"}} {
             wait_for_condition 50 100 {
                 [catch {$primary ping} e] == 1 && [string match {BUSY*} $e]
             } else {
-                fail "Primary did not enter $busy_kind BUSY"
+                fail "Primary did not enter BUSY state"
             }
 
             # Resume the replica: it sends PSYNC and receives -BUSY.
             resume_process $replica2_pid
-            wait_for_log_messages 0 {"*Retrying with SYNC*"} 0 10 1000
-
-            # Wait until the replica process is actually stopped.
-            wait_process_paused $replica2_pid
+            wait_for_log_messages 0 {"*Primary is currently unable to PSYNC but should be in the future: -BUSY*"} 0 10 1000
 
             # Take the primary out of the BUSY state.
             $primary script kill
 
             # Resume the replica: it sends SYNC
-            resume_process $replica2_pid
             wait_for_sync $replica2
+            wait_for_ofs_sync $primary $replica1
+            wait_for_ofs_sync $primary $replica2
 
-            puts "primary offset: [status $primary master_repl_offset]"
-            puts "replica1 offset: [status $replica1 master_repl_offset]"
-            puts "replica2 offset: [status $replica2 master_repl_offset]"
-
+            # Ensure the offset is correct after writing data.
             $primary set key [string repeat A [expr 1024*1024]]
+            wait_for_ofs_sync $primary $replica1
+            wait_for_ofs_sync $primary $replica2
 
-            puts "after a set"
-            puts "primary offset: [status $primary master_repl_offset]"
-            puts "replica1 offset: [status $replica1 master_repl_offset]"
-            puts "replica2 offset: [status $replica2 master_repl_offset]"
+            # Will never attempt SYNC.
+            verify_no_log_message 0 "*Retrying with SYNC*" 0
         }
     }
     $primary_rd close

--- a/tests/integration/replication-busy-psync.tcl
+++ b/tests/integration/replication-busy-psync.tcl
@@ -45,7 +45,7 @@ start_server {tags {"replication" "external:skip"}} {
             # Take the primary out of the BUSY state.
             $primary script kill
 
-            # Resume the replica: it sends SYNC
+            # The replica will retry PSYNC and succeed.
             wait_for_sync $replica2
             wait_for_ofs_sync $primary $replica1
             wait_for_ofs_sync $primary $replica2

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -714,7 +714,7 @@ proc process_is_paused pid {
 
 proc wait_process_paused pid {
     wait_for_condition 50 100 {
-        [string match {*T*} [lindex [exec ps j $pid] 16]]
+        [process_is_paused $pid]
     } else {
         puts [exec ps j $pid]
         fail "process didn't stop"

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -712,14 +712,18 @@ proc process_is_paused pid {
     return [string match {*T*} [lindex [exec ps j $pid] 16]]
 }
 
-proc pause_process pid {
-    exec kill -SIGSTOP $pid
+proc wait_process_paused pid {
     wait_for_condition 50 100 {
         [string match {*T*} [lindex [exec ps j $pid] 16]]
     } else {
         puts [exec ps j $pid]
         fail "process didn't stop"
     }
+}
+
+proc pause_process pid {
+    exec kill -SIGSTOP $pid
+    wait_process_paused $pid
 }
 
 proc resume_process pid {

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -712,6 +712,7 @@ proc process_is_paused pid {
     return [string match {*T*} [lindex [exec ps j $pid] 16]]
 }
 
+# Wait until the process enters a paused state.
 proc wait_process_paused pid {
     wait_for_condition 50 100 {
         [process_is_paused $pid]


### PR DESCRIPTION
When the primary is busy (e.g. running a slow script or module
command) it replies to PSYNC with -BUSY. This was previously
treated as PSYNC_NOT_SUPPORTED, so the replica fell back to the
legacy SYNC command.

A SYNC full resync lacks the +FULLRESYNC offset baseline, leaving
the replica in pre_psync mode with no ACKs, which breaks a lot
of things such as WAIT / PSYNC / FAILOVER.

For instance, such a replica always times out during a manual
failover because its replication offset can never align with
that of the primary node.

Treat -BUSY like -LOADING and -NOMASTERLINK as a transient error
and retry PSYNC later.