### PR TITLE
[8.0] Fix Lua VM cleanup during FUNCTION FLUSH

### DIFF
--- a/src/function_lua.c
+++ b/src/function_lua.c
@@ -309,7 +309,10 @@ static int luaRegisterFunctionReadNamedArgs(lua_State *lua, registerFunctionArgs
             int lua_function_ref = luaL_ref(lua, LUA_REGISTRYINDEX);
 
             lua_f_ctx = zmalloc(sizeof(*lua_f_ctx));
-            lua_f_ctx->lua_function_ref = lua_function_ref;
+            *lua_f_ctx = (luaFunctionCtx){
+                .lua = lua,
+                .lua_function_ref = lua_function_ref,
+            };
             continue; /* value was already popped, so no need to pop it out. */
         } else if (!strcasecmp(key, "flags")) {
             if (!lua_istable(lua, -1)) {
@@ -370,7 +373,10 @@ static int luaRegisterFunctionReadPositionalArgs(lua_State *lua, registerFunctio
     int lua_function_ref = luaL_ref(lua, LUA_REGISTRYINDEX);
 
     lua_f_ctx = zmalloc(sizeof(*lua_f_ctx));
-    lua_f_ctx->lua_function_ref = lua_function_ref;
+    *lua_f_ctx = (luaFunctionCtx){
+        .lua = lua,
+        .lua_function_ref = lua_function_ref,
+    };
 
     luaRegisterFunctionArgsInitialize(register_f_args, name, NULL, lua_f_ctx, 0);
 

--- a/src/function_lua.c
+++ b/src/function_lua.c
@@ -59,6 +59,7 @@ typedef struct luaEngineCtx {
 
 /* Lua function ctx */
 typedef struct luaFunctionCtx {
+    lua_State *lua;
     /* Special ID that allows getting the Lua function object from the Lua registry */
     int lua_function_ref;
 } luaFunctionCtx;
@@ -199,7 +200,9 @@ static void luaEngineFreeFunction(void *engine_ctx, void *compiled_function) {
     luaEngineCtx *lua_engine_ctx = engine_ctx;
     lua_State *lua = lua_engine_ctx->lua;
     luaFunctionCtx *f_ctx = compiled_function;
-    lua_unref(lua, f_ctx->lua_function_ref);
+    if (lua == f_ctx->lua) {
+        lua_unref(lua, f_ctx->lua_function_ref);
+    }
     zfree(f_ctx);
 }
 
@@ -418,9 +421,7 @@ static int luaRegisterFunction(lua_State *lua) {
     return 0;
 }
 
-/* Initialize Lua engine, should be called once on start. */
-int luaEngineInitEngine(void) {
-    luaEngineCtx *lua_engine_ctx = zmalloc(sizeof(*lua_engine_ctx));
+static void luaEngineInitializeLuaState(luaEngineCtx *lua_engine_ctx) {
     lua_engine_ctx->lua = lua_open();
 
     luaRegisterServerAPI(lua_engine_ctx->lua);
@@ -495,6 +496,42 @@ int luaEngineInitEngine(void) {
     lua_replace(lua_engine_ctx->lua, LUA_GLOBALSINDEX);  /* set new global table as the new globals */
     /* Set metatables of basic types (string, number, nil etc.) readonly. */
     luaSetTableProtectionForBasicTypes(lua_engine_ctx->lua);
+}
+
+static void luaEngineFreeLuaState(void *context) {
+    lua_State *lua = context;
+    lua_gc(lua, LUA_GCCOLLECT, 0);
+    lua_close(lua);
+
+#if !defined(USE_LIBC)
+    /* Lua uses libc and may otherwise retain its freed pages for a while. */
+    zlibc_trim();
+#endif
+}
+
+static engineResetCallback *luaEngineReset(void *engine_ctx, int async) {
+    luaEngineCtx *lua_engine_ctx = engine_ctx;
+    lua_State *old_lua = lua_engine_ctx->lua;
+    engineResetCallback *callback = NULL;
+
+    if (async) {
+        callback = zmalloc(sizeof(*callback));
+        *callback = (engineResetCallback){
+            .context = old_lua,
+            .callback = luaEngineFreeLuaState,
+        };
+    } else {
+        luaEngineFreeLuaState(old_lua);
+    }
+
+    luaEngineInitializeLuaState(lua_engine_ctx);
+    return callback;
+}
+
+/* Initialize Lua engine, should be called once on start. */
+int luaEngineInitEngine(void) {
+    luaEngineCtx *lua_engine_ctx = zmalloc(sizeof(*lua_engine_ctx));
+    luaEngineInitializeLuaState(lua_engine_ctx);
 
     engine *lua_engine = zmalloc(sizeof(*lua_engine));
     *lua_engine = (engine){
@@ -505,6 +542,7 @@ int luaEngineInitEngine(void) {
         .get_function_memory_overhead = luaEngineFunctionMemoryOverhead,
         .get_engine_memory_overhead = luaEngineMemoryOverhead,
         .free_function = luaEngineFreeFunction,
+        .reset = luaEngineReset,
     };
     return functionsRegisterEngine(LUA_ENGINE_NAME, lua_engine);
 }

--- a/src/functions.c
+++ b/src/functions.c
@@ -179,29 +179,60 @@ void functionsLibCtxClear(functionsLibCtx *lib_ctx) {
     lib_ctx->cache_memory = 0;
 }
 
+static list *functionsResetEngines(int async) {
+    list *callbacks = async ? listCreate() : NULL;
+    dictIterator *iter = dictGetIterator(engines);
+    dictEntry *entry = NULL;
+    while ((entry = dictNext(iter))) {
+        engineInfo *ei = dictGetVal(entry);
+        engineResetCallback *callback = ei->engine->reset(ei->engine->engine_ctx, async);
+        if (async) {
+            listAddNodeTail(callbacks, callback);
+        }
+    }
+    dictReleaseIterator(iter);
+    return callbacks;
+}
+
 void functionsLibCtxClearCurrent(int async) {
     if (async) {
         functionsLibCtx *old_l_ctx = curr_functions_lib_ctx;
         curr_functions_lib_ctx = functionsLibCtxCreate();
-        freeFunctionsAsync(old_l_ctx);
+        list *engine_callbacks = functionsResetEngines(1);
+        freeFunctionsAsync(old_l_ctx, engine_callbacks);
     } else {
         functionsLibCtxClear(curr_functions_lib_ctx);
+        functionsResetEngines(0);
     }
 }
 
 /* Free the given functions ctx */
-void functionsLibCtxFree(functionsLibCtx *functions_lib_ctx) {
+void functionsLibCtxFree(functionsLibCtx *functions_lib_ctx, list *engine_callbacks) {
     functionsLibCtxClear(functions_lib_ctx);
     dictRelease(functions_lib_ctx->functions);
     dictRelease(functions_lib_ctx->libraries);
     dictRelease(functions_lib_ctx->engines_stats);
     zfree(functions_lib_ctx);
+
+    if (engine_callbacks) {
+        listIter *iter = listGetIterator(engine_callbacks, AL_START_HEAD);
+        listNode *node = NULL;
+        while ((node = listNext(iter))) {
+            engineResetCallback *callback = listNodeValue(node);
+            if (callback) {
+                callback->callback(callback->context);
+                zfree(callback);
+            }
+        }
+        listReleaseIterator(iter);
+        listRelease(engine_callbacks);
+    }
 }
 
 /* Swap the current functions ctx with the given one.
  * Free the old functions ctx. */
 void functionsLibCtxSwapWithCurrent(functionsLibCtx *new_lib_ctx) {
-    functionsLibCtxFree(curr_functions_lib_ctx);
+    functionsLibCtxFree(curr_functions_lib_ctx, NULL);
     curr_functions_lib_ctx = new_lib_ctx;
 }
 
@@ -793,7 +824,7 @@ load_error:
         addReply(c, shared.ok);
     }
     if (functions_lib_ctx) {
-        functionsLibCtxFree(functions_lib_ctx);
+        functionsLibCtxFree(functions_lib_ctx, NULL);
     }
 }
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -54,6 +54,11 @@
 
 typedef struct functionLibInfo functionLibInfo;
 
+typedef struct engineResetCallback {
+    void *context;
+    void (*callback)(void *context);
+} engineResetCallback;
+
 typedef struct engine {
     /* engine specific context */
     void *engine_ctx;
@@ -93,6 +98,10 @@ typedef struct engine {
 
     /* free the given function */
     void (*free_function)(void *engine_ctx, void *compiled_function);
+
+    /* Reset the engine's function runtime. If async is set, return a
+     * callback that releases the old runtime after its functions are freed. */
+    engineResetCallback *(*reset)(void *engine_ctx, int async);
 } engine;
 
 /* Hold information about an engine.
@@ -134,7 +143,7 @@ size_t functionsLibCtxFunctionsLen(functionsLibCtx *functions_ctx);
 functionsLibCtx *functionsLibCtxGetCurrent(void);
 functionsLibCtx *functionsLibCtxCreate(void);
 void functionsLibCtxClearCurrent(int async);
-void functionsLibCtxFree(functionsLibCtx *lib_ctx);
+void functionsLibCtxFree(functionsLibCtx *lib_ctx, list *engine_callbacks);
 void functionsLibCtxClear(functionsLibCtx *lib_ctx);
 void functionsLibCtxSwapWithCurrent(functionsLibCtx *lib_ctx);
 

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -63,8 +63,9 @@ void lazyFreeLuaScripts(void *args[]) {
 /* Release the functions ctx. */
 void lazyFreeFunctionsCtx(void *args[]) {
     functionsLibCtx *functions_lib_ctx = args[0];
+    list *engine_callbacks = args[1];
     size_t len = functionsLibCtxFunctionsLen(functions_lib_ctx);
-    functionsLibCtxFree(functions_lib_ctx);
+    functionsLibCtxFree(functions_lib_ctx, engine_callbacks);
     atomic_fetch_sub_explicit(&lazyfree_objects, len, memory_order_relaxed);
     atomic_fetch_add_explicit(&lazyfreed_objects, len, memory_order_relaxed);
 }
@@ -234,13 +235,13 @@ void freeLuaScriptsAsync(dict *lua_scripts, list *lua_scripts_lru_list, lua_Stat
 }
 
 /* Free functions ctx, if the functions ctx contains enough functions, free it in async way. */
-void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx) {
+void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx, list *engine_callbacks) {
     if (functionsLibCtxFunctionsLen(functions_lib_ctx) > LAZYFREE_THRESHOLD) {
         atomic_fetch_add_explicit(&lazyfree_objects, functionsLibCtxFunctionsLen(functions_lib_ctx),
                                   memory_order_relaxed);
-        bioCreateLazyFreeJob(lazyFreeFunctionsCtx, 1, functions_lib_ctx);
+        bioCreateLazyFreeJob(lazyFreeFunctionsCtx, 2, functions_lib_ctx, engine_callbacks);
     } else {
-        functionsLibCtxFree(functions_lib_ctx);
+        functionsLibCtxFree(functions_lib_ctx, engine_callbacks);
     }
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2263,7 +2263,7 @@ void readSyncBulkPayload(connection *conn) {
                                       NULL);
 
                 disklessLoadDiscardTempDb(diskless_load_tempDb);
-                functionsLibCtxFree(temp_functions_lib_ctx);
+                functionsLibCtxFree(temp_functions_lib_ctx, NULL);
                 serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Discarding temporary DB in background");
             } else {
                 /* Remove the half-loaded data in case we started with an empty replica. */

--- a/src/server.h
+++ b/src/server.h
@@ -3653,7 +3653,7 @@ void luaLdbLineHook(lua_State *lua, lua_Debug *ar);
 void freeLuaScriptsSync(dict *lua_scripts, list *lua_scripts_lru_list, lua_State *lua);
 void freeLuaScriptsAsync(dict *lua_scripts, list *lua_scripts_lru_list, lua_State *lua);
 void scriptingReset(int async);
-void freeFunctionsAsync(functionsLibCtx *lib_ctx);
+void freeFunctionsAsync(functionsLibCtx *lib_ctx, list *engine_callbacks);
 int ldbIsEnabled(void);
 void ldbLog(sds entry);
 void ldbLogRespReply(char *reply);


### PR DESCRIPTION
Backports #1826 and #2750 to the 8.0 branch.

`FUNCTION FLUSH` now recreates the Lua VM so its memory can be reclaimed correctly. The async path also keeps the old Lua state alive until its functions have been freed, preventing a crash when new functions are loaded while cleanup is still running.

Lua function contexts now track their owning Lua state, ensuring registry references are only released from the correct VM.
