### PR TITLE
Deflake: replace flaky wall-clock defrag latency assertion with deterministic gtests

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1338,6 +1338,22 @@ int defragRunCycleForTest(monotime endtime) {
 }
 
 
+/* Test seam (declared locally by src/unit/test_defrag.cpp): expose whether a defrag cycle is in
+ * progress, so a test driving defragWhileBlocked() can loop until the cycle completes. */
+int defragTestIsRunning(void) {
+    return defragIsRunning();
+}
+
+
+/* Test seam (declared locally by src/unit/test_defrag.cpp): begin a defrag cycle exactly as
+ * production does -- including registering the event-loop timer that defragIsRunning() keys on --
+ * so a test can drive the cycle through defragWhileBlocked(). The test never runs the event loop;
+ * defragWhileBlocked() itself simulates the timer proc and deregisters the timer on completion. */
+void defragTestBeginCycle(void) {
+    beginDefragCycle();
+}
+
+
 #define INTERPOLATE(x, x1, x2, y1, y2) ((y1) + ((x) - (x1)) * ((y2) - (y1)) / ((x2) - (x1)))
 #define LIMIT(y, min, max) ((y) < (min) ? min : ((y) > (max) ? max : (y)))
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -955,6 +955,16 @@ static doneStatus defragStageKvstoreHelper(monotime endtime,
 }
 
 
+/* Test seam: declared locally by src/unit/test_defrag.cpp (not in a header -- it exists only for
+ * that test). Drives defragStageKvstoreHelper() over `kvs` using a
+ * count-only scan callback, so it exercises the incremental-iteration + endtime-yield contract
+ * without depending on live object defrag or a fragmented heap. Returns 1 for DEFRAG_DONE,
+ * 0 for DEFRAG_NOT_DONE (yielded). */
+int defragTestRunKvstoreStage(monotime endtime, kvstore *kvs) {
+    return defragStageKvstoreHelper(endtime, kvs, scanHashtableCallbackCountScanned, NULL, NULL) == DEFRAG_DONE;
+}
+
+
 // Target is a DBID
 static doneStatus defragStageDbKeys(monotime endtime, void *target, void *privdata) {
     UNUSED(privdata);
@@ -1081,6 +1091,38 @@ static void endDefragCycle(bool normal_termination) {
 }
 
 
+/* Compute the defrag duty-cycle time.  Extracted from computeDefragCycleUs() so it can be
+ * unit-tested without server state or a clock. */
+long defragComputeDutyCycleUs(int targetCpuPercent, long cycleUs, long waitedUs, long *overageUs) {
+    /* Given the elapsed wait time between calls, compute the necessary duty time needed to
+     *  achieve the desired CPU percentage.
+     *  With:  D = duty time, W = wait time, P = percent
+     *  Solve:    D          P
+     *          -----   =  -----
+     *          D + W       100
+     *  Solving for D:
+     *     D = P * W / (100 - P)
+     *
+     * Note that dutyCycleUs addresses starvation.  If the wait time was long, we will compensate
+     *  with a proportionately long duty-cycle.  This won't significantly affect perceived
+     *  latency, because clients are already being impacted by the long cycle time which caused
+     *  the starvation of the timer. */
+    long dutyCycleUs = targetCpuPercent * waitedUs / (100 - targetCpuPercent);
+
+    // Also adjust for any accumulated overage.
+    dutyCycleUs -= *overageUs;
+    *overageUs = 0;
+
+    if (dutyCycleUs < cycleUs) {
+        /* We never reduce our cycle time, that would increase overhead.  Instead, we track this
+         *  as part of the overage, and increase wait time between cycles. */
+        *overageUs = cycleUs - dutyCycleUs;
+        dutyCycleUs = cycleUs;
+    }
+    return dutyCycleUs;
+}
+
+
 /* Must be called at the start of the timeProc as it measures the delay from the end of the previous
  * timeProc invocation when performing the computation. */
 static int computeDefragCycleUs(void) {
@@ -1105,31 +1147,8 @@ static int computeDefragCycleUs(void) {
         dutyCycleUs = server.active_defrag_cycle_us;
     } else {
         long waitedUs = getMonotonicUs() - defrag.timeproc_end_time;
-        /* Given the elapsed wait time between calls, compute the necessary duty time needed to
-         *  achieve the desired CPU percentage.
-         *  With:  D = duty time, W = wait time, P = percent
-         *  Solve:    D          P
-         *          -----   =  -----
-         *          D + W       100
-         *  Solving for D:
-         *     D = P * W / (100 - P)
-         *
-         * Note that dutyCycleUs addresses starvation.  If the wait time was long, we will compensate
-         *  with a proportionately long duty-cycle.  This won't significantly affect perceived
-         *  latency, because clients are already being impacted by the long cycle time which caused
-         *  the starvation of the timer. */
-        dutyCycleUs = targetCpuPercent * waitedUs / (100 - targetCpuPercent);
-
-        // Also adjust for any accumulated overage.
-        dutyCycleUs -= defrag.timeproc_overage_us;
-        defrag.timeproc_overage_us = 0;
-
-        if (dutyCycleUs < server.active_defrag_cycle_us) {
-            /* We never reduce our cycle time, that would increase overhead.  Instead, we track this
-             *  as part of the overage, and increase wait time between cycles. */
-            defrag.timeproc_overage_us = server.active_defrag_cycle_us - dutyCycleUs;
-            dutyCycleUs = server.active_defrag_cycle_us;
-        }
+        dutyCycleUs = defragComputeDutyCycleUs(targetCpuPercent, server.active_defrag_cycle_us,
+                                               waitedUs, &defrag.timeproc_overage_us);
     }
     return dutyCycleUs;
 }
@@ -1162,6 +1181,35 @@ static int computeDelayMs(monotime intendedEndtime) {
 }
 
 
+/* Run defrag stages until the time budget (endtime, monotonic microseconds) is exhausted or all
+ * stages are complete.  Returns true if work remains (the cycle yielded), false if the cycle is
+ * complete.  Extracted from the timer proc so it and the test seam exercise identical scheduling. */
+static bool defragRunStages(monotime endtime) {
+    bool haveMoreWork = true;
+    do {
+        if (!defrag.current_stage) {
+            defrag.current_stage = listNodeValue(listFirst(defrag.remaining_stages));
+            listDelNode(defrag.remaining_stages, listFirst(defrag.remaining_stages));
+            // Initialize the stage with endtime==0
+            doneStatus status = defrag.current_stage->stage_fn(0, defrag.current_stage->target, defrag.current_stage->privdata);
+            serverAssert(status == DEFRAG_NOT_DONE); // Initialization should always return DEFRAG_NOT_DONE
+        }
+
+        doneStatus status = defrag.current_stage->stage_fn(endtime, defrag.current_stage->target, defrag.current_stage->privdata);
+        if (status == DEFRAG_DONE) {
+            zfree(defrag.current_stage);
+            defrag.current_stage = NULL;
+        }
+
+        haveMoreWork = (defrag.current_stage || listLength(defrag.remaining_stages) > 0);
+        /* If we've completed a stage early, and still have a standard time allotment remaining,
+         * we'll start another stage.  This can happen when defrag is running infrequently, and
+         * starvation protection has increased the duty-cycle. */
+    } while (haveMoreWork && getMonotonicUs() <= endtime - server.active_defrag_cycle_us);
+    return haveMoreWork;
+}
+
+
 /* An independent time proc for defrag.  While defrag is running, this is called much more often
  *  than the server cron.  Frequent short calls provides low latency impact. */
 static long long activeDefragTimeProc(struct aeEventLoop *eventLoop, long long id, void *clientData) {
@@ -1187,31 +1235,10 @@ static long long activeDefragTimeProc(struct aeEventLoop *eventLoop, long long i
     monotime starttime = getMonotonicUs();
     int dutyCycleUs = computeDefragCycleUs();
     monotime endtime = starttime + dutyCycleUs;
-    bool haveMoreWork = true;
-
     mstime_t latency;
     latencyStartMonitor(latency);
 
-    do {
-        if (!defrag.current_stage) {
-            defrag.current_stage = listNodeValue(listFirst(defrag.remaining_stages));
-            listDelNode(defrag.remaining_stages, listFirst(defrag.remaining_stages));
-            // Initialize the stage with endtime==0
-            doneStatus status = defrag.current_stage->stage_fn(0, defrag.current_stage->target, defrag.current_stage->privdata);
-            serverAssert(status == DEFRAG_NOT_DONE); // Initialization should always return DEFRAG_NOT_DONE
-        }
-
-        doneStatus status = defrag.current_stage->stage_fn(endtime, defrag.current_stage->target, defrag.current_stage->privdata);
-        if (status == DEFRAG_DONE) {
-            zfree(defrag.current_stage);
-            defrag.current_stage = NULL;
-        }
-
-        haveMoreWork = (defrag.current_stage || listLength(defrag.remaining_stages) > 0);
-        /* If we've completed a stage early, and still have a standard time allotment remaining,
-         * we'll start another stage.  This can happen when defrag is running infrequently, and
-         * starvation protection has increased the duty-cycle. */
-    } while (haveMoreWork && getMonotonicUs() <= endtime - server.active_defrag_cycle_us);
+    bool haveMoreWork = defragRunStages(endtime);
 
     latencyEndMonitor(latency);
     latencyAddSampleIfNeeded("active-defrag-cycle", latency);
@@ -1248,9 +1275,9 @@ void defragWhileBlocked(void) {
 }
 
 
-static void beginDefragCycle(void) {
-    serverAssert(!defragIsRunning());
-
+/* Build the list of defrag stages for a new cycle and reset per-cycle state.  Does NOT register the
+ * event-loop timer -- shared by beginDefragCycle() and the test seam (defragRunCycleForTest). */
+static void defragSetupCycleStages(void) {
     serverAssert(defrag.remaining_stages == NULL);
     defrag.remaining_stages = listCreate();
 
@@ -1278,9 +1305,36 @@ static void beginDefragCycle(void) {
     defrag.start_defrag_hits = server.stat_active_defrag_hits;
     defrag.timeproc_end_time = 0;
     defrag.timeproc_overage_us = 0;
-    defrag.timeproc_id = aeCreateTimeEvent(server.el, 0, activeDefragTimeProc, NULL, NULL);
-
+    /* endDefragCycle() accumulates elapsedUs(stat_last_active_defrag_time) into the total, so
+     * every cycle setup path must start the clock -- not just the timer-proc path. */
     elapsedStart(&server.stat_last_active_defrag_time);
+}
+
+
+static void beginDefragCycle(void) {
+    serverAssert(!defragIsRunning());
+    defragSetupCycleStages();
+    defrag.timeproc_id = aeCreateTimeEvent(server.el, 0, activeDefragTimeProc, NULL, NULL);
+}
+
+
+/* Test seam (declared locally by src/unit/test_defrag.cpp): run one full defrag cycle bounded by
+ * `endtime` (monotonic
+ * microseconds), using the same stage setup and scheduling code as the timer proc but WITHOUT
+ * registering an event-loop timer, so a test can drive it deterministically with a mocked clock.
+ * On the first call of a cycle it sets up the stages; each call runs stages until the budget is
+ * exhausted.  Returns 1 if the cycle completed (and tears it down), 0 if it yielded with work
+ * remaining (call again to continue). */
+int defragRunCycleForTest(monotime endtime) {
+    if (defrag.remaining_stages == NULL && defrag.current_stage == NULL) {
+        defragSetupCycleStages();
+    }
+    bool haveMoreWork = defragRunStages(endtime);
+    if (!haveMoreWork) {
+        endDefragCycle(true);
+        return 1;
+    }
+    return 0;
 }
 
 

--- a/src/unit/test_defrag.cpp
+++ b/src/unit/test_defrag.cpp
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Component tests for active defrag's bounded-latency contract, verified deterministically.
+ *
+ * Active defrag is incremental: each cycle runs stage functions bounded by an `endtime`
+ * (monotonic microseconds) and must YIELD once the time budget is exceeded, so it never blocks
+ * the event loop for long. Verifying this by measuring the wall-clock latency of a defrag cycle is
+ * non-deterministic: wall-clock latency depends on how much CPU time the process is scheduled,
+ * which is outside the engine's control.
+ *
+ * These tests verify the *mechanism* instead of the emergent wall-clock timing: they drive the
+ * real defrag stage/cycle code with `getMonotonicUs` swapped for a deterministic mock clock, and
+ * assert that a stage/cycle yields exactly when its time budget is exceeded and completes when the
+ * budget is ample -- independent of the machine's timing.
+ */
+
+#include "generated_wrappers.hpp"
+
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+#include "allocator_defrag.h"
+#include "server.h"
+}
+
+#include "test_server_fixture.hpp"
+
+/* Active defrag and its test seams in defrag.c are compiled only when the allocator supports defrag
+ * (HAVE_DEFRAG). defrag.c derives HAVE_DEFRAG from the vendored jemalloc (or DEBUG_FORCE_DEFRAG),
+ * but that macro isn't visible to this unit-test translation unit -- the unit build only exposes
+ * USE_JEMALLOC (and drops it for the libc builds used by the sanitizer and macOS CI jobs). Guard on
+ * that so the suite is compiled out exactly where the seam symbols don't exist -- mirroring how
+ * memefficiency.tcl skips its defrag tests on non-jemalloc. */
+#if defined(USE_JEMALLOC) || defined(DEBUG_FORCE_DEFRAG)
+
+/* Defined in defrag.c (compiled only under HAVE_DEFRAG). Declared here rather than in a public
+ * header because they exist only for these tests -- server.h should not carry test-facing surface.
+ * (defragComputeDutyCycleUs is also used within defrag.c; the test is its only external caller.) */
+extern "C" {
+int defragTestRunKvstoreStage(monotime endtime, kvstore *kvs);
+int defragRunCycleForTest(monotime endtime);
+long defragComputeDutyCycleUs(int targetCpuPercent, long cycleUs, long waitedUs, long *overageUs);
+}
+
+/* ---- kvstore entry callbacks: entries are plain C strings (the entry IS the key) ---- */
+static uint64_t defragTestHash(const void *key) {
+    return hashtableGenHashFunction((const char *)key, strlen((const char *)key));
+}
+static int defragTestCmp(const void *k1, const void *k2) {
+    return strcmp((const char *)k1, (const char *)k2) == 0;
+}
+static void defragTestFree(void *entry) {
+    zfree(entry);
+}
+static char *strFromInt(int v) {
+    char buf[32];
+    int len = snprintf(buf, sizeof(buf), "%d", v);
+    char *s = (char *)zmalloc(len + 1);
+    memcpy(s, buf, len);
+    s[len] = '\0';
+    return s;
+}
+
+/* ---- deterministic mock clock: advances by a fixed step on each read ---- */
+static monotime g_now;
+static monotime g_step;
+static monotime mockClock(void) {
+    g_now += g_step;
+    return g_now;
+}
+
+#define DEFRAG_TEST_ENTRIES 5000
+
+class DefragStageTest : public ::testing::Test {
+  protected:
+    hashtableType type;
+    kvstore *kvs;
+    monotime (*saved_clock)(void);
+
+    /* One-time allocator-defrag init is handled lazily by defragTestSupported(). */
+
+    void SetUp() override {
+        /* Active defrag requires an allocator with defrag support (jemalloc). Sanitizer and macOS
+         * builds use libc malloc, where activeDefragAlloc() would hit allocatorShouldDefrag()'s
+         * defrag_supported assertion -- skip there, mirroring memefficiency.tcl's jemalloc gate. */
+        if (!defragTestSupported()) GTEST_SKIP() << "active defrag requires jemalloc";
+
+        memset(&type, 0, sizeof(type));
+        type.hashFunction = defragTestHash;
+        type.keyCompare = defragTestCmp;
+        type.entryDestructor = defragTestFree;
+        /* kvstore requires its own rehashing/mem-tracking callbacks: it maintains an internal
+         * list of rehashing hashtables. Omitting these corrupts that bookkeeping (crash). */
+        type.rehashingStarted = kvstoreHashtableRehashingStarted;
+        type.rehashingCompleted = kvstoreHashtableRehashingCompleted;
+        type.trackMemUsage = kvstoreHashtableTrackMemUsage;
+        type.getMetadataSize = kvstoreHashtableMetadataSize;
+
+        kvs = kvstoreCreate(&type, 0, KVSTORE_ALLOCATE_HASHTABLES_ON_DEMAND);
+        for (int i = 0; i < DEFRAG_TEST_ENTRIES; i++) {
+            kvstoreHashtableAdd(kvs, 0, strFromInt(i));
+        }
+
+        server.stat_active_defrag_hits = 0;
+        server.stat_active_defrag_scanned = 0;
+
+        saved_clock = getMonotonicUs;
+        getMonotonicUs = mockClock;
+        g_now = 0;
+        g_step = 0;
+    }
+
+    void TearDown() override {
+        if (!defragTestSupported()) return; /* SetUp skipped; nothing was allocated */
+        getMonotonicUs = saved_clock;
+        kvstoreRelease(kvs);
+    }
+};
+
+/* With an effectively-infinite budget (clock frozen well below endtime), the stage scans every
+ * entry and reports completion. */
+TEST_F(DefragStageTest, CompletesWhenBudgetAmple) {
+    g_now = 0;
+    g_step = 0; /* clock never advances -> never exceeds endtime */
+
+    (void)defragTestRunKvstoreStage(0, kvs);            /* initialize the stage */
+    int done = defragTestRunKvstoreStage(1000000, kvs); /* huge endtime */
+
+    EXPECT_EQ(done, 1); /* DEFRAG_DONE */
+    /* Reverse-binary scan of a stable table visits each entry at least once. */
+    EXPECT_GE(server.stat_active_defrag_scanned, (long long)DEFRAG_TEST_ENTRIES);
+}
+
+/* With a tight budget and an advancing clock, the stage must yield before finishing. This is the
+ * incrementality contract that keeps per-cycle latency bounded. */
+TEST_F(DefragStageTest, YieldsWhenBudgetExceeded) {
+    g_now = 0;
+    g_step = 10; /* each clock read advances 10us */
+
+    (void)defragTestRunKvstoreStage(0, kvs);        /* initialize the stage (no clock read) */
+    int done = defragTestRunKvstoreStage(100, kvs); /* tiny budget: exceeded after ~10 reads */
+
+    EXPECT_EQ(done, 0);                                                           /* DEFRAG_NOT_DONE -> yielded */
+    EXPECT_GT(server.stat_active_defrag_scanned, (long long)0);                   /* made progress */
+    EXPECT_LT(server.stat_active_defrag_scanned, (long long)DEFRAG_TEST_ENTRIES); /* did not finish */
+}
+
+/*
+ * Same contract, but over a REAL server.db populated via the reusable server-bootstrap fixture.
+ * This exercises the actual database keys kvstore (kvstoreKeysHashtableType + real robjs), proving
+ * the fixture stands up server state that defrag can traverse -- the foundation for the full
+ * cycle-level tests below (DefragCycleTest).
+ */
+class DefragDbStageTest : public ::testing::Test {
+  protected:
+    monotime (*saved_clock)(void);
+
+    void SetUp() override {
+        if (!defragTestSupported()) GTEST_SKIP() << "active defrag requires jemalloc";
+        testServerInitMinimal(4);
+        testServerEmptyAllDbs();
+        for (int i = 0; i < DEFRAG_TEST_ENTRIES; i++) {
+            char kbuf[32];
+            snprintf(kbuf, sizeof(kbuf), "key:%d", i);
+            testServerAddStringKey(0, kbuf, "v");
+        }
+        server.stat_active_defrag_hits = 0;
+        server.stat_active_defrag_scanned = 0;
+        saved_clock = getMonotonicUs;
+        getMonotonicUs = mockClock;
+        g_now = 0;
+        g_step = 0;
+    }
+
+    void TearDown() override {
+        if (!defragTestSupported()) return; /* SetUp skipped */
+        getMonotonicUs = saved_clock;
+        testServerEmptyAllDbs();
+    }
+};
+
+TEST_F(DefragDbStageTest, CompletesOverRealDb) {
+    g_now = 0;
+    g_step = 0;
+
+    (void)defragTestRunKvstoreStage(0, server.db[0]->keys);
+    int done = defragTestRunKvstoreStage(1000000, server.db[0]->keys);
+
+    EXPECT_EQ(done, 1);
+    EXPECT_GE(server.stat_active_defrag_scanned, (long long)DEFRAG_TEST_ENTRIES);
+}
+
+TEST_F(DefragDbStageTest, YieldsOverRealDb) {
+    g_now = 0;
+    g_step = 10;
+
+    (void)defragTestRunKvstoreStage(0, server.db[0]->keys);
+    int done = defragTestRunKvstoreStage(100, server.db[0]->keys);
+
+    EXPECT_EQ(done, 0);
+    EXPECT_GT(server.stat_active_defrag_scanned, (long long)0);
+    EXPECT_LT(server.stat_active_defrag_scanned, (long long)DEFRAG_TEST_ENTRIES);
+}
+
+/*
+ * Full-cycle contract: drive defragRunCycleForTest() -- the whole scheduler (all stages, outer
+ * loop, teardown) -- with the mock clock. This is the faithful, sufficient bounded-latency test:
+ * it covers the outer stage loop and every stage, not just one kvstore helper. Uses the same
+ * server fixture as DefragDbStageTest.
+ */
+class DefragCycleTest : public DefragDbStageTest {};
+
+/* With an ample budget (clock frozen below endtime), a full cycle runs to completion. */
+TEST_F(DefragCycleTest, CompletesFullCycle) {
+    g_now = 0;
+    g_step = 0;
+
+    int done = 0;
+    int guard = 0;
+    while (!done && guard++ < 1000) {
+        done = defragRunCycleForTest(1000000);
+    }
+    EXPECT_EQ(done, 1);
+    EXPECT_LT(guard, 1000); /* completed, not spinning */
+}
+
+/* With a tight budget and an advancing clock, the first cycle invocation yields (work remains);
+ * draining it with an ample budget then completes. Exercises the yield-and-resume path across the
+ * whole scheduler. */
+TEST_F(DefragCycleTest, YieldsThenCompletes) {
+    g_now = 0;
+    g_step = 10; /* clock advances -> budget exceeded mid-cycle */
+
+    int first = defragRunCycleForTest(200);
+    EXPECT_EQ(first, 0); /* yielded with work remaining */
+
+    /* Drain with an ample (frozen) budget. */
+    g_now = 0;
+    g_step = 0;
+    int done = 0;
+    int guard = 0;
+    while (!done && guard++ < 1000) {
+        done = defragRunCycleForTest(1000000);
+    }
+    EXPECT_EQ(done, 1);
+}
+
+/*
+ * Pure-function test of the defrag duty-cycle budget math (defragComputeDutyCycleUs), the piece the
+ * cycle/stage tests structurally can't cover. No server state or clock -- deterministic arithmetic.
+ * dutyCycle = P*W/(100-P), minus carried overage, clamped up to cycleUs (shortfall -> overage).
+ */
+TEST(DefragDutyCycleTest, FormulaClampAndOverage) {
+    long overage;
+
+    /* P=50, W=1000 -> 50*1000/50 = 1000 >= cycle(500): use 1000, no overage. */
+    overage = 0;
+    EXPECT_EQ(defragComputeDutyCycleUs(50, 500, 1000, &overage), 1000L);
+    EXPECT_EQ(overage, 0L);
+
+    /* P=25, W=1000 -> 25000/75 = 333 < 500: clamp to 500, carry overage 500-333=167. */
+    overage = 0;
+    EXPECT_EQ(defragComputeDutyCycleUs(25, 500, 1000, &overage), 500L);
+    EXPECT_EQ(overage, 167L);
+
+    /* Carried overage is subtracted first: P=50, W=1000, overage=200 -> 1000-200=800 >= 500. */
+    overage = 200;
+    EXPECT_EQ(defragComputeDutyCycleUs(50, 500, 1000, &overage), 800L);
+    EXPECT_EQ(overage, 0L);
+
+    /* Short wait clamps to the minimum cycle time: P=50, W=100 -> 100 < 500 -> 500, overage 400. */
+    overage = 0;
+    EXPECT_EQ(defragComputeDutyCycleUs(50, 500, 100, &overage), 500L);
+    EXPECT_EQ(overage, 400L);
+}
+
+#endif /* USE_JEMALLOC || DEBUG_FORCE_DEFRAG */

--- a/src/unit/test_defrag.cpp
+++ b/src/unit/test_defrag.cpp
@@ -45,6 +45,8 @@ extern "C" {
 extern "C" {
 int defragTestRunKvstoreStage(monotime endtime, kvstore *kvs);
 int defragRunCycleForTest(monotime endtime);
+int defragTestIsRunning(void);
+void defragTestBeginCycle(void);
 long defragComputeDutyCycleUs(int targetCpuPercent, long cycleUs, long waitedUs, long *overageUs);
 }
 
@@ -278,6 +280,306 @@ TEST(DefragDutyCycleTest, FormulaClampAndOverage) {
     overage = 0;
     EXPECT_EQ(defragComputeDutyCycleUs(50, 500, 100, &overage), 500L);
     EXPECT_EQ(overage, 400L);
+}
+
+/*
+ * ---- Big-key (defrag_later) coverage ------------------------------------------------------------
+ *
+ * Keys whose field count exceeds `active-defrag-max-scan-fields` are not defragged inline during
+ * the db-keys scan; they are deferred to the `defrag_later` queue and defragged incrementally
+ * (defragLaterStep + per-type scanLater* resume machinery). Single huge keys are where bounded
+ * latency is hardest to maintain -- the cycle must be able to yield *mid-key* and resume. The TCL
+ * big hash/set/zset/list/stream scenarios exercised this path under the wall-clock latency
+ * assertion; these tests pin the same contract deterministically: with a tight mock-clock budget
+ * the full cycle repeatedly yields (never overrunning its deadline), makes progress across calls,
+ * completes, and leaves the data intact.
+ */
+
+#define BIGKEY_FIELDS 10000
+#define BIGKEY_DEFER_THRESHOLD 100 /* test override for active-defrag-max-scan-fields */
+
+static robj *buildBigHash(void) {
+    robj *o = createHashObject();
+    sds val = sdsnew("hash-value-payload-aaaaaaaaaaaaa");
+    for (int i = 0; i < BIGKEY_FIELDS; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "field:%d", i);
+        sds f = sdsnew(buf);
+        bool expired_overwritten = false;
+        /* HASH_SET_COPY: the hash keeps its own copies; converts to hashtable encoding once
+         * hash-max-listpack-entries (default 128) is exceeded. */
+        hashTypeSet(o, f, val, EXPIRY_NONE, HASH_SET_COPY, &expired_overwritten);
+        sdsfree(f);
+    }
+    sdsfree(val);
+    return o;
+}
+
+static robj *buildBigSet(void) {
+    robj *o = createSetObject(); /* hashtable-encoded */
+    for (int i = 0; i < BIGKEY_FIELDS; i++) {
+        char buf[48];
+        snprintf(buf, sizeof(buf), "member-payload-aaaaaaaaaaaaa:%d", i);
+        sds m = sdsnew(buf);
+        setTypeAdd(o, m);
+        sdsfree(m);
+    }
+    return o;
+}
+
+static robj *buildBigZset(void) {
+    robj *o = createZsetObject(); /* skiplist-encoded */
+    for (int i = 0; i < BIGKEY_FIELDS; i++) {
+        char buf[48];
+        snprintf(buf, sizeof(buf), "element-payload-aaaaaaaaaaaa:%d", i);
+        sds e = sdsnew(buf);
+        int out_flags = 0;
+        double newscore = 0;
+        zsetAdd(o, (double)i, e, ZADD_IN_NONE, &out_flags, &newscore);
+        sdsfree(e);
+    }
+    return o;
+}
+
+/* Small fill so the quicklist has many nodes: scanLaterList yields (and bookmarks) between
+ * nodes, so node count -- not element count -- is what drives its incrementality. */
+#define BIGLIST_FILL 4
+
+static robj *buildBigList(void) {
+    robj *o = createQuicklistObject(BIGLIST_FILL, 0);
+    for (int i = 0; i < BIGKEY_FIELDS; i++) {
+        char buf[48];
+        snprintf(buf, sizeof(buf), "list-item-payload-aaaaaaaaaa:%d", i);
+        robj *v = createStringObject(buf, strlen(buf));
+        listTypePush(o, v, LIST_TAIL);
+        decrRefCount(v);
+    }
+    return o;
+}
+
+static robj *buildBigStream(void) {
+    /* One rax entry per append, so raxSize() (the stream defer criterion and the unit
+     * scanLaterStreamListpacks iterates by) exceeds the defer threshold. */
+    long long saved_node_max_entries = server.stream_node_max_entries;
+    server.stream_node_max_entries = 1;
+    robj *o = createStreamObject();
+    stream *s = (stream *)objectGetVal(o);
+    robj *f = createStringObject("field", 5);
+    for (int i = 0; i < BIGKEY_FIELDS; i++) {
+        char buf[48];
+        snprintf(buf, sizeof(buf), "stream-value-payload-aaaaaa:%d", i);
+        robj *v = createStringObject(buf, strlen(buf));
+        robj *argv[2] = {f, v};
+        streamID added_id;
+        streamAppendItem(s, argv, 1, &added_id, NULL, 0);
+        decrRefCount(v);
+    }
+    decrRefCount(f);
+    server.stream_node_max_entries = saved_node_max_entries;
+    return o;
+}
+
+static unsigned long bigKeyLenHash(robj *o) {
+    return hashTypeLength(o);
+}
+static unsigned long bigKeyLenSet(robj *o) {
+    return setTypeSize(o);
+}
+static unsigned long bigKeyLenZset(robj *o) {
+    return zsetLength(o);
+}
+static unsigned long bigKeyLenList(robj *o) {
+    return listTypeLength(o);
+}
+static unsigned long bigKeyLenStream(robj *o) {
+    return (unsigned long)((stream *)objectGetVal(o))->length;
+}
+
+struct DefragBigKeyParam {
+    const char *name;
+    robj *(*build)(void);
+    int expected_encoding;
+    unsigned long (*length)(robj *o);
+    /* Minimum stat_active_defrag_scanned attributable to the deferred key's field/node scan.
+     * 0 for hash and set: their scanLater callbacks defrag fields without bumping the counter,
+     * so per-field progress isn't observable through it. */
+    long long min_scanned;
+};
+
+class DefragBigKeyTestBase : public ::testing::Test {
+  protected:
+    monotime (*saved_clock)(void);
+    unsigned long saved_max_scan_fields;
+
+    void SetUp() override {
+        if (!defragTestSupported()) GTEST_SKIP() << "active defrag requires jemalloc";
+        testServerInitMinimal(4);
+        testServerEmptyAllDbs();
+        saved_max_scan_fields = server.active_defrag_max_scan_fields;
+        server.active_defrag_max_scan_fields = BIGKEY_DEFER_THRESHOLD;
+        server.stat_active_defrag_hits = 0;
+        server.stat_active_defrag_scanned = 0;
+        saved_clock = getMonotonicUs;
+        getMonotonicUs = mockClock;
+        g_now = 0;
+        g_step = 0;
+    }
+
+    void TearDown() override {
+        if (!defragTestSupported()) return; /* SetUp skipped; nothing was set up */
+        getMonotonicUs = saved_clock;
+        server.active_defrag_max_scan_fields = saved_max_scan_fields;
+        testServerEmptyAllDbs();
+    }
+};
+
+class DefragBigKeyTest : public DefragBigKeyTestBase, public ::testing::WithParamInterface<DefragBigKeyParam> {};
+
+/* Per-call mock-clock budget (~10 clock reads at g_step=10) and the permitted overshoot. After the
+ * deadline passes, every code path reaches a time check within a bounded number of reads, so the
+ * clock may only run a few reads past the deadline -- THAT bound is the latency contract. Time
+ * checks happen at bounded work intervals (16 kvstore buckets / 128 stream entries / each list
+ * node), so per-call work is bounded even though the intervals themselves don't read the clock. */
+#define BIGKEY_CALL_BUDGET 100
+#define BIGKEY_OVERSHOOT_SLACK 200
+
+TEST_P(DefragBigKeyTest, DeferredKeyYieldsIncrementallyAndCompletes) {
+    const DefragBigKeyParam &p = GetParam();
+
+    robj *ob = p.build();
+    ASSERT_EQ(ob->encoding, p.expected_encoding);
+    unsigned long len_before = p.length(ob);
+    ASSERT_GT(len_before, (unsigned long)BIGKEY_DEFER_THRESHOLD); /* must take the defrag_later path */
+    testServerAddObjectKey(0, "bigkey", ob);
+    /* NOTE: `ob` may be relocated by defrag below; re-find it from the db afterwards. */
+
+    g_step = 10;
+    int done = 0;
+    int calls = 0;
+    while (!done && calls < 10000) {
+        monotime deadline = g_now + BIGKEY_CALL_BUDGET;
+        done = defragRunCycleForTest(deadline);
+        calls++;
+        ASSERT_LE(g_now, deadline + BIGKEY_OVERSHOOT_SLACK) << "defrag cycle overran its time budget";
+    }
+    ASSERT_EQ(done, 1) << "cycle did not complete within the call guard";
+    /* The deferred key must force multiple yield/resume rounds -- an empty-db cycle finishes in
+     * ~2 calls at this budget; the big key's incremental scan dominates. */
+    EXPECT_GE(calls, 4);
+    if (p.min_scanned > 0) {
+        EXPECT_GE(server.stat_active_defrag_scanned, p.min_scanned);
+    }
+
+    /* Data integrity across the incremental defrag. */
+    sds key = sdsnew("bigkey");
+    robj *found = dbFind(server.db[0], key);
+    sdsfree(key);
+    ASSERT_TRUE(found != NULL);
+    EXPECT_EQ(found->encoding, p.expected_encoding);
+    EXPECT_EQ(p.length(found), len_before);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Types,
+    DefragBigKeyTest,
+    ::testing::Values(DefragBigKeyParam{"hash", buildBigHash, OBJ_ENCODING_HASHTABLE, bigKeyLenHash, 0},
+                      DefragBigKeyParam{"set", buildBigSet, OBJ_ENCODING_HASHTABLE, bigKeyLenSet, 0},
+                      DefragBigKeyParam{"zset", buildBigZset, OBJ_ENCODING_SKIPLIST, bigKeyLenZset, BIGKEY_FIELDS},
+                      DefragBigKeyParam{"list", buildBigList, OBJ_ENCODING_QUICKLIST, bigKeyLenList,
+                                        BIGKEY_FIELDS / BIGLIST_FILL},
+                      DefragBigKeyParam{"stream", buildBigStream, OBJ_ENCODING_STREAM, bigKeyLenStream,
+                                        BIGKEY_FIELDS}),
+    [](const ::testing::TestParamInfo<DefragBigKeyParam> &info) { return std::string(info.param.name); });
+
+/*
+ * scanLaterList suspend/resume is uniquely stateful: a mid-list yield records position via a
+ * quicklist bookmark ("_AD") and completion deletes it. Verify the bookmark's lifecycle across
+ * yields -- present during at least one yielded state, absent after completion.
+ */
+class DefragListBookmarkTest : public DefragBigKeyTestBase {};
+
+TEST_F(DefragListBookmarkTest, BookmarkLifecycleAcrossYields) {
+    robj *ob = buildBigList();
+    ASSERT_EQ(ob->encoding, OBJ_ENCODING_QUICKLIST);
+    unsigned long len_before = listTypeLength(ob);
+    testServerAddObjectKey(0, "biglist", ob);
+    sds key = sdsnew("biglist");
+
+    g_step = 10;
+    bool saw_bookmark = false;
+    int done = 0;
+    int calls = 0;
+    while (!done && calls < 10000) {
+        done = defragRunCycleForTest(g_now + BIGKEY_CALL_BUDGET);
+        calls++;
+        robj *cur = dbFind(server.db[0], key);
+        ASSERT_TRUE(cur != NULL);
+        quicklist *ql = (quicklist *)objectGetVal(cur);
+        if (!done && quicklistBookmarkFind(ql, "_AD") != NULL) saw_bookmark = true;
+    }
+    ASSERT_EQ(done, 1);
+    EXPECT_TRUE(saw_bookmark) << "expected a mid-list yield to leave the _AD resume bookmark";
+
+    robj *cur = dbFind(server.db[0], key);
+    ASSERT_TRUE(cur != NULL);
+    quicklist *ql = (quicklist *)objectGetVal(cur);
+    EXPECT_TRUE(quicklistBookmarkFind(ql, "_AD") == NULL) << "resume bookmark must be removed on completion";
+    EXPECT_EQ(listTypeLength(cur), len_before);
+    sdsfree(key);
+}
+
+/*
+ * ---- defragWhileBlocked (AOF loading / long script) driver --------------------------------------
+ *
+ * During loading and long scripts, timers are inactive and defrag is driven by whileBlockedCron()
+ * -> defragWhileBlocked(), which simulates a single timer-proc call: it computes its own duty-cycle
+ * budget and must stay within it. This is the path the TCL "Active defrag - AOF loading" scenario's
+ * validate_latency(500) covered. Verify with the mock clock: each defragWhileBlocked() call
+ * consumes at most the duty cycle (+ bounded overshoot), and repeated calls finish the cycle.
+ *
+ * The cycle is started via defragTestBeginCycle (production beginDefragCycle, including the
+ * event-loop timer registration that defragIsRunning() keys on) rather than letting
+ * defragWhileBlocked go through monitorActiveDefrag(), whose start/stop decision depends on live
+ * allocator fragmentation stats and would be nondeterministic.
+ */
+class DefragBlockedCronTest : public DefragBigKeyTestBase {};
+
+TEST_F(DefragBlockedCronTest, BlockedDriverRespectsDutyCycleAndCompletes) {
+    robj *ob = buildBigHash();
+    unsigned long len_before = hashTypeLength(ob);
+    testServerAddObjectKey(0, "bigkey", ob);
+
+    /* activeDefragTimeProc preconditions: enabled, a legal CPU percent, and no child process
+     * (a child pauses defrag indefinitely). */
+    server.active_defrag_enabled = 1;
+    server.active_defrag_cpu_percent = 50;
+    server.child_pid = -1;
+    int saved_cycle_us = server.active_defrag_cycle_us;
+    server.active_defrag_cycle_us = 500; /* the per-call duty cycle floor */
+
+    g_step = 10;
+
+    defragTestBeginCycle();
+    ASSERT_TRUE(defragTestIsRunning());
+
+    int calls = 0;
+    while (defragTestIsRunning() && calls < 10000) {
+        monotime before = g_now;
+        defragWhileBlocked();
+        calls++;
+        /* Duty cycle is clamped to at least active_defrag_cycle_us; allow bounded overshoot for
+         * the driver's own bookkeeping clock reads. */
+        ASSERT_LE(g_now - before, (monotime)(2 * 500)) << "blocked-cron defrag call overran its duty cycle";
+    }
+    server.active_defrag_cycle_us = saved_cycle_us;
+    ASSERT_LT(calls, 10000) << "blocked-cron driver did not finish the cycle";
+    EXPECT_GE(calls, 2); /* the deferred big hash must span multiple blocked-cron calls */
+
+    sds key = sdsnew("bigkey");
+    robj *found = dbFind(server.db[0], key);
+    sdsfree(key);
+    ASSERT_TRUE(found != NULL);
+    EXPECT_EQ(hashTypeLength(found), len_before);
 }
 
 #endif /* USE_JEMALLOC || DEBUG_FORCE_DEFRAG */

--- a/src/unit/test_defrag.cpp
+++ b/src/unit/test_defrag.cpp
@@ -447,7 +447,7 @@ TEST_P(DefragBigKeyTest, DeferredKeyYieldsIncrementallyAndCompletes) {
     const DefragBigKeyParam &p = GetParam();
 
     robj *ob = p.build();
-    ASSERT_EQ(ob->encoding, p.expected_encoding);
+    ASSERT_EQ((int)ob->encoding, p.expected_encoding);
     unsigned long len_before = p.length(ob);
     ASSERT_GT(len_before, (unsigned long)BIGKEY_DEFER_THRESHOLD); /* must take the defrag_later path */
     testServerAddObjectKey(0, "bigkey", ob);
@@ -475,7 +475,7 @@ TEST_P(DefragBigKeyTest, DeferredKeyYieldsIncrementallyAndCompletes) {
     robj *found = dbFind(server.db[0], key);
     sdsfree(key);
     ASSERT_TRUE(found != NULL);
-    EXPECT_EQ(found->encoding, p.expected_encoding);
+    EXPECT_EQ((int)found->encoding, p.expected_encoding);
     EXPECT_EQ(p.length(found), len_before);
 }
 
@@ -500,7 +500,7 @@ class DefragListBookmarkTest : public DefragBigKeyTestBase {};
 
 TEST_F(DefragListBookmarkTest, BookmarkLifecycleAcrossYields) {
     robj *ob = buildBigList();
-    ASSERT_EQ(ob->encoding, OBJ_ENCODING_QUICKLIST);
+    ASSERT_EQ((int)ob->encoding, OBJ_ENCODING_QUICKLIST);
     unsigned long len_before = listTypeLength(ob);
     testServerAddObjectKey(0, "biglist", ob);
     sds key = sdsnew("biglist");

--- a/src/unit/test_server_fixture.cpp
+++ b/src/unit/test_server_fixture.cpp
@@ -35,12 +35,12 @@ void evalInit(void);
  * defrag_supported assertion. Sentinel 1 = not yet initialized (allocatorDefragInit returns 0/-1). */
 static int g_defrag_init_rc = 1;
 
-static void ensureDefragInit(void) {
+void testAllocatorDefragInitOnce(void) {
     if (g_defrag_init_rc == 1) g_defrag_init_rc = allocatorDefragInit();
 }
 
 bool defragTestSupported(void) {
-    ensureDefragInit();
+    testAllocatorDefragInitOnce();
     return g_defrag_init_rc == 0;
 }
 
@@ -49,7 +49,7 @@ void testServerInitMinimal(int dbnum) {
     if (!process_inited) {
         testLsanDisable();
         /* Enable activeDefragAlloc(): allocatorShouldDefrag() asserts defrag_supported. */
-        ensureDefragInit();
+        testAllocatorDefragInitOnce();
         /* Populate all config defaults, including active_defrag_* and maxmemory_policy. */
         initServerConfig();
         /* Initialize the modules subsystem: dbAdd() -> notifyKeyspaceEvent() unconditionally calls

--- a/src/unit/test_server_fixture.cpp
+++ b/src/unit/test_server_fixture.cpp
@@ -96,13 +96,16 @@ void testServerInitMinimal(int dbnum) {
     }
 }
 
-void testServerAddStringKey(int dbid, const char *key, const char *val) {
+void testServerAddObjectKey(int dbid, const char *key, robj *val) {
     robj *k = createStringObject(key, strlen(key));
-    robj *v = createStringObject(val, strlen(val));
     /* dbAdd() copies the key's sds into the stored value object and takes ownership of the
      * value (via valref); it does not take ownership of the key robj. */
-    dbAdd(server.db[dbid], k, &v);
+    dbAdd(server.db[dbid], k, &val);
     decrRefCount(k);
+}
+
+void testServerAddStringKey(int dbid, const char *key, const char *val) {
+    testServerAddObjectKey(dbid, key, createStringObject(val, strlen(val)));
 }
 
 void testServerEmptyAllDbs(void) {

--- a/src/unit/test_server_fixture.cpp
+++ b/src/unit/test_server_fixture.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "test_server_fixture.hpp"
+
+extern "C" {
+#include "allocator_defrag.h"
+/* Defined in server.c but not exposed in any header (used internally and from main()). */
+void initServerConfig(void);
+void createSharedObjects(void);
+void moduleInitModulesSystem(void);
+void evalInit(void);
+}
+
+#include <cstring>
+
+/* The one-time server bootstrap below (config, shared objects, module system, eval, event loop)
+ * is intentionally never torn down -- it lives for the whole test process. Suppress LeakSanitizer
+ * reporting for these allocations so per-test leaks are still caught on sanitizer builds. */
+#ifdef VALKEY_ADDRESS_SANITIZER
+#include <sanitizer/lsan_interface.h>
+#define testLsanDisable() __lsan_disable()
+#define testLsanEnable() __lsan_enable()
+#else
+#define testLsanDisable()
+#define testLsanEnable()
+#endif
+
+/* allocatorDefragInit() may be called only once and returns -1 when the allocator has no active-
+ * defrag support (e.g. libc malloc, which sanitizer and macOS builds use). Cache the result so
+ * tests can skip the defrag paths where they'd otherwise hit allocatorShouldDefrag()'s
+ * defrag_supported assertion. Sentinel 1 = not yet initialized (allocatorDefragInit returns 0/-1). */
+static int g_defrag_init_rc = 1;
+
+static void ensureDefragInit(void) {
+    if (g_defrag_init_rc == 1) g_defrag_init_rc = allocatorDefragInit();
+}
+
+bool defragTestSupported(void) {
+    ensureDefragInit();
+    return g_defrag_init_rc == 0;
+}
+
+void testServerInitMinimal(int dbnum) {
+    static int process_inited = 0;
+    if (!process_inited) {
+        testLsanDisable();
+        /* Enable activeDefragAlloc(): allocatorShouldDefrag() asserts defrag_supported. */
+        ensureDefragInit();
+        /* Populate all config defaults, including active_defrag_* and maxmemory_policy. */
+        initServerConfig();
+        /* Initialize the modules subsystem: dbAdd() -> notifyKeyspaceEvent() unconditionally calls
+         * moduleNotifyKeyspaceEvent(), which dereferences module subscriber structures. This also
+         * makes the defragModuleGlobals stage safe for the full-cycle test. Order matches main(). */
+        moduleInitModulesSystem();
+        createSharedObjects();
+        /* Initialize the Lua/eval subsystem so the defragLuaScripts stage's evalScriptsDict()
+         * returns a valid (empty) dict instead of dereferencing NULL in the full-cycle test. */
+        evalInit();
+        /* beginDefragCycle() registers a timer via aeCreateTimeEvent(server.el, ...). */
+        server.el = aeCreateEventLoop(128);
+        testLsanEnable();
+        process_inited = 1;
+    }
+
+    /* Deterministic, dependency-light environment for defrag component tests. */
+    server.cluster_enabled = 0;
+    server.latency_monitor_threshold = 0; /* skip the latency-event dict dependency */
+    server.notify_keyspace_events = 0;    /* so dbAdd() does not touch pubsub */
+    server.maxmemory = 0;
+    /* The cycle scheduler's outer loop tests `getMonotonicUs() <= endtime - active_defrag_cycle_us`
+     * on unsigned monotime. Production is safe because endtime is an absolute monotonic time far
+     * larger than active_defrag_cycle_us, but a test that passes a small endtime would underflow
+     * (endtime < cycle_us -> ~1.8e19), making the budget effectively infinite and the cycle spin
+     * forever. Setting cycle_us to 0 removes the subtraction; the per-stage endtime checks still
+     * enforce the real bounded-latency (yield) contract. */
+    server.active_defrag_cycle_us = 0;
+
+    if (server.db == NULL) {
+        testLsanDisable();
+        server.dbnum = dbnum;
+        server.db = (serverDb **)zcalloc(sizeof(serverDb *) * server.dbnum);
+        for (int i = 0; i < server.dbnum; i++) createDatabaseIfNeeded(i);
+        server.pubsub_channels =
+            kvstoreCreate(&kvstoreChannelHashtableType, 0, KVSTORE_ALLOCATE_HASHTABLES_ON_DEMAND);
+        server.pubsubshard_channels =
+            kvstoreCreate(&kvstoreChannelHashtableType, 0,
+                          KVSTORE_ALLOCATE_HASHTABLES_ON_DEMAND | KVSTORE_FREE_EMPTY_HASHTABLES);
+        testLsanEnable();
+    } else {
+        /* The first caller's dbnum wins for the whole process; make a mismatch loud. */
+        serverAssert(server.dbnum == dbnum);
+    }
+}
+
+void testServerAddStringKey(int dbid, const char *key, const char *val) {
+    robj *k = createStringObject(key, strlen(key));
+    robj *v = createStringObject(val, strlen(val));
+    /* dbAdd() copies the key's sds into the stored value object and takes ownership of the
+     * value (via valref); it does not take ownership of the key robj. */
+    dbAdd(server.db[dbid], k, &v);
+    decrRefCount(k);
+}
+
+void testServerEmptyAllDbs(void) {
+    if (server.db == NULL) return;
+    for (int i = 0; i < server.dbnum; i++) {
+        serverDb *db = server.db[i];
+        if (db == NULL) continue;
+        /* Entry destructors from the kvstore hashtable types free the stored objects. */
+        kvstoreEmpty(db->keys, NULL);
+        kvstoreEmpty(db->expires, NULL);
+        kvstoreEmpty(db->keys_with_volatile_items, NULL);
+    }
+}

--- a/src/unit/test_server_fixture.hpp
+++ b/src/unit/test_server_fixture.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Reusable minimal in-process server bootstrap for component tests.
+ *
+ * Valkey has no in-process "boot a real server" test tier -- the integration tests spawn a real
+ * valkey-server process, and existing gtests are low-level (they never initialize server.db).
+ * Component tests for subsystems that operate on live server state (e.g. active defrag) need
+ * enough of the server stood up in-process to exercise the real code paths.
+ *
+ * testServerInitMinimal() brings up: allocator-defrag support, config defaults, shared objects,
+ * the modules and eval subsystems (initialized empty, so stages/notifications that touch them are
+ * safe no-ops), an event loop, `dbnum` databases (with their keys/expires/keys_with_volatile_items
+ * kvstores), and the pubsub kvstores. That is sufficient to drive active-defrag's kvstore stages
+ * and the full defrag cycle over a real server.db. It deliberately omits networking, cluster,
+ * threads, and background jobs.
+ */
+
+#ifndef __TEST_SERVER_FIXTURE_HPP
+#define __TEST_SERVER_FIXTURE_HPP
+
+/* Must precede server.h: provides the harness C++ prelude (fmacros, _Atomic handling, gtest). */
+#include "generated_wrappers.hpp"
+
+extern "C" {
+#include "server.h"
+}
+
+/* Bring up minimal server state (idempotent per process). `dbnum` databases are created. */
+void testServerInitMinimal(int dbnum);
+
+/* Add a real string key/value to database `dbid` via the normal dbAdd() path. */
+void testServerAddStringKey(int dbid, const char *key, const char *val);
+
+/* Free all keys in all databases. Safe for keys without TTLs / volatile items (the common
+ * case for these tests). Call between tests to avoid cross-test contamination. */
+void testServerEmptyAllDbs(void);
+
+/* True if active defrag is available (allocator has defrag support, i.e. jemalloc). Also serves
+ * as the process-wide once-only gate for allocatorDefragInit(), which asserts if called twice --
+ * ALL test suites needing allocator-defrag support must init through this, never directly.
+ * Sanitizer and macOS builds use libc malloc, where the defrag scan would hit
+ * allocatorShouldDefrag()'s defrag_supported assertion -- defrag-exercising tests should
+ * GTEST_SKIP() when this is false. */
+bool defragTestSupported(void);
+
+#endif /* __TEST_SERVER_FIXTURE_HPP */

--- a/src/unit/test_server_fixture.hpp
+++ b/src/unit/test_server_fixture.hpp
@@ -40,10 +40,13 @@ void testServerAddStringKey(int dbid, const char *key, const char *val);
  * case for these tests). Call between tests to avoid cross-test contamination. */
 void testServerEmptyAllDbs(void);
 
-/* True if active defrag is available (allocator has defrag support, i.e. jemalloc). Also serves
- * as the process-wide once-only gate for allocatorDefragInit(), which asserts if called twice --
- * ALL test suites needing allocator-defrag support must init through this, never directly.
- * Sanitizer and macOS builds use libc malloc, where the defrag scan would hit
+/* Initialize allocator-defrag support, once per process (idempotent). allocatorDefragInit()
+ * asserts if called twice, so ALL test suites needing it must init through this -- never call
+ * allocatorDefragInit() directly. Safe to call from any suite's SetUpTestSuite(). */
+void testAllocatorDefragInitOnce(void);
+
+/* True if active defrag is available (allocator has defrag support, i.e. jemalloc); initializes
+ * on first use. Sanitizer and macOS builds use libc malloc, where the defrag scan would hit
  * allocatorShouldDefrag()'s defrag_supported assertion -- defrag-exercising tests should
  * GTEST_SKIP() when this is false. */
 bool defragTestSupported(void);

--- a/src/unit/test_server_fixture.hpp
+++ b/src/unit/test_server_fixture.hpp
@@ -36,6 +36,10 @@ void testServerInitMinimal(int dbnum);
 /* Add a real string key/value to database `dbid` via the normal dbAdd() path. */
 void testServerAddStringKey(int dbid, const char *key, const char *val);
 
+/* Add an arbitrary (typed) value object under `key` in database `dbid` via the normal dbAdd()
+ * path. Ownership of `val` passes to the database (as with dbAdd); the key name is copied. */
+void testServerAddObjectKey(int dbid, const char *key, robj *val);
+
 /* Free all keys in all databases. Safe for keys without TTLs / volatile items (the common
  * case for these tests). Call between tests to avoid cross-test contamination. */
 void testServerEmptyAllDbs(void);

--- a/src/unit/test_vset.cpp
+++ b/src/unit/test_vset.cpp
@@ -168,10 +168,7 @@ static int free_mock_entries(void) {
 class VsetTest : public ::testing::Test {
   protected:
     static void SetUpTestSuite() {
-        /* allocatorDefragInit() may only be called once per process (it asserts on a second
-         * call). Route through the shared once-only helper so any combination of suites that
-         * need allocator-defrag support can run in one process. */
-        (void)defragTestSupported();
+        testAllocatorDefragInitOnce();
     }
 
     void TearDown() override {

--- a/src/unit/test_vset.cpp
+++ b/src/unit/test_vset.cpp
@@ -6,6 +6,8 @@
 
 #include "generated_wrappers.hpp"
 
+#include "test_server_fixture.hpp"
+
 /* Ensure assert() is never compiled out, even in Release builds. */
 #undef NDEBUG
 #include <cassert>
@@ -166,7 +168,10 @@ static int free_mock_entries(void) {
 class VsetTest : public ::testing::Test {
   protected:
     static void SetUpTestSuite() {
-        allocatorDefragInit();
+        /* allocatorDefragInit() may only be called once per process (it asserts on a second
+         * call). Route through the shared once-only helper so any combination of suites that
+         * need allocator-defrag support can run in one process. */
+        (void)defragTestSupported();
     }
 
     void TearDown() override {

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -89,9 +89,6 @@ run_solo {defrag} {
     # Start defrag and wait for it to stop
     # The optional code block is executed after defrag has started
     proc perform_defrag {{code_block {}}} {
-        r config set latency-monitor-threshold 5
-        r latency reset
-
         set old_defrag_time [s total_active_defrag_time]
         r config set activedefrag yes
 
@@ -123,28 +120,6 @@ run_solo {defrag} {
 
         r config set activedefrag no
         after 120 ;# ensure memory stats are current when function exits
-    }
-
-    # Checks for any significant latency events
-    proc validate_latency {limit_ms} {
-        if {!$::no_latency} {
-            set max_latency 0
-            foreach event [r latency latest] {
-                lassign $event eventname time latency max
-                if {$eventname == "active-defrag-cycle" || $eventname == "while-blocked-cron"} {
-                    set max_latency $max
-                }
-            }
-            if {$::verbose} {
-                puts "Validating max latency ($max_latency) is LT $limit_ms"
-                if {$max_latency > 0} {
-                    puts [r latency latest]
-                    puts [r latency history active-defrag-cycle]
-                    puts [r latency history while-blocked-cron]
-                }
-            }
-            assert {$max_latency <= $limit_ms}
-        }
     }
 
     # Validate expected fragmentation ratio
@@ -181,9 +156,7 @@ run_solo {defrag} {
     #    populate {code} - required, populates initial unfragmented data
     #    fragment {code} - required, fragments the populated data
     #    while_defragging {code} - optional, code executed after defrag has started
-    #    latency <ms> - optional, verifies the latency to a ms target (default 5)
     proc perform_defrag_test {name args} {
-        set opts(latency) 5
         set opts(while_defragging) {}
         array set opts $args
         assert {[info exists opts(populate)]}
@@ -233,7 +206,6 @@ run_solo {defrag} {
 
         log_frag "after defragging"
         validate_frag_ratio < 1.1
-        validate_latency $opts(latency)
 
         # verify the data isn't corrupted or changed
         set newdigest [debug_digest]
@@ -306,13 +278,6 @@ run_solo {defrag} {
 
                 log_frag "after AOF loading"
 
-                # The AOF contains simple (fast) SET commands (and the cron during loading runs every 1024 commands).
-                # Even so, defrag can get starved for periods exceeding 100ms.  Using 200ms for test stability, and
-                # a 50% CPU requirement, we should allow up to 200ms latency
-                # (as total time = 200 non duty + 200 duty = 400ms, and 50% of 400ms is 200ms).
-                # Added buffer of 300ms to accommodate for slow CI runners
-                validate_latency 500
-
                 # Make sure we had defrag hits during AOF loading.  Note that we don't worry about
                 # the actual fragmentation ratio here.  It will vary based on when defrag stopped
                 # mid-cycle.  Just check that we are defragging by the number of hits.
@@ -327,8 +292,7 @@ run_solo {defrag} {
         test $title {
             set n 50000
 
-            # scripts aren't defragged incrementally, expect big latency
-            perform_defrag_test $title latency 200 populate {
+            perform_defrag_test $title populate {
                 # Populate memory with interleaving script-key pattern of same size
                 set dummy_script "--[string repeat x 450]\nreturn "
                 set rd [valkey_deferring_client]
@@ -387,7 +351,7 @@ run_solo {defrag} {
             # number of total fields.  lists are progressively increasing sizes.
             set n 200000
 
-            perform_defrag_test $title latency 5 populate {
+            perform_defrag_test $title populate {
                 set rd [valkey_deferring_client]
                 $rd client reply off
                 set val [string repeat A 350]


### PR DESCRIPTION
The `validate_latency` assertion in `tests/unit/memefficiency.tcl` bounds the wall-clock `active-defrag-cycle` latency event (5ms; 500ms for AOF loading). On shared CI runners this measures CPU steal, not defrag behaviour: in a 100-loop run of `unit/memefficiency` on a contended runner, 2928 of 3264 Active Defrag test executions failed (~90%), every single one on `validate_latency` (observed max_latency 12-31ms), with zero failures in any other assertion ([before run](https://github.com/valkey-rainfall/valkey/actions/runs/29391497346)). This is the largest source of CI noise in this file (see issue 2444; the AOF-loading bound was already raised 200ms to 500ms in May and still fails).

The property this assertion is trying to protect — active defrag is incremental, each cycle respects its time budget and yields — is testable deterministically. This PR adds gtest component tests that drive the real defrag stage and cycle code with `getMonotonicUs` swapped for a mock clock, and removes the wall-clock assertion whose intent they now cover.

**Commit 1** adds the tests and minimal seams in `defrag.c`:

- `defragTestRunKvstoreStage(endtime, kvs)` — runs one kvstore stage with a count-only scan callback
- `defragRunCycleForTest(endtime)` — runs the full cycle scheduler (stage setup, outer loop, teardown) without registering an event-loop timer
- `defragComputeDutyCycleUs(...)` — duty-cycle budget arithmetic extracted from `computeDefragCycleUs()` as a pure function

7 tests: stage completes with ample budget / yields when budget exceeded (over a synthetic kvstore and over a real `server.db[0]->keys`), full cycle completes / yields-then-resumes, and duty-cycle formula clamp/overage. Compiled only under `USE_JEMALLOC`/`DEBUG_FORCE_DEFRAG`, mirroring the Tcl tests' jemalloc gate. Also adds `test_server_fixture.cpp/.hpp`, a minimal reusable in-process server bootstrap (config, shared objects, `server.db[]`, pubsub kvstores) for component tests that need real server state.

**Commit 2** removes `validate_latency`, its call sites, and the latency-monitor setup that only fed it. The fragmentation-drop assertions, digest integrity check, and `active_defrag_hits` check are unchanged — the Tcl tests still verify defrag reclaims memory.

**Verification:** 100-loop soak of `unit/memefficiency` with this change: 0 failures ([after run](https://github.com/valkey-rainfall/valkey/actions/runs/29435622139), jemalloc job; arm job hit an unrelated apt mirror outage, re-run in progress). All 7 gtests pass in 5-15ms each.