### PR TITLE
Fix slow-clocksource check for HW monotonic clock and non-x86 advisories

### DIFF
--- a/src/syscheck.c
+++ b/src/syscheck.c
@@ -82,11 +82,8 @@ static int clocksourceHasToken(const char *list, const char *name) {
     return 0;
 }
 
-/* Pick a vDSO-capable alternative clocksource from the available list.
- * Only these sources can avoid the syscall path that checkClocksource() measures;
- * suggesting hpet/acpi_pm would not fix the warning. */
+/* Pick a vDSO-capable alternative from available_clocksource, if any. */
 static sds pickAlternativeClocksource(const char *curr, const char *avail) {
-    /* Order matters: prefer the common native sources, then paravirt clocks. */
     static const char *fast_clocksources[] = {
         "tsc", "arch_sys_counter", "kvm-clock", "hyperv_clocksource_tsc_page", NULL};
     int i;
@@ -144,8 +141,8 @@ static int checkClocksource(sds *error_msg) {
         *error_msg = sdscatprintf(sdsempty(),
                                   "Slow system clocksource detected. This can result in degraded performance. "
                                   "Current clocksource: %s. Available clocksources: %s. ",
+                                  curr ? curr : "", avail ? avail : "");
         if (suggest) {
-            /* Only recommend switching when another clocksource actually exists. */
             *error_msg = sdscatprintf(*error_msg,
                                       "Consider changing the system's clocksource. "
                                       "For example: run the command 'echo %s > "
@@ -154,14 +151,10 @@ static int checkClocksource(sds *error_msg) {
                                       "'clocksource=' kernel command line parameter.",
                                       suggest);
         } else if (!curr || !avail) {
-            /* pickAlternativeClocksource() also returns NULL when sysfs reads fail.
-             * Do not claim there is no alternative in that case. */
             *error_msg = sdscat(*error_msg,
                                 "Could not determine the available clocksources from sysfs, "
                                 "so no clocksource change can be recommended.");
         } else {
-            /* No vDSO-capable alternative (common on ARM64 with only arch_sys_counter, or when
-             * only slow sources like hpet/acpi_pm remain). Switching would not help. */
             *error_msg = sdscat(*error_msg,
                                 "No suitable alternative clocksource is available, so changing the system's "
                                 "clocksource is unlikely to help. This may indicate that clock_gettime() is not "

--- a/src/syscheck.c
+++ b/src/syscheck.c
@@ -31,6 +31,7 @@
 #include "syscheck.h"
 #include "sds.h"
 #include "anet.h"
+#include "monotonic.h"
 
 #include <time.h>
 #include <sys/resource.h>
@@ -97,13 +98,16 @@ static sds pickAlternativeClocksource(const char *curr, const char *avail) {
     return NULL;
 }
 
-/* Verify our clocksource implementation doesn't go through a system call (uses vdso).
- * Going through a system call to check the time degrades server performance. */
+/* Verify clock_gettime() does not go through a system call (uses vdso).
+ * Skipped when Valkey is already using a hardware monotonic clock. */
 static int checkClocksource(sds *error_msg) {
     unsigned long test_time_us, system_hz;
     struct timespec ts;
     unsigned long long start_us;
     struct rusage ru_start, ru_end;
+
+    monotonicInit();
+    if (monotonicGetType() == MONOTONIC_CLOCK_HW) return 0;
 
     system_hz = sysconf(_SC_CLK_TCK);
 

--- a/src/syscheck.c
+++ b/src/syscheck.c
@@ -144,9 +144,8 @@ static int checkClocksource(sds *error_msg) {
         *error_msg = sdscatprintf(sdsempty(),
                                   "Slow system clocksource detected. This can result in degraded performance. "
                                   "Current clocksource: %s. Available clocksources: %s. ",
-                                  curr ? curr : "", avail ? avail : "");
         if (suggest) {
-            /* Only recommend a vDSO-capable alternative from the available list. */
+            /* Only recommend switching when another clocksource actually exists. */
             *error_msg = sdscatprintf(*error_msg,
                                       "Consider changing the system's clocksource. "
                                       "For example: run the command 'echo %s > "

--- a/src/syscheck.c
+++ b/src/syscheck.c
@@ -82,27 +82,20 @@ static int clocksourceHasToken(const char *list, const char *name) {
     return 0;
 }
 
-/* Pick an alternative clocksource from the available list, preferring tsc. */
+/* Pick a vDSO-capable alternative clocksource from the available list.
+ * Only these sources can avoid the syscall path that checkClocksource() measures;
+ * suggesting hpet/acpi_pm would not fix the warning. */
 static sds pickAlternativeClocksource(const char *curr, const char *avail) {
-    const char *p;
+    /* Order matters: prefer the common native sources, then paravirt clocks. */
+    static const char *fast_clocksources[] = {
+        "tsc", "arch_sys_counter", "kvm-clock", "hyperv_clocksource_tsc_page", NULL};
+    int i;
 
     if (!curr || !avail) return NULL;
 
-    /* Prefer tsc when available and not already selected (typical x86 fix). */
-    if (strcmp(curr, "tsc") != 0 && clocksourceHasToken(avail, "tsc")) return sdsnew("tsc");
-
-    p = avail;
-    while (*p) {
-        size_t len, currlen;
-        const char *end;
-
-        while (*p == ' ') p++;
-        if (!*p) break;
-        end = strchr(p, ' ');
-        len = end ? (size_t)(end - p) : strlen(p);
-        currlen = strlen(curr);
-        if (len != currlen || memcmp(p, curr, len) != 0) return sdsnewlen(p, len);
-        p = end ? end : p + len;
+    for (i = 0; fast_clocksources[i]; i++) {
+        if (strcmp(curr, fast_clocksources[i]) != 0 && clocksourceHasToken(avail, fast_clocksources[i]))
+            return sdsnew(fast_clocksources[i]);
     }
     return NULL;
 }
@@ -153,8 +146,7 @@ static int checkClocksource(sds *error_msg) {
                                   "Current clocksource: %s. Available clocksources: %s. ",
                                   curr ? curr : "", avail ? avail : "");
         if (suggest) {
-            /* Only recommend switching when another clocksource actually exists.
-             * Do not hard-code tsc: it is x86-specific and may be absent (e.g. ARM64). */
+            /* Only recommend a vDSO-capable alternative from the available list. */
             *error_msg = sdscatprintf(*error_msg,
                                       "Consider changing the system's clocksource. "
                                       "For example: run the command 'echo %s > "
@@ -162,13 +154,20 @@ static int checkClocksource(sds *error_msg) {
                                       "To permanently change the system's clocksource you'll need to set the "
                                       "'clocksource=' kernel command line parameter.",
                                       suggest);
-        } else {
-            /* Common on ARM64 where arch_sys_counter is often the only clocksource.
-             * The check may still be useful if vDSO is disabled, but switching is impossible. */
+        } else if (!curr || !avail) {
+            /* pickAlternativeClocksource() also returns NULL when sysfs reads fail.
+             * Do not claim there is no alternative in that case. */
             *error_msg = sdscat(*error_msg,
-                                "No alternative clocksource is available, so the system's clocksource cannot be "
-                                "changed. This may indicate that clock_gettime() is not using the vDSO fast path "
-                                "(for example due to a kernel timer workaround or virtualization limitation).");
+                                "Could not determine the available clocksources from sysfs, "
+                                "so no clocksource change can be recommended.");
+        } else {
+            /* No vDSO-capable alternative (common on ARM64 with only arch_sys_counter, or when
+             * only slow sources like hpet/acpi_pm remain). Switching would not help. */
+            *error_msg = sdscat(*error_msg,
+                                "No suitable alternative clocksource is available, so changing the system's "
+                                "clocksource is unlikely to help. This may indicate that clock_gettime() is not "
+                                "using the vDSO fast path (for example due to a kernel timer workaround or "
+                                "virtualization limitation).");
         }
         sdsfree(suggest);
         sdsfree(avail);

--- a/src/syscheck.c
+++ b/src/syscheck.c
@@ -61,6 +61,52 @@ static sds read_sysfs_line(char *path) {
     return res;
 }
 
+/* Return 1 if `name` appears as a whitespace-separated token in `list`. */
+static int clocksourceHasToken(const char *list, const char *name) {
+    const char *p = list;
+    size_t namelen;
+
+    if (!list || !name || !*name) return 0;
+    namelen = strlen(name);
+    while (*p) {
+        size_t len;
+        const char *end;
+
+        while (*p == ' ') p++;
+        if (!*p) break;
+        end = strchr(p, ' ');
+        len = end ? (size_t)(end - p) : strlen(p);
+        if (len == namelen && memcmp(p, name, len) == 0) return 1;
+        p = end ? end : p + len;
+    }
+    return 0;
+}
+
+/* Pick an alternative clocksource from the available list, preferring tsc. */
+static sds pickAlternativeClocksource(const char *curr, const char *avail) {
+    const char *p;
+
+    if (!curr || !avail) return NULL;
+
+    /* Prefer tsc when available and not already selected (typical x86 fix). */
+    if (strcmp(curr, "tsc") != 0 && clocksourceHasToken(avail, "tsc")) return sdsnew("tsc");
+
+    p = avail;
+    while (*p) {
+        size_t len, currlen;
+        const char *end;
+
+        while (*p == ' ') p++;
+        if (!*p) break;
+        end = strchr(p, ' ');
+        len = end ? (size_t)(end - p) : strlen(p);
+        currlen = strlen(curr);
+        if (len != currlen || memcmp(p, curr, len) != 0) return sdsnewlen(p, len);
+        p = end ? end : p + len;
+    }
+    return NULL;
+}
+
 /* Verify our clocksource implementation doesn't go through a system call (uses vdso).
  * Going through a system call to check the time degrades server performance. */
 static int checkClocksource(sds *error_msg) {
@@ -100,15 +146,31 @@ static int checkClocksource(sds *error_msg) {
     if (stime_us * 10 > stime_us + utime_us) {
         sds avail = read_sysfs_line("/sys/devices/system/clocksource/clocksource0/available_clocksource");
         sds curr = read_sysfs_line("/sys/devices/system/clocksource/clocksource0/current_clocksource");
+        sds suggest = pickAlternativeClocksource(curr, avail);
+
         *error_msg = sdscatprintf(sdsempty(),
                                   "Slow system clocksource detected. This can result in degraded performance. "
-                                  "Consider changing the system's clocksource. "
-                                  "Current clocksource: %s. Available clocksources: %s. "
-                                  "For example: run the command 'echo tsc > "
-                                  "/sys/devices/system/clocksource/clocksource0/current_clocksource' as root. "
-                                  "To permanently change the system's clocksource you'll need to set the "
-                                  "'clocksource=' kernel command line parameter.",
+                                  "Current clocksource: %s. Available clocksources: %s. ",
                                   curr ? curr : "", avail ? avail : "");
+        if (suggest) {
+            /* Only recommend switching when another clocksource actually exists.
+             * Do not hard-code tsc: it is x86-specific and may be absent (e.g. ARM64). */
+            *error_msg = sdscatprintf(*error_msg,
+                                      "Consider changing the system's clocksource. "
+                                      "For example: run the command 'echo %s > "
+                                      "/sys/devices/system/clocksource/clocksource0/current_clocksource' as root. "
+                                      "To permanently change the system's clocksource you'll need to set the "
+                                      "'clocksource=' kernel command line parameter.",
+                                      suggest);
+        } else {
+            /* Common on ARM64 where arch_sys_counter is often the only clocksource.
+             * The check may still be useful if vDSO is disabled, but switching is impossible. */
+            *error_msg = sdscat(*error_msg,
+                                "No alternative clocksource is available, so the system's clocksource cannot be "
+                                "changed. This may indicate that clock_gettime() is not using the vDSO fast path "
+                                "(for example due to a kernel timer workaround or virtualization limitation).");
+        }
+        sdsfree(suggest);
         sdsfree(avail);
         sdsfree(curr);
         return -1;


### PR DESCRIPTION
Fixes #4269

## Summary

`valkey-server --check-system` used to probe `clock_gettime(CLOCK_MONOTONIC)`
and, on failure, always suggested switching to `tsc`. That is wrong on ARM64,
where `arch_sys_counter` is normal and often the only available clocksource.

Two changes, as discussed in #4269:

1. **Skip the probe when Valkey uses a hardware monotonic clock**
   (`monotonicGetType() == MONOTONIC_CLOCK_HW`, e.g. aarch64 `CNTVCT` /
   x86 `TSC`). In that case the server hot path does not depend on the Linux
   `clock_gettime` / clocksource path, so the warning is not actionable for
   Valkey and can also false-positive due to short `getrusage()` noise.
   The probe is kept for the POSIX fallback path.

2. **Fix the advisory text when the probe still runs**
   - Suggest a concrete vDSO-capable alternative when one is available
     (`tsc`, `arch_sys_counter`, `kvm-clock`, `hyperv_clocksource_tsc_page`).
   - If none exists, do not recommend switching (and do not hard-code `tsc`).
   - If sysfs cannot be read, say so instead of claiming there is no alternative.

This does not whitelist `arch_sys_counter` by name.

## Test plan

- [ ] With `CFLAGS=-DNO_PROCESSOR_CLOCK` (POSIX fallback): probe still runs;
      warning does not hard-code `tsc`
- [ ] On aarch64/x86 with HW monotonic clock: `--check-system` shows
      `[slow-clocksource]...skipped`
- [ ] Single-clocksource system: no suggestion to switch to an unavailable source
- [ ] Multi-clocksource system with a slow current source: suggests a suitable
      fast alternative when available