### PR TITLE
fix(debug): add bounds check in memtest_test_linux_anonymous_maps to prevent stack buffer overflow

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2205,6 +2205,7 @@ int memtest_test_linux_anonymous_maps(void) {
         end_addr = strtoul(end, NULL, 16);
         size = end_addr - start_addr;
 
+        if (regions >= MEMTEST_MAX_REGIONS) break;
         start_vect[regions] = start_addr;
         size_vect[regions] = size;
         snprintf(logbuf, sizeof(logbuf), "*** Preparing to test memory region %lx (%lu bytes)\n",


### PR DESCRIPTION
## Summary
- Add bounds check to prevent stack buffer overflow when parsing /proc/self/maps in the memory test function

## Bug
The `start_vect` and `size_vect` arrays are sized at `MEMTEST_MAX_REGIONS` (128), but the parsing loop increments `regions` without checking against this limit. Systems with many mapped memory regions can overflow these stack-allocated arrays, corrupting the stack frame in a segfault handler.

## Fix
Add `if (regions >= MEMTEST_MAX_REGIONS) break;` before writing to the arrays.
