### PR TITLE
[7.2] Backport FUNCTION FLUSH and cluster receiver fixes

### DIFF
--- a/src/function_lua.c
+++ b/src/function_lua.c
@@ -59,6 +59,7 @@ typedef struct luaEngineCtx {
 
 /* Lua function ctx */
 typedef struct luaFunctionCtx {
+    lua_State *lua;
     /* Special ID that allows getting the Lua function object from the Lua registry */
     int lua_function_ref;
 } luaFunctionCtx;
@@ -200,7 +201,9 @@ static void luaEngineFreeFunction(void *engine_ctx, void *compiled_function) {
     luaEngineCtx *lua_engine_ctx = engine_ctx;
     lua_State *lua = lua_engine_ctx->lua;
     luaFunctionCtx *f_ctx = compiled_function;
-    lua_unref(lua, f_ctx->lua_function_ref);
+    if (lua == f_ctx->lua) {
+        lua_unref(lua, f_ctx->lua_function_ref);
+    }
     zfree(f_ctx);
 }
 
@@ -420,9 +423,7 @@ static int luaRegisterFunction(lua_State *lua) {
     return 0;
 }
 
-/* Initialize Lua engine, should be called once on start. */
-int luaEngineInitEngine(void) {
-    luaEngineCtx *lua_engine_ctx = zmalloc(sizeof(*lua_engine_ctx));
+static void luaEngineInitializeLuaState(luaEngineCtx *lua_engine_ctx) {
     lua_engine_ctx->lua = lua_open();
 
     luaRegisterRedisAPI(lua_engine_ctx->lua);
@@ -498,6 +499,42 @@ int luaEngineInitEngine(void) {
 
     /* Set metatables of basic types (string, number, nil etc.) readonly. */
     luaSetTableProtectionForBasicTypes(lua_engine_ctx->lua);
+}
+
+static void luaEngineFreeLuaState(void *context) {
+    lua_State *lua = context;
+    lua_gc(lua, LUA_GCCOLLECT, 0);
+    lua_close(lua);
+
+#if !defined(USE_LIBC)
+    /* Lua uses libc and may otherwise retain its freed pages for a while. */
+    zlibc_trim();
+#endif
+}
+
+static engineResetCallback *luaEngineReset(void *engine_ctx, int async) {
+    luaEngineCtx *lua_engine_ctx = engine_ctx;
+    lua_State *old_lua = lua_engine_ctx->lua;
+    engineResetCallback *callback = NULL;
+
+    if (async) {
+        callback = zmalloc(sizeof(*callback));
+        *callback = (engineResetCallback){
+            .context = old_lua,
+            .callback = luaEngineFreeLuaState,
+        };
+    } else {
+        luaEngineFreeLuaState(old_lua);
+    }
+
+    luaEngineInitializeLuaState(lua_engine_ctx);
+    return callback;
+}
+
+/* Initialize Lua engine, should be called once on start. */
+int luaEngineInitEngine(void) {
+    luaEngineCtx *lua_engine_ctx = zmalloc(sizeof(*lua_engine_ctx));
+    luaEngineInitializeLuaState(lua_engine_ctx);
 
     engine *lua_engine = zmalloc(sizeof(*lua_engine));
     *lua_engine = (engine) {
@@ -508,6 +545,7 @@ int luaEngineInitEngine(void) {
         .get_function_memory_overhead = luaEngineFunctionMemoryOverhead,
         .get_engine_memory_overhead = luaEngineMemoryOverhead,
         .free_function = luaEngineFreeFunction,
+        .reset = luaEngineReset,
     };
     return functionsRegisterEngine(LUA_ENGINE_NAME, lua_engine);
 }

--- a/src/function_lua.c
+++ b/src/function_lua.c
@@ -310,7 +310,10 @@ static int luaRegisterFunctionReadNamedArgs(lua_State *lua, registerFunctionArgs
             int lua_function_ref = luaL_ref(lua, LUA_REGISTRYINDEX);
 
             lua_f_ctx = zmalloc(sizeof(*lua_f_ctx));
-            lua_f_ctx->lua_function_ref = lua_function_ref;
+            *lua_f_ctx = (luaFunctionCtx){
+                .lua = lua,
+                .lua_function_ref = lua_function_ref,
+            };
             continue; /* value was already popped, so no need to pop it out. */
         } else if (!strcasecmp(key, "flags")) {
             if (!lua_istable(lua, -1)) {
@@ -372,7 +375,10 @@ static int luaRegisterFunctionReadPositionalArgs(lua_State *lua, registerFunctio
     int lua_function_ref = luaL_ref(lua, LUA_REGISTRYINDEX);
 
     lua_f_ctx = zmalloc(sizeof(*lua_f_ctx));
-    lua_f_ctx->lua_function_ref = lua_function_ref;
+    *lua_f_ctx = (luaFunctionCtx){
+        .lua = lua,
+        .lua_function_ref = lua_function_ref,
+    };
 
     luaRegisterFunctionArgsInitialize(register_f_args, name, NULL, lua_f_ctx, 0);
 

--- a/src/functions.c
+++ b/src/functions.c
@@ -191,29 +191,60 @@ void functionsLibCtxClear(functionsLibCtx *lib_ctx) {
     curr_functions_lib_ctx->cache_memory = 0;
 }
 
+static list *functionsResetEngines(int async) {
+    list *callbacks = async ? listCreate() : NULL;
+    dictIterator *iter = dictGetIterator(engines);
+    dictEntry *entry = NULL;
+    while ((entry = dictNext(iter))) {
+        engineInfo *ei = dictGetVal(entry);
+        engineResetCallback *callback = ei->engine->reset(ei->engine->engine_ctx, async);
+        if (async) {
+            listAddNodeTail(callbacks, callback);
+        }
+    }
+    dictReleaseIterator(iter);
+    return callbacks;
+}
+
 void functionsLibCtxClearCurrent(int async) {
     if (async) {
         functionsLibCtx *old_l_ctx = curr_functions_lib_ctx;
         curr_functions_lib_ctx = functionsLibCtxCreate();
-        freeFunctionsAsync(old_l_ctx);
+        list *engine_callbacks = functionsResetEngines(1);
+        freeFunctionsAsync(old_l_ctx, engine_callbacks);
     } else {
         functionsLibCtxClear(curr_functions_lib_ctx);
+        functionsResetEngines(0);
     }
 }
 
 /* Free the given functions ctx */
-void functionsLibCtxFree(functionsLibCtx *functions_lib_ctx) {
+void functionsLibCtxFree(functionsLibCtx *functions_lib_ctx, list *engine_callbacks) {
     functionsLibCtxClear(functions_lib_ctx);
     dictRelease(functions_lib_ctx->functions);
     dictRelease(functions_lib_ctx->libraries);
     dictRelease(functions_lib_ctx->engines_stats);
     zfree(functions_lib_ctx);
+
+    if (engine_callbacks) {
+        listIter *iter = listGetIterator(engine_callbacks, AL_START_HEAD);
+        listNode *node = NULL;
+        while ((node = listNext(iter))) {
+            engineResetCallback *callback = listNodeValue(node);
+            if (callback) {
+                callback->callback(callback->context);
+                zfree(callback);
+            }
+        }
+        listReleaseIterator(iter);
+        listRelease(engine_callbacks);
+    }
 }
 
 /* Swap the current functions ctx with the given one.
  * Free the old functions ctx. */
 void functionsLibCtxSwapWithCurrent(functionsLibCtx *new_lib_ctx) {
-    functionsLibCtxFree(curr_functions_lib_ctx);
+    functionsLibCtxFree(curr_functions_lib_ctx, NULL);
     curr_functions_lib_ctx = new_lib_ctx;
 }
 
@@ -803,7 +834,7 @@ load_error:
         addReply(c, shared.ok);
     }
     if (functions_lib_ctx) {
-        functionsLibCtxFree(functions_lib_ctx);
+        functionsLibCtxFree(functions_lib_ctx, NULL);
     }
 }
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -49,6 +49,11 @@
 
 typedef struct functionLibInfo functionLibInfo;
 
+typedef struct engineResetCallback {
+    void *context;
+    void (*callback)(void *context);
+} engineResetCallback;
+
 typedef struct engine {
     /* engine specific context */
     void *engine_ctx;
@@ -83,6 +88,10 @@ typedef struct engine {
 
     /* free the given function */
     void (*free_function)(void *engine_ctx, void *compiled_function);
+
+    /* Reset the engine's function runtime. If async is set, return a
+     * callback that releases the old runtime after its functions are freed. */
+    engineResetCallback *(*reset)(void *engine_ctx, int async);
 } engine;
 
 /* Hold information about an engine.
@@ -124,7 +133,7 @@ size_t functionsLibCtxfunctionsLen(functionsLibCtx *functions_ctx);
 functionsLibCtx* functionsLibCtxGetCurrent(void);
 functionsLibCtx* functionsLibCtxCreate(void);
 void functionsLibCtxClearCurrent(int async);
-void functionsLibCtxFree(functionsLibCtx *lib_ctx);
+void functionsLibCtxFree(functionsLibCtx *lib_ctx, list *engine_callbacks);
 void functionsLibCtxClear(functionsLibCtx *lib_ctx);
 void functionsLibCtxSwapWithCurrent(functionsLibCtx *lib_ctx);
 

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -51,8 +51,9 @@ void lazyFreeLuaScripts(void *args[]) {
 /* Release the functions ctx. */
 void lazyFreeFunctionsCtx(void *args[]) {
     functionsLibCtx *functions_lib_ctx = args[0];
+    list *engine_callbacks = args[1];
     size_t len = functionsLibCtxfunctionsLen(functions_lib_ctx);
-    functionsLibCtxFree(functions_lib_ctx);
+    functionsLibCtxFree(functions_lib_ctx, engine_callbacks);
     atomicDecr(lazyfree_objects,len);
     atomicIncr(lazyfreed_objects,len);
 }
@@ -209,12 +210,12 @@ void freeLuaScriptsAsync(dict *lua_scripts) {
 }
 
 /* Free functions ctx, if the functions ctx contains enough functions, free it in async way. */
-void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx) {
+void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx, list *engine_callbacks) {
     if (functionsLibCtxfunctionsLen(functions_lib_ctx) > LAZYFREE_THRESHOLD) {
         atomicIncr(lazyfree_objects,functionsLibCtxfunctionsLen(functions_lib_ctx));
-        bioCreateLazyFreeJob(lazyFreeFunctionsCtx,1,functions_lib_ctx);
+        bioCreateLazyFreeJob(lazyFreeFunctionsCtx, 2, functions_lib_ctx, engine_callbacks);
     } else {
-        functionsLibCtxFree(functions_lib_ctx);
+        functionsLibCtxFree(functions_lib_ctx, engine_callbacks);
     }
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -8818,7 +8818,7 @@ void VM_RegisterClusterMessageReceiver(ValkeyModuleCtx *ctx, uint8_t type, Valke
                 if (prev)
                     prev->next = r->next;
                 else
-                    clusterReceivers[type]->next = r->next;
+                    clusterReceivers[type] = r->next;
                 zfree(r);
             }
             return;

--- a/src/replication.c
+++ b/src/replication.c
@@ -2148,7 +2148,7 @@ void readSyncBulkPayload(connection *conn) {
                                       NULL);
 
                 disklessLoadDiscardTempDb(diskless_load_tempDb);
-                functionsLibCtxFree(temp_functions_lib_ctx);
+                functionsLibCtxFree(temp_functions_lib_ctx, NULL);
                 serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Discarding temporary DB in background");
             } else {
                 /* Remove the half-loaded data in case we started with an empty replica. */

--- a/src/server.h
+++ b/src/server.h
@@ -3357,7 +3357,7 @@ sds luaCreateFunction(client *c, robj *body);
 void luaLdbLineHook(lua_State *lua, lua_Debug *ar);
 void freeLuaScriptsAsync(dict *lua_scripts);
 void scriptingReset(int async);
-void freeFunctionsAsync(functionsLibCtx *lib_ctx);
+void freeFunctionsAsync(functionsLibCtx *lib_ctx, list *engine_callbacks);
 int ldbIsEnabled(void);
 void ldbLog(sds entry);
 void ldbLogRedisReply(char *reply);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -688,6 +688,15 @@ int jemalloc_purge(void) {
 
 #endif
 
+/* This function provides us access to the libc malloc_trim(). */
+void zlibc_trim(void) {
+#if defined(__GLIBC__) && !defined(USE_LIBC)
+    malloc_trim(0);
+#else
+    return;
+#endif
+}
+
 #if defined(__APPLE__)
 /* For proc_pidinfo() used later in zmalloc_get_smap_bytes_by_field().
  * Note that this file cannot be included in zmalloc.h because it includes

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -71,6 +71,7 @@
  */
 #ifndef ZMALLOC_LIB
 #define ZMALLOC_LIB "libc"
+#define USE_LIBC 1
 
 #if !defined(NO_MALLOC_USABLE_SIZE) && \
     (defined(__GLIBC__) || defined(__FreeBSD__) || \

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -93,6 +93,11 @@
 #endif
 #endif
 
+/* Includes for malloc_trim(), see zlibc_trim(). */
+#if defined(__GLIBC__) && !defined(USE_LIBC)
+#include <malloc.h>
+#endif
+
 /* We can enable the Redis defrag capabilities only if we are using Jemalloc
  * and the version used is our special version modified for Redis having
  * the ability to return per-allocation fragmentation hints. */
@@ -129,6 +134,7 @@ size_t zmalloc_get_private_dirty(long pid);
 size_t zmalloc_get_smap_bytes_by_field(char *field, long pid);
 size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
+void zlibc_trim(void);
 void zmadvise_dontneed(void *ptr);
 
 #ifdef HAVE_DEFRAG

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -62,7 +62,8 @@ TEST_MODULES = \
     usercall.so \
     postnotifications.so \
     moduleauthtwo.so \
-    rdbloadsave.so
+    rdbloadsave.so \
+    cluster.so
 
 .PHONY: all
 

--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -1,0 +1,51 @@
+#include "valkeymodule.h"
+
+#define UNUSED(x) (void)(x)
+#define MSGTYPE_TEST_UAF 3
+
+static void testReceiver(ValkeyModuleCtx *ctx,
+                         const char *sender_id,
+                         uint8_t type,
+                         const unsigned char *payload,
+                         uint32_t len) {
+    ValkeyModule_Log(ctx, "notice", "DING (type %d) RECEIVED from %.*s: '%.*s'",
+                    type, VALKEYMODULE_NODE_ID_LEN, sender_id, (int)len, (const char *)payload);
+}
+
+static int testRegisterReceiver(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_UAF, testReceiver);
+    return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+static int testUnregisterReceiver(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_UAF, NULL);
+    return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+static int testSendMessage(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_TEST_UAF, "TestUAF", 7);
+    return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+
+    if (ValkeyModule_Init(ctx, "cluster", 1, VALKEYMODULE_APIVER_1) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "test.register_receiver", testRegisterReceiver, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+    if (ValkeyModule_CreateCommand(ctx, "test.unregister_receiver", testUnregisterReceiver, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+    if (ValkeyModule_CreateCommand(ctx, "test.send_msg_type3", testSendMessage, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    return VALKEYMODULE_OK;
+}

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -299,6 +299,41 @@ start_server {tags {"scripting"}} {
         assert_match {} [r function list]
     }
 
+    test {FUNCTION - test function flush will re-create the lua engine} {
+        for {set i 0} {$i < 60} {incr i} {
+            r function load [get_function_code lua test_$i test_$i {local a = 1 while true do a = a + 1 end}]
+        }
+        set before_flush_memory [s used_memory_vm_functions]
+        r function flush sync
+        set after_flush_memory [s used_memory_vm_functions]
+        assert_lessthan $after_flush_memory $before_flush_memory
+
+        for {set i 0} {$i < 100} {incr i} {
+            r function load [get_function_code lua test_$i test_$i {local a = 1 while true do a = a + 1 end}]
+        }
+        set before_flush_memory [s used_memory_vm_functions]
+        r function flush async
+        set after_flush_memory [s used_memory_vm_functions]
+        assert_lessthan $after_flush_memory $before_flush_memory
+    }
+
+    test {FUNCTION - test loading function during the flush async} {
+        for {set i 0} {$i < 10000} {incr i} {
+            r function load [get_function_code LUA test_$i test_$i {return 'hello'}]
+        }
+        r function flush sync
+
+        for {set i 0} {$i < 10000} {incr i} {
+            r function load [get_function_code LUA test_$i test_$i {return 'hello'}]
+        }
+        r function flush async
+
+        for {set i 0} {$i < 10000} {incr i} {
+            r function load [get_function_code LUA test_$i test_$i {return 'hello'}]
+        }
+        r function flush
+    }
+
     test {FUNCTION - test function wrong argument} {
         catch {r function flush bad_arg} e
         assert_match {*only supports SYNC|ASYNC*} $e

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -215,6 +215,29 @@ start_cluster 2 2 [list config_lines $modules] {
     }
 }
 
+set testmodule [file normalize tests/modules/cluster.so]
+set modules [list loadmodule $testmodule]
+start_cluster 3 0 [list config_lines $modules] {
+    set node1 [srv 0 client]
+    set node2 [srv -1 client]
+
+    test "VM_RegisterClusterMessageReceiver - unregister head and re-register does not crash" {
+        assert_equal OK [$node1 test.register_receiver]
+        assert_equal OK [$node1 test.unregister_receiver]
+        assert_equal OK [$node1 test.register_receiver]
+
+        R 0 CONFIG RESETSTAT
+        assert_equal OK [$node2 test.send_msg_type3]
+
+        wait_for_condition 50 100 {
+            [CI 0 cluster_stats_messages_module_received] >= 1
+        } else {
+            fail "node1 didn't receive cluster module message after re-registration"
+        }
+        verify_log_message 0 "*DING (type 3) RECEIVED*TestUAF*" 0
+    }
+}
+
 }
 
 set testmodule [file normalize tests/modules/basics.so]


### PR DESCRIPTION
Backports #1826, #2750, and #3846 to the 7.2 branch.

This fixes two separate issues:

- `FUNCTION FLUSH` now recreates the Lua VM so memory is reclaimed correctly, while safely handling functions loaded during asynchronous cleanup.
- Unregistering the first cluster message receiver now updates the receiver array correctly, preventing it from retaining a pointer to freed memory.