### PR TITLE
[8.0] Fix lua-enable-insecure-api default value cannot be changed to yes (#3548)

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -7017,6 +7017,13 @@ int main(int argc, char **argv) {
     if (server.cluster_enabled) {
         clusterInitLast();
     }
+
+    /* Sync lua_insecure_api_current with the final config value after all
+     * config sources (default, config file, command-line args) have been
+     * applied, so that updateLuaEnableInsecureApi() can correctly detect
+     * subsequent changes via CONFIG SET. */
+    server.lua_insecure_api_current = server.lua_enable_insecure_api;
+
     InitServerLast();
 
     if (!server.sentinel_mode) {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -695,6 +695,38 @@ start_server {tags {"scripting"}} {
         }
     } {} {external:skip}
 
+    start_server {tags {"scripting external:skip"} overrides {lua-enable-insecure-api yes}} {
+        test {Dynamic reset of lua engine with insecure API config change - default yes} {
+            # Ensure insecure API is available by default
+            assert_equal {} [r eval "return getfenv()" 0]
+
+            # Verify that disabling the config `lua-enable-insecure-api` disallows insecure API access
+            r config set lua-enable-insecure-api no
+            assert_error {*Script attempted to access nonexistent global variable 'getfenv'*} {
+                r eval "return getfenv()" 0
+            }
+
+            r config set lua-enable-insecure-api yes
+            assert_equal {} [r eval "return getfenv()" 0]
+        }
+    }
+
+    start_server {tags {"scripting external:skip"} config {default.conf} overrides {lua-enable-insecure-api no} args {--lua-enable-insecure-api yes}} {
+        test {Dynamic reset of lua engine with insecure API config change - command line yes} {
+            # Ensure insecure API is available by default
+            assert_equal {} [r eval "return getfenv()" 0]
+
+            # Verify that disabling the config `lua-enable-insecure-api` disallows insecure API access
+            r config set lua-enable-insecure-api no
+            assert_error {*Script attempted to access nonexistent global variable 'getfenv'*} {
+                r eval "return getfenv()" 0
+            }
+
+            r config set lua-enable-insecure-api yes
+            assert_equal {} [r eval "return getfenv()" 0]
+        }
+    }
+
     test {SCRIPTING FLUSH ASYNC} {
         r script flush sync
         for {set j 0} {$j < 100} {incr j} {


### PR DESCRIPTION
Backport of #3548 to 8.0. Same adaptation as the 9.0 (#4182) and 8.1 (#4183) backports.

**Adaptation for 8.0:** only the second fix from the original PR (the
`lua_insecure_api_current` sync in server.c) applies here. The first fix does
not exist on 8.0: the Lua engine is not modularized on this branch (Lua
scripting lives in src/script_lua.c / src/eval.c; there is no engine_lua.c).
The deprecated-API allowlist gate reads `server.lua_enable_insecure_api`
directly in `luaNewIndexAllowList` (src/script_lua.c), and `scriptingInit()`
runs in `initServer()` after `loadServerConfig()`, so the config-file value is
already honored at Lua state initialization. The engine_lua.c hunk is
therefore dropped. Note: on this branch `updateLuaEnableInsecureApi()` calls
`scriptingReset()` rather than `evalReset()` — behavior is equivalent for
this fix.

**Validation on 8.0:**
- Full `unit/scripting` suite passes with the fix
- Both new tests fail without the fix with the expected symptom: `getfenv()`
  remains accessible after `CONFIG SET lua-enable-insecure-api no`