### PR TITLE
Validate slot import ranges when loading from RDB

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -400,6 +400,11 @@ int clusterRDBLoadSlotImport(rio *rdb) {
         uint64_t end_slot;
         if ((start_slot = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto err;
         if ((end_slot = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto err;
+        if (start_slot >= CLUSTER_SLOTS || end_slot >= CLUSTER_SLOTS || start_slot > end_slot) {
+            serverLog(LL_WARNING, "Invalid slot import range in RDB: start=%llu end=%llu",
+                      (unsigned long long)start_slot, (unsigned long long)end_slot);
+            goto err;
+        }
 
         slotRange *slot_range = zmalloc(sizeof(slotRange));
         slot_range->start_slot = start_slot;

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -149,7 +149,7 @@ static unsigned long long kvstoreCursorToHashtableCursor(kvstore *kvs, unsigned 
 }
 
 int kvstoreIsImporting(kvstore *kvs, int didx) {
-    assert(didx < kvs->num_hashtables);
+    assert(didx >= 0 && didx < kvs->num_hashtables);
     return hashtableFind(kvs->importing, (void *)(intptr_t)didx, NULL);
 }
 
@@ -944,7 +944,7 @@ bool kvstoreHashtableDelete(kvstore *kvs, int didx, const void *key) {
  * are not included in hashtable metrics and are excluded from scanning and
  * random key lookup. */
 void kvstoreSetIsImporting(kvstore *kvs, int didx, int is_importing) {
-    assert(didx < kvs->num_hashtables);
+    assert(didx >= 0 && didx < kvs->num_hashtables);
 
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
 


### PR DESCRIPTION
When loading slot migration import jobs from the RDB, the start and
end slots of each range were not validated. A corrupted or truncated
RDB could produce out-of-range slot values or a reversed range
(start > end), which would then be used to build migration jobs and
slot ranges.

Reject any slot import range whose start or end slot is greater than
or equal to CLUSTER_SLOTS, or whose start slot is greater than the
end slot, logging a warning and aborting the load.

Fixes #4222.