### PR TITLE
Add configurable auth options for CLUSTER MIGRATESLOTS (#2392)

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -88,6 +88,10 @@ typedef struct slotMigrationJob {
     /* State needed during client establishment */
     connection *conn; /* Connection to slot import source node. */
     sds response_buf;
+
+    /* Authentication for migrating slot */
+    sds auth_username;
+    sds auth_password;
 } slotMigrationJob;
 
 static bool isSlotMigrationJobFinished(slotMigrationJob *job);
@@ -1157,8 +1161,34 @@ void clusterCommandMigrateSlots(client *c) {
     list *new_slot_migrations = listCreate();
     listSetFreeMethod(new_slot_migrations, freeSlotMigrationJob);
     list *slot_ranges = NULL;
+    sds auth_username = NULL;
+    sds auth_password = NULL;
 
     while (curr_index < c->argc) {
+        /* The credentials, if given, trail every migration group and are used
+         * for all of them. */
+        if (!strcasecmp(objectGetVal(c->argv[curr_index]), "auth")) {
+            if (curr_index + 1 >= c->argc) {
+                addReplyErrorObject(c, shared.syntaxerr);
+                goto cleanup;
+            }
+            auth_password = objectGetVal(c->argv[curr_index + 1]);
+            redactClientCommandArgument(c, curr_index + 1);
+            curr_index += 2;
+            break;
+        } else if (!strcasecmp(objectGetVal(c->argv[curr_index]), "auth2")) {
+            if (curr_index + 2 >= c->argc) {
+                addReplyErrorObject(c, shared.syntaxerr);
+                goto cleanup;
+            }
+            auth_username = objectGetVal(c->argv[curr_index + 1]);
+            redactClientCommandArgument(c, curr_index + 1);
+            auth_password = objectGetVal(c->argv[curr_index + 2]);
+            redactClientCommandArgument(c, curr_index + 2);
+            curr_index += 3;
+            break;
+        }
+
         if (strcasecmp(objectGetVal(c->argv[curr_index]), "slotsrange")) {
             addReplyErrorObject(c, shared.syntaxerr);
             goto cleanup;
@@ -1228,10 +1258,30 @@ void clusterCommandMigrateSlots(client *c) {
         slot_ranges = NULL;
     }
 
+    /* Parsing the credentials breaks out of the loop above, so anything left
+     * over is trailing garbage. */
+    if (curr_index < c->argc) {
+        addReplyErrorObject(c, shared.syntaxerr);
+        goto cleanup;
+    }
+
+    /* Credentials without any migration group to apply them to. */
+    if (listLength(new_slot_migrations) == 0) {
+        addReplyErrorObject(c, shared.syntaxerr);
+        goto cleanup;
+    }
+
     /* If we reach here, we have successfully parsed all arguments */
     listIter li;
     listRewind(new_slot_migrations, &li);
     listNode *ln;
+    while ((ln = listNext(&li))) {
+        slotMigrationJob *job = ln->value;
+        if (auth_username) job->auth_username = sdsdup(auth_username);
+        if (auth_password) job->auth_password = sdsdup(auth_password);
+    }
+
+    listRewind(new_slot_migrations, &li);
     sds client_info = catClientInfoShortString(sdsempty(), c,
                                                server.hide_user_data_from_log);
     while ((ln = listNext(&li))) {
@@ -1378,9 +1428,28 @@ void slotMigrationJobReadAuthResponse(connection *conn) {
  * job's connection. */
 void slotMigrationJobSendAuth(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
-    serverAssert(server.primary_auth);
 
-    sds err = replicationSendAuth(job->conn);
+    sds err = NULL;
+    if (job->auth_password) {
+        /* Credentials given to CLUSTER MIGRATESLOTS take precedence over the
+         * primary auth configuration. */
+        err = sendAuthCommand(job->conn, job->auth_username, job->auth_password);
+    } else if (server.primary_auth) {
+        err = replicationSendAuth(job->conn);
+    } else {
+        /* The auth configuration was cleared after this job entered the
+         * SLOT_EXPORT_SEND_AUTH state. There is nothing to authenticate with,
+         * so move on and let the target node reject us if it still wants
+         * credentials. */
+        serverLog(LL_WARNING,
+                  "No credentials available to authenticate slot migration %s, "
+                  "skipping the AUTH command.",
+                  job->description);
+        updateSlotMigrationJobState(job, SLOT_EXPORT_SEND_ESTABLISH);
+        proceedWithSlotMigration(job);
+        return;
+    }
+
     if (err) {
         sds status_msg = sdscatfmt(sdsempty(), "Failed to send AUTH command to target node: %s", err);
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status_msg);
@@ -2019,7 +2088,7 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             if (!completed) return;
             serverLog(LL_NOTICE, "Slot migration %s connection established.",
                       job->description);
-            if (server.primary_auth) {
+            if (job->auth_password || server.primary_auth) {
                 updateSlotMigrationJobState(job, SLOT_EXPORT_SEND_AUTH);
             } else {
                 updateSlotMigrationJobState(job, SLOT_EXPORT_SEND_ESTABLISH);
@@ -2177,6 +2246,8 @@ void freeSlotMigrationJob(void *o) {
     sdsfree(job->status_msg);
     sdsfree(job->response_buf);
     sdsfree(job->description);
+    sdsfree(job->auth_username);
+    sdsfree(job->auth_password);
     zfree(o);
 }
 

--- a/src/commands.def
+++ b/src/commands.def
@@ -781,9 +781,22 @@ struct COMMAND_ARG CLUSTER_MIGRATESLOTS_migration_group_Subargs[] = {
 {MAKE_ARG("node-id",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
+/* CLUSTER MIGRATESLOTS authentication auth2 argument table */
+struct COMMAND_ARG CLUSTER_MIGRATESLOTS_authentication_auth2_Subargs[] = {
+{MAKE_ARG("username",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("password",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* CLUSTER MIGRATESLOTS authentication argument table */
+struct COMMAND_ARG CLUSTER_MIGRATESLOTS_authentication_Subargs[] = {
+{MAKE_ARG("auth",ARG_TYPE_STRING,-1,"AUTH",NULL,"10.0.0",CMD_ARG_NONE,0,NULL),.display_text="password"},
+{MAKE_ARG("auth2",ARG_TYPE_BLOCK,-1,"AUTH2",NULL,"10.0.0",CMD_ARG_NONE,2,NULL),.subargs=CLUSTER_MIGRATESLOTS_authentication_auth2_Subargs},
+};
+
 /* CLUSTER MIGRATESLOTS argument table */
 struct COMMAND_ARG CLUSTER_MIGRATESLOTS_Args[] = {
 {MAKE_ARG("migration-group",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,4,NULL),.subargs=CLUSTER_MIGRATESLOTS_migration_group_Subargs},
+{MAKE_ARG("authentication",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=CLUSTER_MIGRATESLOTS_authentication_Subargs},
 };
 
 /********** CLUSTER MYID ********************/
@@ -1158,7 +1171,7 @@ struct COMMAND_STRUCT CLUSTER_Subcommands[] = {
 {MAKE_CMD("keyslot","Returns the hash slot for a key.","O(N) where N is the number of bytes in the key","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_KEYSLOT_History,0,CLUSTER_KEYSLOT_Tips,0,clusterKeySlotCommand,3,CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_KEYSLOT_Keyspecs,0,NULL,1),.args=CLUSTER_KEYSLOT_Args},
 {MAKE_CMD("links","Returns a list of all TCP links to and from peer nodes.","O(N) where N is the total number of Cluster nodes","7.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_LINKS_History,0,CLUSTER_LINKS_Tips,1,clusterCommand,2,CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_LINKS_Keyspecs,0,NULL,0)},
 {MAKE_CMD("meet","Forces a node to handshake with another node.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MEET_History,1,CLUSTER_MEET_Tips,0,clusterCommand,-4,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_MEET_Keyspecs,0,NULL,3),.args=CLUSTER_MEET_Args},
-{MAKE_CMD("migrateslots","Migrate the given slots from this node to the specified nodes.","O(N) where N is the total number of the slots between all start slot and end slot arguments.","9.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MIGRATESLOTS_History,0,CLUSTER_MIGRATESLOTS_Tips,0,clusterCommand,-4,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE|CMD_ALL_DBS,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_MIGRATESLOTS_Keyspecs,0,NULL,1),.args=CLUSTER_MIGRATESLOTS_Args},
+{MAKE_CMD("migrateslots","Migrate the given slots from this node to the specified nodes.","O(N) where N is the total number of the slots between all start slot and end slot arguments.","9.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MIGRATESLOTS_History,0,CLUSTER_MIGRATESLOTS_Tips,0,clusterCommand,-4,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE|CMD_ALL_DBS,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_MIGRATESLOTS_Keyspecs,0,NULL,2),.args=CLUSTER_MIGRATESLOTS_Args},
 {MAKE_CMD("myid","Returns the ID of a node.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MYID_History,0,CLUSTER_MYID_Tips,0,clusterCommand,2,CMD_LOADING|CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_MYID_Keyspecs,0,NULL,0)},
 {MAKE_CMD("myshardid","Returns the shard ID of a node.","O(1)","7.2.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MYSHARDID_History,0,CLUSTER_MYSHARDID_Tips,1,clusterCommand,2,CMD_LOADING|CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_MYSHARDID_Keyspecs,0,NULL,0)},
 {MAKE_CMD("nodes","Returns the cluster configuration for a node.","O(N) where N is the total number of Cluster nodes","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_NODES_History,0,CLUSTER_NODES_Tips,1,clusterCommand,2,CMD_LOADING|CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_NODES_Keyspecs,0,NULL,0)},

--- a/src/commands/cluster-migrateslots.json
+++ b/src/commands/cluster-migrateslots.json
@@ -53,6 +53,37 @@
                         "description": "40 character node name of the node to migrate to"
                     }
                 ]
+            },
+            {
+                "name": "authentication",
+                "type": "oneof",
+                "optional": true,
+                "description": "Credentials used to authenticate against every target node of this command",
+                "arguments": [
+                    {
+                        "token": "AUTH",
+                        "name": "auth",
+                        "display": "password",
+                        "type": "string",
+                        "since": "10.0.0"
+                    },
+                    {
+                        "token": "AUTH2",
+                        "name": "auth2",
+                        "type": "block",
+                        "since": "10.0.0",
+                        "arguments": [
+                            {
+                                "name": "username",
+                                "type": "string"
+                            },
+                            {
+                                "name": "password",
+                                "type": "string"
+                            }
+                        ]
+                    }
+                ]
             }
         ],
         "reply_schema": {

--- a/src/replication.c
+++ b/src/replication.c
@@ -3073,19 +3073,26 @@ int sendCurrentOffsetToReplica(client *replica) {
     return C_OK;
 }
 
-sds replicationSendAuth(connection *conn) {
+/* Send an AUTH command on conn with the given credentials. A NULL user sends
+ * the single argument form. The password is an sds so that binary-safe
+ * passwords are sent in full. */
+sds sendAuthCommand(connection *conn, char *user, sds password) {
     char *args[] = {"AUTH", NULL, NULL};
     size_t lens[] = {4, 0, 0};
     int argc = 1;
-    if (server.primary_user) {
-        args[argc] = server.primary_user;
-        lens[argc] = strlen(server.primary_user);
+    if (user) {
+        args[argc] = user;
+        lens[argc] = strlen(user);
         argc++;
     }
-    args[argc] = server.primary_auth;
-    lens[argc] = sdslen(server.primary_auth);
+    args[argc] = password;
+    lens[argc] = sdslen(password);
     argc++;
     return sendCommandArgv(conn, argc, args, lens);
+}
+
+sds replicationSendAuth(connection *conn) {
+    return sendAuthCommand(conn, server.primary_user, server.primary_auth);
 }
 
 robj *generateSelectCommand(int dictid) {

--- a/src/server.h
+++ b/src/server.h
@@ -3260,6 +3260,7 @@ void addRdbReplicaToPsyncWait(client *replica);
 void initClientReplicationData(client *c);
 void freeClientReplicationData(client *c);
 void replicaReceiveRDBFromPrimaryToDisk(connection *conn, int is_dual_channel);
+sds sendAuthCommand(connection *conn, char *user, sds password);
 sds replicationSendAuth(connection *conn);
 sds receiveSynchronousResponse(connection *conn);
 ConnectionType *connTypeOfReplication(void);

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -200,6 +200,15 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         assert_error "*Slot ranges in migrations overlap*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 1 1 NODE $node1_id SLOTSRANGE 0 2 NODE $node2_id}
         assert_error "*Slot ranges in migrations overlap*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 2 2 NODE $node1_id SLOTSRANGE 2 2 NODE $node2_id}
 
+        # AUTH and AUTH2 must be complete, and must trail every migration group.
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH}
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH2}
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH2 user}
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node1_id AUTH pass EXTRA}
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS AUTH pass SLOTSRANGE 0 0 NODE $node1_id}
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS AUTH pass}
+        assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS AUTH2 user pass}
+
         set source_node_id [R 0 CLUSTER MYID]
         set target_node_id [R 1 CLUSTER MYID]
         R 0 CLUSTER SETSLOT 0 MIGRATING $target_node_id
@@ -2530,5 +2539,63 @@ start_cluster 3 0 {tags {logreqres:skip external:skip cluster} overrides {cluste
         # Resume R0 and wait for R0 to finish the migration.
         resume_process [srv 0 pid]
         wait_for_migration 0 16383
+    }
+}
+
+start_cluster 2 0 {tags {logreqres:skip external:skip cluster}} {
+    set sourcenode 0
+    set targetnode 1
+
+    test "CLUSTER MIGRATESLOTS AUTH credentials are redacted in the command log" {
+        R $sourcenode CONFIG SET commandlog-execution-slower-than 0
+        R $sourcenode COMMANDLOG RESET SLOW
+
+        # Both fail on the missing migration group, but only after the
+        # credentials have been parsed and redacted.
+        assert_error "*syntax error*" {R $sourcenode CLUSTER MIGRATESLOTS AUTH topsecret}
+        assert_error "*syntax error*" {R $sourcenode CLUSTER MIGRATESLOTS AUTH2 someuser topsecret}
+
+        R $sourcenode CONFIG SET commandlog-execution-slower-than -1
+        set entries [R $sourcenode COMMANDLOG GET -1 SLOW]
+        assert_equal {CLUSTER MIGRATESLOTS AUTH (redacted)} [lindex [lindex $entries 1] 3]
+        assert_equal {CLUSTER MIGRATESLOTS AUTH2 (redacted) (redacted)} [lindex [lindex $entries 0] 3]
+    }
+
+    test "CLUSTER MIGRATESLOTS with AUTH/AUTH2 arguments" {
+        set target_id [R $targetnode CLUSTER MYID]
+
+        # A non-default user, so that AUTH2 exercises the username path.
+        R $targetnode ACL SETUSER migrator on >migratorpass ~* &* +@all
+
+        # Require authentication on the target node. This also de-authenticates
+        # our own connection to it, so authenticate again before using it.
+        R $targetnode CONFIG SET requirepass "mypassword"
+        R $targetnode AUTH mypassword
+
+        # Without credentials the job cannot authenticate and ends up failed. A
+        # failed job is finished, so it does not block later migrations and does
+        # not need to be cancelled. Each case uses its own slot so that
+        # get_job_name cannot match a job from a previous case.
+        assert_match "OK" [R $sourcenode CLUSTER MIGRATESLOTS SLOTSRANGE 1000 1000 NODE $target_id]
+        set jobname [get_job_name $sourcenode 1000]
+        wait_for_migration_field $sourcenode $jobname state failed
+
+        # A wrong password fails too, and reports why.
+        assert_match "OK" [R $sourcenode CLUSTER MIGRATESLOTS SLOTSRANGE 1003 1003 NODE $target_id AUTH "wrongpassword"]
+        set jobname [get_job_name $sourcenode 1003]
+        wait_for_migration_field $sourcenode $jobname state failed
+        assert_match "*WRONGPASS*" [dict get [get_migration_by_name $sourcenode $jobname] message]
+
+        # AUTH with the correct password migrates the slot.
+        assert_match "OK" [R $sourcenode CLUSTER MIGRATESLOTS SLOTSRANGE 1001 1001 NODE $target_id AUTH "mypassword"]
+        wait_for_migration $targetnode 1001
+
+        # AUTH2 with a dedicated ACL user migrates the slot.
+        assert_match "OK" [R $sourcenode CLUSTER MIGRATESLOTS SLOTSRANGE 1002 1002 NODE $target_id AUTH2 migrator "migratorpass"]
+        wait_for_migration $targetnode 1002
+
+        # Reset password to clear test environment
+        R $targetnode CONFIG SET requirepass ""
+        R $targetnode ACL DELUSER migrator
     }
 }


### PR DESCRIPTION
Fixes #2392

This introduces the AUTH and AUTH2 arguments to the CLUSTER MIGRATESLOTS command, allowing users to specify credentials explicitly. This effectively mirrors the behavior of MIGRATE and offers a way to migrate cluster slots while properly handling cross-node authentication constraints.

- Expanded command schema in cluster-migrateslots.json and commands.def
- Handles logic in clusterCommandMigrateSlots and modified slotMigrationJobSendAuth to build 2 and 3 argument AUTH payloads
- Includes integration tests coverage against target nodes enforcing requirepass

Signed-off-by: Warren Zhu <warren.zhu25@gmail.com>