### PR TITLE
[7.2] Backport fixes for weekly CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,15 @@ jobs:
       # Fail build if there are warnings
       # build with TLS just for compilation coverage
       run: make SERVER_CFLAGS='-Werror' BUILD_TLS=yes
+    - name: install old server for compatibility testing
+      run: |
+        cd tests/tmp
+        wget https://download.valkey.io/releases/valkey-7.2.7-noble-x86_64.tar.gz
+        tar -xvf valkey-7.2.7-noble-x86_64.tar.gz
     - name: test
       run: |
         sudo apt-get install tcl8.6 tclx
-        ./runtest --verbose --tags -slow --dump-logs
+        ./runtest --verbose --tags -slow --dump-logs --other-server-path tests/tmp/valkey-7.2.7-noble-x86_64/bin/valkey-server
     - name: module api test
       run: CFLAGS='-Werror' ./runtest-moduleapi --verbose --dump-logs
     - name: validate commands.def up to date
@@ -92,4 +97,3 @@ jobs:
       run: |
         dnf -y install epel-release gcc make procps-ng which
         make -j SERVER_CFLAGS='-Werror'
-

--- a/src/valkey-check-aof.c
+++ b/src/valkey-check-aof.c
@@ -33,7 +33,7 @@
 #include <sys/types.h>
 #include <regex.h>
 #include <libgen.h>
-
+#include <stdint.h>
 #define AOF_CHECK_OK 0
 #define AOF_CHECK_EMPTY 1
 #define AOF_CHECK_TRUNCATED 2
@@ -191,21 +191,21 @@ int processAnnotations(FILE *fp, char *filename, int last_file) {
         }
         if (ts <= to_timestamp) return 1;
         if (epos == 0) {
-            printf("AOF %s has nothing before timestamp %ld, "
-                    "aborting...\n", filename, to_timestamp);
+            printf("AOF %s has nothing before timestamp %jd, "
+                    "aborting...\n", filename, (intmax_t)to_timestamp);
             exit(1);
         }
         if (!last_file) {
-            printf("Failed to truncate AOF %s to timestamp %ld to offset %ld because it is not the last file.\n",
-                filename, to_timestamp, (long int)epos);
+            printf("Failed to truncate AOF %s to timestamp %jd to offset %lld because it is not the last file.\n",
+                filename, (intmax_t)to_timestamp, (long long)epos);
             printf("If you insist, please delete all files after this file according to the manifest "
                 "file and delete the corresponding records in manifest file manually. Then re-run valkey-check-aof.\n");
             exit(1);
         }
         /* Truncate remaining AOF if exceeding 'to_timestamp' */
         if (ftruncate(fileno(fp), epos) == -1) {
-            printf("Failed to truncate AOF %s to timestamp %ld\n",
-                    filename, to_timestamp);
+            printf("Failed to truncate AOF %s to timestamp %jd\n",
+                    filename, (intmax_t)to_timestamp);
             exit(1);
         } else {
             return 0;
@@ -292,7 +292,7 @@ int checkSingleAof(char *aof_filename, char *aof_filepath, int last_file, int fi
 
     /* In truncate-to-timestamp mode, just exit if there is nothing to truncate. */
     if (diff == 0 && to_timestamp) {
-        printf("Truncate nothing in AOF %s to timestamp %ld\n", aof_filename, to_timestamp);
+        printf("Truncate nothing in AOF %s to timestamp %jd\n", aof_filename, (intmax_t)to_timestamp);
         fclose(fp);
         return AOF_CHECK_OK;
     }
@@ -443,8 +443,8 @@ void printAofStyle(int ret, char *aofFileName, char *aofType) {
     } else if (ret == AOF_CHECK_EMPTY) {
         printf("%s %s is empty\n", aofType, aofFileName);
     } else if (ret == AOF_CHECK_TIMESTAMP_TRUNCATED) {
-        printf("Successfully truncated AOF %s to timestamp %ld\n",
-            aofFileName, to_timestamp);
+        printf("Successfully truncated AOF %s to timestamp %jd\n",
+            aofFileName, (intmax_t)to_timestamp);
     } else if (ret == AOF_CHECK_TRUNCATED) {
         printf("Successfully truncated AOF %s\n", aofFileName);
     }

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,13 +11,14 @@ external server, tests tagged `external:skip` are skipped.
 There are additional runtime options that can further adjust the test suite to
 match different external server configurations:
 
-| Option               | Impact                                                   |
-| -------------------- | -------------------------------------------------------- |
-| `--singledb`         | Only use database 0, don't assume others are supported. |
-| `--ignore-encoding`  | Skip all checks for specific encoding.  |
-| `--ignore-digest`    | Skip key value digest validations. |
-| `--cluster-mode`     | Run in strict Redis Cluster compatibility mode. |
-| `--large-memory`     | Enables tests that consume more than 100mb |
+| Option                     | Impact                                                  |
+| -------------------------- | ------------------------------------------------------- |
+| `--singledb`               | Only use database 0, don't assume others are supported. |
+| `--ignore-encoding`        | Skip all checks for specific encoding. |
+| `--ignore-digest`          | Skip key value digest validations. |
+| `--cluster-mode`           | Run in strict Redis Cluster compatibility mode. |
+| `--large-memory`           | Enables tests that consume more than 100mb. |
+| `--other-server-path PATH` | Run compatibility tests with an other server executable. |
 
 Tags
 ----
@@ -34,18 +35,22 @@ Tags can be applied in different context levels:
 The following compatibility and capability tags are currently used:
 
 | Tag                       | Indicates |
-| ---------------------     | --------- |
+| ------------------------- | --------- |
 | `external:skip`           | Not compatible with external servers. |
+| `cluster`                 | Uses cluster with multiple nodes. |
 | `cluster:skip`            | Not compatible with `--cluster-mode`. |
 | `large-memory`            | Test that requires more than 100mb |
+| `tls`                     | Uses TLS. |
 | `tls:skip`                | Not compatible with `--tls`. |
-| `needs:repl`              | Uses replication and needs to be able to `SYNC` from server. |
+| `ipv6`                    | Uses IPv6. |
+| `needs:repl`, `repl`      | Uses replication and needs to be able to `SYNC` from server. |
 | `needs:debug`             | Uses the `DEBUG` command or other debugging focused commands (like `OBJECT REFCOUNT`). |
 | `needs:pfdebug`           | Uses the `PFDEBUG` command. |
 | `needs:config-maxmemory`  | Uses `CONFIG SET` to manipulate memory limit, eviction policies, etc. |
 | `needs:config-resetstat`  | Uses `CONFIG RESETSTAT` to reset statistics. |
 | `needs:reset`             | Uses `RESET` to reset client connections. |
 | `needs:save`              | Uses `SAVE` or `BGSAVE` to create an RDB file. |
+| `needs:other-server`      | Requires `--other-server-path`. |
 
 When using an external server (`--host` and `--port`), filtering using the
 `external:skip` tags is done automatically.
@@ -60,4 +65,3 @@ In addition, it is possible to specify additional configuration. For example, to
 run tests on a server that does not permit `SYNC` use:
 
     ./runtest --host <host> --port <port> --tags -needs:repl
-

--- a/tests/integration/cross-version-replication.tcl
+++ b/tests/integration/cross-version-replication.tcl
@@ -1,0 +1,34 @@
+# Test replication from an older version primary.
+#
+# Use minimal.conf to make sure we don't use any configs not supported on the old version.
+
+proc server_name_and_version {} {
+    set server_name [s server_name]
+    if {$server_name eq {}} {
+        set server_name redis
+    }
+    set server_version [s "${server_name}_version"]
+    return "$server_name $server_version"
+}
+
+start_server {tags {"repl needs:other-server external:skip compatible-redis"} start-other-server 1 config "minimal.conf"} {
+    set primary_name_and_version [server_name_and_version]
+    r set foo bar
+
+    start_server {} {
+        test "Start replication from $primary_name_and_version" {
+            r replicaof [srv -1 host] [srv -1 port]
+            wait_for_sync r 500 100
+            # The key has been transferred.
+            assert_equal bar [r get foo]
+            assert_equal up [s master_link_status]
+        }
+
+        test "Replicate a SET command from $primary_name_and_version" {
+            r -1 set baz quux
+            wait_for_ofs_sync [srv 0 client] [srv -1 client]
+            set reply [r get baz]
+            assert_equal $reply quux
+        }
+    }
+}

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -370,9 +370,15 @@ foreach mdl {no yes} {
                             # Make sure no more commands processed
                             wait_load_handlers_disconnected -3
 
-                            wait_for_ofs_sync $master [lindex $slaves 0]
-                            wait_for_ofs_sync $master [lindex $slaves 1]
-                            wait_for_ofs_sync $master [lindex $slaves 2]
+                            # Slower libc runners can take more than the generic
+                            # five-second offset-sync timeout to drain this load.
+                            wait_for_condition 500 100 {
+                                [status $master master_repl_offset] eq [status [lindex $slaves 0] master_repl_offset] &&
+                                [status $master master_repl_offset] eq [status [lindex $slaves 1] master_repl_offset] &&
+                                [status $master master_repl_offset] eq [status [lindex $slaves 2] master_repl_offset]
+                            } else {
+                                fail "replica offsets didn't match in time"
+                            }
 
                             # Check digests
                             set digest [$master debug digest]

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -2,9 +2,9 @@ set ::global_overrides {}
 set ::tags {}
 set ::valgrind_errors {}
 
-proc start_server_error {config_file error} {
+proc start_server_error {executable config_file error} {
     set err {}
-    append err "Can't start the Redis server\n"
+    append err "Can't start $executable\n"
     append err "CONFIGURATION:"
     append err [exec cat $config_file]
     append err "\nERROR:"
@@ -213,6 +213,11 @@ proc tags_acceptable {tags err_return} {
         return 0
     }
 
+    if {$::other_server_path eq {} && [lsearch $tags "needs:other-server"] >= 0} {
+        set err "Other server path not provided"
+        return 0
+    }
+
     if {$::external && [lsearch $tags "external:skip"] >= 0} {
         set err "Not supported on external server"
         return 0
@@ -276,8 +281,8 @@ proc create_server_config_file {filename config config_lines} {
     close $fp
 }
 
-proc spawn_server {config_file stdout stderr args} {
-    set cmd [list src/valkey-server $config_file]
+proc spawn_server {executable config_file stdout stderr args} {
+    set cmd [list $executable $config_file]
     set args {*}$args
     if {[llength $args] > 0} {
         lappend cmd {*}$args
@@ -306,7 +311,7 @@ proc spawn_server {config_file stdout stderr args} {
 }
 
 # Wait for actual startup, return 1 if port is busy, 0 otherwise
-proc wait_server_started {config_file stdout pid} {
+proc wait_server_started {executable config_file stdout pid} {
     set checkperiod 100; # Milliseconds
     set maxiter [expr {120*1000/$checkperiod}] ; # Wait up to 2 minutes.
     set port_busy 0
@@ -317,7 +322,7 @@ proc wait_server_started {config_file stdout pid} {
         after $checkperiod
         incr maxiter -1
         if {$maxiter == 0} {
-            start_server_error $config_file "No PID detected in log $stdout"
+            start_server_error $executable $config_file "No PID detected in log $stdout"
             puts "--- LOG CONTENT ---"
             puts [exec cat $stdout]
             puts "-------------------"
@@ -421,10 +426,14 @@ proc start_server {options {code undefined}} {
     set args {}
     set keep_persistence false
     set config_lines {}
+    set start_other_server 0
 
     # parse options
     foreach {option value} $options {
         switch $option {
+            "start-other-server" {
+                set start_other_server $value ; # boolean, 0 or 1
+            }
             "config" {
                 set baseconfig $value
             }
@@ -470,6 +479,15 @@ proc start_server {options {code undefined}} {
 
         set ::tags [lrange $::tags 0 end-[llength $tags]]
         return
+    }
+
+    if {$start_other_server} {
+        set executable $::other_server_path
+        if {![file executable $executable]} {
+            error "File not found or not executable: $executable"
+        }
+    } else {
+        set executable "src/valkey-server"
     }
 
     set data [split [exec cat "tests/assets/$baseconfig"] "\n"]
@@ -556,15 +574,15 @@ proc start_server {options {code undefined}} {
     set server_started 0
     while {$server_started == 0} {
         if {$::verbose} {
-            puts -nonewline "=== ($tags) Starting server ${::host}:${port} "
+            puts -nonewline "=== ($tags) Starting server on ${::host}:${port} "
         }
 
         send_data_packet $::test_server_fd "server-spawning" "port $port"
 
-        set pid [spawn_server $config_file $stdout $stderr $args]
+        set pid [spawn_server $executable $config_file $stdout $stderr $args]
 
         # check that the server actually started
-        set port_busy [wait_server_started $config_file $stdout $pid]
+        set port_busy [wait_server_started $executable $config_file $stdout $pid]
 
         # Sometimes we have to try a different port, even if we checked
         # for availability. Other test clients may grab the port before we
@@ -602,7 +620,7 @@ proc start_server {options {code undefined}} {
         if {!$serverisup} {
             set err {}
             append err [exec cat $stdout] "\n" [exec cat $stderr]
-            start_server_error $config_file $err
+            start_server_error $executable $config_file $err
             return
         }
         set server_started 1
@@ -615,6 +633,7 @@ proc start_server {options {code undefined}} {
     if {[dict exists $config $port_param]} { set port [dict get $config $port_param] }
 
     # setup config dict
+    dict set srv "executable" $executable
     dict set srv "config_file" $config_file
     dict set srv "config" $config
     dict set srv "pid" $pid
@@ -767,12 +786,13 @@ proc restart_server {level wait_ready rotate_logs {reconnect 1} {shutdown sigter
         close $fd
     }
 
+    set executable [dict get $srv "executable"]
     set config_file [dict get $srv "config_file"]
 
-    set pid [spawn_server $config_file $stdout $stderr {}]
+    set pid [spawn_server $executable $config_file $stdout $stderr {}]
 
     # check that the server actually started
-    wait_server_started $config_file $stdout $pid
+    wait_server_started $executable $config_file $stdout $pid
 
     # update the pid in the servers list
     dict set srv "pid" $pid

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -110,8 +110,8 @@ proc waitForBgrewriteaof r {
     }
 }
 
-proc wait_for_sync r {
-    wait_for_condition 50 100 {
+proc wait_for_sync {r {maxtries 50} {delay 100}} {
+    wait_for_condition $maxtries $delay {
         [status $r master_link_status] eq "up"
     } else {
         fail "replica didn't sync in time"

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -41,6 +41,7 @@ set ::all_tests {
     unit/latency-monitor
     integration/block-repl
     integration/replication
+    integration/cross-version-replication
     integration/replication-2
     integration/replication-3
     integration/replication-4
@@ -129,6 +130,7 @@ set ::single_tests {}
 set ::run_solo_tests {}
 set ::skip_till ""
 set ::external 0; # If "1" this means, we are running against external instance
+set ::other_server_path {}; # Used in upgrade and inter-version tests
 set ::file ""; # If set, runs only the tests in this comma separated list
 set ::curfile ""; # Hold the filename of the current suite
 set ::accurate 0; # If true runs fuzz tests with more iterations
@@ -684,10 +686,13 @@ proc print_help_screen {} {
         "--stack-logging    Enable OSX leaks/malloc stack logging."
         "--accurate         Run slow randomized tests for more iterations."
         "--quiet            Don't show individual tests."
-        "--single <unit>    Just execute the specified unit (see next option). This option can be repeated."
+        "--single <unit>    Just execute the specified unit (see next option). This"
+        "                   option can be repeated."
         "--verbose          Increases verbosity."
         "--list-tests       List all the available test units."
-        "--only <test>      Just execute the specified test by test name or tests that match <test> regexp (if <test> starts with '/'). This option can be repeated."
+        "--only <test>      Just execute the specified test by test name or tests that"
+        "                   match <test> regexp (if <test> starts with '/'). This option"
+        "                   can be repeated."
         "--skip-till <unit> Skip all units until (and including) the specified one."
         "--skipunit <unit>  Skip one unit."
         "--clients <num>    Number of test clients (default 16)."
@@ -706,12 +711,15 @@ proc print_help_screen {} {
         "--stop             Blocks once the first test fails."
         "--loop             Execute the specified set of tests forever."
         "--loops <count>    Execute the specified set of tests several times."
-        "--wait-server      Wait after server is started (so that you can attach a debugger)."
+        "--wait-server      Wait after server is started (so that you can attach a"
+        "                   debugger)."
         "--dump-logs        Dump server log on test failure."
         "--tls              Run tests in TLS mode."
         "--tls-module       Run tests in TLS mode with Redis module."
         "--host <addr>      Run tests against an external host."
         "--port <port>      TCP port to use against external host."
+        "--other-server-path <path>"
+        "                   Path to another version of valkey-server, used for inter-version compatibility testing."
         "--baseport <port>  Initial port number for spawned redis servers."
         "--portcount <num>  Port range for spawned redis servers."
         "--singledb         Use a single database, avoid SELECT."
@@ -781,6 +789,9 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         incr j
     } elseif {$opt eq {--port}} {
         set ::port $arg
+        incr j
+    } elseif {$opt eq {--other-server-path}} {
+        set ::other_server_path $arg
         incr j
     } elseif {$opt eq {--baseport}} {
         set ::baseport $arg


### PR DESCRIPTION
The [weekly 7.2 run](https://github.com/valkey-io/valkey/actions/runs/29472272327) exposed three branch-specific failure classes:

- The cross-version job could not run the 7.2 test harness against an older server binary.
- The 32-bit time64 build failed under `-Werror=format` because `time_t` has a different underlying type.
- The high-load, three-replica test timed out while waiting for the replication backlog to drain on slower runners.

#### What changed

- Backport the cross-version test framework from #1371 and #2336:
  - Add `--other-server-path` support to the test harness.
  - Add a cross-version replication test.
  - Run the compatibility job against Valkey 7.2.7.
- Backport the portable `time_t` formatting fix from #3787, using `intmax_t` and `%jd`.
- Allow the affected three-replica offset check up to 50 seconds to complete, without relaxing the shared synchronization helper.

#### Scope

The `test-s390x` and `reply-schemas-validator` failures from the same weekly run are workflow-level issues. They are being fixed separately against `unstable`, whose reusable `daily.yml` is used by the weekly workflow.