### PR TITLE
fix: preserve original file permissions on ACL SAVE [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2686,6 +2686,7 @@ static sds ACLLoadFromFile(const char *filename) {
 static int ACLSaveToFile(const char *filename) {
     sds acl = sdsempty();
     int fd = -1;
+    struct stat original_st = {0};
     sds tmpfilename = NULL;
     int retval = C_ERR;
 
@@ -2736,6 +2737,10 @@ static int ACLSaveToFile(const char *filename) {
     fd = -1;
 
     /* Let's replace the new file with the old one. */
+    /* Save original file permissions before renaming. */
+    if (stat(filename, &original_st) == -1) {
+        memset(&original_st, 0, sizeof(original_st));
+    }
     if (rename(tmpfilename, filename) == -1) {
         serverLog(LL_WARNING, "Renaming ACL file for ACL SAVE: %s", strerror(errno));
         goto cleanup;
@@ -2743,6 +2748,10 @@ static int ACLSaveToFile(const char *filename) {
     if (fsyncFileDir(filename) == -1) {
         serverLog(LL_WARNING, "Syncing ACL directory for ACL SAVE: %s", strerror(errno));
         goto cleanup;
+    }
+    /* Preserve the original file permissions if the file already existed. */
+    if (original_st.st_mode != 0) {
+        chmod(filename, original_st.st_mode);
     }
     sdsfree(tmpfilename);
     tmpfilename = NULL;


### PR DESCRIPTION
Fixes #4014

## Problem

When `ACL SAVE` is executed, the function `ACLSaveToFile()` creates a temporary file with `open(..., 0644)` and then renames it over the original. This replaces the original file's permissions (e.g., `0440` owned by `root:valkey`) with the default `0644` (`-rw-r--r--`), overriding the admin's intent.

## Fix

1. Before the rename, `stat()` the original file to capture its permissions
2. After the rename succeeds, `chmod()` the new file to match the original permissions

## Test plan

1. Set up an ACL file with restrictive permissions: `chmod 0440 /path/to/users.acl`
2. Start valkey with `aclfile /path/to/users.acl`
3. Run `ACL SAVE`
4. Verify the file permissions are still `0440` (not `0644`)