### PR TITLE
Deflake ccov: Contain slot migration test failures with a recovery barrier

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -181,15 +181,86 @@ proc has_active_slot_migration {node_idx} {
     return 0
 }
 
+# Record which primary owns each slot, so a failed test that dies
+# mid-migration can have slot ownership restored by the recovery barrier.
+proc capture_canonical_slot_layout {} {
+    # Node IDs are how CLUSTER SLOTS reports owners, but tests address nodes
+    # by R index -- record the mapping so layouts can be compared later.
+    set ::canonical_node_ids {}
+    foreach n {0 1 2} {
+        dict set ::canonical_node_ids [R $n CLUSTER MYID] $n
+    }
+    # -1 marks slots with no recorded owner; the restore skips them.
+    for {set s 0} {$s < 16384} {incr s} {set ::canonical_slot_owner($s) -1}
+    # Each CLUSTER SLOTS entry is {start end {ip port id ...} ...} with the
+    # owning primary listed first; expand each range into a per-slot owner map.
+    foreach entry [R 0 CLUSTER SLOTS] {
+        set owner_id [lindex [lindex $entry 2] 2]
+        if {![dict exists $::canonical_node_ids $owner_id]} continue
+        set owner_idx [dict get $::canonical_node_ids $owner_id]
+        for {set s [lindex $entry 0]} {$s <= [lindex $entry 1]} {incr s} {
+            set ::canonical_slot_owner($s) $owner_idx
+        }
+    }
+}
+
+# Migrate any slots displaced from the canonical layout back to their
+# canonical owner. Contiguous displaced slots with the same source and
+# destination move as a single range.
+proc restore_canonical_slot_layout {} {
+    if {![info exists ::canonical_slot_owner]} return
+    # Build the current per-slot owner map, same shape as the canonical one.
+    set current {}
+    foreach entry [R 0 CLUSTER SLOTS] {
+        set owner_id [lindex [lindex $entry 2] 2]
+        if {![dict exists $::canonical_node_ids $owner_id]} continue
+        set owner_idx [dict get $::canonical_node_ids $owner_id]
+        for {set s [lindex $entry 0]} {$s <= [lindex $entry 1]} {incr s} {
+            dict set current $s $owner_idx
+        }
+    }
+    # Sweep all slots, run-length grouping consecutive displaced slots that
+    # share the same current and canonical owner, and migrate each group back
+    # as a single range. A run ends when the slot is no longer mismatched or
+    # its source/destination pair changes; the sweep deliberately goes one
+    # past the last slot (16384) so a run ending at slot 16383 is flushed.
+    # Slots with no canonical owner recorded (-1) or currently unserved
+    # (absent from CLUSTER SLOTS) are never treated as mismatched.
+    set run_start -1
+    for {set s 0} {$s <= 16384} {incr s} {
+        set mismatch 0
+        if {$s < 16384 && [dict exists $current $s]} {
+            set want $::canonical_slot_owner($s)
+            set have [dict get $current $s]
+            if {$want >= 0 && $have != $want} {set mismatch 1}
+        }
+        if {$mismatch && $run_start == -1} {
+            set run_start $s
+            set run_have $have
+            set run_want $want
+        } elseif {$run_start != -1 && (!$mismatch || $have != $run_have || $want != $run_want)} {
+            set want_id [R $run_want CLUSTER MYID]
+            # Best-effort: the barrier must never raise from block level.
+            catch {
+                assert_match "OK" [R $run_have CLUSTER MIGRATESLOTS SLOTSRANGE $run_start [expr {$s - 1}] NODE $want_id]
+                wait_for_migration $run_want $run_start
+            }
+            set run_start [expr {$mismatch ? $s : -1}]
+            if {$mismatch} {set run_have $have; set run_want $want}
+        }
+    }
+}
+
 # Recovery barrier for tests that start slot migrations. When such a test
 # fails an assertion mid-flight, it leaks state: an in-flight migration,
 # DEBUG SLOTMIGRATION PREVENT-* flags, and config tweaks. The next test to
 # call CLUSTER MIGRATESLOTS then hits a non-assertion error such as
 # "ERR I am already migrating slot", which aborts the whole test client and
 # discards the rest of the run. Calling this barrier after a
-# migration-starting test contains a failure to that single test. Restoring
-# slot ownership is intentionally out of scope; tests use ensure_slot_on_node
-# for that. All steps are best-effort so the barrier itself cannot abort the
+# migration-starting test contains a failure to that single test. After
+# migrations drain, slot ownership displaced by the failed test is migrated
+# back to the canonical layout captured at cluster setup. All steps are
+# best-effort so the barrier itself cannot abort the
 # client from block level.
 proc recover_slot_migration_state {} {
     catch {set_debug_prevent_pause 0}
@@ -209,6 +280,7 @@ proc recover_slot_migration_state {} {
                 fail "Node $n still has an active slot migration after recovery"
             }
         }
+        restore_canonical_slot_layout
         wait_for_cluster_propagation
     }
 }
@@ -221,6 +293,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
     set node1_id [R 1 CLUSTER MYID]
     set node2_id [R 2 CLUSTER MYID]
     set fake_jobname "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    capture_canonical_slot_layout
 
     test "General command interface" {
         assert_error "*wrong number of arguments*" {R 0 CLUSTER MIGRATESLOTS}

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -172,6 +172,48 @@ proc do_node_restart {idx} {
     }
 }
 
+proc has_active_slot_migration {node_idx} {
+    foreach migration [R $node_idx CLUSTER GETSLOTMIGRATIONS] {
+        if {[dict get $migration state] ni {success cancelled failed}} {
+            return 1
+        }
+    }
+    return 0
+}
+
+# Recovery barrier for tests that start slot migrations. When such a test
+# fails an assertion mid-flight, it leaks state: an in-flight migration,
+# DEBUG SLOTMIGRATION PREVENT-* flags, and config tweaks. The next test to
+# call CLUSTER MIGRATESLOTS then hits a non-assertion error such as
+# "ERR I am already migrating slot", which aborts the whole test client and
+# discards the rest of the run. Calling this barrier after a
+# migration-starting test contains a failure to that single test. Restoring
+# slot ownership is intentionally out of scope; tests use ensure_slot_on_node
+# for that. All steps are best-effort so the barrier itself cannot abort the
+# client from block level.
+proc recover_slot_migration_state {} {
+    catch {set_debug_prevent_pause 0}
+    catch {set_debug_prevent_failover 0}
+    for {set i 0} {$i < [llength $::servers]} {incr i} {
+        catch {R $i CONFIG SET rdb-key-save-delay 0}
+        catch {R $i CONFIG SET repl-timeout 60}
+    }
+    foreach n {0 1 2} {
+        catch {R $n CLUSTER CANCELSLOTMIGRATIONS}
+    }
+    catch {
+        foreach n {0 1 2} {
+            wait_for_condition 100 100 {
+                ![has_active_slot_migration $n]
+            } else {
+                fail "Node $n still has an active slot migration after recovery"
+            }
+        }
+        wait_for_cluster_propagation
+    }
+}
+
+
 # Disable replica migration to prevent empty nodes from joining other shards.
 start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluster-allow-replica-migration no cluster-node-timeout 15000 cluster-databases 16}} {
 
@@ -649,6 +691,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             wait_for_migration 2 16383
         }
     }
+    recover_slot_migration_state
 
     test "Import with hz set to 1" {
         assert_does_not_resync {
@@ -684,6 +727,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             R 2 CONFIG SET hz $old_hz
         }
     }
+    recover_slot_migration_state
 
     # Catch-all test for covering commands sent during incremental replication
     test "Single source import - Incremental Command Coverage" {
@@ -1153,6 +1197,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             assert_match "OK" [R 2 FLUSHDB SYNC]
         }
     }
+    recover_slot_migration_state
 
     test "Partial data removed on cancel" {
         assert_does_not_resync {
@@ -1544,6 +1589,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             set_debug_prevent_pause 0
         }
     }
+    recover_slot_migration_state
 
     test "FLUSH on target during import" {
         assert_does_not_resync {
@@ -1878,6 +1924,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             wait_for_migration 2 16383
         }
     }
+    recover_slot_migration_state
 
     test "Export client buffer excluded from maxmemory" {
         assert_does_not_resync {
@@ -1975,6 +2022,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             R 2 CONFIG SET rdb-key-save-delay 0
         }
     }
+    recover_slot_migration_state
 
     foreach testcase [list \
         [list 0 0 1] \
@@ -2135,6 +2183,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             # Since we are restarting primaries, we need to ensure the cluster becomes stable
             wait_for_cluster_state ok
         }
+        recover_slot_migration_state
     }
 }
 

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -173,7 +173,9 @@ proc do_node_restart {idx} {
 }
 
 proc has_active_slot_migration {node_idx} {
-    foreach migration [R $node_idx CLUSTER GETSLOTMIGRATIONS] {
+    set migrations {}
+    catch {set migrations [R $node_idx CLUSTER GETSLOTMIGRATIONS]}
+    foreach migration $migrations {
         if {[dict get $migration state] ni {success cancelled failed}} {
             return 1
         }
@@ -181,72 +183,110 @@ proc has_active_slot_migration {node_idx} {
     return 0
 }
 
-# Record which primary owns each slot, so a failed test that dies
+# Record which shard owns each slot, so a failed test that dies
 # mid-migration can have slot ownership restored by the recovery barrier.
+# Ownership is tracked per shard rather than per node: a failover inside a
+# test moves slots to the promoted replica, and the restore only needs slots
+# back on the right shard, whichever member is currently its primary.
 proc capture_canonical_slot_layout {} {
     # Node IDs are how CLUSTER SLOTS reports owners, but tests address nodes
-    # by R index -- record the mapping so layouts can be compared later.
-    set ::canonical_node_ids {}
-    foreach n {0 1 2} {
-        dict set ::canonical_node_ids [R $n CLUSTER MYID] $n
+    # by R index -- record the mapping for every node, including replicas,
+    # so owners can be resolved after a failover promotes one.
+    set ::node_id_to_idx {}
+    for {set n 0} {$n < [llength $::servers]} {incr n} {
+        dict set ::node_id_to_idx [R $n CLUSTER MYID] $n
     }
+    # Each CLUSTER SLOTS entry is {start end {ip port id ...} ...} listing
+    # the owning primary first and its replicas after it. Every member of a
+    # shard maps to the same canonical shard, identified by the R index of
+    # the shard's primary at capture time.
+    set ::idx_to_shard {}
     # -1 marks slots with no recorded owner; the restore skips them.
     for {set s 0} {$s < 16384} {incr s} {set ::canonical_slot_owner($s) -1}
-    # Each CLUSTER SLOTS entry is {start end {ip port id ...} ...} with the
-    # owning primary listed first; expand each range into a per-slot owner map.
     foreach entry [R 0 CLUSTER SLOTS] {
-        set owner_id [lindex [lindex $entry 2] 2]
-        if {![dict exists $::canonical_node_ids $owner_id]} continue
-        set owner_idx [dict get $::canonical_node_ids $owner_id]
+        set primary_id [lindex [lindex $entry 2] 2]
+        if {![dict exists $::node_id_to_idx $primary_id]} continue
+        set shard [dict get $::node_id_to_idx $primary_id]
+        foreach member [lrange $entry 2 end] {
+            set member_id [lindex $member 2]
+            if {[dict exists $::node_id_to_idx $member_id]} {
+                dict set ::idx_to_shard [dict get $::node_id_to_idx $member_id] $shard
+            }
+        }
         for {set s [lindex $entry 0]} {$s <= [lindex $entry 1]} {incr s} {
-            set ::canonical_slot_owner($s) $owner_idx
+            set ::canonical_slot_owner($s) $shard
         }
     }
 }
 
+# Resolve the R index of the node currently acting as primary for a shard,
+# or -1 if none is found. After a failover this may be a different node than
+# the shard's primary at capture time.
+proc current_shard_primary {shard} {
+    for {set n 0} {$n < [llength $::servers]} {incr n} {
+        if {[dict exists $::idx_to_shard $n] &&
+            [dict get $::idx_to_shard $n] == $shard &&
+            [lindex [R $n ROLE] 0] eq "master"} {
+            return $n
+        }
+    }
+    return -1
+}
+
 # Migrate any slots displaced from the canonical layout back to their
-# canonical owner. Contiguous displaced slots with the same source and
+# canonical shard. Contiguous displaced slots with the same source and
 # destination move as a single range.
 proc restore_canonical_slot_layout {} {
     if {![info exists ::canonical_slot_owner]} return
-    # Build the current per-slot owner map, same shape as the canonical one.
+    # Build the current per-slot owner map at shard granularity. Owners
+    # reported by CLUSTER SLOTS are primaries by definition, which may be
+    # promoted replicas rather than the capture-time primaries.
     set current {}
     foreach entry [R 0 CLUSTER SLOTS] {
         set owner_id [lindex [lindex $entry 2] 2]
-        if {![dict exists $::canonical_node_ids $owner_id]} continue
-        set owner_idx [dict get $::canonical_node_ids $owner_id]
+        if {![dict exists $::node_id_to_idx $owner_id]} continue
+        set owner_idx [dict get $::node_id_to_idx $owner_id]
+        if {![dict exists $::idx_to_shard $owner_idx]} continue
+        set owner_shard [dict get $::idx_to_shard $owner_idx]
         for {set s [lindex $entry 0]} {$s <= [lindex $entry 1]} {incr s} {
-            dict set current $s $owner_idx
+            dict set current $s [list $owner_idx $owner_shard]
         }
     }
     # Sweep all slots, run-length grouping consecutive displaced slots that
-    # share the same current and canonical owner, and migrate each group back
-    # as a single range. A run ends when the slot is no longer mismatched or
-    # its source/destination pair changes; the sweep deliberately goes one
-    # past the last slot (16384) so a run ending at slot 16383 is flushed.
-    # Slots with no canonical owner recorded (-1) or currently unserved
-    # (absent from CLUSTER SLOTS) are never treated as mismatched.
+    # share the same current owner and canonical shard, and migrate each
+    # group back as a single range. A run ends when the slot is no longer
+    # mismatched or its source/destination pair changes; the sweep
+    # deliberately goes one past the last slot (16384) so a run ending at
+    # slot 16383 is flushed. Slots with no canonical owner recorded (-1) or
+    # currently unserved (absent from CLUSTER SLOTS) are never treated as
+    # mismatched.
     set run_start -1
     for {set s 0} {$s <= 16384} {incr s} {
         set mismatch 0
         if {$s < 16384 && [dict exists $current $s]} {
             set want $::canonical_slot_owner($s)
-            set have [dict get $current $s]
-            if {$want >= 0 && $have != $want} {set mismatch 1}
+            lassign [dict get $current $s] have_idx have_shard
+            if {$want >= 0 && $have_shard != $want} {set mismatch 1}
         }
         if {$mismatch && $run_start == -1} {
             set run_start $s
-            set run_have $have
+            set run_have_idx $have_idx
             set run_want $want
-        } elseif {$run_start != -1 && (!$mismatch || $have != $run_have || $want != $run_want)} {
-            set want_id [R $run_want CLUSTER MYID]
-            # Best-effort: the barrier must never raise from block level.
-            catch {
-                assert_match "OK" [R $run_have CLUSTER MIGRATESLOTS SLOTSRANGE $run_start [expr {$s - 1}] NODE $want_id]
-                wait_for_migration $run_want $run_start
+        } elseif {$run_start != -1 && (!$mismatch || $have_idx != $run_have_idx || $want != $run_want)} {
+            # The destination must be whichever member of the canonical
+            # shard is currently its primary, which after a failover is not
+            # necessarily the capture-time primary.
+            set dst [current_shard_primary $run_want]
+            if {$dst >= 0} {
+                set want_id [R $dst CLUSTER MYID]
+                # Best-effort: the barrier must never raise from block level.
+                catch {
+                    assert_match "OK" [R $run_have_idx CLUSTER MIGRATESLOTS SLOTSRANGE $run_start [expr {$s - 1}] NODE $want_id]
+                    wait_for_migration $dst $run_start
+                }
             }
             set run_start [expr {$mismatch ? $s : -1}]
-            if {$mismatch} {set run_have $have; set run_want $want}
+            if {$mismatch} {set run_have_idx $have_idx; set run_want $want}
         }
     }
 }
@@ -270,11 +310,13 @@ proc recover_slot_migration_state {} {
         catch {R $i CONFIG SET repl-timeout 60}
         catch {R $i CONFIG SET hz 10}
     }
-    foreach n {0 1 2} {
+    # Cancel and drain on every node: after a failover inside a test, the
+    # primary holding a migration job may be a promoted replica.
+    for {set n 0} {$n < [llength $::servers]} {incr n} {
         catch {R $n CLUSTER CANCELSLOTMIGRATIONS}
     }
     catch {
-        foreach n {0 1 2} {
+        for {set n 0} {$n < [llength $::servers]} {incr n} {
             wait_for_condition 100 100 {
                 ![has_active_slot_migration $n]
             } else {

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -268,6 +268,7 @@ proc recover_slot_migration_state {} {
     for {set i 0} {$i < [llength $::servers]} {incr i} {
         catch {R $i CONFIG SET rdb-key-save-delay 0}
         catch {R $i CONFIG SET repl-timeout 60}
+        catch {R $i CONFIG SET hz 10}
     }
     foreach n {0 1 2} {
         catch {R $n CLUSTER CANCELSLOTMIGRATIONS}


### PR DESCRIPTION
## Summary

When a test in cluster-migrateslots.tcl fails an assertion mid-migration, it leaks state: the in-flight migration, DEBUG SLOTMIGRATION PREVENT-* flags, config tweaks (rdb-key-save-delay, repl-timeout), and displaced slot ownership. The framework recovers from the assertion and continues, but the next code to touch the cluster hits a non-assertion error (`ERR I am already migrating slot`, `MOVED`, `ERR Slots are not served by this node`), which aborts the entire test client and discards all remaining tests in the run. Issue 2692 fixed one instance of this cascade at the seeding test; this PR addresses the amplification mechanism itself, which is also the dominant way this file destroys Codecov runs (coverage-side data in issue 4153). Leaked config even manufactures downstream "flakes": a failed run of the repl-timeout test leaves `rdb-key-save-delay 100000` set, injecting 100 seconds of artificial snapshot delay (1000 keys x 100ms) into the restart-test loop that follows.

Commit 1 adds `recover_slot_migration_state`, a best-effort recovery barrier called after each migration-starting test observed to seed cascades (one call inside the parameterized restart loop covers its 8 variants): cancel in-flight migrations on all primaries, reset the leaked debug flags and configs, wait for all migration jobs to reach a terminal state, and wait for cluster convergence. Every step is catch-wrapped — the barrier runs at block level, where an escaping error would itself abort the client.

Commit 2 adds slot ownership restoration, since cancelling a migration does not move slots back: capture the canonical slot-to-primary layout once at cluster setup, and in the barrier — after migrations drain — migrate any displaced ranges back to their canonical owners.

## Verification (local)

Full file passes 105/105 with the barrier, identical to baseline — the barrier is a no-op beyond cheap checks when tests pass.

Forced-failure experiments: injecting `fail` immediately after MIGRATESLOTS starts in the restart loop costs, with the barrier, 8 [err] with all remaining 97 tests passing; the identical injection without the barrier reproduces the historical cascade — 1 [err], then `[exception]: ERR I am already migrating slot`, client abort, 24 tests discarded. Forcing a failure that leaves slot ownership displaced costs exactly one [err] with the restore, and causes collateral failures in later tests without it.

## Soak results (gcov-instrumented builds matching the Codecov job, 50 loops x 4 shards per mode, fork CI)

Run 1 — barrier only vs its base commit (https://github.com/valkey-rainfall/valkey/actions/runs/29466298795): baseline retained 11105 of 21000 [ok] results (53%) with 3 client aborts; barrier retained 17098 (81%) with 2 aborts, and the `already migrating slot` abort class dropped to zero.

Run 2 — barrier + ownership restore vs base (https://github.com/valkey-rainfall/valkey/actions/runs/29621384929): baseline retained 9062 (43%) with 3 aborts; guarded retained 18304 (87%) with 2 aborts, with two of four guarded shards fully contained — one flaky [err], zero aborts, everything else retained.

Per-iteration flake rates are unchanged between modes in both runs, as expected — this PR reduces the blast radius of a failure, it does not deflake the failing tests themselves (root-cause fixes for the top flakes are planned separately).

## Known limitations

The two guarded-mode aborts in run 2 have understood causes, left as future work: (1) the ownership restore is single-shot and silent-on-failure — it can race the just-cancelled migration and give up, so a retry/verify loop would harden it; (2) the barrier covers the observed cascade-seeding tests, not every migration-starting test, so an unguarded test (e.g. "FLUSH on target during import" in run 2) can still seed a cascade — per-test coverage is possible if maintainers prefer it; (3) block-level setup code between tests executes outside any test body and remains exposed to leaked state.

## References

Issue #2692 (prior instance of this cascade, fixed per-test)
issue #4153 (coverage-job impact data)
issue #3685 (an open flake in this file that this PR contains but does not fix).
