### PR TITLE
fix: increase wait_for_migration_field timeout to 20s for slower TLS+IO threads environments

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -47,7 +47,7 @@ proc get_migration_by_name {node_idx name} {
 }
 
 proc wait_for_migration_field {node_idx jobname field value} {
-    wait_for_condition 100 100 {
+    wait_for_condition 200 100 {
         [get_migration_by_name $node_idx $jobname] ne "" && [dict get [get_migration_by_name $node_idx $jobname] $field] eq $value
     } else {
         set curr_state [get_migration_by_name $node_idx $jobname]


### PR DESCRIPTION
## Description

This PR fixes a flaky test failure in `tests/unit/cluster/cluster-migrateslots.tcl`.

**Problem:**
The `wait_for_migration_field` helper uses a hardcoded 10-second timeout (100 × 100ms). In TLS + IO threads CI environments (`test-ubuntu-tls-io-threads`), the slot migration can take longer than 10 seconds to reach the `waiting-to-pause` state because the connection establishment phase (`reading-establish-response`) is slower with TLS handshake overhead.

**Error from CI:**
```
Migration ... on node 2 did not have state == waiting-to-pause (currently ... state reading-establish-response ...) within 10000 ms
```

**Fix:**
Increase the timeout from 10s (100 × 100ms) to 20s (200 × 100ms). This is consistent with other wait helpers in the test suite that already use 20-second timeouts (e.g., `wait_for_condition 200 100` in existing tests).

**Related issues:**
- Fixes #4271