### PR TITLE
deflake ccov: Use _exit() when a child is killed by SIGUSR1

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1433,7 +1433,7 @@ void checkChildrenDone(void) {
 
         if (WIFSIGNALED(statloc)) bysignal = WTERMSIG(statloc);
 
-        /* sigKillChildHandler catches the signal and calls exit(), but we
+        /* sigKillChildHandler catches the signal and calls _exit(), but we
          * must make sure not to flag lastbgsave_status, etc incorrectly.
          * We could directly terminate the child process via SIGUSR1
          * without handling it */
@@ -7102,7 +7102,12 @@ static void sigKillChildHandler(int sig) {
     UNUSED(sig);
     int level = server.in_fork_child == CHILD_TYPE_MODULE ? LL_VERBOSE : LL_WARNING;
     serverLogRawFromHandler(level, "Received SIGUSR1 in child, exiting now.");
-    exitFromChild(SERVER_CHILD_NOERROR_RETVAL);
+    /* Only async-signal-safe functions may be called from a signal handler,
+     * so use _exit() directly rather than exitFromChild(), whose exit() path
+     * in coverage builds runs the gcov atexit dump. A child killed by its
+     * parent intentionally skips the coverage dump: the dump serializes on
+     * profile data files shared with every concurrently exiting process. */
+    _exit(SERVER_CHILD_NOERROR_RETVAL);
 }
 
 void setupChildSignalHandlers(void) {


### PR DESCRIPTION
**Problem.** cluster-migrateslots is the dominant source of coverage-run failures on the Codecov job (#4153). PR #4223 contains the blast radius of a failure; this PR removes the largest remaining cause of the failures themselves. Investigation of gcov soaks (test runs and analysis by an AI agent; runs linked below) found that every residual failing iteration shares one engine-side signature — a migration stuck in waiting-to-snapshot behind a child process that was killed long before but never exited:

```
22:21:13.318 * Started child process 78673 for slot migration {...}
22:21:13.322 * Slot migration target dropped, killing fork child.
22:21:13.322 * Killing running slot migration child: 78673
22:21:13.430 * Slot migration initiated through CLUSTER MIGRATESLOTS {...}
22:21:14.946 * waiting before snapshotting due to active child process.
   (repeats every 5s; 31s in this instance, 93+s observed elsewhere)
22:21:44.196 * connection lost / state transition: waiting-to-snapshot -> failed
```

**Mechanism.** `sigKillChildHandler` calls `exitFromChild()`, which under COVERAGE_TEST (set by `make gcov`) calls `exit()` so coverage data is flushed. Two problems. First, `exit()` is not async-signal-safe, and this call runs inside a signal handler. Second, the gcov atexit dump writes and lock-merges every .gcda file in the build tree, which is shared by all servers and children the test harness spawns across its 16 parallel clients — and tests that cancel migrations in tight loops kill a fresh child every few hundred milliseconds, so a killed child's `exit()` can stall for tens of seconds on the lock convoy. The parent correctly reports an active child throughout, the next migration legitimately cannot snapshot, and the test's wait expires regardless of its budget: harness-wide 3x wait scaling (#4153) and a controlled 10s-vs-30s A/B soak (200 iterations per arm, https://github.com/valkey-rainfall/valkey/actions/runs/29782958430) both left the failure rate unchanged. Corroborating detail: children reaped as `terminated by signal 10` (killed before installing the SIGUSR1 handler, so no coverage flush) never stall; only the handler/`exit()` path does.

**Fix.** Killed children call `_exit()` directly: the kill path regains async-signal-safety, and a killed child's coverage contribution — redundant with children that complete normally — is intentionally skipped. Non-coverage builds are behaviorally unchanged (`_exit()` either way).

## Verification

Full cluster-migrateslots file passes locally 105/105 (this file exercises the kill path heavily). Code coverage for children is now discarded but this was redundant -- coverage is exactly the same after this change except for missing `sigKillChildHandler` coverage.

A/B soak on gcov-instrumented builds matching the Codecov job, 50 loops x 4 shards per arm (https://github.com/valkey-rainfall/valkey/actions/runs/29860994762): baseline (parent commit) failed in all 4 shards — one [err] plus one cascade abort each (~5.4% per iteration), with the waiting-before-snapshotting stall visible in every failure's dumped logs — while the fixed arm completed all 4 shards fully clean: 5250/5250 [ok] per shard, zero errors, zero aborts, across 200 iterations (Fisher p ≈ 0.005).
