### PR TITLE
[9.1] Fix use-after-free in tlsProcessPendingData() on CLIENT KILL

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1775,14 +1775,27 @@ static int tlsHasPendingData(void) {
 }
 
 static int tlsProcessPendingData(void) {
-    listIter li;
     listNode *ln;
 
     int processed = 0;
-    listRewind(pending_list, &li);
-    while ((ln = listNext(&li))) {
+    /* Pop each connection off the list before handling it. A handler may
+     * synchronously free another pending connection (e.g. CLIENT KILL ->
+     * freeClient -> connTLSClose -> listDelNode), so we must not hold an
+     * iterator into a node that could be freed out from under us.
+     *
+     * Connections with buffered data re-add themselves to the tail, so the
+     * length captured on entry bounds the loop and guarantees termination. */
+    unsigned long remaining = listLength(pending_list);
+    while (remaining-- > 0 && (ln = listFirst(pending_list)) != NULL) {
         tls_connection *conn = listNodeValue(ln);
-        if (conn->flags & TLS_CONN_FLAG_POSTPONE_UPDATE_STATE) continue;
+        listDelNode(pending_list, ln);
+        conn->pending_list_node = NULL;
+        if (conn->flags & TLS_CONN_FLAG_POSTPONE_UPDATE_STATE) {
+            /* Not handled now, but keep it pending for a later call. */
+            listAddNodeTail(pending_list, conn);
+            conn->pending_list_node = listLast(pending_list);
+            continue;
+        }
         tlsHandleEvent(conn, AE_READABLE);
         processed++;
     }


### PR DESCRIPTION
Backport of #4234 to `9.1`.

`tlsProcessPendingData()` walked `pending_list` with a `listIter`, which caches the next node. A handler invoked during the walk (e.g. `CLIENT KILL` -> `freeClient` -> `connTLSClose` -> `listDelNode`) can synchronously free another connection still on the list, including the node the iterator cached as its next element. The following `listNext()` then dereferenced freed memory, crashing the server (authenticated remote DoS, potential RCE via heap spray).

Instead of iterating, pop each connection off the head before handling it, so we never hold a reference into a node a handler might free. A connection that still has buffered TLS data re-adds itself to the tail; the list length captured on entry bounds the loop and guarantees termination.

---
*This was generated by AI but verified, with love, by a human.*
