### PR TITLE
Say non-negative in the shared positive-count range error message

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1186,7 +1186,7 @@ int getPositiveLongFromObjectOrReply(client *c, robj *o, long *target, const cha
     if (msg) {
         return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, msg);
     } else {
-        return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, "value is out of range, must be positive");
+        return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, "value is out of range, must be non-negative");
     }
 }
 

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1138,13 +1138,13 @@ start_server {tags {"zset"}} {
 
             test "$pop with negative count" {
                 r set zset foo
-                assert_error "ERR *must be positive" {r $pop zset -1}
+                assert_error "ERR *must be non-negative" {r $pop zset -1}
 
                 r del zset
-                assert_error "ERR *must be positive" {r $pop zset -2}
+                assert_error "ERR *must be non-negative" {r $pop zset -2}
 
                 r zadd zset 1 a 2 b 3 c
-                assert_error "ERR *must be positive" {r $pop zset -3}
+                assert_error "ERR *must be non-negative" {r $pop zset -3}
             }
         }
 


### PR DESCRIPTION
getPositiveLongFromObjectOrReply validates against [0, LONG_MAX] but its default error says "value is out of range, must be positive", which reads as excluding 0 — yet 0 is accepted:

```
> RPUSH k a b c
(integer) 3
> LPOP k 0
(empty array)
> LPOP k -1
(error) ERR value is out of range, must be positive
```

All five call sites of the default message (LPOP/RPOP, SPOP, ZPOPMIN/ZPOPMAX, DEBUG keys/valsize) accept a non-negative count, so the wording is wrong for every one of them. Change the shared default to "must be non-negative" — one change, consistent everywhere.

Updated the three ZPOPMIN/ZPOPMAX assertions in zset.tcl that pinned the old wording. list.tcl matches loosely on `*ERR*range*` and set.tcl has no message assertion, so both are unaffected; the count=0 tests still pass. The stream ENTRIESREAD/ENTRIESADDED messages are separate literals (#4145/#4146) and out of scope.

Reported by @power-edge. Fixes #4150.