### PR TITLE
make getMonotonicUs static in libvalkeylua

### DIFF
--- a/src/modules/lua/function_lua.c
+++ b/src/modules/lua/function_lua.c
@@ -59,7 +59,7 @@ typedef uint64_t monotime;
 /* Use the engine's version */
 #include "../../monotonic.h"
 #else
-monotime getMonotonicUs(void) {
+static monotime getMonotonicUs(void) {
     /* clock_gettime() is specified in POSIX.1b (1993).  Even so, some systems
      * did not support this until much later.  CLOCK_MONOTONIC is technically
      * optional and may not be supported - but it appears to be universal.
@@ -68,11 +68,11 @@ monotime getMonotonicUs(void) {
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return ((uint64_t)ts.tv_sec) * 1000000 + ts.tv_nsec / 1000;
 }
-inline uint64_t elapsedUs(monotime start_time) {
+static inline uint64_t elapsedUs(monotime start_time) {
     return getMonotonicUs() - start_time;
 }
 
-inline uint64_t elapsedMs(monotime start_time) {
+static inline uint64_t elapsedMs(monotime start_time) {
     return elapsedUs(start_time) / 1000;
 }
 #endif


### PR DESCRIPTION
Fixes #3812

Fixes a segfault when running a Lua module build under alpine/musl. The dynamic linker was resolving the `getMonotonicUs` function in `libvalkeylua` to `getMonotonicUs` in the main binary, which is a function pointer. Calls to `getMonoticUs` via the PLT were resolving to the variable in `.bss`, causing a segfault.
I marked the functions as static to fix this, and I imagine they should have been static in the first place (correct me if I'm wrong). 

Stack trace:
```
[ #3] 0x7f968ed83de2 <__restore_rt>
[ #4] 0x561cae23dd30 <getMonotonicUs>
[*#5] 0x7f968ebcd186 <luaFunctionLibraryCreate+0xd6>
```

```
gdb> vmmap 0x561cae23dd30
Start              End                Size               Offset             Perm Path
0x0000561cae1d8000 0x0000561cae25d000 0x0000000000085000 0x00000000002fe000 rw- ./src/valkey-server +0x65d30  <-  $rcx
```

This issue only occurs on alpine because the musl dynamic linker doesn't support the [`RTLD_DEEPBIND` option](https://github.com/valkey-io/valkey/blob/unstable/src/module.c#L13483). The glibc dynamic linker was resolving the `getMonotonicUs` in `libvalkeylua` and not the "global" symbol which is a function pointer.

---
## Reproduce

This is script to spawn a docker alpine container to reproduce the crash, based on the instructions in #3812
```bash
#!/usr/bin/env bash
cleanup() {
    echo "deleting container"
    docker rm -f valkey-repro
}

trap cleanup EXIT

echo "create alpine container"

rm -f dump.rdb

docker run -d \
	--name valkey-repro \
	--rm \
	-v "$PWD":"$PWD" \
	-w "$PWD" \
	-it \
	alpine:3.23.5 \
    sleep infinity


echo "install deps"
docker exec valkey-repro sh -c 'apk add build-base linux-headers openssl-dev tcl'

echo "build"
docker exec valkey-repro sh -c 'make distclean && make clean'
docker exec valkey-repro sh -c 'make BUILD_LUA=module USE_JEMALLOC=no MALLOC=libc -j25'

echo "waiting for server to send command"
(
    until docker exec valkey-repro test -S /tmp/valkey.sock; do
        sleep 0.05
    done

    echo "======== server is up, sending command ========="

    docker exec valkey-repro \
        ./src/valkey-cli \
        -s /tmp/valkey.sock \
        FUNCTION LOAD "#!LUA name=test2
        server.register_function('test2', function(KEYS, ARGV)
            return 'hello'
        end)"
) &

echo "start server"

docker exec valkey-repro \
    ./src/valkey-server \
    --port 0 \
    --unixsocket /tmp/valkey.sock \
    --loadmodule ./src/modules/lua/libvalkeylua.so

echo "opening shell in container"
docker exec -it valkey-repro sh

```