### PR TITLE
ci: run weekly release-branch tests two at a time

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         release-branch: ${{ fromJson(needs.determine-release-branches.outputs.branches) }}
-      max-parallel: 1
+      max-parallel: 2
     uses: ./.github/workflows/daily.yml
     with:
       use_repo: valkey-io/valkey


### PR DESCRIPTION
Bump max-parallel from 1 to 2 so two release branches run concurrently instead of serially. fail-fast stays false.