### PR TITLE
Deflake: Harden copy-avoidance obuf tests and replica output-bytes metric test

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -196,7 +196,12 @@ start_server {tags {"repl external:skip"}} {
         }
         
         test {Replica output bytes metric} {
-            # reset stats 
+            # Make sure no replication traffic (initial sync, backlog writes)
+            # is still in flight before resetting stats, so the zero-baseline
+            # assertion below doesn't race with it.
+            wait_for_ofs_sync $A $B
+
+            # reset stats
             $A config resetstat
             
             set info [$A info stats]
@@ -207,7 +212,7 @@ start_server {tags {"repl external:skip"}} {
             $A set key value
             
             # wait for command propagation
-            wait_for_condition 50 100 {
+            wait_for_condition 100 100 {
                 [$B get key] eq {value}
             } else {
                 fail "Replica did not receive the command"

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -332,28 +332,48 @@ start_server {tags {"obuf-limits external:skip logreqres:skip"}} {
         $rd client setname iothread_test
         assert {[$rd read] eq "OK"}
         
-        # Send multiple GETs without reading
+        # Send multiple GETs without reading, until the output-buffer limit
+        # enforcement is observable: either we see omem exceed the limit, or
+        # the server has already disconnected the client (with IO threads the
+        # disconnect can happen between polls, and a write to the closed
+        # connection raises an error). The loop is bounded so a broken
+        # accounting path fails the test instead of hanging it.
         set omem 0
-        while {1} {
-            $rd get iothread_key
-            $rd flush
+        set disconnected 0
+        for {set i 0} {$i < 500} {incr i} {
+            if {[catch {
+                $rd get iothread_key
+                $rd flush
+            }]} {
+                # Write failed: the server closed the connection, meaning the
+                # output buffer limit was enforced.
+                set disconnected 1
+                break
+            }
             after 10
-            set clients [r client list]
-            foreach client_info [split $clients "\r\n"] {
+            set found 0
+            foreach client_info [split [r client list] "\r\n"] {
                 if {[string match "*name=iothread_test*" $client_info]} {
+                    set found 1
                     regexp {omem=([0-9]+)} $client_info _ omem
                     break
                 }
             }
+            if {!$found} {
+                set disconnected 1
+                break
+            }
             if {$omem >= 200000} break
-            if {[lsearch [split [r client list] "\r\n"] *name=iothread_test*] == -1} break
         }
-        
-        # Wait for disconnection
-        wait_for_condition 50 100 {
-            [lsearch [split [r client list] "\r\n"] *name=iothread_test*] == -1
-        } else {
-            fail "Client not disconnected with IO threads (omem=$omem)"
+
+        if {!$disconnected} {
+            assert {$omem >= 200000}
+            # We observed omem over the limit; the server must now disconnect.
+            wait_for_condition 50 100 {
+                [lsearch [split [r client list] "\r\n"] *name=iothread_test*] == -1
+            } else {
+                fail "Client not disconnected with IO threads (omem=$omem)"
+            }
         }
         
         # Restore settings
@@ -394,13 +414,14 @@ start_server {tags {"obuf-limits external:skip logreqres:skip"}} {
         $rd flush
 
         set spilled_to_reply_list 0
-        for {set i 0} {$i < 100} {incr i} {
+        # Generous budget: valgrind slows IO-thread reply processing 10-50x.
+        for {set i 0} {$i < 200} {incr i} {
             set oll [get_field_in_client_list $client_id [r client list] oll]
             if {$oll ne "" && $oll > 0} {
                 set spilled_to_reply_list 1
                 break
             }
-            after 50
+            after 100
         }
         if {!$spilled_to_reply_list} {
             fail "Client never spilled copy-avoided replies into c->reply"
@@ -418,7 +439,8 @@ start_server {tags {"obuf-limits external:skip logreqres:skip"}} {
         }
 
         set fully_drained 0
-        for {set i 0} {$i < 100} {incr i} {
+        # Generous budget: valgrind slows IO-thread reply processing 10-50x.
+        for {set i 0} {$i < 200} {incr i} {
             set client_list [r client list]
             set obl [get_field_in_client_list $client_id $client_list obl]
             set oll [get_field_in_client_list $client_id $client_list oll]
@@ -426,7 +448,7 @@ start_server {tags {"obuf-limits external:skip logreqres:skip"}} {
                 set fully_drained 1
                 break
             }
-            after 50
+            after 100
         }
         if {!$fully_drained} {
             fail "Client reply buffers did not fully drain"


### PR DESCRIPTION
## Summary

Test-only hardening for three rare intermittent CI failures (flake data from 466 daily-CI runs on `unstable`, 2025-03-27 → 2026-07-05).

## Changes

### 1. Bound the send loop in copy-avoidance obuf tracking test (tests/unit/obuf-limits.tcl)

`Copy avoidance obuf tracking with IO threads` pushed GETs in an unbounded `while {1}` loop polling omem. Two fragilities:

- With IO threads the server can disconnect the client between polls, making the next pipelined write raise a Tcl error that aborts the test.
- If the accounting path under test ever breaks, the loop hangs until the 20-minute harness watchdog fires instead of failing fast.

Bound the loop (500 iterations), treat a failed write as the disconnect signal (the limit enforcement this test verifies), and assert omem actually exceeded the limit when exiting via the omem branch. Previously, the fallback exit silently skipped verification.

The same commit widens the two poll budgets in `Copy avoidance spill to reply list returns omem to zero after drain` from 100×50 ms to 200×100 ms — that test timed out on [test-valgrind-no-malloc-usable-size-test in the 2026-07-01 daily run](https://github.com/valkey-io/valkey/actions/runs/28485397389/job/84430649470), where reply processing is drastically slower.

### 2. Drain replication traffic before resetstat (tests/integration/replication.tcl)

`Replica output bytes metric` resets stats and immediately asserts `total_net_repl_output_bytes` is zero, racing any in-flight replication traffic (initial-sync tail, backlog writes) that can land between the `config resetstat` and the INFO read. Wait for primary/replica offsets to match (`wait_for_ofs_sync`) before resetting, and double the propagation wait budget.

## Testing

- Local: `unit/obuf-limits` 13/13 (plus 5-loop repeat of both copy-avoidance tests), `integration/replication` 67/67.
- Fork-CI soak, **0 failures**:
  - obuf-limits whole file × 100 loops (1300 passed per job = 13 tests × 100): [test-ubuntu-jemalloc](https://github.com/valkey-rainfall/valkey/actions/runs/29212863599/job/86703423112), [test-ubuntu-arm](https://github.com/valkey-rainfall/valkey/actions/runs/29212863599/job/86703423121)
  - replication whole file × 25 loops (1675 passed per job = 67 tests × 25): [test-ubuntu-jemalloc](https://github.com/valkey-rainfall/valkey/actions/runs/29212865870/job/86703429513), [test-ubuntu-arm](https://github.com/valkey-rainfall/valkey/actions/runs/29212865870/job/86703429495)
- Valgrind soak (the condition the spill-test timeout manifests under), **0 failures**: [test-valgrind-no-malloc-usable-size-test](https://github.com/valkey-rainfall/valkey/actions/runs/29227227175/job/86743784936) (50 tracking + 49 spill iterations; this is the job the original timeout occurred on), [test-valgrind-test](https://github.com/valkey-rainfall/valkey/actions/runs/29227227175/job/86743785012) (49 tracking + 48 spill). Jobs were stopped at the 6-hour CI ceiling just short of the full 50 loops each — counts are completed iterations from the job logs.