### PR TITLE
Always log "possibly failing" when a node reaches PFAIL

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6375,12 +6375,11 @@ void clusterCron(void) {
             /* Timeout reached. Set the node as possibly failing if it is
              * not already in this state. */
             if (!(node->flags & (CLUSTER_NODE_PFAIL | CLUSTER_NODE_FAIL))) {
+                serverLog(LL_NOTICE, "NODE %.40s (%s) possibly failing.", node->name, humanNodename(node));
                 node->flags |= CLUSTER_NODE_PFAIL;
                 update_state = 1;
                 if (clusterNodeIsVotingPrimary(myself)) {
                     markNodeAsFailingIfNeeded(node);
-                } else {
-                    serverLog(LL_NOTICE, "NODE %.40s (%s) possibly failing.", node->name, humanNodename(node));
                 }
             }
         }


### PR DESCRIPTION
The "NODE <name> possibly failing" notice was only emitted
when the local node was not a voting primary. When it was a
voting primary it took the markNodeAsFailingIfNeeded() path
and the log line was skipped

So we will lost the PFAIL notification log regardless of
whether the node stayed PFAIL (no quorum) or was later
promoted to FAIL.

Move the log before the branch so it is always printed once
a node enters the possibly-failing state.