### PR TITLE
Fix ENTRIESREAD error message to include the accepted value 0

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2602,7 +2602,7 @@ void xgroupCommand(client *c) {
                        i + 1 < c->argc) {
                 if (getLongLongFromObjectOrReply(c, c->argv[i + 1], &entries_read, NULL) != C_OK) return;
                 if (entries_read < 0 && entries_read != SCG_INVALID_ENTRIES_READ) {
-                    addReplyError(c, "value for ENTRIESREAD must be positive or -1");
+                    addReplyError(c, "value for ENTRIESREAD must be non-negative, or -1 for unknown");
                     return;
                 }
                 i += 2;

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -15,7 +15,7 @@ start_server {
         r XADD mystream 1-2 b 2
         r XADD mystream 1-3 c 3
         r XADD mystream 1-4 d 4
-        assert_error "*value for ENTRIESREAD must be positive or -1*" {r XGROUP CREATE mystream mygroup $ ENTRIESREAD -3}
+        assert_error "*value for ENTRIESREAD must be non-negative, or -1 for unknown*" {r XGROUP CREATE mystream mygroup $ ENTRIESREAD -3}
 
         r XGROUP CREATE mystream mygroup1 $ ENTRIESREAD 0
         r XGROUP CREATE mystream mygroup2 $ ENTRIESREAD 3


### PR DESCRIPTION
## Problem

`XGROUP CREATE` / `XGROUP SETID` accept an `ENTRIESREAD` value of `0`, but the error message for an invalid value claims the value `must be positive or -1` — an enumeration that excludes `0`.

The validation only rejects negatives other than the `-1` sentinel (`src/t_stream.c`):

```c
if (entries_read < 0 && entries_read != SCG_INVALID_ENTRIES_READ) {  /* SCG_INVALID_ENTRIES_READ == -1 */
    addReplyError(c, "value for ENTRIESREAD must be positive or -1");
    return;
}
```

So the accepted set is `{ n >= 0 } ∪ { -1 }`, which includes `0` — yet the message enumerates only "positive or -1". That `0` is intentionally valid is already asserted by the existing test (`tests/unit/type/stream-cgroups.tcl`, `XGROUP CREATE ... ENTRIESREAD 0` succeeds).

`-1` is the `SCG_INVALID_ENTRIES_READ` sentinel meaning the read counter is unknown (XINFO reports it back as `null`).

## Fix

Reword the message to `value for ENTRIESREAD must be non-negative, or -1 for unknown`, which matches the values actually accepted and names what `-1` means, and update the one test assertion that pins the old wording.

## Testing

- `tests/unit/type/stream-cgroups.tcl` already exercises `ENTRIESREAD 0` (succeeds) and `ENTRIESREAD -3` (rejected); the latter assertion is updated to the new wording.
- No behavior change — message text only.
