### PR TITLE
Update module.c with missing FLAG_REPLICA description

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3958,6 +3958,8 @@ int modulePopulateReplicationInfoStructure(void *ri, int structver) {
  *                                               for applying replicated
  *                                               commands from the primary.
  *     VALKEYMODULE_CLIENTINFO_FLAG_REPLICA      Client is a replica connection.
+ *                                               Also set for MONITOR clients,
+ *                                               together with FLAG_MONITOR.
  *     VALKEYMODULE_CLIENTINFO_FLAG_MONITOR      Client in monitor mode.
  *     VALKEYMODULE_CLIENTINFO_FLAG_MODULE       Client is a module.
  *     VALKEYMODULE_CLIENTINFO_FLAG_AUTHENTICATED

--- a/src/module.c
+++ b/src/module.c
@@ -3954,9 +3954,10 @@ int modulePopulateReplicationInfoStructure(void *ri, int structver) {
  *     VALKEYMODULE_CLIENTINFO_FLAG_UNIXSOCKET   Client using unix domain socket.
  *     VALKEYMODULE_CLIENTINFO_FLAG_MULTI        Client in MULTI state.
  *     VALKEYMODULE_CLIENTINFO_FLAG_READONLY     Client in ReadOnly state.
- *     VALKEYMODULE_CLIENTINFO_FLAG_PRIMARY      Client is a fake client used
- *                                               for applying replicated
- *                                               commands from the primary.
+ *     VALKEYMODULE_CLIENTINFO_FLAG_PRIMARY      Client is the replication link
+ *                                               from this replica's primary,
+ *                                               over which replicated commands
+ *                                               are applied.
  *     VALKEYMODULE_CLIENTINFO_FLAG_REPLICA      Client is a replica connection.
  *                                               Also set for MONITOR clients,
  *                                               together with FLAG_MONITOR.

--- a/src/module.c
+++ b/src/module.c
@@ -3957,6 +3957,7 @@ int modulePopulateReplicationInfoStructure(void *ri, int structver) {
  *     VALKEYMODULE_CLIENTINFO_FLAG_PRIMARY      Client is a fake client used
  *                                               for applying replicated
  *                                               commands from the primary.
+ *     VALKEYMODULE_CLIENTINFO_FLAG_REPLICA      Client is a replica connection.
  *     VALKEYMODULE_CLIENTINFO_FLAG_MONITOR      Client in monitor mode.
  *     VALKEYMODULE_CLIENTINFO_FLAG_MODULE       Client is a module.
  *     VALKEYMODULE_CLIENTINFO_FLAG_AUTHENTICATED


### PR DESCRIPTION
This PR updates module.c with a missing flag added in #2868. This allows the generate-module-api-doc.rb script to update front facing documentation for the modules-api-ref.md file in the valkey-doc repo.

I also noticed that the FLAG_PRIMARY description reads a bit weirdly: "Client is a fake client used for applying replicated commands from the primary" 

Which sounds like it's actually describing a replication-link client maybe? Not literally "this client is the primary."

I could fix this as well if needed since I am writing in this PR anyway the above fix.