### PR TITLE
Fix macOS unit test by wrapping test object symbols

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -713,6 +713,7 @@ $(SERVER_NAME): $(ENGINE_SERVER_OBJ) $(LUA_MODULE)
 
 # Valkey static library, used to compile against for unit testing
 $(ENGINE_LIB_NAME): $(ENGINE_SERVER_OBJ)
+	@rm -f $@
 	$(SERVER_AR) rcs $@ $^
 
 # valkey-sentinel

--- a/src/unit/Makefile
+++ b/src/unit/Makefile
@@ -113,6 +113,7 @@ ifeq ($(uname_S), Darwin)
 WRAP_DIR := wrapped
 VALKEY_SERVER_WRAP_LIB := $(WRAP_DIR)/wrappedlibvalkey.a
 ENGINE_SERVER_WRAP_OBJ := $(addprefix $(WRAP_DIR)/, $(ENGINE_SERVER_OBJ))
+TEST_WRAP_OBJ := $(addprefix $(WRAP_DIR)/, $(ALL_OBJECTS))
 
 # Homebrew does not add llvm/bin to PATH by default, so we check the standard
 # Homebrew prefix locations for both Apple Silicon (/opt/homebrew) and Intel (/usr/local).
@@ -126,7 +127,7 @@ endif
 $(WRAP_DIR):
 	@mkdir -p $(WRAP_DIR)
 
-$(WRAP_DIR)/%.o: ../%.o $(WRAP_DIR) generated_wrappers.o
+define wrap-object
 	@mkdir -p $(dir $@)
 	@if file $< | grep -q "LLVM bitcode"; then \
 		llc $< -filetype=obj -o $(WRAP_DIR)/$*_temp.o; \
@@ -138,8 +139,18 @@ $(WRAP_DIR)/%.o: ../%.o $(WRAP_DIR) generated_wrappers.o
 		llvm-objcopy --redefine-syms=$(WRAP_DIR)/$*-wrap-syms $< $@; \
 	fi
 	@rm -f $(WRAP_DIR)/$*-wrap-syms
+endef
+
+# Wrap server library objects
+$(ENGINE_SERVER_WRAP_OBJ): $(WRAP_DIR)/%.o: ../%.o $(WRAP_DIR) generated_wrappers.o
+	$(wrap-object)
+
+# Wrap test objects, so that calls to wrapped functions are redirected to __wrap_*
+$(TEST_WRAP_OBJ): $(WRAP_DIR)/%.o: %.o $(WRAP_DIR) generated_wrappers.o
+	$(wrap-object)
 
 $(VALKEY_SERVER_WRAP_LIB): $(VALKEY_SERVER_LIB) $(ENGINE_SERVER_WRAP_OBJ) generated_wrappers.o
+	@rm -f $@
 	$(SERVER_AR) rcs $@ $(ENGINE_SERVER_WRAP_OBJ)
 endif
 
@@ -207,9 +218,8 @@ generated_wrappers.o: generated_wrappers.cpp
 
 # Generate the single test binary in parent directory.
 ifeq ($(uname_S), Darwin)
-valkey-unit-gtests: $(ALL_OBJECTS) generated_wrappers.o $(VALKEY_SERVER_WRAP_LIB) $(FINAL_LIBS)
+valkey-unit-gtests: $(TEST_WRAP_OBJ) generated_wrappers.o $(VALKEY_SERVER_WRAP_LIB) $(FINAL_LIBS)
 	$(CXX) -g $(LDFLAGS) -fno-lto \
-		-Wl,-flat_namespace -Wl,-undefined,dynamic_lookup \
 		-Wall -Wno-deprecated-declarations \
 		-o $@ $^ $(LD_LIBS) \
 		-lm -pthread -ldl


### PR DESCRIPTION
### This PR fixes two things when running unit tests on macOS system:

1. On macOS, ar rcs produces a fat archive (libvalkey.a), when the second build happens, Apple's ar cannot update the archive in-place since libvalkey is a very fat file. The fix is to always delete previous archive so ar creates a fresh one every time.

2. When a test file calls a wrapped function directly, it won't go to the real implementation or the wrapped one, since we redefines the wrapped function to either `__real_func` or `__wrap_func`, no object files defines the original `_func`. The fix is to redefine the test object symbols, `_func` becomes `__wrap_func`, which correctly routes through the mock.