### PR TITLE
Skip Daily Tests for Version changes

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -10,6 +10,7 @@ on:
       - '**/*.md'
       - '**/00-RELEASENOTES'
       - '**/COPYING'
+      - 'src/version.h'
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:


### PR DESCRIPTION
Currently, we run all the daily tests whenever a PR is raised to one of the released branches.

We have started to automate the release process with automated release notes PR like https://github.com/valkey-io/valkey/pull/4247. 

Daily tests are time consuming and often flaky. I think we do not need to run daily tests on these PRs, and CI could still be a good sanity check for `version.h` file changes. 

This can help the release notes PR to be ready faster.