### PR TITLE
Add script-check-maxmemory to bound memory growth of scripts

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3391,6 +3391,7 @@ standardConfig static_configs[] = {
     createBoolConfig("lua-enable-insecure-api", "lua-enable-deprecated-api", MODIFIABLE_CONFIG | HIDDEN_CONFIG | PROTECTED_CONFIG, server.lua_enable_insecure_api, 0, NULL, updateLuaEnableInsecureApi),
     createBoolConfig("import-mode", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.import_mode, 0, NULL, NULL),
     createBoolConfig("io-threads-always-active", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.io_threads_always_active, 0, NULL, NULL),
+    createBoolConfig("script-check-maxmemory", NULL, MODIFIABLE_CONFIG, server.script_check_maxmemory, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/evict.c
+++ b/src/evict.c
@@ -431,8 +431,10 @@ int performEvictions(void) {
     monotime evictionTimer;
     elapsedStart(&evictionTimer);
 
-    /* Try to smoke-out bugs (server.also_propagate should be empty here) */
+    /* Try to smoke-out bugs (server.also_propagate should be empty here,
+     * and never called from within a script.) */
     serverAssert(server.also_propagate.numops == 0);
+    serverAssert(!scriptIsRunning());
     /* Evictions are performed on random keys that have nothing to do with the current command slot. */
 
     while (mem_freed < (long long)mem_tofree) {

--- a/src/expire.c
+++ b/src/expire.c
@@ -36,6 +36,7 @@
  */
 
 #include "server.h"
+#include "script.h"
 #include "cluster.h"
 #include "cluster_migrateslots.h"
 #include "util.h"
@@ -489,8 +490,10 @@ ustime_t activeExpireCycle(int type) {
     static bool expireCycleStartWithFields = 0;
     ustime_t elapsed = 0;
 
-    /* Try to smoke-out bugs (server.also_propagate should be empty here) */
+    /* Try to smoke-out bugs (server.also_propagate should be empty here,
+     * and never called from within a script.) */
     serverAssert(server.also_propagate.numops == 0);
+    serverAssert(!scriptIsRunning());
 
     if (expireCycleStartWithFields) {
         elapsed += activeExpireCycleJob(FIELDS, type, timelimit_us - elapsed);

--- a/src/module.c
+++ b/src/module.c
@@ -6747,6 +6747,15 @@ static void moduleCallCommandHelper(ValkeyModuleCtx *ctx, client *c, robj **argv
                 flags &= ~VALKEYMODULE_CALL_ARGV_RESPECT_DENY_OOM;
             }
         }
+
+        /* We are currently using command propagation, so this should be dead code.
+         * But just to be safe, allow running any command in these cases. */
+        if (is_running_script && server.primary_host && server.repl_replica_ignore_maxmemory) {
+            flags &= ~VALKEYMODULE_CALL_ARGV_RESPECT_DENY_OOM;
+        }
+        if (is_running_script && server.current_client && mustObeyClient(server.current_client)) {
+            flags &= ~VALKEYMODULE_CALL_ARGV_RESPECT_DENY_OOM;
+        }
     }
 
     if (flags & VALKEYMODULE_CALL_ARGV_RESPECT_DENY_OOM && server.maxmemory) {

--- a/src/module.c
+++ b/src/module.c
@@ -6725,7 +6725,27 @@ static void moduleCallCommandHelper(ValkeyModuleCtx *ctx, client *c, robj **argv
          * first write in the context of this script, otherwise we can't stop
          * in the middle. */
         if (is_running_script && scriptIsWriteDirty()) {
-            flags &= ~VALKEYMODULE_CALL_ARGV_RESPECT_DENY_OOM;
+            /* Clearing RESPECT_DENY_OOM here means every write after the first
+             * one skips the maxmemory check, so the script can finish atomically.
+             *
+             * The downside is that the script can then grow memory without bound,
+             * which can be abused in two ways:
+             *   1. Memory is fine when the script starts, so the first write passes
+             *      the check; the script then runs a huge loop of writes that all
+             *      bypass the maxmemory check.
+             *   2. The script first issues a deletion command (e.g. DEL or ZREM),
+             *      which is a write but is NOT flagged CMD_DENYOOM and allocates no
+             *      memory. It still marks the script as "write dirty", so every
+             *      following (possibly deny-oom) write skips the maxmemory check.
+             *
+             * When the 'script-check-maxmemory' config is enabled we instead keep
+             * enforcing the maxmemory check for every write command executed *during*
+             * the script (i.e. we do NOT clear the RESPECT_DENY_OOM flag here). This
+             * lets such a runaway script be aborted early, trading the atomicity of
+             * the script for protection against unbounded memory growth. */
+            if (!server.script_check_maxmemory) {
+                flags &= ~VALKEYMODULE_CALL_ARGV_RESPECT_DENY_OOM;
+            }
         }
     }
 
@@ -6737,7 +6757,14 @@ static void moduleCallCommandHelper(ValkeyModuleCtx *ctx, client *c, robj **argv
                  * Because it is only set on the main thread, in such case we will check
                  * the actual memory usage. */
                 oom_state = (getMaxmemoryState(NULL, NULL, NULL, NULL) == C_ERR);
+            } else if (is_running_script && scriptIsWriteDirty() && server.script_check_maxmemory) {
+                /* Extra check from 'script-check-maxmemory' for writes in the middle
+                 * of a script (after its first dirty write): look at the live memory
+                 * usage, since server.pre_command_oom_state was captured before the
+                 * script started and would miss the memory the script itself allocated. */
+                oom_state = (getMaxmemoryState(NULL, NULL, NULL, NULL) == C_ERR);
             } else {
+                /* All other cases keep the original pre_command_oom_state semantics. */
                 oom_state = server.pre_command_oom_state;
             }
             if (oom_state) {

--- a/src/server.h
+++ b/src/server.h
@@ -2207,6 +2207,10 @@ struct valkeyServer {
     int maxmemory_policy;                       /* Policy for key eviction */
     int maxmemory_samples;                      /* Precision of random sampling */
     int maxmemory_eviction_tenacity;            /* Aggressiveness of eviction processing */
+    int script_check_maxmemory;                 /* Keep enforcing the maxmemory (OOM) check for every write
+                                                 * command executed during a script, so a runaway script can be
+                                                 * aborted early instead of growing memory without bound. This
+                                                 * trades script atomicity for protection against OOM. */
     long long proto_max_bulk_len;               /* Protocol bulk length maximum size. */
     int oom_score_adj_values[CONFIG_OOM_COUNT]; /* Linux oom_score_adj configuration */
     int oom_score_adj;                          /* If true, oom_score_adj is managed */

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -2719,6 +2719,7 @@ start_server {tags {"scripting"}} {
     test "Don't stop the dirty scripts when an OOM occurs midway through execution" {
         r flushall
         r config set maxmemory 1
+        r config set script-check-maxmemory no
         r eval {
             server.call('get', KEYS[1])
             server.call('del', KEYS[1])
@@ -2731,6 +2732,7 @@ start_server {tags {"scripting"}} {
     test "Stop the non-dirty scripts when an OOM occurs midway through execution" {
         r flushall
         r config set maxmemory 1
+        r config set script-check-maxmemory no
         assert_error {OOM *} {
             r eval {
                 server.call('get', KEYS[1])
@@ -2739,5 +2741,114 @@ start_server {tags {"scripting"}} {
         }
        assert_equal {} [r get foo]
        r config set maxmemory 0
+    }
+
+    test "script-check-maxmemory aborts a dirty script after a non-deny-oom write (noeviction)" {
+        r flushall sync
+        r config set script-check-maxmemory yes
+        r config set maxmemory-policy noeviction
+
+        # Pre-populate a key so the DEL below has an observable effect, proving
+        # the script really entered execution (not rejected up front). DEL is a
+        # write NOT flagged deny-oom that allocates nothing, yet it marks the
+        # script "write dirty"; with script-check-maxmemory the following deny-oom
+        # SET is still OOM-checked and aborts the whole script.
+        r set k1{t} v1
+        r config set maxmemory 1
+        assert_error {OOM *} {
+            r eval {
+                server.call('del', KEYS[1])
+                server.call('set', KEYS[2], ARGV[1])
+            } 2 k1{t} k2{t} v2
+        }
+        assert_equal 0 [r dbsize]
+
+        r config set maxmemory 0
+        r config set script-check-maxmemory no
+    }
+
+    test "script-check-maxmemory rejects the write via pcall but keeps the script running" {
+        r flushall sync
+        r config set script-check-maxmemory yes
+
+        # Pre-populate the keys so the DEL below has an observable effect.
+        r mset k1{t} v1 k3{t} v3
+        r config set maxmemory 1
+
+        # pcall swallows the OOM error, but the deny-oom write is rejected before
+        # it runs, so the dataset does not grow while the script keeps running.
+        assert_equal {rejected} [
+            r eval {
+                server.call('del', KEYS[1])
+                local t = server.pcall('set', KEYS[2], ARGV[1])
+                server.call('del', KEYS[3])
+                if t and t['err'] then return 'rejected' else return 'stored' end
+            } 3 k1{t} k2{t} k3{t} v2
+        ]
+        assert_equal 0 [r dbsize]
+
+        r config set maxmemory 0
+        r config set script-check-maxmemory no
+    }
+
+    test "script-check-maxmemory aborts a mid-script write loop under an eviction policy (allkeys-random)" {
+        r flushall sync
+        r config set script-check-maxmemory yes
+        r config set maxmemory-policy allkeys-random
+
+        # Leave head room so EVAL enters and the first writes succeed, then let the
+        # loop allocate past maxmemory.
+        set used [s used_memory]
+        r config set maxmemory [expr {$used + 1024*5000}]
+        assert_error {OOM *} {
+            r eval {
+                for i = 1, 1000000 do
+                    server.call('set', 'k{t}:' .. i, string.rep('x', 1024))
+                end
+            } 0
+        }
+        assert_range [r dbsize] 1 999999
+
+        r config set maxmemory 0
+        r config set maxmemory-policy noeviction
+        r config set script-check-maxmemory no
+    }
+
+    test "script-check-maxmemory does not abort a dirty script that stays under maxmemory" {
+        r flushall sync
+        r config set script-check-maxmemory yes
+        r config set maxmemory 1GB
+        r config set maxmemory-policy noeviction
+
+        assert_equal OK [
+            r eval {
+                server.call('del', KEYS[1])
+                for i = 1, 100 do
+                    server.call('set', 'k{t}:' .. i, ARGV[1])
+                end
+                return 'OK'
+            } 1 k1{t} v
+        ]
+        assert_equal 100 [r dbsize]
+
+        r config set maxmemory 0
+        r config set script-check-maxmemory no
+    }
+
+    test "script-check-maxmemory does not affect scripts flagged with allow-oom" {
+        r flushall sync
+        r config set script-check-maxmemory yes
+        r config set maxmemory 1
+
+        assert_equal 1 [
+            r eval {#!lua flags=allow-oom
+                server.call('del', KEYS[1])
+                server.call('set', KEYS[1], ARGV[1])
+                return 1
+            } 1 k1{t} bar
+        ]
+        assert_equal bar [r get k1{t}]
+        r config set maxmemory 0
+        r config set script-check-maxmemory no
     }
 }

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -2767,6 +2767,51 @@ start_server {tags {"scripting"}} {
         r config set script-check-maxmemory no
     }
 
+    test "script-check-maxmemory aborts a dirty script loaded via EVALSHA (noeviction)" {
+        r flushall sync
+        r config set script-check-maxmemory yes
+        r config set maxmemory-policy noeviction
+
+        # Same dirty-script scenario as above, but executed through EVALSHA to
+        # prove the check is on the shared script execution path, not EVAL only.
+        r set k1{t} v1
+        set sha [r script load {
+            server.call('del', KEYS[1])
+            server.call('set', KEYS[2], ARGV[1])
+        }]
+        r config set maxmemory 1
+        assert_error {OOM *} {r evalsha $sha 2 k1{t} k2{t} v2}
+        assert_equal 0 [r dbsize]
+
+        r config set maxmemory 0
+        r config set script-check-maxmemory no
+    }
+
+    test "script-check-maxmemory aborts a mid-function write loop via FCALL (noeviction)" {
+        r flushall sync
+        r config set script-check-maxmemory yes
+        r config set maxmemory-policy noeviction
+
+        # Unlike a no-shebang EVAL/EVALSHA (which runs in backwards-compat mode and
+        # skips the up-front OOM gate), a function is subject to that gate.
+        r function load replace {#!lua name=oomlib
+            server.register_function('oomfn', function(keys, args)
+                for i = 1, 1000000 do
+                    server.call('set', 'k{t}:' .. i, string.rep('x', 1024))
+                end
+            end)
+        }
+        set used [s used_memory]
+        r config set maxmemory [expr {$used + 1024*5000}]
+        assert_error {OOM *} {r fcall oomfn 0}
+        assert_range [r dbsize] 1 999999
+
+        r config set maxmemory 0
+        r config set maxmemory-policy noeviction
+        r config set script-check-maxmemory no
+        r function flush
+    }
+
     test "script-check-maxmemory rejects the write via pcall but keeps the script running" {
         r flushall sync
         r config set script-check-maxmemory yes

--- a/valkey.conf
+++ b/valkey.conf
@@ -1398,9 +1398,11 @@ acllog-max-len 128
 # When 'script-check-maxmemory' is enabled, the maxmemory check is kept enforced
 # for the deny-oom write commands executed during the script. If maxmemory is
 # reached in the middle of the script, the offending command fails with an OOM
-# error and the script is aborted. This protects against unbounded memory growth
-# at the cost of the script's atomicity (it may be stopped after having performed
-# some writes).
+# error. An *unhandled* OOM error aborts the script, which protects against
+# unbounded memory growth at the cost of the script's atomicity (it may be
+# stopped after having performed some writes). Note that the OOM error can be
+# caught by 'pcall()', in which case the script continues running instead of
+# being aborted.
 #
 # script-check-maxmemory no
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -1390,6 +1390,20 @@ acllog-max-len 128
 #
 # replica-ignore-maxmemory yes
 
+# By default, once a script (EVAL / EVALSHA / FCALL) has issued its first write
+# command, the maxmemory (OOM) check is skipped for the remaining commands of
+# that script, so that the script cannot be interrupted in the middle and stays
+# atomic. The downside is that a script may grow memory without bound.
+#
+# When 'script-check-maxmemory' is enabled, the maxmemory check is kept enforced
+# for the write commands executed during the script. If maxmemory is reached in
+# the middle of the script, the offending command fails with an OOM error and
+# the script is aborted. This protects against unbounded memory growth at the
+# cost of the script's atomicity (it may be stopped after having performed some
+# writes).
+#
+# script-check-maxmemory no
+
 # The server reclaims expired keys in two ways: upon access when those keys are
 # found to be expired, and also in the background, in what is called the
 # "active expire key". The key space is slowly and incrementally scanned

--- a/valkey.conf
+++ b/valkey.conf
@@ -1396,11 +1396,11 @@ acllog-max-len 128
 # atomic. The downside is that a script may grow memory without bound.
 #
 # When 'script-check-maxmemory' is enabled, the maxmemory check is kept enforced
-# for the write commands executed during the script. If maxmemory is reached in
-# the middle of the script, the offending command fails with an OOM error and
-# the script is aborted. This protects against unbounded memory growth at the
-# cost of the script's atomicity (it may be stopped after having performed some
-# writes).
+# for the deny-oom write commands executed during the script. If maxmemory is
+# reached in the middle of the script, the offending command fails with an OOM
+# error and the script is aborted. This protects against unbounded memory growth
+# at the cost of the script's atomicity (it may be stopped after having performed
+# some writes).
 #
 # script-check-maxmemory no
 


### PR DESCRIPTION
Add script-check-maxmemory to bound memory growth of scripts

Currently, once a script (EVAL/EVALSHA/FCALL) has issued its first write,
the maxmemory (OOM) check is skipped for the rest of the script so that it
cannot be interrupted in the middle and stays atomic.

The downside is that a script can then grow memory without bound, well
beyond the configured maxmemory. This can be abused in two ways:

1. Memory is fine when the script starts, so the first write passes the
   check; the script then runs a huge write loop that all bypass the check.
2. The script first issues a write that is NOT flagged deny-oom and
   allocates nothing (e.g. DEL of a missing key), which still marks the
   script "write dirty", so every following deny-oom write skips the check.

Add a new 'script-check-maxmemory' config (default off, only effective when
maxmemory is set). When enabled, the maxmemory check keeps being enforced
for every write executed during the script; the offending command fails
with an OOM error and the script is aborted. This trades the script's
atomicity for protection against unbounded memory growth. 

Add a new 'script-check-maxmemory' config (default off, only effective when
maxmemory is set). When enabled, the maxmemory check keeps being enforced
for every deny-oom write executed during the script; the offending command
fails with an OOM error. An *unhandled* OOM error aborts the script, which
trades the script's atomicity for protection against unbounded memory growth.
Note that the OOM error can be caught by `pcall()`, in which case the script
continues running instead of being aborted.

Also add assertions in performEvictions() and activeExpireCycle() that they
are never called from within a running script.