### PR TITLE
Out of Bounds read in valkey-benchmark

### DIFF
--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -2513,7 +2513,7 @@ int main(int argc, char **argv) {
         int seq_len = 0; /* Total number of commands in the sequence. */
         sds cmd_seq = sdsempty();
         for (i = 0; i <= argc; i++) {
-            if (i == start && sds_args[i][0] >= '1' && sds_args[i][0] <= '9') {
+            if (i < argc && i == start && sds_args[i][0] >= '1' && sds_args[i][0] <= '9') {
                 /* Command prefixed by number means repeat command N times. */
                 repeat = atoi(sds_args[i]);
                 start++;


### PR DESCRIPTION
## Description

Running:

```sh
./valkey-benchmark -t get 10000
```

causes `valkey-benchmark` to segfault.

After option parsing, the remaining argument (`10000`) is interpreted as a repeat count for an arbitrary command sequence. Since no command follows the repeat count, `start` becomes equal to `argc`.

When `start` becomes equal to `argc`, the parser evaluates `sds_args[i][0]` before checking that `i` is still within bounds, resulting in an out-of-bounds read and undefined behaviour.

This change guards the repeat-count parsing by checking `i < argc` before accessing `sds_args[i]`.

## Expected Behaviour

The benchmark should reject the malformed input instead of crashing.

## How to Reproduce

1. Build Valkey:

```sh
make
```

or

```sh
make SANITIZER=address
```

2. Run:

```sh
./valkey-benchmark -t get 10000
```

## Testing

- Reproduced the crash.
- Verified the out-of-bounds read with AddressSanitizer & gdb.
- Ran `make test`.

## Further

- This avoids reading out of bounds but still does not handle what happens after that.