### PR TITLE
Deflake gossip-count and blocking-module-auth assertions

### DIFF
--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -134,7 +134,12 @@ start_cluster 10 0 {tags {external:skip cluster tls:skip}} {
         binary scan $reply @14Su count
 
         assert_equal 1 $type
-        assert_morethan_equal $count 7
-        assert_lessthan_equal $count 9
+        # The exact count depends on the membership-table state at the moment
+        # the reply is crafted (the fake MEET node may or may not be counted
+        # yet), so allow some slack. The property under test is scaling: at 80%
+        # gossip-perc the count must be far above the default-perc baseline
+        # of 1-2 entries.
+        assert_morethan_equal $count 5
+        assert_lessthan_equal $count 10
     }
 }

--- a/tests/unit/moduleapi/moduleauth.tcl
+++ b/tests/unit/moduleapi/moduleauth.tcl
@@ -358,8 +358,9 @@ start_server {tags {"modules"}} {
 
         # Validate that even the new blocking module auth cb which was registered in the middle of
         # blocking module auth is attempted - making it take twice the duration (2x 500000 us).
+        # Allow 10% slack for scheduler/timer jitter; a skipped callback measures ~500000.
         regexp "usec_per_call=(\[0-9]{1,})\.*," $stats all usec_per_call
-        assert {$usec_per_call >= 1000000}
+        assert {$usec_per_call >= 900000}
     }
 
     test {Module unload during blocking module auth} {


### PR DESCRIPTION
## Summary

Two over-tight numeric assertions that fail intermittently on CI runners, with no product change. Flake data comes from tracking 466 daily-CI runs on `unstable` (2025-03-27 → 2026-07-05).

## Changes

### 1. `Gossip count scales with cluster-message-gossip-perc` (tests/unit/cluster/packet.tcl)

Failed in 23 of 466 daily runs (2.8%). The test crafts a MEET packet against a 10-node cluster with `cluster-message-gossip-perc 80` and asserts the reply's gossip count is in 7–9. The exact count depends on the membership-table state at the moment the reply is built — the fake MEET node may or may not have been integrated yet — which is nondeterministic.

Widen the accepted range to 5–10. The property under test is *scaling*: at 80% the count must be far above the default-perc baseline of 1–2 entries, which the widened floor still guarantees. A regression in the percentage scaling logic still fails the assertion.

### 2. `test RM_RegisterAuthCallback Module API during blocking module auth` (tests/unit/moduleapi/moduleauth.tcl)

The test asserts `usec_per_call >= 1000000` for two 500 ms blocking auth callbacks. Under scheduler preemption the measured average can land marginally below the exact 2×500000 µs floor.

Relax the floor to 900000 µs (10% jitter allowance). The assertion still proves both callbacks ran: a regression that skips the callback registered mid-auth measures ~500000 µs, far below the new floor.

## Testing

- Both files pass locally (`unit/cluster/packet` 4/4 incl. 10-loop repeat; `unit/moduleapi/moduleauth` 16/16).
- Fork-CI soak: 100 loops on two jobs (test-ubuntu-jemalloc, test-ubuntu-arm) = 200 iterations per test, **0 failures** ([gossip run](https://github.com/valkey-rainfall/valkey/actions/runs/29211790418), [moduleauth run](https://github.com/valkey-rainfall/valkey/actions/runs/29211792584)). At the historical 2.8% rate, ~5–6 gossip failures would be expected in 200 clean-code iterations.