### PR TITLE
Fix HRANDFIELD CASE 4 test to actually invoke HRANDFIELD

### DIFF
--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1557,7 +1557,8 @@ start_server {tags {"hashexpire"}} {
         after 100
         assert_equal 100 [r HLEN myhash]
 
-        # Should return at most 29 valid fields without
+        # Should return at most 29 valid fields without looping forever
+        set result [r HRANDFIELD myhash 30]
         assert_lessthan_equal [llength $result] 29
 
         r DEBUG SET-ACTIVE-EXPIRE 1


### PR DESCRIPTION
## Summary
- The test added in #4047 ("HRANDFIELD - CASE 4: does not loop forever when valid fields fewer than count") asserts on `$result` but never calls `HRANDFIELD` to populate it — the test fails with an undefined-variable error rather than exercising the `maxtries` guard.
- Add the missing `set result [r HRANDFIELD myhash 30]` call and complete the truncated comment.

## Test plan
- [x] `./runtest --single tests/unit/hashexpire.tcl --only "/HRANDFIELD - CASE 4: does not loop" --config enable-debug-command local` passes (4 passed, 0 failed)