### PR TITLE
Convert oversized hash listpacks during RDB load

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2384,9 +2384,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
         /* Fix the object encoding, and make sure to convert the encoded
          * data type into the base type if accordingly to the current
          * configuration there are too many elements in the encoded data
-         * type. Hash listpacks also check the maximum field and value size.
-         * Other encodings only check the length; eventually everything gets
-         * converted. */
+         * type. Hash encodings also check the maximum field and value size.
+         * Other listpack encodings only check the length; eventually
+         * everything gets converted. */
         switch (rdbtype) {
         case RDB_TYPE_HASH_ZIPMAP:
             /* Since we don't keep zipmaps anymore, the rdb loading for these

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1930,7 +1930,7 @@ static bool rdbHashListpackExceedsMaxValue(unsigned char *lp) {
 
     while (p) {
         lpGet(p, &len, intbuf);
-        if (len > server.hash_max_listpack_value) return true;
+        if ((size_t)len > server.hash_max_listpack_value) return true;
         p = lpNext(lp, p);
     }
 
@@ -2384,8 +2384,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
         /* Fix the object encoding, and make sure to convert the encoded
          * data type into the base type if accordingly to the current
          * configuration there are too many elements in the encoded data
-         * type. Note that we only check the length and not max element
-         * size as this is an O(N) scan. Eventually everything will get
+         * type. Hash listpacks also check the maximum field and value size.
+         * Other encodings only check the length; eventually everything gets
          * converted. */
         switch (rdbtype) {
         case RDB_TYPE_HASH_ZIPMAP:
@@ -2587,7 +2587,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 goto emptykey;
             }
 
-            if (hashTypeLength(o) > server.hash_max_listpack_entries)
+            if (hashTypeLength(o) > server.hash_max_listpack_entries ||
+                rdbHashListpackExceedsMaxValue(objectGetVal(o)))
                 hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
             else
                 objectSetVal(o, lpShrinkToFit(objectGetVal(o)));

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1921,6 +1921,22 @@ int lpValidateIntegrityAndDups(unsigned char *lp, size_t size, int pairs) {
     return ret;
 }
 
+/* Check whether a hash listpack contains a field or value that exceeds the
+ * configured listpack value limit. */
+static bool rdbHashListpackExceedsMaxValue(unsigned char *lp) {
+    unsigned char intbuf[LP_INTBUF_SIZE];
+    int64_t len;
+    unsigned char *p = lpFirst(lp);
+
+    while (p) {
+        lpGet(p, &len, intbuf);
+        if (len > server.hash_max_listpack_value) return true;
+        p = lpNext(lp, p);
+    }
+
+    return false;
+}
+
 /* Load an Object of the specified type from the specified file.
  * On success a newly allocated object is returned, otherwise NULL.
  * When the function returns NULL and if 'error' is not NULL, the
@@ -2593,7 +2609,10 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 goto emptykey;
             }
 
-            if (hashTypeLength(o) > server.hash_max_listpack_entries) hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
+            if (hashTypeLength(o) > server.hash_max_listpack_entries ||
+                rdbHashListpackExceedsMaxValue(objectGetVal(o))) {
+                hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
+            }
             break;
         default:
             /* totally unreachable */

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -52,6 +52,23 @@ start_server [list overrides [list "dir" $server_path "dbfilename" "encodings.rd
   } $csv_dump
 }
 
+set hash_server_path [tmpdir "server.rdb-hash-listpack-value"]
+
+start_server [list overrides [list "dir" $hash_server_path] keep_persistence true] {
+    test "RDB saves a listpack hash with a value above a later limit" {
+        r hset hash field oversized
+        assert_encoding listpack hash
+        r save
+    }
+}
+
+start_server [list overrides [list "dir" $hash_server_path "hash-max-listpack-value" 1] keep_persistence true] {
+    test "RDB load converts a listpack hash that exceeds hash-max-listpack-value" {
+        assert_encoding hashtable hash
+        assert_equal oversized [r hget hash field]
+    }
+}
+
 start_server_and_kill_it [list "dir" $server_path "dbfilename" "encodings-rdb987.rdb"] {
     test "RDB future version loading, strict version check" {
         wait_for_condition 50 100 {


### PR DESCRIPTION
## Summary

- Check fields and values in loaded hash listpacks against `hash-max-listpack-value`.
- Convert the hash to a hashtable when either the entry-count or value-size limit is exceeded.
- Add a restart-based regression test.

## Root cause

The `RDB_TYPE_HASH_LISTPACK` load path checked only `hash-max-listpack-entries`. A hash saved as a listpack under a larger value limit therefore stayed listpack after restart when `hash-max-listpack-value` had been lowered.

## Testing

- `git diff --check`
- Formatted `src/rdb.c` with `clang-format-18`
- The full test suite was not run locally because this Windows environment lacks the POSIX shell required by the build; CI should validate the added integration test.

Fixes #4203