### PR TITLE
Fix module loading tests after async loading guard change

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -692,10 +692,10 @@ foreach testType {Successful Aborted} {
                         assert_error {LOADING*} {$replica REPLICAOF no one}
                     }
 
-                    test {MODULE LOAD is blocked during async-loading} {
+                    test {MODULE LOAD and LOADEX are blocked during async-loading} {
                         set testmodule [file normalize tests/modules/basics.so]
-                        catch {$replica MODULE LOAD $testmodule} err
-                        assert_match "*Error loading module: cannot load module during async replication*" $err
+                        assert_error {LOADING*} {$replica MODULE LOAD $testmodule}
+                        assert_error {LOADING*} {$replica MODULE LOADEX $testmodule}
                     }
 
                     # Make sure that next sync will not start immediately so that we can catch the replica in between syncs

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -336,9 +336,9 @@ start_cluster 3 0 [list config_lines $modules] {
     }
 }
 
-set testmodule [file normalize tests/modules/basics.so]
 start_cluster 2 0 {overrides {cluster-node-timeout 1000}} {
     test "MODULE LOAD is blocked during atomic slot migration" {
+        set testmodule [file normalize tests/modules/basics.so]
         set node0_id [R 0 CLUSTER MYID]
         set node1_id [R 1 CLUSTER MYID]
 


### PR DESCRIPTION
Related to #3039 

After #3039, `MODULE LOAD` is blocked during async replication loading by the command-level `NO_ASYNC_LOADING` guard before execution reaches `moduleLoad()`.

The existing test expected the lower-level module loading error, so it failed even though the command was being blocked correctly.

Failure Link: https://github.com/valkey-io/valkey/actions/runs/29378841117/job/87237862780

Resolves #4170