### PR TITLE
[9.0] Fix lua-enable-insecure-api default value cannot be changed to yes (#3548)

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -7396,6 +7396,13 @@ __attribute__((weak)) int main(int argc, char **argv) {
     if (server.cluster_enabled) {
         clusterInitLast();
     }
+
+    /* Sync lua_insecure_api_current with the final config value after all
+     * config sources (default, config file, command-line args) have been
+     * applied, so that updateLuaEnableInsecureApi() can correctly detect
+     * subsequent changes via CONFIG SET. */
+    server.lua_insecure_api_current = server.lua_enable_insecure_api;
+
     InitServerLast();
 
     if (!server.sentinel_mode) {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -695,6 +695,38 @@ start_server {tags {"scripting"}} {
         }
     } {} {external:skip}
 
+    start_server {tags {"scripting external:skip"} overrides {lua-enable-insecure-api yes}} {
+        test {Dynamic reset of lua engine with insecure API config change - default yes} {
+            # Ensure insecure API is available by default
+            assert_equal {} [r eval "return getfenv()" 0]
+
+            # Verify that disabling the config `lua-enable-insecure-api` disallows insecure API access
+            r config set lua-enable-insecure-api no
+            assert_error {*Script attempted to access nonexistent global variable 'getfenv'*} {
+                r eval "return getfenv()" 0
+            }
+
+            r config set lua-enable-insecure-api yes
+            assert_equal {} [r eval "return getfenv()" 0]
+        }
+    }
+
+    start_server {tags {"scripting external:skip"} config {default.conf} overrides {lua-enable-insecure-api no} args {--lua-enable-insecure-api yes}} {
+        test {Dynamic reset of lua engine with insecure API config change - command line yes} {
+            # Ensure insecure API is available by default
+            assert_equal {} [r eval "return getfenv()" 0]
+
+            # Verify that disabling the config `lua-enable-insecure-api` disallows insecure API access
+            r config set lua-enable-insecure-api no
+            assert_error {*Script attempted to access nonexistent global variable 'getfenv'*} {
+                r eval "return getfenv()" 0
+            }
+
+            r config set lua-enable-insecure-api yes
+            assert_equal {} [r eval "return getfenv()" 0]
+        }
+    }
+
     test {SCRIPTING FLUSH ASYNC} {
         r script flush sync
         for {set j 0} {$j < 100} {incr j} {


### PR DESCRIPTION
Backport of #3548 to 9.0. Picked up from the "Needs attention" list in sweep #4167,
which skipped it because the target branch lacks src/modules/lua/engine_lua.c.

**Adaptation for 9.0:** only fix #2 from the original PR (the
`lua_insecure_api_current` sync in server.c) applies here. Fix #1 does not
exist on 9.0: the Lua engine is not modularized on this branch (src/lua/, not
src/modules/lua/), there is no per-engine-context `lua_enable_insecure_api`
field hardcoded to 0, and the deprecated-API allowlist gate reads
`server.lua_enable_insecure_api` directly in `luaNewIndexAllowList`
(script_lua.c). Since `evalInit()` runs in `initServer()` after
`loadServerConfig()`, the config-file value is already honored at Lua state
initialization. The engine_lua.c hunk is therefore dropped.

**Validation on 9.0:**
- Full `unit/scripting` suite passes with the fix
- Both new tests fail without the fix with the expected symptom: `getfenv()`
  remains accessible after `CONFIG SET lua-enable-insecure-api no` because
  `updateLuaEnableInsecureApi()` sees `0 != 0` as false and skips `evalReset()`