### PR TITLE
Deflake slot-migration replica redirects, dual-channel COB overrun, and HGETEX EXAT notifications

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -820,7 +820,10 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             pause_process $replica_pid
             wait_and_resume_process -1
             $primary debug pause-after-fork 0
-            wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 100 100
+            # Use a generous retry budget: under valgrind the primary fills the
+            # COB much more slowly, and the write load needs time to overflow
+            # the limit before the disconnect log appears.
+            wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 500 100
             wait_for_condition 50 100 {
                 [string match {*replicas_waiting_psync:0*} [$primary info replication]]
             } else {

--- a/tests/unit/cluster/slot-migration.tcl
+++ b/tests/unit/cluster/slot-migration.tcl
@@ -157,22 +157,26 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-allow-replica
     }
 
     test "Replica redirects key access in migrating slots" {
-        # Validate initial states
-        assert_equal [get_open_slots 0] "\[609->-$R1_id\]"
-        assert_equal [get_open_slots 1] "\[609-<-$R0_id\]"
-        assert_equal [get_open_slots 3] "\[609->-$R1_id\]"
-        assert_equal [get_open_slots 4] "\[609-<-$R0_id\]"
+        # Validate initial states. Use wait_for_slot_state since the replicas
+        # (R3/R4) learn the migration state via gossip, which may still be
+        # propagating when this test starts.
+        wait_for_slot_state 0 "\[609->-$R1_id\]"
+        wait_for_slot_state 1 "\[609-<-$R0_id\]"
+        wait_for_slot_state 3 "\[609->-$R1_id\]"
+        wait_for_slot_state 4 "\[609-<-$R0_id\]"
         catch {[R 3 get aga]} e
         set port0 [srv 0 port]
         assert_equal "MOVED 609 127.0.0.1:$port0" $e
     }
 
     test "Replica of migrating node returns ASK redirect after READONLY" {
-        # Validate initial states
-        assert_equal [get_open_slots 0] "\[609->-$R1_id\]"
-        assert_equal [get_open_slots 1] "\[609-<-$R0_id\]"
-        assert_equal [get_open_slots 3] "\[609->-$R1_id\]"
-        assert_equal [get_open_slots 4] "\[609-<-$R0_id\]"
+        # Validate initial states. Use wait_for_slot_state since the replicas
+        # (R3/R4) learn the migration state via gossip, which may still be
+        # propagating when this test starts.
+        wait_for_slot_state 0 "\[609->-$R1_id\]"
+        wait_for_slot_state 1 "\[609-<-$R0_id\]"
+        wait_for_slot_state 3 "\[609->-$R1_id\]"
+        wait_for_slot_state 4 "\[609-<-$R0_id\]"
         # Read missing key in readonly replica in migrating state.
         assert_equal OK [R 3 READONLY]
         set port1 [srv -1 port]
@@ -182,11 +186,13 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-allow-replica
     }
 
     test "Replica of migrating node returns TRYAGAIN after READONLY" {
-        # Validate initial states
-        assert_equal [get_open_slots 0] "\[609->-$R1_id\]"
-        assert_equal [get_open_slots 1] "\[609-<-$R0_id\]"
-        assert_equal [get_open_slots 3] "\[609->-$R1_id\]"
-        assert_equal [get_open_slots 4] "\[609-<-$R0_id\]"
+        # Validate initial states. Use wait_for_slot_state since the replicas
+        # (R3/R4) learn the migration state via gossip, which may still be
+        # propagating when this test starts.
+        wait_for_slot_state 0 "\[609->-$R1_id\]"
+        wait_for_slot_state 1 "\[609-<-$R0_id\]"
+        wait_for_slot_state 3 "\[609->-$R1_id\]"
+        wait_for_slot_state 4 "\[609-<-$R0_id\]"
         # Read some existing and some missing keys in readonly replica in
         # migrating state results in TRYAGAIN, just like its primary would do.
         assert_equal OK [R 3 READONLY]
@@ -196,11 +202,13 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-allow-replica
     }
 
     test "Replica of importing node returns TRYAGAIN after READONLY and ASKING" {
-        # Validate initial states
-        assert_equal [get_open_slots 0] "\[609->-$R1_id\]"
-        assert_equal [get_open_slots 1] "\[609-<-$R0_id\]"
-        assert_equal [get_open_slots 3] "\[609->-$R1_id\]"
-        assert_equal [get_open_slots 4] "\[609-<-$R0_id\]"
+        # Validate initial states. Use wait_for_slot_state since the replicas
+        # (R3/R4) learn the migration state via gossip, which may still be
+        # propagating when this test starts.
+        wait_for_slot_state 0 "\[609->-$R1_id\]"
+        wait_for_slot_state 1 "\[609-<-$R0_id\]"
+        wait_for_slot_state 3 "\[609->-$R1_id\]"
+        wait_for_slot_state 4 "\[609-<-$R0_id\]"
         # A client follows an ASK redirect to a primary, but wants to read from a replica.
         # The replica returns TRYAGAIN just like a primary would do for two missing keys.
         assert_equal OK [R 4 READONLY]

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -36,6 +36,11 @@ proc check_myhash_and_expired_subkeys {r myhash expected_len initial_expired exp
     }
 }
 
+# Note: the EXAT margin is +2 (not +1) because [clock seconds] truncates: at
+# X.99s a +1 timestamp is only ~10ms in the future, and any scheduling stall
+# makes it already-past by the time the server executes the command. That
+# takes the immediate-expiry path, which emits hexpired without a preceding
+# hexpire notification and breaks notification-ordering assertions.
 proc get_short_expire_value {command} {
     expr {
         ($command eq "HEXPIRE" || $command eq "EX") ? 1 :
@@ -44,11 +49,6 @@ proc get_short_expire_value {command} {
         [clock milliseconds] + 1000
     }
 }
-# Note: the EXAT margin is +2 (not +1) because [clock seconds] truncates: at
-# X.99s a +1 timestamp is only ~10ms in the future, and any scheduling stall
-# makes it already-past by the time the server executes the command. That
-# takes the immediate-expiry path, which emits hexpired without a preceding
-# hexpire notification and breaks notification-ordering assertions.
 
 proc get_long_expire_value {command} {
     expr {

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -40,10 +40,15 @@ proc get_short_expire_value {command} {
     expr {
         ($command eq "HEXPIRE" || $command eq "EX") ? 1 :
         ($command eq "HPEXPIRE" || $command eq "PX") ? 1000 :
-        ($command eq "HEXPIREAT" || $command eq "EXAT") ? [clock seconds] + 1 :
+        ($command eq "HEXPIREAT" || $command eq "EXAT") ? [clock seconds] + 2 :
         [clock milliseconds] + 1000
     }
 }
+# Note: the EXAT margin is +2 (not +1) because [clock seconds] truncates: at
+# X.99s a +1 timestamp is only ~10ms in the future, and any scheduling stall
+# makes it already-past by the time the server executes the command. That
+# takes the immediate-expiry path, which emits hexpired without a preceding
+# hexpire notification and breaks notification-ordering assertions.
 
 proc get_long_expire_value {command} {
     expr {


### PR DESCRIPTION
## Summary

Three test-only fixes for intermittent CI failures. Flake data from 466 daily-CI runs on `unstable` (2025-03-27 → 2026-07-05).

## Changes

### 1. Wait for slot state propagation in replica redirect tests (tests/unit/cluster/slot-migration.tcl)

Four tests (`Replica redirects key access in migrating slots` and the ASK/TRYAGAIN READONLY variants) validate their initial state with instantaneous `get_open_slots` assertions on replicas R3/R4. The replicas learn the migration state set up by earlier tests via gossip, which may still be propagating when the test starts. Each of the four failed in 5 of 466 daily runs (1.1%).

Convert the initial-state assertions to `wait_for_slot_state`, matching the eventual-consistency pattern neighboring tests in the same file already use. The redirect behavior assertions are unchanged.

### 2. Widen COB overrun log wait (tests/integration/dual-channel-replication.tcl)

`Test dual-channel-replication primary gets cob overrun before established psync` waits for the output-buffer-limit disconnect log with a 100×100 ms budget. Under valgrind the primary fills the COB much more slowly and the 10 s budget expires before the overflow occurs (4 occurrences, still active; an earlier fix in #3242 reduced but did not eliminate the flake). Raise the budget to 500×100 ms.

### 3. Fix already-past EXAT timestamp in hash-field-expire test helper (tests/unit/hashexpire.tcl)

Closes #4088

`get_short_expire_value` returns `[clock seconds]+1` for EXAT, but clock truncation means the timestamp can be mere milliseconds in the future (at X.99 s a +1 value is ~10 ms away). Any scheduling stall makes it already-past when the server executes HGETEX, taking the immediate-expiry path which emits `hexpired` with no preceding `hexpire` notification — exactly the failure in the issue's trace:

```
Expected 'pmessage __keyevent@* __keyevent@9__:hexpired myhash'
to match 'pmessage __keyevent@* __keyevent@*:hexpire myhash'
```

Use `+2` to guarantee ~1 s of margin. All 38 users of the helper pass unchanged (397/397 hashexpire tests).

## Testing

- Local: `unit/cluster/slot-migration` 31/31, `unit/hashexpire` 397/397, dual-channel COB overrun test passes in isolation.
- Fork-CI soak, 100 loops per job, **0 failures**:
  - slot-migration whole file (3100 passed per job = 31 tests × 100): [test-ubuntu-jemalloc](https://github.com/valkey-rainfall/valkey/actions/runs/29212397390/job/86702219634), [test-ubuntu-arm](https://github.com/valkey-rainfall/valkey/actions/runs/29212397390/job/86702219600)
  - HGETEX notification tests (all 4 variants) + COB overrun: [test-ubuntu-jemalloc](https://github.com/valkey-rainfall/valkey/actions/runs/29212399664/job/86702226809), [test-ubuntu-arm](https://github.com/valkey-rainfall/valkey/actions/runs/29212399664/job/86702226782)
- Valgrind soak (the condition the COB overrun flake manifests under), **0 failures** across 68 completed iterations: [test-valgrind-test](https://github.com/valkey-rainfall/valkey/actions/runs/29227224214/job/86743774545) (31 iterations), [test-valgrind-no-malloc-usable-size-test](https://github.com/valkey-rainfall/valkey/actions/runs/29227224214/job/86743774578) (37 iterations). Jobs were stopped at the 6-hour CI ceiling before completing all 50 loops — counts are completed iterations from the job logs.