### PR TITLE
Fix XSETID ENTRIESADDED error message to include the accepted value 0

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2753,7 +2753,7 @@ void xsetidCommand(client *c) {
             if (getLongLongFromObjectOrReply(c, c->argv[i + 1], &entries_added, NULL) != C_OK) {
                 return;
             } else if (entries_added < 0) {
-                addReplyError(c, "entries_added must be positive");
+                addReplyError(c, "entries_added must be non-negative");
                 return;
             }
             i += 2;

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -949,7 +949,7 @@ start_server {tags {"stream"}} {
     test {XSETID errors on negative offset} {
         catch {r XSETID stream 1-1 ENTRIESADDED -1 MAXDELETEDID 0-0} err
         set _ $err
-    } {ERR *must be positive}
+    } {ERR *must be non-negative}
 
     test {XSETID cannot set the maximal tombstone with larger ID} {
         r DEL x


### PR DESCRIPTION
## Problem

`XSETID` accepts an `ENTRIESADDED` value of `0`, but the error message for an invalid value claims it `must be positive` — which excludes `0`.

The validation only rejects negatives (`src/t_stream.c`):

```c
} else if (entries_added < 0) {
    addReplyError(c, "entries_added must be positive");
    return;
}
```

So `0` is accepted (and is meaningful — a stream that has had entries added and then fully trimmed can legitimately record `entries-added` of `0`), yet the message says "must be positive".

This is the same class of wording bug as #4145 (`ENTRIESREAD`), in the sibling `XSETID` argument.

## Fix

Reword the message to `entries_added must be non-negative`, matching the value actually accepted, and update the one test assertion that pins the old wording.

## Testing

- `tests/unit/type/stream.tcl` "XSETID errors on negative offset" passes `ENTRIESADDED -1` (still rejected — the guard is unchanged) and pins the message; the assertion is updated to the new wording.
- No behavior change — message text only.
