### PR TITLE
fix: remove duplicated words and correct grammar in comments

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -303,7 +303,7 @@ list *listDup(list *orig) {
         }
 
         if (listAddNodeTail(copy, value) == NULL) {
-            /* Free value if dup succeed but listAddNodeTail failed. */
+            /* Free value if dup succeeds but listAddNodeTail failed. */
             if (copy->free) copy->free(value);
 
             listRelease(copy);

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -521,7 +521,7 @@ int hllPatLen(unsigned char *ele, size_t elesize, long *regp) {
  * additional byte on the right. This requirement is met by sds strings
  * automatically since they are implicitly null terminated.
  *
- * The function always succeed, however if as a result of the operation
+ * The function always succeeds, however if as a result of the operation
  * the approximated cardinality changed, 1 is returned. Otherwise 0
  * is returned. */
 int hllDenseSet(uint8_t *registers, long index, uint8_t count) {

--- a/src/modules/lua/function_lua.c
+++ b/src/modules/lua/function_lua.c
@@ -112,7 +112,7 @@ static void freeCompiledFunc(lua_State *lua,
 
 /*
  * Compile a given script code by generating a set of compiled functions. These
- * functions are also saved into the the registry of the Lua environment.
+ * functions are also saved into the registry of the Lua environment.
  *
  * Returns an array of compiled functions. The `compileFunction` struct stores a
  * Lua ref that allows to later retrieve the function from the registry.

--- a/src/networking.c
+++ b/src/networking.c
@@ -4068,7 +4068,7 @@ void discardCommandQueue(client *c) {
     queue->off = queue->len = queue->cap = 0;
 }
 
-/* Returns the number of keys in the the incr_states array after adding keys. */
+/* Returns the number of keys in the incr_states array after adding keys. */
 static int addKeysToIncrFindBatch(client *c,
                                   struct serverCommand *cmd,
                                   robj **argv,
@@ -6359,7 +6359,7 @@ static void pauseClientsByClient(mstime_t endTime, int isPauseClientAll) {
  * This function is also internally used by Cluster for the manual
  * failover procedure implemented by CLUSTER FAILOVER.
  *
- * The function always succeed, even if there is already a pause in progress.
+ * The function always succeeds, even if there is already a pause in progress.
  * The new paused_actions of a given 'purpose' will override the old ones and
  * end time will be updated if new end time is bigger than currently configured */
 void pauseActions(pause_purpose purpose, mstime_t end, uint32_t actions) {

--- a/src/server.c
+++ b/src/server.c
@@ -807,7 +807,7 @@ dictType migrateCacheDictType = {
     .entryDestructor = dictEntryDestructorSdsKey,
 };
 
-/* Dict for for case-insensitive search using null terminated C strings.
+/* Dict for case-insensitive search using null terminated C strings.
  * The keys stored in dict are sds though. */
 dictType stringSetDictType = {
     .entryGetKey = dictEntryGetKey,
@@ -816,7 +816,7 @@ dictType stringSetDictType = {
     .entryDestructor = dictEntryDestructorSdsKey,
 };
 
-/* Dict for for case-insensitive search using null terminated C strings.
+/* Dict for case-insensitive search using null terminated C strings.
  * The key and value do not have a destructor. */
 dictType externalStringType = {
     .entryGetKey = dictEntryGetKey,
@@ -3703,7 +3703,7 @@ void alsoPropagate(int dbid, robj **argv, int argc, int target, int slot) {
 }
 
 /* It is possible to call the function forceCommandPropagation() inside a
- * command implementation in order to to force the propagation of a
+ * command implementation in order to force the propagation of a
  * specific command execution into AOF / Replication. */
 void forceCommandPropagation(client *c, int flags) {
     serverAssert(c->cmd->flags & (CMD_WRITE | CMD_MAY_REPLICATE));

--- a/src/syncio.c
+++ b/src/syncio.c
@@ -78,7 +78,7 @@ ssize_t syncWrite(int fd, char *ptr, ssize_t size, long long timeout) {
 }
 
 /* Read the specified amount of bytes from 'fd'. If all the bytes are read
- * within 'timeout' milliseconds the operation succeed and 'size' is returned.
+ * within 'timeout' milliseconds the operation succeeds and 'size' is returned.
  * Otherwise the operation fails, -1 is returned, and an unspecified amount of
  * data could be read from the file descriptor. */
 ssize_t syncRead(int fd, char *ptr, ssize_t size, long long timeout) {

--- a/tests/modules/postnotifications.c
+++ b/tests/modules/postnotifications.c
@@ -36,9 +36,9 @@
  *             that increase a counter indicating how many times the string key was changed.
  *             In addition, it increase another counter that counts the total changes that
  *             was made on all strings keys.
- * * EXPIRED - the module register to expired event and set post notification job that that
+ * * EXPIRED - the module register to expired event and set post notification job that
  *             counts the total number of expired events.
- * * EVICTED - the module register to evicted event and set post notification job that that
+ * * EVICTED - the module register to evicted event and set post notification job that
  *             counts the total number of evicted events.
  *
  * In addition, the module register a new command, 'postnotification.async_set', that performs a set


### PR DESCRIPTION
## Description

This PR removes 7 duplicated words and fixes 4 grammar issues in code comments across the codebase:

**Duplicate words removed:**
| File | Typo | Fix |
|------|------|-----|
| server.c:3706 | `order to to force` | `order to force` |
| server.c:810,819 | `Dict for for case-insensitive` | `Dict for case-insensitive` |
| networking.c:4071 | `in the the incr_states` | `in the incr_states` |
| function_lua.c:115 | `into the the registry` | `into the registry` |
| postnotifications.c:39,41 | `job that that counts` | `job that counts` |

**Grammar fixes (subject-verb agreement):**
| File | Typo | Fix |
|------|------|-----|
| networking.c:6362 | `The function always succeed` | `The function always succeeds` |
| hyperloglog.c:524 | `The function always succeed` | `The function always succeeds` |
| syncio.c:81 | `the operation succeed` | `the operation succeeds` |
| adlist.c:306 | `if dup succeed but` | `if dup succeeds but` |

All changes are in comments only - no code logic changes.

Signed-off-by: Akanksha Trehan <akankshatrehun@gmail.com>