### PR TITLE
valkey-benchmark: fix -r option to support keyspace values above INT_MAX

### DIFF
--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -447,3 +447,7 @@ valkeyContext *valkeyConnectWrapper(enum valkeyConnectionType ct, const char *ip
 
     return valkeyConnectWithOptions(&options);
 }
+
+uint64_t rand62(void) {
+    return ((uint64_t)random() << 31) | (uint64_t)random();
+}

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -3,6 +3,7 @@
 
 #include <valkey/valkey.h>
 #include "sds.h"
+#include <stdint.h>
 
 typedef struct cliSSLconfig {
     /* Requested SNI, or NULL */
@@ -52,5 +53,9 @@ void freeCliConnInfo(cliConnInfo connInfo);
 sds cliVersion(void);
 
 valkeyContext *valkeyConnectWrapper(enum valkeyConnectionType ct, const char *ip_or_path, int port, const struct timeval tv, int nonblock, int multipath);
+
+/* Two random() calls combined for 62-bit range. Not genrand64_int64: its
+ * state is unlocked and callers are multi-threaded. Seed via srandom(). */
+uint64_t rand62(void);
 
 #endif /* __CLICOMMON_H */

--- a/src/fuzzer_client.c
+++ b/src/fuzzer_client.c
@@ -728,7 +728,7 @@ static int runClients(const char *host, int port, int commands_num, int clients_
 
 /* Run fuzzer clients with specified parameters
  * This function is called by valkey-benchmark when fuzz mode is enabled */
-int runFuzzerClients(const char *host, int port, int commands_num, int clients_num, int cluster_mode, int num_keys, cliSSLconfig *ssl_config, const char *log_level, int fuzz_flags) {
+int runFuzzerClients(const char *host, int port, int commands_num, int clients_num, int cluster_mode, long long num_keys, cliSSLconfig *ssl_config, const char *log_level, int fuzz_flags) {
     /* Set log level from parameter */
     if (log_level) {
         if (strcmp(log_level, "none") == 0) {

--- a/src/fuzzer_command_generator.c
+++ b/src/fuzzer_command_generator.c
@@ -103,7 +103,7 @@ typedef struct {
     dict *configDict;
     sds *aclCategories;
     size_t aclCategoriesCount;
-    int max_keys;
+    long long max_keys;
     int cluster_mode;
 } FuzzerContext;
 
@@ -1047,7 +1047,7 @@ void initializeRandomSeed(void) {
 }
 
 /* Initialize the fuzzer with a connected Valkey context */
-int initFuzzer(valkeyContext *ctx, int num_keys, int cluster_mode, int fuzz_flags) {
+int initFuzzer(valkeyContext *ctx, long long num_keys, int cluster_mode, int fuzz_flags) {
     int ret = -1;
     fuzz_ctx = zmalloc(sizeof(FuzzerContext));
     /* Set global configuration values */
@@ -1190,14 +1190,14 @@ static void addKeysToCommand(FuzzerCommand *cmd, int numkeys, CommandArgument *a
     }
 
     for (int i = 0; i < numkeys; i++) {
-        int keyNumber = rand() % fuzz_ctx->max_keys;
+        long long keyNumber = (long long)(((uint64_t)random() << 31) | (uint64_t)random()) % fuzz_ctx->max_keys;
         sds keyName;
 
         /* In cluster mode, ensure all keys use the same slot tag to map to the same slot */
         if (fuzz_ctx->cluster_mode && client_ctx && client_ctx->current_slot_tag) {
-            keyName = sdscatprintf(sdsempty(), "%s%s:%d", client_ctx->current_slot_tag, keyPrefix, keyNumber);
+            keyName = sdscatprintf(sdsempty(), "%s%s:%lld", client_ctx->current_slot_tag, keyPrefix, keyNumber);
         } else {
-            keyName = sdscatprintf(sdsempty(), "%s:%d", keyPrefix, keyNumber);
+            keyName = sdscatprintf(sdsempty(), "%s:%lld", keyPrefix, keyNumber);
         }
 
         appendArg(cmd, keyName);

--- a/src/fuzzer_command_generator.c
+++ b/src/fuzzer_command_generator.c
@@ -7,6 +7,7 @@
 #include <valkey/valkey.h>
 #include "commands.h"
 #include "fuzzer_command_generator.h"
+#include "cli_common.h"
 #include "sds.h"
 #include "dict.h"
 #include "zmalloc.h"
@@ -1044,6 +1045,8 @@ void initializeRandomSeed(void) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     srand(time(NULL) ^ (unsigned long)pthread_self() ^ tv.tv_usec);
+    /* rand62() uses random(), whose state is separate from rand(). */
+    srandom(time(NULL) ^ (unsigned long)pthread_self() ^ tv.tv_usec);
 }
 
 /* Initialize the fuzzer with a connected Valkey context */
@@ -1190,7 +1193,7 @@ static void addKeysToCommand(FuzzerCommand *cmd, int numkeys, CommandArgument *a
     }
 
     for (int i = 0; i < numkeys; i++) {
-        long long keyNumber = (long long)(((uint64_t)random() << 31) | (uint64_t)random()) % fuzz_ctx->max_keys;
+        long long keyNumber = (long long)rand62() % fuzz_ctx->max_keys;
         sds keyName;
 
         /* In cluster mode, ensure all keys use the same slot tag to map to the same slot */

--- a/src/fuzzer_command_generator.h
+++ b/src/fuzzer_command_generator.h
@@ -16,7 +16,7 @@ typedef enum {
     FUZZ_MODE_CONFIG_COMMANDS = (1 << 1)
 } FuzzMode;
 
-int initFuzzer(valkeyContext *ctx, int num_keys, int cluster_mode, int fuzz_flags);
+int initFuzzer(valkeyContext *ctx, long long num_keys, int cluster_mode, int fuzz_flags);
 void cleanupFuzzer(void);
 void initThreadClientCtx(int fuzz_flags);
 void resetClientFuzzCtx(void);

--- a/src/valkey-benchmark-dataset.c
+++ b/src/valkey-benchmark-dataset.c
@@ -33,7 +33,7 @@ static int findFieldIndex(dataset *ds, const char *field_name, size_t field_name
 static const char *extractDatasetFieldValue(dataset *ds, int field_idx, int record_index);
 static sds replaceOccurrence(sds processed_arg, const char *pos, const char *replacement);
 static sds processFieldsInArg(dataset *ds, sds arg, int record_index);
-static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key, int replace_placeholders, int keyspacelen, int sequential_replacement);
+static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key, int replace_placeholders, long long keyspacelen, int sequential_replacement);
 
 dataset *datasetInit(const char *filename, int max_documents, int has_field_placeholders, sds *template_argv, int template_argc, int verbose) {
     if (!filename) return NULL;
@@ -160,7 +160,7 @@ size_t datasetGetRecordCount(dataset *ds) {
     return ds ? ds->record_count : 0;
 }
 
-sds datasetGenerateCommand(dataset *ds, int record_index, sds *template_argv, int template_argc, _Atomic uint64_t *seq_key, int replace_placeholders, int keyspacelen, int sequential_replacement) {
+sds datasetGenerateCommand(dataset *ds, int record_index, sds *template_argv, int template_argc, _Atomic uint64_t *seq_key, int replace_placeholders, long long keyspacelen, int sequential_replacement) {
     if (!ds || !template_argv) return NULL;
 
     sds *processed_argv = zmalloc(template_argc * sizeof(sds));
@@ -414,7 +414,7 @@ static sds processFieldsInArg(dataset *ds, sds arg, int record_index) {
     return arg;
 }
 
-static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key, int replace_placeholders, int keyspacelen, int sequential_replacement) {
+static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key, int replace_placeholders, long long keyspacelen, int sequential_replacement) {
     if (!replace_placeholders || keyspacelen == 0) return cmd;
 
     for (int ph = 0; ph < PLACEHOLDER_COUNT; ph++) {
@@ -427,7 +427,7 @@ static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key,
             if (sequential_replacement) {
                 shared_key = atomic_fetch_add_explicit(&seq_key[ph], 1, memory_order_relaxed);
             } else {
-                shared_key = (uint64_t)random();
+                shared_key = ((uint64_t)random() << 31) | (uint64_t)random();
             }
             shared_key %= keyspacelen;
         }
@@ -441,7 +441,7 @@ static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key,
                 if (sequential_replacement) {
                     key = atomic_fetch_add_explicit(&seq_key[ph], 1, memory_order_relaxed);
                 } else {
-                    key = (uint64_t)random();
+                    key = ((uint64_t)random() << 31) | (uint64_t)random();
                 }
                 key %= keyspacelen;
             }

--- a/src/valkey-benchmark-dataset.c
+++ b/src/valkey-benchmark-dataset.c
@@ -8,6 +8,7 @@
 #include "fmacros.h"
 
 #include "valkey-benchmark-dataset.h"
+#include "cli_common.h"
 #include "zmalloc.h"
 #include <valkey/valkey.h>
 #include <stdbool.h>
@@ -427,7 +428,7 @@ static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key,
             if (sequential_replacement) {
                 shared_key = atomic_fetch_add_explicit(&seq_key[ph], 1, memory_order_relaxed);
             } else {
-                shared_key = ((uint64_t)random() << 31) | (uint64_t)random();
+                shared_key = rand62();
             }
             shared_key %= keyspacelen;
         }
@@ -441,7 +442,7 @@ static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key,
                 if (sequential_replacement) {
                     key = atomic_fetch_add_explicit(&seq_key[ph], 1, memory_order_relaxed);
                 } else {
-                    key = ((uint64_t)random() << 31) | (uint64_t)random();
+                    key = rand62();
                 }
                 key %= keyspacelen;
             }

--- a/src/valkey-benchmark-dataset.h
+++ b/src/valkey-benchmark-dataset.h
@@ -58,7 +58,7 @@ size_t datasetGetRecordCount(dataset *ds);
 
 #ifndef __cplusplus
 /* Generate complete command for given record index (caller must sdsfree) */
-sds datasetGenerateCommand(dataset *ds, int record_index, sds *template_argv, int template_argc, _Atomic uint64_t *seq_key, int replace_placeholders, int keyspacelen, int sequential_replacement);
+sds datasetGenerateCommand(dataset *ds, int record_index, sds *template_argv, int template_argc, _Atomic uint64_t *seq_key, int replace_placeholders, long long keyspacelen, int sequential_replacement);
 #endif
 
 #endif /* VALKEY_BENCHMARK_DATASET_H */

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -78,6 +78,9 @@
 
 #define PLACEHOLDER_COUNT 10
 static const size_t PLACEHOLDER_LEN = 12; // length of BENCHMARK_PLACEHOLDERS strings
+/* Cap on -r. Keys are written into PLACEHOLDER_LEN-wide fixed slots, so
+ * bumping this requires widening the placeholder handling too. */
+#define MAX_KEYSPACELEN 999999999999LL
 static const char *PLACEHOLDERS[PLACEHOLDER_COUNT] = {
     "__rand_int__", "__rand_1st__", "__rand_2nd__", "__rand_3rd__", "__rand_4th__",
     "__rand_5th__", "__rand_6th__", "__rand_7th__", "__rand_8th__", "__rand_9th__"};
@@ -487,7 +490,7 @@ static void replacePlaceholder(const size_t *indices, const size_t count, char *
         if (config.sequential_replacement) {
             key = atomic_fetch_add_explicit(key_counter, 1, memory_order_relaxed);
         } else {
-            key = ((uint64_t)random() << 31) | (uint64_t)random();
+            key = rand62();
         }
         key %= config.keyspacelen;
     }
@@ -1801,8 +1804,8 @@ int parseOptions(int argc, char **argv) {
                 fprintf(stderr, "Invalid value for -r: '%s' is not a valid number\n", next);
                 exit(1);
             }
-            if (errno == ERANGE || val < 0 || val > 999999999999LL) {
-                fprintf(stderr, "Invalid value for -r: keyspacelen must be between 0 and 999999999999\n");
+            if (errno == ERANGE || val < 0 || val > MAX_KEYSPACELEN) {
+                fprintf(stderr, "Invalid value for -r: keyspacelen must be between 0 and %lld\n", MAX_KEYSPACELEN);
                 exit(1);
             }
             config.replace_placeholders = 1;

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -118,7 +118,7 @@ static struct config {
     int keysize;
     int datasize;
     int replace_placeholders;
-    int keyspacelen;
+    long long keyspacelen;
     int sequential_replacement;
     int keepalive;
     int pipeline;
@@ -261,7 +261,7 @@ static void freeServerConfig(serverConfig *cfg);
 static int fetchClusterSlotsConfiguration(client c);
 static void updateClusterSlotsConfiguration(void);
 static long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData);
-int runFuzzerClients(const char *host, int port, int max_commands, int parallel_clients, int cluster_mode, int num_keys, cliSSLconfig *ssl_config, const char *log_level, int fuzz_flags);
+int runFuzzerClients(const char *host, int port, int max_commands, int parallel_clients, int cluster_mode, long long num_keys, cliSSLconfig *ssl_config, const char *log_level, int fuzz_flags);
 static int parseCommandTemplate(int argc, char **argv);
 
 /* Dict callbacks */
@@ -487,7 +487,7 @@ static void replacePlaceholder(const size_t *indices, const size_t count, char *
         if (config.sequential_replacement) {
             key = atomic_fetch_add_explicit(key_counter, 1, memory_order_relaxed);
         } else {
-            key = random();
+            key = ((uint64_t)random() << 31) | (uint64_t)random();
         }
         key %= config.keyspacelen;
     }
@@ -1793,14 +1793,20 @@ int parseOptions(int argc, char **argv) {
             if (config.pipeline <= 0) config.pipeline = 1;
         } else if (!strcmp(argv[i], "-r")) {
             if (lastarg) goto invalid;
-            const char *next = argv[++i], *p = next;
-            if (*p == '-') {
-                p++;
-                if (*p < '0' || *p > '9') goto invalid;
+            const char *next = argv[++i];
+            char *endptr;
+            errno = 0;
+            long long val = strtoll(next, &endptr, 10);
+            if (endptr == next || *endptr != '\0') {
+                fprintf(stderr, "Invalid value for -r: '%s' is not a valid number\n", next);
+                exit(1);
+            }
+            if (errno == ERANGE || val < 0 || val > 999999999999LL) {
+                fprintf(stderr, "Invalid value for -r: keyspacelen must be between 0 and 999999999999\n");
+                exit(1);
             }
             config.replace_placeholders = 1;
-            config.keyspacelen = atoi(next);
-            if (config.keyspacelen < 0) config.keyspacelen = 0;
+            config.keyspacelen = val;
         } else if (!strcmp(argv[i], "--sequential")) {
             config.sequential_replacement = 1;
         } else if (!strcmp(argv[i], "-q")) {

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -468,6 +468,12 @@ tags {"benchmark network external:skip logreqres:skip"} {
             assert_match "*must be between 0 and 999999999999*" $error
         }
 
+        test {benchmark: -r rejects non-numeric value} {
+            set cmd [valkeybenchmark $master_host $master_port "-r abc -n 5 -t set"]
+            catch { exec {*}$cmd } error
+            assert_match "*is not a valid number*" $error
+        }
+
         test {benchmark: -r with large keyspace generates keys above 2^31} {
             set cmd [valkeybenchmark $master_host $master_port "-r 999999999999 -n 100 -t set"]
             common_bench_setup $cmd

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -462,6 +462,28 @@ tags {"benchmark network external:skip logreqres:skip"} {
             assert_match "*Options -n and --duration are mutually exclusive*" $error
         }
 
+        test {benchmark: -r rejects overflow value} {
+            set cmd [valkeybenchmark $master_host $master_port "-r 99999999999999999999 -n 5 -t set"]
+            catch { exec {*}$cmd } error
+            assert_match "*must be between 0 and 999999999999*" $error
+        }
+
+        test {benchmark: -r with large keyspace generates keys above 2^31} {
+            set cmd [valkeybenchmark $master_host $master_port "-r 999999999999 -n 100 -t set"]
+            common_bench_setup $cmd
+            set keys [r keys *]
+            set found_large 0
+            foreach key $keys {
+                set num [string range $key 4 end]
+                scan $num %lld num
+                if {$num > 2147483647} {
+                    set found_large 1
+                    break
+                }
+            }
+            assert_equal 1 $found_large
+        }
+
         test {benchmark: warmup applies to all tests in multi-test run} {
             set start_time [clock clicks -millisec]
             set cmd [valkeybenchmark $master_host $master_port "-r 5 --warmup 2 -n 50 -t set,get,incr"]


### PR DESCRIPTION
Fixes #4228

## Changes
  - Convert `config.keyspacelen` from `int` to `long long` (64-bit on all platforms)
  - Replace `atoi` with `strtoll` for proper overflow and input validation
  - Widen RNG from `random()` (31-bit) to 62-bit by combining two calls
  - Cap accepted values at 999,999,999,999 (12-digit key limit)
  - Propagate `long long` through dataset and fuzzer function signatures
  - Add integration tests for overflow rejection and large keyspace key generation

## Design note
`random()` only gives 31 bits, so two calls are combined for 62-bit range. A 64-bit random number generator (`mt19937-64.c`) is already included in valkey-benchmark, but its state is shared and unlocked — using it from `--threads` or the fuzzer's per-client threads would race. Stuck with two `random()` calls instead since it's already thread-safe.