### PR TITLE
Account for deferred client frees during eviction

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -6585,16 +6585,33 @@ void evictClients(void) {
     size_t client_eviction_limit = getClientEvictionLimit();
     if (client_eviction_limit == 0) return;
 
+    /* Variable to track memory of clients marked for close but not yet freed */
+    size_t pending_freed = 0;
+
     while (server.stat_clients_type_memory[CLIENT_TYPE_NORMAL] +
                server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB] >
-           client_eviction_limit) {
+           client_eviction_limit + pending_freed) {
         listNode *ln = listNext(&bucket_iter);
         if (ln) {
             client *c = ln->value;
+            if (c->flag.close_asap) {
+                /* Already scheduled to close. Count memory as freed and skip. */
+                pending_freed += c->last_memory_usage;
+                continue;
+            }
             sds ci = catClientInfoString(sdsempty(), c, server.hide_user_data_from_log);
             serverLog(LL_NOTICE, "Evicting client: %s", ci);
-            if (freeClient(c)) server.stat_evictedclients++;
             sdsfree(ci);
+            server.stat_evictedclients++;
+
+            if (freeClient(c) == 0) {
+                /* Client was only scheduled for asynchronous free (e.g. protected
+                 * or has pending IO) - its memory won't drop from the stats above
+                 * until that completes. Count it as freed here so we don't keep
+                 * evicting further clients while waiting for it. */
+                pending_freed += c->last_memory_usage;
+                continue;
+            }
         } else {
             curr_bucket--;
             if (curr_bucket < 0) {

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -629,5 +629,80 @@ start_server {} {
     }
 }
 
+start_server {} {
+    # Disable copy avoidance
+    r config set min-io-threads-avoid-copy-reply 0
+    r config set min-string-size-avoid-copy-reply 0
+    r config set min-string-size-avoid-copy-reply-threaded 0
+
+    test "a client pending an async free doesn't cause over-eviction of other clients" {
+        r debug replybuffer resizing 0
+        r client setname control
+        r client no-evict on
+        r config set maxmemory-clients 0
+
+        # A large client we'll protect (simulating a deferred/async close), plus two
+        # small clients that must survive once the protected client's memory is accounted for.
+        set big_size [mb 2]
+        set small_size [kb 100]
+
+        set rr_big [valkey_client]
+        $rr_big client setname big_client
+        $rr_big write [join [list "*2\r\n\$$big_size\r\n" [string repeat v $big_size]] ""]
+        $rr_big flush
+        wait_for_condition 200 10 {
+            [client_field big_client tot-mem] >= $big_size
+        } else {
+            fail "Failed to fill qbuf for big_client"
+        }
+
+        set small_rrs {}
+        for {set j 0} {$j < 2} {incr j} {
+            set rr [valkey_client]
+            lappend small_rrs $rr
+            $rr client setname small_client$j
+            $rr write [join [list "*2\r\n\$$small_size\r\n" [string repeat v $small_size]] ""]
+            $rr flush
+            wait_for_condition 200 10 {
+                [client_field small_client$j tot-mem] >= $small_size
+            } else {
+                fail "Failed to fill qbuf for small_client$j"
+            }
+        }
+
+        set big_mem [client_field big_client tot-mem]
+        set small0_mem [client_field small_client0 tot-mem]
+        set small1_mem [client_field small_client1 tot-mem]
+        set control_mem [client_field control tot-mem]
+
+        # Protect big_client so freeClient() can only defer to an async close.
+        # Fetch its id via CLIENT LIST (rr_big's own connection is mid-parse, see above).
+        set big_id [client_field big_client id]
+        r debug protect-client $big_id
+
+        # Set the limit so freeing just the big client's memory suffices; the
+        # small clients must not need to be touched.
+        set limit [expr {$control_mem + $small0_mem + $small1_mem + 1024}]
+        r config set maxmemory-clients $limit
+
+        # The big client should be marked for (async) close: flags contains 'A'.
+        wait_for_condition 50 100 {
+            [string match {*A*} [client_field big_client flags]]
+        } else {
+            fail "protected big client was not scheduled for close"
+        }
+
+        # Still present (only unlinked once actually freed), and the small clients
+        # must not have been evicted to compensate.
+        assert {[client_exists big_client]}
+        assert {[client_exists small_client0]}
+        assert {[client_exists small_client1]}
+
+        r debug replybuffer resizing 1
+        catch {$rr_big close}
+        foreach rr $small_rrs {$rr close}
+    } {} {needs:debug tls:skip}
+}
+
 } ;# tags
 


### PR DESCRIPTION
`evictClients()` only checked live `server.stat_clients_type_memory` counters when deciding whether to keep disconnecting clients. When `freeClient()` defers a close instead of freeing immediately (client protected, in the RDB-channel grace period, or with pending IO-thread work), that client's memory isn't subtracted from those counters until the deferred close actually completes later. The loop had no way to credit memory already scheduled to be freed, so it kept disconnecting additional, unrelated clients to compensate even when the deferred client alone would have brought usage back under the limit.

This accounting previously existed in `evictClients()` and was dropped during an unrelated cleanup pass.

Track memory of clients whose free was deferred in the current pass and count it toward the limit, and skip clients already marked close_asap from an earlier pass so they aren't repeatedly re-selected.

Track deferred clients' credit via `c->last_memory_usage` rather than a fresh memory computation, matching the exact value freeClient() later subtracts and avoiding a buffer read on clients with pending IO-thread work.

Adds a regression test using `DEBUG PROTECT-CLIENT` to deterministically force a client onto the deferred-close path and assert that unrelated smaller clients survive the eviction pass.

Fixes: #4151 