### PR TITLE
[9.0] Backport 32-bit Alpine CI coverage and fixes

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1607,6 +1607,7 @@ jobs:
       - test-freebsd
       - test-alpine-jemalloc
       - test-alpine-libc-malloc
+      - test-alpine-32bit
       - reply-schemas-validator
     steps:
       - name: Collect job status

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -321,6 +321,69 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: ./src/valkey-unit-tests --accurate
 
+  test-alpine-32bit:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
+        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+      !contains(github.event.inputs.skipjobs, 'alpine') &&
+      !contains(github.event.inputs.skipjobs, '32bit')
+    timeout-minutes: 1440
+    steps:
+      - name: prep
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "GITHUB_REPOSITORY=${{github.event.inputs.use_repo}}" >> $GITHUB_ENV
+          echo "GITHUB_HEAD_REF=${{github.event.inputs.use_git_ref}}" >> $GITHUB_ENV
+          echo "skipjobs: ${{github.event.inputs.skipjobs}}"
+          echo "skiptests: ${{github.event.inputs.skiptests}}"
+          echo "test_args: ${{github.event.inputs.test_args}}"
+          echo "cluster_test_args: ${{github.event.inputs.cluster_test_args}}"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ env.GITHUB_REPOSITORY }}
+          ref: ${{ env.GITHUB_HEAD_REF }}
+      - name: Run 32-bit Alpine tests
+        env:
+          RUN_ACCURATE: ${{ github.event_name != 'pull_request' && '--accurate' || '' }}
+          SKIPTESTS: ${{ github.event.inputs.skiptests }}
+          TEST_ARGS: ${{ github.event.inputs.test_args }}
+          CLUSTER_TEST_ARGS: ${{ github.event.inputs.cluster_test_args }}
+        run: |
+          docker run --rm \
+            --platform linux/386 \
+            -v "$PWD:/src" \
+            -w /src \
+            -e RUN_ACCURATE \
+            -e SKIPTESTS \
+            -e TEST_ARGS \
+            -e CLUSTER_TEST_ARGS \
+            i386/alpine:latest \
+            sh -euxc '
+              apk add --no-cache bash build-base git gtest-dev linux-headers procps python3 tcl tclx
+
+              make SERVER_CFLAGS="-Werror" 32bit
+
+              case "${SKIPTESTS:-}" in
+                *valkey*) ;;
+                *) ./runtest ${RUN_ACCURATE:-} --verbose --dump-logs ${TEST_ARGS:-} ;;
+              esac
+
+              case "${SKIPTESTS:-}" in
+                *modules*) ;;
+                *)
+                  make -C tests/modules 32bit
+                  CFLAGS="-Werror" ./runtest-moduleapi --verbose --dump-logs ${TEST_ARGS:-}
+                  ;;
+              esac
+
+              case "${SKIPTESTS:-}" in
+                *sentinel*) ;;
+                *) ./runtest-sentinel ${CLUSTER_TEST_ARGS:-} ;;
+              esac
+            '
+
   test-ubuntu-tls:
     runs-on: ubuntu-latest
     if: |

--- a/src/unit/test_entry.c
+++ b/src/unit/test_entry.c
@@ -1,3 +1,4 @@
+#include "../fmacros.h"
 #include "../entry.h"
 #include "test_help.h"
 #include "../expire.h"

--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "../fmacros.h"
 #include <strings.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/unit/test_vset.c
+++ b/src/unit/test_vset.c
@@ -614,7 +614,7 @@ int test_vset_fuzzer(int argc, char **argv, int flags) {
         }
     }
     /* now expire all the entries and check that we have no entries left */
-    expire_mock_entries(&set, LONG_LONG_MAX);
+    expire_mock_entries(&set, LLONG_MAX);
     TEST_ASSERT(vsetIsEmpty(&set) && mock_entry_count == 0);
     vsetRelease(&set);
     free_mock_entries(); /* Just in case */

--- a/src/valkey-check-aof.c
+++ b/src/valkey-check-aof.c
@@ -34,7 +34,7 @@
 #include <sys/types.h>
 #include <regex.h>
 #include <libgen.h>
-
+#include <stdint.h>
 #define AOF_CHECK_OK 0
 #define AOF_CHECK_EMPTY 1
 #define AOF_CHECK_TRUNCATED 2
@@ -193,14 +193,14 @@ int processAnnotations(FILE *fp, char *filename, int last_file) {
         }
         if (ts <= to_timestamp) return 1;
         if (epos == 0) {
-            printf("AOF %s has nothing before timestamp %ld, "
+            printf("AOF %s has nothing before timestamp %jd, "
                    "aborting...\n",
-                   filename, to_timestamp);
+                   filename, (intmax_t)to_timestamp);
             exit(1);
         }
         if (!last_file) {
-            printf("Failed to truncate AOF %s to timestamp %ld to offset %ld because it is not the last file.\n",
-                   filename, to_timestamp, (long int)epos);
+            printf("Failed to truncate AOF %s to timestamp %jd to offset %lld because it is not the last file.\n",
+                   filename, (intmax_t)to_timestamp, (long long)epos);
             printf(
                 "If you insist, please delete all files after this file according to the manifest "
                 "file and delete the corresponding records in manifest file manually. Then re-run valkey-check-aof.\n");
@@ -208,7 +208,7 @@ int processAnnotations(FILE *fp, char *filename, int last_file) {
         }
         /* Truncate remaining AOF if exceeding 'to_timestamp' */
         if (ftruncate(fileno(fp), epos) == -1) {
-            printf("Failed to truncate AOF %s to timestamp %ld\n", filename, to_timestamp);
+            printf("Failed to truncate AOF %s to timestamp %jd\n", filename, (intmax_t)to_timestamp);
             exit(1);
         } else {
             return 0;
@@ -296,7 +296,7 @@ int checkSingleAof(char *aof_filename, char *aof_filepath, int last_file, int fi
 
     /* In truncate-to-timestamp mode, just exit if there is nothing to truncate. */
     if (diff == 0 && to_timestamp) {
-        printf("Truncate nothing in AOF %s to timestamp %ld\n", aof_filename, to_timestamp);
+        printf("Truncate nothing in AOF %s to timestamp %jd\n", aof_filename, (intmax_t)to_timestamp);
         fclose(fp);
         return AOF_CHECK_OK;
     }
@@ -446,7 +446,7 @@ void printAofStyle(int ret, char *aofFileName, char *aofType) {
     } else if (ret == AOF_CHECK_EMPTY) {
         printf("%s %s is empty\n", aofType, aofFileName);
     } else if (ret == AOF_CHECK_TIMESTAMP_TRUNCATED) {
-        printf("Successfully truncated AOF %s to timestamp %ld\n", aofFileName, to_timestamp);
+        printf("Successfully truncated AOF %s to timestamp %jd\n", aofFileName, (intmax_t)to_timestamp);
     } else if (ret == AOF_CHECK_TRUNCATED) {
         printf("Successfully truncated AOF %s\n", aofFileName);
     }


### PR DESCRIPTION
The [weekly 9.0 32-bit Alpine job](https://github.com/valkey-io/valkey/actions/runs/29472272327/job/87618375768) failed under `-Werror=format` because `time_t` is `long long` on 32-bit time64 systems.

Adding equivalent coverage directly to the 9.0 workflow also exposed two musl-specific unit-test build issues:

- Feature macros were included after system headers, conflicting with musl's predefined compatibility macros.
- A unit test used the glibc-specific `LONG_LONG_MAX` constant.

#### What changed

- Backport the applicable `valkey-check-aof` fix from #3787, formatting `time_t` through `intmax_t` and `%jd`.
- Add the 32-bit Alpine build and test job to the 9.0 daily workflow.
- Include `fmacros.h` before system headers in the affected unit tests.
- Replace `LONG_LONG_MAX` with the portable `LLONG_MAX`.
- Include the new job in the aggregate CI result.