### PR TITLE
Bump minimum cmake version to 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.24)
 
 # Must be done first
 if (APPLE)


### PR DESCRIPTION
Currently the `src/CMakeLists.txt` is using [Link Features](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#link-features) which was added in version 3.24.

Increase `cmake_minimum_required` to 3.24 to reflect the actual minimum version required to run `cmake`.

