### PR TITLE
Deflake aofrw child-kill wait and failover completion wait

### DIFF
--- a/tests/integration/failover.tcl
+++ b/tests/integration/failover.tcl
@@ -79,8 +79,9 @@ start_server {overrides {save {}}} {
         # Execute the failover
         $node_0 failover to $node_1_host $node_1_port
 
-        # Wait for failover to end
-        wait_for_condition 50 100 {
+        # Wait for failover to end. Budget is generous for loaded CI runners;
+        # the failover must still complete, so this cannot hide a hang.
+        wait_for_condition 100 200 {
             [s 0 master_failover_state] == "no-failover"
         } else {
             fail "Failover from node 0 to node 1 did not finish"

--- a/tests/unit/aofrw.tcl
+++ b/tests/unit/aofrw.tcl
@@ -73,12 +73,9 @@ start_server {tags {"aofrw external:skip"} overrides {aof-use-rdb-preamble no}} 
         r bgrewriteaof
 
         # disable AOF and wait for the child to be killed
+        set loglines [count_log_lines 0]
         r config set appendonly no
-        wait_for_condition 50 100 {
-            [string match {*Killing*AOF*child*} [exec tail -5 < [srv 0 stdout]]]
-        } else {
-            fail "Can't find 'Killing AOF child' into recent logs"
-        }
+        wait_for_log_messages 0 {"*Killing*AOF*child*"} $loglines 100 100
         r config set rdb-key-save-delay 0
     }
 


### PR DESCRIPTION
## Overview

Two small test-only fixes for intermittent CI failures. Both waits are on eventual conditions, so neither change weakens the tests — a genuine regression still fails, only false timeouts are eliminated.

## Fix 1: `Turning off AOF kills the background writing child if any` (tests/unit/aofrw.tcl)

The test waited with `wait_for_condition 50 100` grepping only the last 5 log lines (`tail -5`), so on slow or instrumented builds (notably the code-coverage config) the "Killing AOF child" message can scroll out of the 5-line window before the check runs — a false timeout even when the child was correctly killed. Switched to `wait_for_log_messages`, which scans the whole log from a captured offset, with a larger retry budget. Assertion intent unchanged.

## Fix 2: `failover command to specific replica works` (tests/integration/failover.tcl)

The test waits 50x100ms (5s) for `master_failover_state` to return to `no-failover` after issuing the FAILOVER command; on loaded CI runners this intermittently expires while the failover is still legitimately completing (observed in a 6-month analysis of daily CI runs). Widened to 100x200ms (20s).

## Validation

- Combined branch, local: unit/aofrw + integration/failover both pass (35/35, both target tests executed).
- Failover fix, 100x soak (jemalloc + arm): [run 29391071823](https://github.com/valkey-rainfall/valkey/actions/runs/29391071823) — target test executed 100/100 per job (verified non-vacuous by counting `[ok]` lines), 0 failures, 0 errors anywhere in the file.
- Failover fix, second independent 100x run on both platforms: [run 29391497346](https://github.com/valkey-rainfall/valkey/actions/runs/29391497346) — 0 failover failures. That run's overall status is red due to a different flaky test (the active-defrag latency assertion in memefficiency.tcl), which we're addressing separately.
- Aofrw fix, on its source branch: full [CI](https://github.com/valkey-rainfall/valkey/actions/runs/29215931620) and [Codecov](https://github.com/valkey-rainfall/valkey/actions/runs/29215931572) runs green — Codecov being the instrumented configuration where this flake surfaces. The originally failing commit also passed its parallel Codecov run, supporting environment-not-regression.