### PR TITLE
fix: increase wait_for_migration timeout to 20s for slower TLS+IO threads environments

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -66,7 +66,7 @@ proc wait_for_countkeysinslot {node_idx slot value} {
 
 proc wait_for_migration {node_idx slot} {
     set target_id [R $node_idx CLUSTER MYID]
-    wait_for_condition 100 100 {
+    wait_for_condition 200 100 {
         [is_slot_migrated $node_idx $slot]
     } else {
         set nodes [get_cluster_nodes $node_idx]


### PR DESCRIPTION
## Description

This PR fixes a flaky test failure in `tests/unit/cluster/cluster-migrateslots.tcl`.

**Problem:**
The `wait_for_migration` helper uses a hardcoded 10-second timeout (100 × 100ms). In TLS + IO threads CI environments (`test-ubuntu-tls-io-threads`), the slot migration can take longer than 10 seconds to complete because the connection establishment phase is slower with TLS handshake overhead.

**Error from CI:**
```
Cluster node cb3aad900755ec668c949e1b3ab28ce7ed28a9e2 did not get slot 16383 within 10000 ms
```

**Fix:**
Increase the timeout from 10s (100 × 100ms) to 20s (200 × 100ms). This is consistent with the 20-second timeout pattern used in the `wait_for_migration_field` helper (fixed in PR #4282 for issue #4271).

**Related issues:**
- Fixes #4266