### PR TITLE
Fix test-s390x unit test invocation for release branches

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -263,6 +263,9 @@ jobs:
               make test-unit
             elif [ -f ./src/valkey-unit-tests ]; then
               ./src/valkey-unit-tests
+            else
+              echo "No unit-test binary was produced"
+              exit 1
             fi
   test-ubuntu-jemalloc-fortify:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -259,7 +259,11 @@ jobs:
             apt-get update
             apt-get install -y build-essential pkg-config libgtest-dev libgmock-dev python3
             make all-with-unit-tests SERVER_CFLAGS='-Werror'
-            ./src/unit/valkey-unit-gtests
+            if [ -f ./src/unit/valkey-unit-gtests ]; then
+              make test-unit
+            elif [ -f ./src/valkey-unit-tests ]; then
+              ./src/valkey-unit-tests
+            fi
   test-ubuntu-jemalloc-fortify:
     runs-on: ubuntu-latest
     if: |


### PR DESCRIPTION
The `test-s390x` job in the daily workflow directly invokes `./src/unit/valkey-unit-gtests`. When the workflow runs against release branches via the weekly test workflow for released branches, the checked-out source builds the old unit test framework binary at `./src/valkey-unit-tests` instead, so the job fails with exit code 127 after completing the full QEMU build — the unit tests never actually run on big endian for release branches.

Example failure (9.0): https://github.com/valkey-io/valkey/actions/runs/29390255527/job/87358434671

This applies the same branch-compatibility pattern that PR 3375 established for the other daily jobs: run `make test-unit` when the gtest binary exists (which also gains gtest-parallel per-test process isolation on unstable), and fall back to directly running the old binary on release branches.

Verification: dispatched the daily workflow from this branch on a fork so the fixed YAML was exercised end-to-end, with only the s390x job enabled. Against the 9.0 release ref (the previously failing scenario) the fallback path ran the old framework binary and passed: 24 test suites executed, 24 passed, 0 failed — https://github.com/valkey-rainfall/valkey/actions/runs/29445130013. Against unstable, `make test-unit` ran the gtests via gtest-parallel and passed — https://github.com/valkey-rainfall/valkey/actions/runs/29445137214.