### PR TITLE
fix(acl): prevent NULL pointer dereference on malformed selector in ACL file

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2580,6 +2580,8 @@ static sds ACLLoadFromFile(const char *filename) {
         if (!acl_args) {
             errors = sdscatprintf(errors, "%s:%d: Unmatched parenthesis in selector definition.", server.acl_filename,
                                   linenum);
+            sdsfreesplitres(argv, argc);
+            continue;
         }
 
         int syntax_error = 0;


### PR DESCRIPTION
## Summary
- Fix NULL pointer dereference when loading ACL file with unmatched parenthesis in selector definition

## Bug
When `ACLMergeSelectorArguments()` returns NULL due to an unmatched parenthesis, the error message is set but execution continues to a for loop that dereferences `acl_args` (which is NULL), causing a server crash.

## Fix
Add `continue` after the error message to skip the processing loop when acl_args is NULL.
