### PR TITLE
Add per-direction cluster link established counter info fields

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1629,6 +1629,8 @@ void resetClusterStats(void) {
     server.cluster->stats_bus_module_bytes_sent = 0;
     server.cluster->stats_bus_module_bytes_received = 0;
     server.cluster->stat_cluster_links_buffer_limit_exceeded = 0;
+    server.cluster->stat_cluster_links_established_inbound = 0;
+    server.cluster->stat_cluster_links_established_outbound = 0;
 }
 
 void clusterCommandFlushslot(client *c) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1878,6 +1878,10 @@ static void clusterConnAcceptHandler(connection *conn) {
 
     /* Register read handler */
     connSetReadHandler(conn, clusterReadHandler);
+
+    /* Count a successfully accepted (inbound) cluster link. This reflects
+     * how often peers (re)establish connections to us. */
+    server.cluster->stat_cluster_links_established_inbound++;
 }
 
 void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
@@ -4625,6 +4629,10 @@ void clusterLinkConnectHandler(connection *conn) {
 
     /* Register a read handler from now on */
     connSetReadHandler(conn, clusterReadHandler);
+
+    /* Count a successfully connected (outbound) cluster link. This reflects
+     * how often we (re)connect to peers. */
+    server.cluster->stat_cluster_links_established_outbound++;
 
     /* Queue a PING in the new connection ASAP: this is crucial
      * to avoid false positives in failure detection.
@@ -7495,8 +7503,13 @@ sds genClusterInfoString(sds info) {
                      (unsigned long long)server.cluster->stats_bus_module_bytes_sent,
                      (unsigned long long)server.cluster->stats_bus_module_bytes_received);
 
-    info = sdscatfmt(info, "total_cluster_links_buffer_limit_exceeded:%U\r\n",
-                     (unsigned long long)server.cluster->stat_cluster_links_buffer_limit_exceeded);
+    info = sdscatfmt(info,
+                     "total_cluster_links_buffer_limit_exceeded:%U\r\n"
+                     "total_cluster_links_established_inbound:%U\r\n"
+                     "total_cluster_links_established_outbound:%U\r\n",
+                     (unsigned long long)server.cluster->stat_cluster_links_buffer_limit_exceeded,
+                     (unsigned long long)server.cluster->stat_cluster_links_established_inbound,
+                     (unsigned long long)server.cluster->stat_cluster_links_established_outbound);
 
     return info;
 }

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -486,6 +486,10 @@ struct clusterState {
                                                                     excluding nodes without address. */
     unsigned long long stat_cluster_links_buffer_limit_exceeded; /* Total number of cluster links freed due to exceeding
                                                                     buffer limit */
+    unsigned long long stat_cluster_links_established_inbound;   /* Total number of inbound cluster links
+                                                                    successfully established via accept. */
+    unsigned long long stat_cluster_links_established_outbound;  /* Total number of outbound cluster links
+                                                                    successfully established via connect. */
 
     /* Bit map for slots that are no longer claimed by the owner in cluster PING
      * messages. During slot migration, the owner will stop claiming the slot after

--- a/tests/unit/cluster/info.tcl
+++ b/tests/unit/cluster/info.tcl
@@ -61,7 +61,7 @@ start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
             [CI 0 total_cluster_links_established_outbound] >= 2 &&
             [CI 1 total_cluster_links_established_inbound] >= 2 &&
             [CI 1 total_cluster_links_established_outbound] >= 2 &&
-            [CI 2 total_cluster_links_established_outbound] >= 2 &&
+            [CI 2 total_cluster_links_established_inbound] >= 2 &&
             [CI 2 total_cluster_links_established_outbound] >= 2
         } else {
             fail "Cluster established links counters are not as expected"

--- a/tests/unit/cluster/info.tcl
+++ b/tests/unit/cluster/info.tcl
@@ -52,6 +52,22 @@ start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
         }
     }
 
+    test "Cluster info reports established links counters" {
+        # After the cluster is up, both peers must have (re)established
+        # their links with each other: each node accepts one inbound link
+        # and initiates one outbound link.
+        wait_for_condition 1000 50 {
+            [CI 0 total_cluster_links_established_inbound] >= 2 &&
+            [CI 0 total_cluster_links_established_outbound] >= 2 &&
+            [CI 1 total_cluster_links_established_inbound] >= 2 &&
+            [CI 1 total_cluster_links_established_outbound] >= 2 &&
+            [CI 2 total_cluster_links_established_outbound] >= 2 &&
+            [CI 2 total_cluster_links_established_outbound] >= 2
+        } else {
+            fail "Cluster established links counters are not as expected"
+        }
+    }
+
     test "fail reason changed" {
         # Kill one primary, so the cluster fail with not-full-coverage.
         pause_process [srv 0 pid]
@@ -80,7 +96,9 @@ start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
             [CI 0 cluster_stats_messages_received] >= 1 &&
             [CI 0 cluster_stats_bytes_sent] >= 1 &&
             [CI 0 cluster_stats_bytes_received] >= 1 &&
-            [CI 0 total_cluster_links_buffer_limit_exceeded] >= 1
+            [CI 0 total_cluster_links_buffer_limit_exceeded] >= 1 &&
+            [CI 0 total_cluster_links_established_inbound] >= 1 &&
+            [CI 0 total_cluster_links_established_outbound] >= 1
         } else {
             fail "R 0 related info fields are not as expected"
         }
@@ -99,6 +117,8 @@ start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
         assert_equal [getInfoProperty $info cluster_stats_module_bytes_sent] 0
         assert_equal [getInfoProperty $info cluster_stats_module_bytes_received] 0
         assert_equal [getInfoProperty $info total_cluster_links_buffer_limit_exceeded] 0
+        assert_equal [getInfoProperty $info total_cluster_links_established_inbound] 0
+        assert_equal [getInfoProperty $info total_cluster_links_established_outbound] 0
 
         R 0 config set cluster-link-sendbuf-limit 0
     }    


### PR DESCRIPTION
Expose two new CLUSTER INFO counters to track cluster link:
- total_cluster_links_established_inbound: inbound links
  successfully established with peers via accept
- total_cluster_links_established_outbound: outbound links
  successfully established to peers via connect

Unlike the existing topology-derived cluster_connections field,
these are precise cumulative counters incremented when a link
is actually established (on accept, and on successful connect).
They help surface network flapping / frequent re-connections
between nodes.