### PR TITLE
Fix out-of-memory DoS on HRANDFIELD, ZRANDMEMBER and SRANDMEMBER with massive negative counts

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3531,6 +3531,7 @@ standardConfig static_configs[] = {
     createLongLongConfig("commandlog-reply-larger-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold, 1024 * 1024, MEMORY_CONFIG | SIGNED_MEMORY_CONFIG, NULL, NULL),
     createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("proto-max-bulk-len", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024 * 1024, LONG_MAX, server.proto_max_bulk_len, 512ll * 1024 * 1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
+    createSizeTConfig("rand-max-reply-size", NULL, MODIFIABLE_CONFIG, 0, SIZE_MAX, server.rand_max_reply_size, 512ull * 1024 * 1024, MEMORY_CONFIG, NULL, NULL),
     createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.repl_backlog_size, 10 * 1024 * 1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 10mb */
     createLongLongConfig("cluster-manual-failover-timeout", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.cluster_mf_timeout, 5000, INTEGER_CONFIG, NULL, NULL),

--- a/src/networking.c
+++ b/src/networking.c
@@ -1057,6 +1057,73 @@ void addReplyErrorExpireTime(client *c) {
     addReplyErrorFormat(c, "invalid expire time in '%s' command", c->cmd->fullname);
 }
 
+/* Number of bytes a payload of the given length occupies once emitted as a RESP
+ * bulk string: "$<len>\r\n<payload>\r\n". */
+size_t bulkReplySize(size_t payload_len) {
+    return 1 + digits10(payload_len) + 2 + payload_len + 2;
+}
+
+/* Size of a listpack entry once emitted as a RESP bulk string. */
+size_t listpackEntryReplySize(listpackEntry *e) {
+    return bulkReplySize(e->sval ? e->slen : sdigits10(e->lval));
+}
+
+/* The commands returning random elements with a negative count (HRANDFIELD,
+ * ZRANDMEMBER, SRANDMEMBER) return duplicates, so the size of the reply is
+ * bounded by the count the caller asks for rather than by the size of the key.
+ * The whole reply is materialized in the output buffer before a single byte of
+ * it is written to the socket, so an unbounded count lets one command exhaust
+ * the server's memory.
+ *
+ * Estimate the reply size from 'element_size', the average size of one element
+ * of the reply, and reject counts that would not fit in 'rand-max-reply-size'.
+ * Returns 1 and replies with an error if the count is too large, 0 otherwise.
+ *
+ * This is the estimate, not the guarantee: it assumes the sampled elements are
+ * representative of the key. The limit is also enforced against the reply as it
+ * is built, see randReplyLimitReached(). */
+int randCountReplyTooLarge(client *c, unsigned long count, size_t element_size) {
+    size_t limit = server.rand_max_reply_size;
+
+    /* No limit configured, or nothing to sample so the reply stays empty. */
+    if (limit == 0 || element_size == 0) return 0;
+    if (count <= limit / element_size) return 0;
+
+    addReplyErrorFormat(c, "count is too large, the reply would exceed the 'rand-max-reply-size' limit of %llu bytes",
+                        (unsigned long long)limit);
+    return 1;
+}
+
+/* Return 1 if the reply of duplicated random elements being built for 'c' must
+ * stop growing, either because the client is already scheduled to be closed or
+ * because the 'emitted' bytes of reply produced so far have grown past
+ * 'rand-max-reply-size'.
+ *
+ * A key whose elements differ wildly in size can defeat the estimate made by
+ * randCountReplyTooLarge() before the reply was started, so the limit is also
+ * enforced here, against the bytes the reply is actually made of. Those bytes
+ * are counted by the caller rather than read back from the output buffer, whose
+ * accounting rounds up to whole reply blocks and would make a limit smaller than
+ * one block reject replies that do fit in it.
+ *
+ * By this point half of the reply is serialized and cannot be replaced with an
+ * error, so the client is closed, exactly as it is when it overruns its output
+ * buffer limit. */
+int randReplyLimitReached(client *c, size_t emitted) {
+    size_t limit = server.rand_max_reply_size;
+
+    if (c->flag.close_asap) return 1;
+    if (limit == 0 || emitted <= limit) return 0;
+
+    sds client_info = catClientInfoString(sdsempty(), c, 0);
+    serverLog(LL_WARNING,
+              "Client %s scheduled to be closed ASAP: the reply of '%s' grew past the 'rand-max-reply-size' limit of %llu bytes.",
+              client_info, c->cmd->fullname, (unsigned long long)limit);
+    sdsfree(client_info);
+    freeClientAsync(c);
+    return 1;
+}
+
 void addReplyStatusLength(client *c, const char *s, size_t len) {
     addReplyProto(c, "+", 1);
     addReplyProto(c, s, len);

--- a/src/server.h
+++ b/src/server.h
@@ -2206,6 +2206,8 @@ struct valkeyServer {
     int maxmemory_samples;                      /* Precision of random sampling */
     int maxmemory_eviction_tenacity;            /* Aggressiveness of eviction processing */
     long long proto_max_bulk_len;               /* Protocol bulk length maximum size. */
+    size_t rand_max_reply_size;                 /* Max reply size of a *RAND* command asking for
+                                                   duplicates, 0 means no limit. */
     int oom_score_adj_values[CONFIG_OOM_COUNT]; /* Linux oom_score_adj configuration */
     int oom_score_adj;                          /* If true, oom_score_adj is managed */
     int disable_thp;                            /* If true, disable THP by syscall */
@@ -2962,6 +2964,12 @@ void addReplyErrorSdsSafe(client *c, sds err);
 void addReplyError(client *c, const char *err);
 void addReplyErrorArity(client *c);
 void addReplyErrorExpireTime(client *c);
+size_t bulkReplySize(size_t payload_len);
+size_t listpackEntryReplySize(listpackEntry *e);
+int randCountReplyTooLarge(client *c, unsigned long count, size_t element_size);
+int randReplyLimitReached(client *c, size_t emitted);
+/* Elements sampled to estimate the average reply size of one element. */
+#define RAND_REPLY_SIZE_SAMPLES 16
 void addReplyStatus(client *c, const char *status);
 void addReplyDouble(client *c, double d);
 void addReplyBigNum(client *c, const char *num, size_t len);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2149,6 +2149,22 @@ void hpexpiretimeCommand(client *c) {
  * the number of randoms per time. */
 #define HRANDFIELD_RANDOM_SAMPLE_LIMIT 1000
 
+/* Estimate the average size of one element of the reply of HRANDFIELD, by
+ * sampling the hash. Returns 0 if no element could be sampled. */
+static size_t hrandfieldElementReplySize(robj *hash, unsigned long size, int withvalues) {
+    size_t total = 0;
+    int samples = 0;
+
+    for (int i = 0; i < RAND_REPLY_SIZE_SAMPLES; i++) {
+        listpackEntry field, value;
+        if (hashTypeRandomElement(hash, size, &field, &value) != C_OK) break;
+        total += listpackEntryReplySize(&field);
+        if (withvalues) total += listpackEntryReplySize(&value);
+        samples++;
+    }
+    return samples ? total / samples : 0;
+}
+
 void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     unsigned long count, size;
     int uniq = 1;
@@ -2170,6 +2186,10 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         return;
     }
 
+    /* A negative count returns duplicates, so the caller alone decides how large
+     * the reply is. Refuse counts whose reply would not fit in memory. */
+    if (!uniq && randCountReplyTooLarge(c, count, hrandfieldElementReplySize(hash, size, withvalues))) return;
+
     writePreparedClient *wpc = prepareClientForFutureWrites(c);
     if (!wpc) return;
 
@@ -2182,6 +2202,9 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
      * structures. This case is the only one that also needs to return the
      * elements in random order. */
     if (!uniq || count == 1) {
+        /* Bytes of reply emitted so far, to enforce 'rand-max-reply-size'. */
+        size_t emitted = 0;
+
         if (hash->encoding == OBJ_ENCODING_HASHTABLE) {
             while (count--) {
                 listpackEntry field, value;
@@ -2194,7 +2217,9 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
                 if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
                 addWritePreparedReplyBulkCBuffer(wpc, field.sval, field.slen);
                 if (withvalues) addWritePreparedReplyBulkCBuffer(wpc, value.sval, value.slen);
-                if (c->flag.close_asap) break;
+                emitted += listpackEntryReplySize(&field);
+                if (withvalues) emitted += listpackEntryReplySize(&value);
+                if (randReplyLimitReached(c, emitted)) break;
                 reply_size++;
             }
         } else if (hash->encoding == OBJ_ENCODING_LISTPACK) {
@@ -2210,7 +2235,11 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
                 reply_size += sample_count;
                 lpRandomPairs(objectGetVal(hash), sample_count, fields, vals);
                 hrandfieldReplyWithListpack(wpc, sample_count, fields, vals);
-                if (c->flag.close_asap) break;
+                for (unsigned long i = 0; i < sample_count; i++) {
+                    emitted += listpackEntryReplySize(&fields[i]);
+                    if (withvalues) emitted += listpackEntryReplySize(&vals[i]);
+                }
+                if (randReplyLimitReached(c, emitted)) break;
             }
             zfree(fields);
             zfree(vals);
@@ -2366,6 +2395,8 @@ void hrandfieldCommand(client *c) {
             return;
         } else if (c->argc == 4) {
             withvalues = 1;
+            /* The RESP2 reply holds two entries per element, so the array length
+             * we emit must not overflow. */
             if (l < -LONG_MAX / 2 || l > LONG_MAX / 2) {
                 addReplyError(c, "value is out of range");
                 return;

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1002,6 +1002,22 @@ void spopCommand(client *c) {
  * the number of randoms per time. */
 #define SRANDFIELD_RANDOM_SAMPLE_LIMIT 1000
 
+/* Estimate the average size of one element of the reply of SRANDMEMBER, by
+ * sampling the set. Returns 0 if no element could be sampled. */
+static size_t srandmemberElementReplySize(robj *set, unsigned long size) {
+    size_t total = 0;
+
+    if (size == 0) return 0;
+    for (int i = 0; i < RAND_REPLY_SIZE_SAMPLES; i++) {
+        char *str;
+        size_t len;
+        int64_t llele;
+        setTypeRandomElement(set, &str, &len, &llele);
+        total += bulkReplySize(str ? len : sdigits10(llele));
+    }
+    return total / RAND_REPLY_SIZE_SAMPLES;
+}
+
 void srandmemberWithCountCommand(client *c) {
     long l;
     unsigned long count, size;
@@ -1030,12 +1046,19 @@ void srandmemberWithCountCommand(client *c) {
         return;
     }
 
+    /* A negative count returns duplicates, so the caller alone decides how large
+     * the reply is. Refuse counts whose reply would not fit in memory. */
+    if (!uniq && randCountReplyTooLarge(c, count, srandmemberElementReplySize(set, size))) return;
+
     /* CASE 1: The count was negative, so the extraction method is just:
      * "return N random elements" sampling the whole set every time.
      * This case is trivial and can be served without auxiliary data
      * structures. This case is the only one that also needs to return the
      * elements in random order. */
     if (!uniq || count == 1) {
+        /* Bytes of reply emitted so far, to enforce 'rand-max-reply-size'. */
+        size_t emitted = 0;
+
         addReplyArrayLen(c, count);
 
         if (set->encoding == OBJ_ENCODING_LISTPACK && count > 1) {
@@ -1052,8 +1075,9 @@ void srandmemberWithCountCommand(client *c) {
                         addReplyBulkCBuffer(c, entries[i].sval, entries[i].slen);
                     else
                         addReplyBulkLongLong(c, entries[i].lval);
+                    emitted += listpackEntryReplySize(&entries[i]);
                 }
-                if (c->flag.close_asap) break;
+                if (randReplyLimitReached(c, emitted)) break;
             }
             zfree(entries);
             return;
@@ -1066,7 +1090,8 @@ void srandmemberWithCountCommand(client *c) {
             } else {
                 addReplyBulkCBuffer(c, str, len);
             }
-            if (c->flag.close_asap) break;
+            emitted += bulkReplySize(str ? len : sdigits10(llele));
+            if (randReplyLimitReached(c, emitted)) break;
         }
         return;
     }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4147,6 +4147,30 @@ static void zrandmemberReplyWithListpack(client *c, unsigned int count, listpack
  * the number of randoms per time. */
 #define ZRANDMEMBER_RANDOM_SAMPLE_LIMIT 1000
 
+/* Size of a score once emitted by addReplyDouble(). RESP3 frames it as
+ * ",<digits>\r\n" and RESP2 as a bulk string, so charging the bulk framing
+ * covers both. */
+static size_t scoreReplySize(double score) {
+    char buf[MAX_D2STRING_CHARS];
+    return bulkReplySize(d2string(buf, sizeof(buf), score));
+}
+
+/* Estimate the average size of one element of the reply of ZRANDMEMBER, by
+ * sampling the sorted set. Returns 0 if no element could be sampled. */
+static size_t zrandmemberElementReplySize(robj *zsetobj, unsigned long size, int withscores) {
+    size_t total = 0;
+
+    if (size == 0) return 0;
+    for (int i = 0; i < RAND_REPLY_SIZE_SAMPLES; i++) {
+        listpackEntry key;
+        double score;
+        zsetTypeRandomElement(zsetobj, size, &key, &score);
+        total += bulkReplySize(key.sval ? key.slen : sdigits10(key.lval));
+        if (withscores) total += scoreReplySize(score);
+    }
+    return total / RAND_REPLY_SIZE_SAMPLES;
+}
+
 void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     unsigned long count, size;
     int uniq = 1;
@@ -4169,12 +4193,19 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         return;
     }
 
+    /* A negative count returns duplicates, so the caller alone decides how large
+     * the reply is. Refuse counts whose reply would not fit in memory. */
+    if (!uniq && randCountReplyTooLarge(c, count, zrandmemberElementReplySize(zsetobj, size, withscores))) return;
+
     /* CASE 1: The count was negative, so the extraction method is just:
      * "return N random elements" sampling the whole set every time.
      * This case is trivial and can be served without auxiliary data
      * structures. This case is the only one that also needs to return the
      * elements in random order. */
     if (!uniq || count == 1) {
+        /* Bytes of reply emitted so far, to enforce 'rand-max-reply-size'. */
+        size_t emitted = 0;
+
         if (withscores && c->resp == 2)
             addReplyArrayLen(c, count * 2);
         else
@@ -4189,7 +4220,9 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
                 sds ele = zslGetNodeElement(node);
                 addReplyBulkCBuffer(c, ele, sdslen(ele));
                 if (withscores) addReplyDouble(c, node->score);
-                if (c->flag.close_asap) break;
+                emitted += bulkReplySize(sdslen(ele));
+                if (withscores) emitted += scoreReplySize(node->score);
+                if (randReplyLimitReached(c, emitted)) break;
             }
         } else if (zsetobj->encoding == OBJ_ENCODING_LISTPACK) {
             listpackEntry *keys, *vals = NULL;
@@ -4202,7 +4235,11 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
                 count -= sample_count;
                 lpRandomPairs(objectGetVal(zsetobj), sample_count, keys, vals);
                 zrandmemberReplyWithListpack(c, sample_count, keys, vals);
-                if (c->flag.close_asap) break;
+                for (unsigned long i = 0; i < sample_count; i++) {
+                    emitted += listpackEntryReplySize(&keys[i]);
+                    if (withscores) emitted += listpackEntryReplySize(&vals[i]);
+                }
+                if (randReplyLimitReached(c, emitted)) break;
             }
             zfree(keys);
             zfree(vals);
@@ -4356,6 +4393,8 @@ void zrandmemberCommand(client *c) {
             return;
         } else if (c->argc == 4) {
             withscores = 1;
+            /* The RESP2 reply holds two entries per element, so the array length
+             * we emit must not overflow. */
             if (l < -LONG_MAX / 2 || l > LONG_MAX / 2) {
                 addReplyError(c, "value is out of range");
                 return;

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -220,7 +220,10 @@ start_server {tags {"obuf-limits external:skip logreqres:skip"}} {
     test "Obuf limit, HRANDFIELD with huge count stopped mid-run" {
         r config set client-output-buffer-limit {normal 1000000 0 0}
         r hset myhash a b
-        catch {r hrandfield myhash -999999999} e
+        # The count has to be one that 'rand-max-reply-size' accepts, otherwise
+        # HRANDFIELD is rejected before it emits anything and the output buffer
+        # limit, which is what this test is about, is never reached.
+        catch {r hrandfield myhash -10000000} e
         assert_match "*I/O error*" $e
         reconnect
     }

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -78,6 +78,61 @@ start_server {tags {"hash"}} {
         assert_error {*value is out of range*} {r hrandfield myhash -9223372036854775808}
     } {}
 
+    test "HRANDFIELD with a negative count whose reply would exceed rand-max-reply-size" {
+        r del myhash
+        r hmset myhash a 1 b 2
+        # An element replies as "$1\r\na\r\n", 7 bytes, so a 1kb budget serves
+        # about 146 duplicated elements and nothing close to a huge count.
+        r config set rand-max-reply-size 1kb
+        assert_equal 100 [llength [r hrandfield myhash -100]]
+        assert_error {*count is too large*} {r hrandfield myhash -1000}
+        assert_error {*count is too large*} {r hrandfield myhash -9223372036854775807}
+        assert_error {*count is too large*} {r hrandfield myhash -4611686018427387903}
+
+        # A positive count is bounded by the size of the hash, so it is served.
+        assert_equal {a b} [lsort [r hrandfield myhash 9223372036854775807]]
+
+        # The check is opt-out.
+        r config set rand-max-reply-size 0
+        assert_equal 1000 [llength [r hrandfield myhash -1000]]
+        r config set rand-max-reply-size 512mb
+        r del myhash
+    }
+
+    test "HRANDFIELD stops a reply that grows past rand-max-reply-size" {
+        r del myhash
+        # 999 fields with a tiny name and one with a 100kb name. Sampling the hash
+        # to estimate the reply size almost always misses the large field, so a
+        # count of 100000 is estimated at well under the 1mb limit and accepted.
+        # The elements actually drawn take the reply to roughly 10mb, so it has to
+        # be stopped while it is being built.
+        for {set i 0} {$i < 999} {incr i} { r hset myhash f$i v }
+        r hset myhash [string repeat x 100000] v
+        r config set rand-max-reply-size 1mb
+
+        set orig_mem [s used_memory]
+        set rd [valkey_deferring_client]
+        $rd client setname randbig
+        assert_equal OK [$rd read]
+        $rd hrandfield myhash -100000
+        $rd flush
+        after 100
+
+        # Before we read the reply, the server has closed this client, and the
+        # reply it was building never grew far past the limit.
+        assert_no_match "*name=randbig*" [r client list]
+        assert {[s used_memory] < $orig_mem + 5000000}
+        assert_equal {} [$rd rawread]
+        $rd close
+
+        # The server logs the overrun, as it does for an output buffer overrun.
+        verify_log_message 0 "*grew past the 'rand-max-reply-size' limit*" 0
+        assert_equal PONG [r ping]
+
+        r del myhash
+        r config set rand-max-reply-size 512mb
+    } {OK} {external:skip}
+
     test "HRANDFIELD with <count> against non existing key" {
         r hrandfield nonexisting_key 100
     } {}

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -827,6 +827,25 @@ foreach type {single multiple single_multiple} {
         assert_error {*value is out of range*} {r srandmember myset -9223372036854775808}
     } {}
 
+    test "SRANDMEMBER with a negative count whose reply would exceed rand-max-reply-size" {
+        r del myset
+        r sadd myset a b
+        r config set rand-max-reply-size 1kb
+        assert_equal 100 [llength [r srandmember myset -100]]
+        assert_error {*count is too large*} {r srandmember myset -1000}
+        assert_error {*count is too large*} {r srandmember myset -9223372036854775807}
+
+        # A positive count is bounded by the size of the set, so it is served.
+        assert_equal {a b} [lsort [r srandmember myset 9223372036854775807]]
+
+        # The check is opt-out.
+        r config set rand-max-reply-size 0
+        assert_equal 1000 [llength [r srandmember myset -1000]]
+
+        r config set rand-max-reply-size 512mb
+        r del myset
+    }
+
     # Make sure we can distinguish between an empty array and a null response
     r readraw 1
 

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2471,6 +2471,22 @@ start_server {tags {"zset"}} {
         assert_error {*value is out of range*} {r zrandmember myzset -9223372036854775808}
     } {}
 
+    test "ZRANDMEMBER with a negative count whose reply would exceed rand-max-reply-size" {
+        r del myzset
+        r zadd myzset 0 a 1 b
+        r config set rand-max-reply-size 1kb
+        assert_equal 100 [llength [r zrandmember myzset -100]]
+        assert_error {*count is too large*} {r zrandmember myzset -1000}
+        assert_error {*count is too large*} {r zrandmember myzset -9223372036854775807}
+        assert_error {*count is too large*} {r zrandmember myzset -4611686018427387903}
+
+        # A positive count is bounded by the size of the sorted set, so it is served.
+        assert_equal {a b} [lsort [r zrandmember myzset 9223372036854775807]]
+
+        r config set rand-max-reply-size 512mb
+        r del myzset
+    }
+
     # Make sure we can distinguish between an empty array and a null response
     r readraw 1
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -2491,6 +2491,15 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 #
 # proto-max-bulk-len 512mb
 
+# HRANDFIELD, ZRANDMEMBER and SRANDMEMBER return duplicated elements when they
+# are called with a negative count, so the size of their reply is bounded by the
+# requested count and not by the size of the key. The reply is built in memory
+# before being sent, so a very large count can make a single command allocate an
+# arbitrary amount of memory. Such a command is rejected when its estimated reply
+# would be larger than the limit below. Set it to 0 to disable the check.
+#
+# rand-max-reply-size 512mb
+
 # The server calls an internal function to perform many background tasks, like
 # closing connections of clients in timeout, purging expired keys that are
 # never requested, and so forth.


### PR DESCRIPTION
## Summary

`HRANDFIELD`, `ZRANDMEMBER` and `SRANDMEMBER` return duplicated elements when called with a negative count, so the size of their reply is bounded by the count the caller asks for and not by the size of the key. The whole reply is materialized in the client output buffer before a single byte of it is written to the socket, so a count such as `-LONG_MAX` makes one command allocate an unbounded amount of memory and the server dies of OOM.

```
HRANDFIELD myhash -9223372036854775807
```

The output buffer limit does not save us here. The reply loops do break out on `c->flag.close_asap`, but normal clients default to `client-output-buffer-limit normal 0 0 0`, so the flag is never set and the loop runs away.

## Solution

Bound the reply in **bytes**, which is the resource that actually runs out. A bound expressed as a count cannot work: even `LONG_MAX / 2` elements is far more than any machine can materialize, so simply tightening the numeric range leaves the crash in place.

Before generating the reply, estimate its size by sampling a few random elements of the key and multiplying their average RESP size by the requested count. Elements on this path are drawn uniformly at random, so `count × mean` is the expected reply size. If it exceeds the new `rand-max-reply-size` limit, the command is rejected with an error before anything is emitted:

```
127.0.0.1:6379> HRANDFIELD myhash -9223372036854775807
(error) ERR count is too large, the reply would exceed the 'rand-max-reply-size' limit of 536870912 bytes
```

The check applies **only to the negative-count path**. A positive count is already bounded by the size of the key, so large positive counts keep returning the whole key exactly as before.

## New config

`rand-max-reply-size` (default `512mb`, `0` disables the check) — the maximum estimated reply size of a `*RAND*` command asking for duplicates.

## Note on the `LONG_MAX / 2` check

The pre-existing `LONG_MAX / 2` check stays where it was, inside the `WITHVALUES` / `WITHSCORES` branch, and is now commented. It guards the RESP2 array length, which holds two entries per element and must not overflow. It was never a memory bound, and hoisting it out of that branch would both fail to fix this bug and regress large positive counts.

## Testing

Verified against the reproducer from #844: server RSS stays flat (4.5MB → 4.9MB) where it previously grew ~290MB/sec until the process died. Ordinary negative counts (`-1000`) and large positive counts are unaffected. New tests cover the limit, the opt-out, and the positive-count path in `hash.tcl`, `set.tcl` and `zset.tcl`.

Fixes #844

Signed-off-by: Warren Zhu <warren.zhu25@gmail.com>
