### PR TITLE
Fix MOVE/COPY command skip the current-DB ACL check

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1863,17 +1863,28 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
         int *positions = cmd->get_dbid_args(argv, argc, &count);
         if (positions) {
             for (int i = 0; i < count; i++) {
-                long long dbid;
+                long long argdbid;
                 /* The helper has already validated argv[positions[i]] as a
                  * valid in-range dbid, so this should never fail. */
-                serverAssert(getLongLongFromObject(argv[positions[i]], &dbid) == C_OK);
-                if (!ACLSelectorCanAccessDb(selector, (int)dbid)) {
+                serverAssert(getLongLongFromObject(argv[positions[i]], &argdbid) == C_OK);
+                if (!ACLSelectorCanAccessDb(selector, (int)argdbid)) {
                     if (keyidxptr) *keyidxptr = positions[i];
                     zfree(positions);
                     return ACL_DENIED_DB;
                 }
             }
             zfree(positions);
+        }
+        /* Commands such as MOVE and COPY also read from / operate on the keys
+         * in the current database, not just the destination database named in
+         * their arguments. The current database must therefore be authorized
+         * as well, otherwise a user without access to the current DB could use
+         * MOVE/COPY to exfiltrate its keys into a database it can access.
+         * This only applies to commands that carry real keys: SELECT and SWAPDB
+         * also declare dbid args but do not touch the current DB's keys. */
+        if (doesCommandHaveKeys(cmd) && !ACLSelectorCanAccessDb(selector, dbid)) {
+            if (keyidxptr) *keyidxptr = 0;
+            return ACL_DENIED_DB;
         }
     } else if ((cmd->flags & CMD_ALL_DBS) && !(selector->flags & SELECTOR_FLAG_ALLDBS)) {
         for (int i = 0; i < server.dbnum; i++) {

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -1546,5 +1546,55 @@ start_server {tags {"acl external:skip"}} {
         }
     }
 
+    test {MOVE cannot leak data out of an unauthorized current DB} {
+        r select 0
+        r set secret-move "top-secret-db0"
+
+        r ACL SETUSER leak-move on nopass +@all ~* db=1
+
+        # Fresh raw client that never issues SELECT, so it stays on DB 0.
+        set rc [valkey [srv 0 host] [srv 0 port] 0 $::tls]
+        $rc auth leak-move password
+
+        # A direct read on the current DB 0 is denied ...
+        assert_error "*NOPERM*database*" {$rc get secret-move}
+
+        # ... and MOVE is denied too, because the source (current) DB 0 is validated.
+        assert_error "*NOPERM*database*" {$rc move secret-move 1}
+
+        # The secret never reached DB 1.
+        $rc select 1
+        assert_equal {} [$rc get secret-move]
+
+        # cleanup
+        $rc close
+        r del secret-move
+        r ACL DELUSER leak-move
+    }
+
+    test {COPY cannot leak data out of an unauthorized current DB} {
+        r select 0
+        r set secret-copy "top-secret-db0"
+
+        r ACL SETUSER leak-copy on nopass +@all ~* db=1
+
+        set rc [valkey [srv 0 host] [srv 0 port] 0 $::tls]
+        $rc auth leak-copy password
+
+        assert_error "*NOPERM*database*" {$rc get secret-copy}
+
+        # COPY is denied because the current (source) DB 0 is validated as well.
+        assert_error "*NOPERM*database*" {$rc copy secret-copy stolen DB 1}
+
+        $rc select 1
+        assert_equal {} [$rc get stolen]
+
+        # cleanup
+        $rc close
+        r select 0
+        r del secret-copy
+        r ACL DELUSER leak-copy
+    }
+
     $r2 close
 }


### PR DESCRIPTION
## Problem

`MOVE` and `COPY` move/duplicate a key from the **current** database into a **destination** database. Today the ACL layer only checks the user's permission on the *destination* DB and never on the *current* (source) DB.

As a result, a user who is denied access to DB 0 but allowed on DB 1 can still read DB 0's data: they stay on DB 0 (the default for a fresh connection) and `MOVE`/`COPY` the secret key into DB 1, where they are permitted to read it.

This PR adds the missing current-DB authorization check for commands that both declare a destination-DB argument and operate on keys in the current DB.

```
127.0.0.1:6379> SET secret-move "top-secret-db0"      # written on DB 0 by admin
OK
127.0.0.1:6379> ACL SETUSER leak on nopass +@all ~* db=1
OK

# New connection authenticates as `leak` and stays on DB 0.
127.0.0.1:6379> AUTH leak password
OK
127.0.0.1:6379> GET secret-move                        # direct read: correctly denied
(error) NOPERM No permissions to access database

# MOVE the key into DB 1, where `leak` is allowed to read:
127.0.0.1:6379> MOVE secret-move 1
```

- **Before:** `MOVE` returns `1`; the attacker then `SELECT 1` + `GET secret-move` and reads DB 0's secret. Same story for `COPY secret-move stolen DB 1`.
- **After:** `MOVE`/`COPY` are rejected with `NOPERM No permissions to access database`, because DB 0 (the current DB) is now validated. The secret never reaches DB 1.
