### PR TITLE
Clarify dismissObject comments on THP and string handling

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -830,15 +830,22 @@ void dismissStreamObject(robj *o, size_t size_hint) {
  * it can reduce unnecessary iteration for complex data types that are probably
  * not going to release any memory. */
 void dismissObject(robj *o, size_t size_hint) {
+    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
+     * so we avoid these pointless loops when they're not going to do anything. */
+#if defined(USE_JEMALLOC) && defined(__linux__)
+    if (objectGetRefcount(o) != 1) return;
+
+    /* Strings are freed via sdsfree, not madvise, so they work regardless of
+     * THP. Handle them before the THP check that guards the madvise paths. */
+    if (objectGetType(o) == OBJ_STRING) {
+        dismissStringObject(o);
+        return;
+    }
+
     /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
     if (server.thp_enabled) return;
 
-        /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
-         * so we avoid these pointless loops when they're not going to do anything. */
-#if defined(USE_JEMALLOC) && defined(__linux__)
-    if (objectGetRefcount(o) != 1) return;
     switch (objectGetType(o)) {
-    case OBJ_STRING: dismissStringObject(o); break;
     case OBJ_LIST: dismissListObject(o, size_hint); break;
     case OBJ_SET: dismissSetObject(o, size_hint); break;
     case OBJ_ZSET: dismissZsetObject(o, size_hint); break;

--- a/src/object.c
+++ b/src/object.c
@@ -830,22 +830,15 @@ void dismissStreamObject(robj *o, size_t size_hint) {
  * it can reduce unnecessary iteration for complex data types that are probably
  * not going to release any memory. */
 void dismissObject(robj *o, size_t size_hint) {
-    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
-     * so we avoid these pointless loops when they're not going to do anything. */
-#if defined(USE_JEMALLOC) && defined(__linux__)
-    if (objectGetRefcount(o) != 1) return;
-
-    /* Strings are freed via sdsfree, not madvise, so they work regardless of
-     * THP. Handle them before the THP check that guards the madvise paths. */
-    if (objectGetType(o) == OBJ_STRING) {
-        dismissStringObject(o);
-        return;
-    }
-
     /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
     if (server.thp_enabled) return;
 
+        /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
+         * so we avoid these pointless loops when they're not going to do anything. */
+#if defined(USE_JEMALLOC) && defined(__linux__)
+    if (objectGetRefcount(o) != 1) return;
     switch (objectGetType(o)) {
+    case OBJ_STRING: dismissStringObject(o); break;
     case OBJ_LIST: dismissListObject(o, size_hint); break;
     case OBJ_SET: dismissSetObject(o, size_hint); break;
     case OBJ_ZSET: dismissZsetObject(o, size_hint); break;

--- a/src/object.c
+++ b/src/object.c
@@ -830,11 +830,17 @@ void dismissStreamObject(robj *o, size_t size_hint) {
  * it can reduce unnecessary iteration for complex data types that are probably
  * not going to release any memory. */
 void dismissObject(robj *o, size_t size_hint) {
-    /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
+    /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled.
+     * This also skips strings: under THP, sdsfree may touch allocator metadata
+     * on a huge page and trigger CoW, which for many tiny strings can raise the
+     * child's memory during BGSAVE rather than lower it. THP is rarely enabled
+     * with Valkey, so it is not worth touching it. */
     if (server.thp_enabled) return;
 
-        /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
-         * so we avoid these pointless loops when they're not going to do anything. */
+    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
+     * so we avoid these pointless loops when they're not going to do anything.
+     * Strings use sdsfree rather than madvise, but are kept inside this guard
+     * along with the other types. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     if (objectGetRefcount(o) != 1) return;
     switch (objectGetType(o)) {

--- a/src/object.c
+++ b/src/object.c
@@ -837,10 +837,10 @@ void dismissObject(robj *o, size_t size_hint) {
      * with Valkey, so it is not worth touching it. */
     if (server.thp_enabled) return;
 
-    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
-     * so we avoid these pointless loops when they're not going to do anything.
-     * Strings use sdsfree rather than madvise, but are kept inside this guard
-     * along with the other types. */
+        /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
+         * so we avoid these pointless loops when they're not going to do anything.
+         * Strings use sdsfree rather than madvise, but are kept inside this guard
+         * along with the other types. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     if (objectGetRefcount(o) != 1) return;
     switch (objectGetType(o)) {


### PR DESCRIPTION
Since #905 switched dismissSds to sdsfree (a plain allocator
free that does not depend on madvise or page size), the comments
here didn't mention this change, so they are somewhat misleading.

Adjust the comments in dismissObject() to explain the existing
behavior more accurately, without changing any logic.