### PR TITLE
Fix ping_sent getting stuck when peer traffic keeps link alive

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6339,6 +6339,18 @@ void clusterCron(void) {
             freeClusterLink(node->link);
         }
 
+        /* In some situations the check above cannot disconnect the link,
+         * because data_received keeps being refreshed by the peer's own PINGs
+         * even though our PING was lost. If our PING stays outstanding for a
+         * full node timeout without a PONG, force a reconnect so a fresh PING
+         * is sent and the stale state clears. */
+        if (node->link &&
+            now - node->link->ctime > server.cluster_node_timeout &&
+            node->ping_sent && ping_delay > server.cluster_node_timeout) {
+            /* Disconnect the link, it will be reconnected automatically. */
+            freeClusterLink(node->link);
+        }
+
         /* If we have currently no active ping in this instance, and the
          * received PONG is older than half the cluster timeout, send
          * a new ping now, to ensure all the nodes are pinged without

--- a/src/debug.c
+++ b/src/debug.c
@@ -634,9 +634,11 @@ void debugCommand(client *c) {
         long packet_type;
         if (getLongFromObjectOrReply(c, c->argv[2], &packet_type, NULL) != C_OK) return;
         server.cluster_drop_packet_filter = packet_type;
+        serverLog(LL_NOTICE, "Setting drop-cluster-packet-filter to %ld", packet_type);
         addReply(c, shared.ok);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "close-cluster-link-on-packet-drop") && c->argc == 3) {
         server.debug_cluster_close_link_on_packet_drop = atoi(objectGetVal(c->argv[2]));
+        serverLog(LL_NOTICE, "Setting close-cluster-link-on-packet-drop to %d", atoi(objectGetVal(c->argv[2])));
         addReply(c, shared.ok);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "disable-cluster-random-ping") && c->argc == 3) {
         server.debug_cluster_disable_random_ping = atoi(objectGetVal(c->argv[2]));

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -160,6 +160,8 @@ start_cluster 2 0 {tags {cluster external:skip needs:debug}} {
         wait_for_condition 1000 50 {
            [cluster_has_flag [cluster_get_node_by_id 0 $R1_nodeid] "fail?"]
         } else {
+            puts "R 0 cluster nodes:"
+            puts [R 0 cluster nodes]
             fail "R0 did not mark R1 as PFAIL"
         }
 
@@ -180,8 +182,10 @@ start_cluster 2 0 {tags {cluster external:skip needs:debug}} {
 
         # Ensure ping_sent does not get stuck and R0 can send PINGs.
         wait_for_condition 1000 50 {
-           [dict get [cluster_get_node_by_id 0 $R1_nodeid] ping_sent] > $R0_ping_sent
+           [dict get [cluster_get_node_by_id 0 $R1_nodeid] ping_sent] != $R0_ping_sent
         } else {
+            puts "R 0 cluster nodes:"
+            puts [R 0 cluster nodes]
             fail "R0 did not send the PING"
         }
 
@@ -190,6 +194,8 @@ start_cluster 2 0 {tags {cluster external:skip needs:debug}} {
         wait_for_condition 1000 50 {
             ![cluster_has_flag [cluster_get_node_by_id 0 $R1_nodeid] "fail?"]
         } else {
+            puts "R 0 cluster nodes:"
+            puts [R 0 cluster nodes]
             fail "R0 did not remove the PFAIL flag"
         }
         wait_for_cluster_state ok

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -143,3 +143,44 @@ start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-require-full-
         wait_for_cluster_state ok
     }
 }
+
+start_cluster 2 0 {tags {cluster external:skip needs:debug}} {
+    test "A lost PING does not leave a node stuck in PFAIL when the peer keeps sending PINGs" {
+        set CLUSTER_PACKET_TYPE_MEET 2
+        set CLUSTER_PACKET_TYPE_NONE -1
+        set CLUSTER_PACKET_TYPE_ALL -2
+        set R1_nodeid [R 1 cluster myid]
+
+        # Configure different timeout values to better reproduce the issue.
+        R 0 config set cluster-node-timeout 15000
+        R 1 config set cluster-node-timeout 1500
+
+        # Drop all packets on R0 and wait for pfail.
+        R 0 debug drop-cluster-packet-filter $CLUSTER_PACKET_TYPE_ALL
+        wait_for_condition 1000 50 {
+           [cluster_has_flag [cluster_get_node_by_id 0 $R1_nodeid] "fail?"]
+        } else {
+            fail "R0 did not mark R1 as PFAIL"
+        }
+
+        # Restore the DEBUG setting on R0, but exclude MEET first to avoid
+        # multiple MEET reconnections. We will restore it after R0 receives
+        # the PING and refreshes data_received.
+        set R0_ping_received [CI 0 cluster_stats_messages_ping_received]
+        R 0 debug drop-cluster-packet-filter $CLUSTER_PACKET_TYPE_MEET
+        wait_for_condition 1000 50 {
+           [CI 0 cluster_stats_messages_ping_received] > $R0_ping_received
+        } else {
+            fail "R0 did not receive the PING"
+        }
+        R 0 debug drop-cluster-packet-filter $CLUSTER_PACKET_TYPE_NONE
+
+        # All packets are being sent and received normally, and R0 should be
+        # able to remove the PFAIL flag.
+        wait_for_condition 1000 50 {
+            ![cluster_has_flag [cluster_get_node_by_id 0 $R1_nodeid] "fail?"]
+        } else {
+            fail "R0 did not remove the PFAIL flag"
+        }
+    }
+}

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -163,10 +163,13 @@ start_cluster 2 0 {tags {cluster external:skip needs:debug}} {
             fail "R0 did not mark R1 as PFAIL"
         }
 
+        # Remember some information after the PFAIL.
+        set R0_ping_sent [dict get [cluster_get_node_by_id 0 $R1_nodeid] ping_sent]
+        set R0_ping_received [CI 0 cluster_stats_messages_ping_received]
+
         # Restore the DEBUG setting on R0, but exclude MEET first to avoid
         # multiple MEET reconnections. We will restore it after R0 receives
         # the PING and refreshes data_received.
-        set R0_ping_received [CI 0 cluster_stats_messages_ping_received]
         R 0 debug drop-cluster-packet-filter $CLUSTER_PACKET_TYPE_MEET
         wait_for_condition 1000 50 {
            [CI 0 cluster_stats_messages_ping_received] > $R0_ping_received
@@ -175,6 +178,13 @@ start_cluster 2 0 {tags {cluster external:skip needs:debug}} {
         }
         R 0 debug drop-cluster-packet-filter $CLUSTER_PACKET_TYPE_NONE
 
+        # Ensure ping_sent does not get stuck and R0 can send PINGs.
+        wait_for_condition 1000 50 {
+           [dict get [cluster_get_node_by_id 0 $R1_nodeid] ping_sent] > $R0_ping_sent
+        } else {
+            fail "R0 did not send the PING"
+        }
+
         # All packets are being sent and received normally, and R0 should be
         # able to remove the PFAIL flag.
         wait_for_condition 1000 50 {
@@ -182,5 +192,6 @@ start_cluster 2 0 {tags {cluster external:skip needs:debug}} {
         } else {
             fail "R0 did not remove the PFAIL flag"
         }
+        wait_for_cluster_state ok
     }
 }


### PR DESCRIPTION
The broken-link detection in clusterCron only reconnects a link when
no traffic is seen for more than half the node timeout (data_delay >
cluster_node_timeout/2).

This leaves ping_sent unable to advance in this case: while ping_sent
is set we never send another PING (clusterCron skips nodes with an
outstanding ping), and ping_sent is only cleared by a PONG. If the peer
keeps the link alive with its own PINGs (refreshing the data_received)
while our outgoing PING was lost, the link is never reconnected, so
ping_sent stays set forever and we can not send PING.

Force a reconnect when our PING has been outstanding for a full node
timeout without a PONG, independent of data_received. The reconnect itself
sends a fresh PING, letting us receive a PONG and clear the stale state.

A practical example is a two-node cluster: with no third node to confirm
or correct the failure, a lost PING combined with the peer's own PINGs
leaves the node permanently stuck in PFAIL state.