### PR TITLE
Optimize exact XTRIM MAXLEN zero

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -719,6 +719,15 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
     if (trim_strategy == TRIM_STRATEGY_NONE) return 0;
     if (trim_strategy == TRIM_STRATEGY_MAXLEN && s->length <= maxlen) return 0;
+    if (trim_strategy == TRIM_STRATEGY_MAXLEN && maxlen == 0 && !approx && limit == 0) {
+        int64_t deleted = s->length;
+        raxFreeWithCallback(s->rax, lpFreeVoid);
+        s->rax = raxNew();
+        s->length = 0;
+        s->first_id.ms = 0;
+        s->first_id.seq = 0;
+        return deleted;
+    }
 
     raxIterator ri;
     raxStart(&ri, s->rax);

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -719,6 +719,18 @@ start_server {
         assert {[r XLEN mystream] == 400}
     }
 
+    test {XTRIM with MAXLEN 0 keeps an empty stream key} {
+        r DEL mystream
+        r XADD mystream 1-0 f v
+        r XADD mystream 2-0 f v
+        assert_equal 2 [r XTRIM mystream MAXLEN = 0]
+        assert_equal 1 [r EXISTS mystream]
+        set reply [r XINFO STREAM mystream]
+        assert_equal 0 [dict get $reply length]
+        assert_equal "2-0" [dict get $reply last-generated-id]
+        assert_equal "0-0" [dict get $reply recorded-first-entry-id]
+    }
+
     test {XADD with LIMIT consecutive calls} {
         r del mystream
         r config set stream-node-max-entries 10


### PR DESCRIPTION
Exact `XTRIM key MAXLEN = 0` removes every stream entry while retaining the stream key and its metadata. The generic path removes radix-tree nodes individually and repeatedly re-positions its iterator, even though the final entry tree must be empty.

This change adds a fast path for exact scenario.

| Workload | Baseline RPS | Candidate RPS | Change |
|---|---:|---:|---:|
| `XTRIM MAXLEN = 0` | 14,875.81 | 36,910.15 | **+148.12%** |


Found this fast path while debugging with Codex!