### PR TITLE
Fix ZRANGE XX option schema and test failures under force-resp3

### DIFF
--- a/src/commands/zrange.json
+++ b/src/commands/zrange.json
@@ -47,6 +47,10 @@
         "reply_schema": {
             "anyOf": [
                 {
+                    "description": "Key does not exist and XX option is specified.",
+                    "type": "null"
+                },
+                {
                     "description": "A list of member elements",
                     "type": "array",
                     "uniqueItems": true,

--- a/src/commands/zrangebylex.json
+++ b/src/commands/zrangebylex.json
@@ -41,12 +41,20 @@
             }
         ],
         "reply_schema": {
-            "type": "array",
-            "description": "List of elements in the specified score range.",
-            "uniqueItems": true,
-            "items": {
-                "type": "string"
-            }
+            "anyOf": [
+                {
+                    "description": "Key does not exist and XX option is specified.",
+                    "type": "null"
+                },
+                {
+                    "type": "array",
+                    "description": "List of elements in the specified score range.",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
         },
         "arguments": [
             {

--- a/src/commands/zrangebyscore.json
+++ b/src/commands/zrangebyscore.json
@@ -47,6 +47,10 @@
         "reply_schema": {
             "anyOf": [
                 {
+                    "description": "Key does not exist and XX option is specified.",
+                    "type": "null"
+                },
+                {
                     "type": "array",
                     "description": "List of the elements in the specified score range, as not WITHSCORES.",
                     "uniqueItems": true,

--- a/src/commands/zrevrange.json
+++ b/src/commands/zrevrange.json
@@ -43,6 +43,10 @@
         "reply_schema": {
             "anyOf": [
                 {
+                    "description": "Key does not exist and XX option is specified.",
+                    "type": "null"
+                },
+                {
                     "description": "List of member elements.",
                     "type": "array",
                     "uniqueItems": true,

--- a/src/commands/zrevrangebylex.json
+++ b/src/commands/zrevrangebylex.json
@@ -41,12 +41,20 @@
             }
         ],
         "reply_schema": {
-            "type": "array",
-            "description": "List of the elements in the specified score range.",
-            "uniqueItems": true,
-            "items": {
-                "type": "string"
-            }
+            "anyOf": [
+                {
+                    "description": "Key does not exist and XX option is specified.",
+                    "type": "null"
+                },
+                {
+                    "type": "array",
+                    "description": "List of the elements in the specified score range.",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
         },
         "arguments": [
             {

--- a/src/commands/zrevrangebyscore.json
+++ b/src/commands/zrevrangebyscore.json
@@ -47,6 +47,10 @@
         "reply_schema": {
             "anyOf": [
                 {
+                    "description": "Key does not exist and XX option is specified.",
+                    "type": "null"
+                },
+                {
                     "type": "array",
                     "description": "List of the elements in the specified score range, as not WITHSCORES.",
                     "uniqueItems": true,

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -477,7 +477,8 @@ start_server {tags {"zset"}} {
 
             # Test nullarray (key does not exist) in RESP2
             set null_res [r zrevrange non_existent_key 0 -1 XX]
-            assert_equal {*-1} $null_res
+            set expected_null [expr {$::force_resp3 ? "_" : "*-1"}]
+            assert_equal $expected_null $null_res
 
             # Test emptyarray (key exists but no matching elements) in RESP2
             set empty_res [r zrevrange ztmp 10 20 XX]
@@ -699,7 +700,8 @@ start_server {tags {"zset"}} {
 
             # Test nullarray (key does not exist) in RESP2
             set null_res [r zrangebyscore non_existent_key 0 10 XX]
-            assert_equal {*-1} $null_res
+            set expected_null [expr {$::force_resp3 ? "_" : "*-1"}]
+            assert_equal $expected_null $null_res
 
             # Test emptyarray (key exists but no matching elements) in RESP2
             set empty_res [r zrangebyscore zset 10 20 XX]
@@ -848,7 +850,8 @@ start_server {tags {"zset"}} {
 
             # Test nullarray (key does not exist) in RESP2
             set null_res [r zrangebylex non_existent_key - + XX]
-            assert_equal {*-1} $null_res
+            set expected_null [expr {$::force_resp3 ? "_" : "*-1"}]
+            assert_equal $expected_null $null_res
 
             # Test emptyarray (key exists but no matching elements) in RESP2
             set empty_res [r zrangebylex zset \[zzz + XX]
@@ -2604,7 +2607,8 @@ start_server {tags {"zset"}} {
 
         # Test nullarray (key does not exist) in RESP2
         set null_res [r zrange non_existent_key 0 -1 XX]
-        assert_equal {*-1} $null_res
+        set expected_null [expr {$::force_resp3 ? "_" : "*-1"}]
+        assert_equal $expected_null $null_res
 
         # Test emptyarray (key exists but no matching elements) in RESP2
         set empty_res [r zrange zset_XX 10 20 XX]


### PR DESCRIPTION
Update reply_schema for ZRANGE, ZRANGEBYSCORE, ZRANGEBYLEX and their ZREVRANGE counterparts to support 'null' type when XX option is used. Fix tests in zset.tcl to handle raw RESP2 null array assertion when force_resp3 is enabled (where HELLO 2 is translated to HELLO 3, returning RESP3 null instead of RESP2 null array).