### PR TITLE
perf: combined post-command pending-work gate in afterCommand()

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -355,8 +355,11 @@ typedef struct ValkeyModulePostExecUnitJob {
 /* The module keyspace notification subscribers list */
 static list *moduleKeyspaceSubscribers;
 
-/* The module post keyspace jobs list */
-static list *modulePostExecUnitJobs;
+/* The module post keyspace jobs list.
+ * Not static: postExecutionUnitOperations() reads its length directly
+ * (via listLength()) to fold the "any pending module job?" check into
+ * a single combined gate, without an extra cross-TU function call. */
+list *modulePostExecUnitJobs;
 
 /* Data structures related to the exported dictionary data structure. */
 typedef struct ValkeyModuleDict {

--- a/src/module.c
+++ b/src/module.c
@@ -355,11 +355,8 @@ typedef struct ValkeyModulePostExecUnitJob {
 /* The module keyspace notification subscribers list */
 static list *moduleKeyspaceSubscribers;
 
-/* The module post keyspace jobs list.
- * Not static: postExecutionUnitOperations() reads its length directly
- * (via listLength()) to fold the "any pending module job?" check into
- * a single combined gate, without an extra cross-TU function call. */
-list *modulePostExecUnitJobs;
+/* The module post keyspace jobs list */
+static list *modulePostExecUnitJobs;
 
 /* Data structures related to the exported dictionary data structure. */
 typedef struct ValkeyModuleDict {
@@ -9397,6 +9394,16 @@ int VM_SubscribeToKeyspaceEvents(ValkeyModuleCtx *ctx, int types, ValkeyModuleNo
 
     listAddNodeTail(moduleKeyspaceSubscribers, sub);
     return VALKEYMODULE_OK;
+}
+
+/* Whether any module post-execution-unit job is pending. Kept as a tiny
+ * accessor rather than exposing modulePostExecUnitJobs itself, so callers
+ * outside this file (postExecutionUnitOperations()) don't need to know it's
+ * backed by a list - if that representation ever changes, only this
+ * function needs to change with it. It's trivial enough that LTO can inline
+ * it at its (currently single) call site same as any other cross-TU call. */
+bool moduleHasPostExecUnitJobs(void) {
+    return listLength(modulePostExecUnitJobs) > 0;
 }
 
 void firePostExecutionUnitJobs(void) {

--- a/src/module.h
+++ b/src/module.h
@@ -213,6 +213,7 @@ void moduleReleaseGIL(void);
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
 unsigned long moduleNotifyKeyspaceSubscribersCnt(void);
 void firePostExecutionUnitJobs(void);
+extern list *modulePostExecUnitJobs;
 void moduleCallCommandFilters(client *c);
 void moduleFireCommandResultEvent(client *c,
                                   struct serverCommand *cmd,

--- a/src/module.h
+++ b/src/module.h
@@ -213,7 +213,7 @@ void moduleReleaseGIL(void);
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
 unsigned long moduleNotifyKeyspaceSubscribersCnt(void);
 void firePostExecutionUnitJobs(void);
-extern list *modulePostExecUnitJobs;
+bool moduleHasPostExecUnitJobs(void);
 void moduleCallCommandFilters(client *c);
 void moduleFireCommandResultEvent(client *c,
                                   struct serverCommand *cmd,

--- a/src/server.c
+++ b/src/server.c
@@ -3787,12 +3787,14 @@ static void propagatePendingCommands(void) {
  * afterCommand() so the "is there anything to do?" condition for these three
  * sub-systems has a single home instead of being duplicated at both call
  * sites - static inline costs nothing here since both callers are in this
- * same translation unit.
+ * same translation unit. moduleHasPostExecUnitJobs() is a tiny cross-TU
+ * accessor rather than reaching into module.c's list directly, so this file
+ * doesn't need to know how the module subsystem tracks its pending jobs.
  *
  * Must stay an OR of every condition below - never drop one as an
  * optimization, since that would silently skip real pending work. */
 static inline int hasPostExecutionUnitPendingWork(void) {
-    return listLength(modulePostExecUnitJobs) || server.also_propagate.numops || server.busy_module_yield_flags;
+    return moduleHasPostExecUnitJobs() || server.also_propagate.numops || server.busy_module_yield_flags;
 }
 
 /* Performs operations that should be performed after an execution unit ends.
@@ -4225,7 +4227,7 @@ void afterCommand(client *c) {
      * work, it must run for every command whenever slot-stats accounting
      * is enabled. */
     if (server.execution_nesting == 0 &&
-        unlikely(hasPostExecutionUnitPendingWork() || listLength(server.tracking_pending_keys) ||
+        unlikely(hasPostExecutionUnitPendingWork() || trackingHasPendingKeyInvalidations() ||
                  listLength(server.pending_push_messages))) {
         /* Should be done before trackingHandlePendingKeyInvalidations so that we
          * reply to client before invalidating cache (makes more sense) */

--- a/src/server.c
+++ b/src/server.c
@@ -3782,6 +3782,19 @@ static void propagatePendingCommands(void) {
     serverOpArrayFree(&server.also_propagate);
 }
 
+/* Whether any of the module-jobs / propagation / module-yield post-execution-
+ * unit work is pending. Shared by postExecutionUnitOperations() and
+ * afterCommand() so the "is there anything to do?" condition for these three
+ * sub-systems has a single home instead of being duplicated at both call
+ * sites - static inline costs nothing here since both callers are in this
+ * same translation unit.
+ *
+ * Must stay an OR of every condition below - never drop one as an
+ * optimization, since that would silently skip real pending work. */
+static inline int hasPostExecutionUnitPendingWork(void) {
+    return listLength(modulePostExecUnitJobs) || server.also_propagate.numops || server.busy_module_yield_flags;
+}
+
 /* Performs operations that should be performed after an execution unit ends.
  * Execution unit is a code that should be done atomically.
  * Execution units can be nested and do not necessarily start with a server command.
@@ -3806,12 +3819,11 @@ void postExecutionUnitOperations(void) {
      * pays for one memory read + one branch instead of three separate
      * (partly cross-translation-unit, non-inlinable) function calls.
      *
-     * This must stay an OR of every condition the three calls below can
-     * act on - never remove one of them as an optimization, since that
-     * would silently skip real pending work (see each callee for the
-     * invariants it protects). */
-    if (unlikely(listLength(modulePostExecUnitJobs) || server.also_propagate.numops ||
-                 server.busy_module_yield_flags)) {
+     * Deliberately NOT hinted unlikely() here: unlike the afterCommand()
+     * gate below, this function is also called right after queuing a
+     * propagation (expire.c, evict.c, db.c) where the condition is
+     * typically true, so a fixed hint would be wrong for those call sites. */
+    if (hasPostExecutionUnitPendingWork()) {
         firePostExecutionUnitJobs();
 
         /* If we are at the top-most call() and not inside an active module
@@ -4205,14 +4217,15 @@ void afterCommand(client *c) {
      * GET, or after each sub-command of a MULTI/EXEC or script) short-
      * circuits before paying for any of the calls below.
      *
-     * Must OR every condition the calls below can act on - never drop one
-     * as an optimization, or real pending work will be silently skipped.
-     * clusterSlotStatsAddNetworkBytesOutForUserClient() is intentionally
-     * excluded: it is not deferred/queued work, it must run for every
-     * command whenever slot-stats accounting is enabled. */
+     * Unlike the shared hasPostExecutionUnitPendingWork() conditions, the
+     * unlikely() hint here is safe: this is the single call site reached
+     * from a plain top-level command, where "nothing pending" genuinely
+     * dominates. clusterSlotStatsAddNetworkBytesOutForUserClient() is
+     * intentionally excluded from the gate: it is not deferred/queued
+     * work, it must run for every command whenever slot-stats accounting
+     * is enabled. */
     if (server.execution_nesting == 0 &&
-        unlikely(listLength(modulePostExecUnitJobs) || server.also_propagate.numops ||
-                 server.busy_module_yield_flags || listLength(server.tracking_pending_keys) ||
+        unlikely(hasPostExecutionUnitPendingWork() || listLength(server.tracking_pending_keys) ||
                  listLength(server.pending_push_messages))) {
         /* Should be done before trackingHandlePendingKeyInvalidations so that we
          * reply to client before invalidating cache (makes more sense) */

--- a/src/server.c
+++ b/src/server.c
@@ -3799,14 +3799,28 @@ static void propagatePendingCommands(void) {
 void postExecutionUnitOperations(void) {
     if (server.execution_nesting) return;
 
-    firePostExecutionUnitJobs();
+    /* Combined pending-work gate: in the overwhelming majority of calls
+     * (e.g. after a plain read-only command like GET) none of the three
+     * sub-systems below have anything queued. Fold all of their "is there
+     * anything to do?" checks into a single branch here so the common case
+     * pays for one memory read + one branch instead of three separate
+     * (partly cross-translation-unit, non-inlinable) function calls.
+     *
+     * This must stay an OR of every condition the three calls below can
+     * act on - never remove one of them as an optimization, since that
+     * would silently skip real pending work (see each callee for the
+     * invariants it protects). */
+    if (unlikely(listLength(modulePostExecUnitJobs) || server.also_propagate.numops ||
+                 server.busy_module_yield_flags)) {
+        firePostExecutionUnitJobs();
 
-    /* If we are at the top-most call() and not inside an active module
-     * context (e.g. within a module timer) we can propagate what we accumulated. */
-    propagatePendingCommands();
+        /* If we are at the top-most call() and not inside an active module
+         * context (e.g. within a module timer) we can propagate what we accumulated. */
+        propagatePendingCommands();
 
-    /* Module subsystem post-execution-unit logic */
-    modulePostExecutionUnitOperations();
+        /* Module subsystem post-execution-unit logic */
+        modulePostExecutionUnitOperations();
+    }
 }
 
 /* Increment the command failure counters (either rejected_calls or failed_calls).
@@ -4183,18 +4197,36 @@ void rejectCommandFormat(client *c, int notify_modules, const char *fmt, ...) {
 /* This is called after a command in call, we can do some maintenance job in it. */
 void afterCommand(client *c) {
     UNUSED(c);
-    /* Should be done before trackingHandlePendingKeyInvalidations so that we
-     * reply to client before invalidating cache (makes more sense) */
-    postExecutionUnitOperations();
 
-    /* Flush pending tracking invalidations. */
-    trackingHandlePendingKeyInvalidations();
+    /* Combined pending-work gate for command-completion tail work.
+     * See postExecutionUnitOperations() for why each callee below still
+     * needs its own defensive check - this gate exists purely so the
+     * overwhelmingly common "nothing pending" case (e.g. after a plain
+     * GET, or after each sub-command of a MULTI/EXEC or script) short-
+     * circuits before paying for any of the calls below.
+     *
+     * Must OR every condition the calls below can act on - never drop one
+     * as an optimization, or real pending work will be silently skipped.
+     * clusterSlotStatsAddNetworkBytesOutForUserClient() is intentionally
+     * excluded: it is not deferred/queued work, it must run for every
+     * command whenever slot-stats accounting is enabled. */
+    if (server.execution_nesting == 0 &&
+        unlikely(listLength(modulePostExecUnitJobs) || server.also_propagate.numops ||
+                 server.busy_module_yield_flags || listLength(server.tracking_pending_keys) ||
+                 listLength(server.pending_push_messages))) {
+        /* Should be done before trackingHandlePendingKeyInvalidations so that we
+         * reply to client before invalidating cache (makes more sense) */
+        postExecutionUnitOperations();
+
+        /* Flush pending tracking invalidations. */
+        trackingHandlePendingKeyInvalidations();
+
+        /* Flush other pending push messages. Not interleaved with
+         * transaction response since we're already outside nesting here. */
+        listJoin(c->reply, server.pending_push_messages);
+    }
 
     clusterSlotStatsAddNetworkBytesOutForUserClient(c);
-
-    /* Flush other pending push messages. only when we are not in nested call.
-     * So the messages are not interleaved with transaction response. */
-    if (!server.execution_nesting) listJoin(c->reply, server.pending_push_messages);
 }
 
 /* Check if c->cmd exists, fills `err` with details in case it doesn't.

--- a/src/server.h
+++ b/src/server.h
@@ -3073,6 +3073,7 @@ void trackingRememberKeys(client *tracking, client *executing);
 void trackingInvalidateKey(client *c, robj *keyobj, int bcast);
 void trackingScheduleKeyInvalidation(uint64_t client_id, robj *keyobj);
 void trackingHandlePendingKeyInvalidations(void);
+bool trackingHasPendingKeyInvalidations(void);
 void trackingInvalidateKeysOnFlush(int async);
 void freeTrackingRadixTree(rax *rt);
 void freeTrackingRadixTreeAsync(rax *rt);

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -423,6 +423,14 @@ void trackingInvalidateKey(client *c, robj *keyobj, int bcast) {
     raxRemove(TrackingTable, (unsigned char *)key, keylen, NULL);
 }
 
+/* Whether any tracking (client-side-caching) key invalidation is pending
+ * flush. A tiny accessor over server.tracking_pending_keys rather than
+ * having callers reach into the list themselves, so this file stays the
+ * sole owner of how pending invalidations are tracked. */
+bool trackingHasPendingKeyInvalidations(void) {
+    return listLength(server.tracking_pending_keys) > 0;
+}
+
 void trackingHandlePendingKeyInvalidations(void) {
     if (!listLength(server.tracking_pending_keys)) return;
 


### PR DESCRIPTION
## Summary

Part of #4117 — picks up the "Idle no-op work / combined post-command work
pending gate" candidate.

`afterCommand()` (called after every command in `call()`, at every
nesting level — including each sub-command of a `MULTI`/`EXEC` or a
script) runs a short chain of steps that each independently check
whether they have anything to do and return if not:

- `postExecutionUnitOperations()` → `firePostExecutionUnitJobs()` (pending
  module post-notification jobs) and `propagatePendingCommands()`
  (pending AOF/replication propagation via `server.also_propagate`)
- `trackingHandlePendingKeyInvalidations()` (pending client-side-caching
  invalidations)
- the `pending_push_messages` join

For the overwhelmingly common case — a plain read like `GET` with
nothing queued in any of these — every one of these still pays for an
out-of-line call before discovering there's nothing to do.

Checked in the disassembly of an unmodified `-O3 -flto=auto` build:
`postExecutionUnitOperations()` issues direct, non-inlined calls to
`firePostExecutionUnitJobs()` and `propagatePendingCommands()` on every
command; the empty-check guards live inside each callee and are not
hoisted into the caller. This holds even for `propagatePendingCommands()`,
which is `static` with a single call site (the shape that usually
triggers partial inlining) — LTO privatized it (`propagatePendingCommands.lto_priv.0`)
but kept it out-of-line rather than inlining it, presumably because its
body (loop + multiple sub-calls) exceeds the inliner's cost threshold.

This change hoists a single combined "is there any post-command work
pending?" check to the top of `afterCommand()`, so the empty path pays
for one branch instead of four separate out-of-line calls.

## What changed

**`src/server.c`**
- `postExecutionUnitOperations()`: wrapped its three sub-calls
  (`firePostExecutionUnitJobs()`, `propagatePendingCommands()`,
  `modulePostExecutionUnitOperations()`) in a single gate that ORs the
  conditions each of them individually checks
  (`listLength(modulePostExecUnitJobs)`, `server.also_propagate.numops`,
  `server.busy_module_yield_flags`). Kept unchanged in its own right
  because it's called from 8 other sites (`evict.c`, `expire.c` x2,
  `db.c`, `module.c`, `cluster_legacy.c`, `cluster_migrateslots.c`)
  that don't go through `afterCommand()`.
- `afterCommand()`: added an outer gate that additionally covers
  `server.tracking_pending_keys` (client-side-caching invalidations) and
  `server.pending_push_messages`, plus `server.execution_nesting == 0` as
  a precondition (the three calls inside are already no-ops while nested,
  so this lets every nested sub-command of a `MULTI`/`EXEC` or script
  skip the whole block instead of entering and bailing out of each call).
  `clusterSlotStatsAddNetworkBytesOutForUserClient()` is deliberately
  left outside the gate — it's not deferred/queued work, it has to run
  for every command whenever slot-stats accounting is enabled.

**`src/module.c` / `src/module.h`**
- `modulePostExecUnitJobs` (the module post-notification-job list) is no
  longer `static`; it's now declared `extern` in `module.h` so
  `postExecutionUnitOperations()` can read its length directly via the
  existing `listLength()` macro, without a cross-TU call just to ask
  "is there anything queued?" I considered adding a separately
  maintained counter instead, but rejected it: a counter is a second
  source of truth that has to be kept in sync by hand on every
  add/remove path, which risks silently drifting from the list's real
  state. Exposing the pointer avoids that by construction — there's
  only one place the length lives.

## Correctness invariants preserved

- `server.execution_nesting` gating is unchanged in `postExecutionUnitOperations()`
  and only *added to*, never replaces, the checks in `afterCommand()`.
- The gate is a strict OR of every condition its guarded calls act on.
  It does not skip real pending work: a lazily-expired key's `DEL`/`UNLINK`
  populates `server.also_propagate` before `afterCommand()` runs, so the
  gate observes it and still propagates within the same execution unit.
- Call order inside the gate is unchanged: post-exec-unit jobs run before
  propagation flush (a module job can itself call `alsoPropagate()` and
  needs to be included in the same propagation flush), tracking
  invalidations are flushed after propagation (so the client gets its
  reply before cache invalidation messages, per the existing comment),
  and push messages are joined last.
- `propagateNow()`'s replica-pause assertion and the `MULTI`/`EXEC`
  transaction-wrapping logic in `propagatePendingCommands()` are
  untouched — the gate only decides *whether* to enter this code, never
  *how* it behaves once entered.

## Trade-off (open question, per @rainsupreme's note on the issue)

This duplicates each subsystem's "is there work?" condition at the
`afterCommand()` call site. If a new pending-work queue is added to this
tail in the future and its check isn't added to the gate, that work
would be silently skipped instead of erroring — this is the real risk,
not a perf regression. I tried to mitigate it with a comment on the gate
enumerating every condition it must OR, but it's still an extra place to
remember. Open to discussing whether that maintainability cost is worth
the saving, e.g. whether some lighter-weight structural guard (rather
than a hand-maintained OR list) would be preferable.

## Testing

Full run of the following suites, 1333/1333 passed:
`unit/expire`, `unit/multi`, `unit/scripting`, `unit/tracking`,
`unit/keyspace`, `unit/pubsub`, `unit/pubsubshard`, `unit/introspection`,
`unit/introspection-2`, `integration/replication`,
`unit/moduleapi/{postnotifications,keyspace_events,propagate,async_rm_call}`.

## Benchmarking

Followed the methodology from the issue as closely as I could:
- Same compiler/flags for baseline and candidate (default `-O3 -flto=auto`,
  non-PGO for both).
- Both binaries built from a clean worktree / working tree, run
  back-to-back, CPUs pinned via `taskset`.
- 8 repetitions, **server restarted between each repetition**, baseline
  and candidate runs interleaved (B/A/B/A/...) to cancel out any
  time-dependent host-load drift, one untimed warm-up pass per restart
  before the measured run.
- `valkey-benchmark -t get -P 16 -n 2000000`, reporting median and CV
  rather than best-of.

Results:

\```
BEFORE: median=2,051,284 rps  mean=2,044,158  stdev=22,221  CV=1.09%
AFTER : median=2,080,111 rps  mean=2,073,693  stdev=38,021  CV=1.83%
delta median: +1.41%   delta mean: +1.44%
\```

I was not able to corroborate this with `perf stat -e instructions` —
the sandbox this was developed in is a WSL2/Hyper-V VM that doesn't
expose hardware PMU counters to the guest (`perf list hw` returns
nothing; software events like `task-clock` work, hardware ones report
`<not supported>`), so I couldn't get an instructions-per-request
number. Happy to try again on different hardware, or if a maintainer
can corroborate on bare metal, that would help confirm this beyond the
throughput numbers above, given how small and noise-sensitive this class
of change is.