### PR TITLE
Optimize notifyKeyspaceEvent to avoid unnecessary allocations

### DIFF
--- a/src/notify.c
+++ b/src/notify.c
@@ -105,7 +105,6 @@ sds keyspaceEventsFlagsToString(int flags) {
 void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
     sds chan;
     robj *chanobj, *eventobj;
-    int len = -1;
     char buf[24];
     client *c = server.executing_client;
     debugServerAssert(moduleNotifyKeyspaceSubscribersCnt() == 0 ||
@@ -130,30 +129,40 @@ void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
     /* If notifications for this class of events are off, return ASAP. */
     if (!(server.notify_keyspace_events & type)) return;
 
-    eventobj = createStringObject(event, strlen(event));
+    /* If neither keyspace nor keyevent notifications are enabled, or there
+     * are no clients subscribed to any channel or pattern, there is no point
+     * in building the event object and the channel names. */
+    if (!(server.notify_keyspace_events & (NOTIFY_KEYSPACE | NOTIFY_KEYEVENT))) return;
+    if (serverPubsubSubscriptionCount() == 0) return;
+
+    size_t eventlen = strlen(event);
+    int len = ll2string(buf, sizeof(buf), dbid);
 
     /* __keyspace@<db>__:<key> <event> notifications. */
     if (server.notify_keyspace_events & NOTIFY_KEYSPACE) {
-        chan = sdsnewlen("__keyspace@", 11);
-        len = ll2string(buf, sizeof(buf), dbid);
+        chan = sdsnewlen(SDS_NOINIT, 11 + len + 3 + sdslen(objectGetVal(key)));
+        sdsclear(chan);
+        chan = sdscatlen(chan, "__keyspace@", 11);
         chan = sdscatlen(chan, buf, len);
         chan = sdscatlen(chan, "__:", 3);
         chan = sdscatsds(chan, objectGetVal(key));
         chanobj = createObject(OBJ_STRING, chan);
+        eventobj = createStringObject(event, eventlen);
         pubsubPublishMessage(chanobj, eventobj, 0);
         decrRefCount(chanobj);
+        decrRefCount(eventobj);
     }
 
     /* __keyevent@<db>__:<event> <key> notifications. */
     if (server.notify_keyspace_events & NOTIFY_KEYEVENT) {
-        chan = sdsnewlen("__keyevent@", 11);
-        if (len == -1) len = ll2string(buf, sizeof(buf), dbid);
+        chan = sdsnewlen(SDS_NOINIT, 11 + len + 3 + eventlen);
+        sdsclear(chan);
+        chan = sdscatlen(chan, "__keyevent@", 11);
         chan = sdscatlen(chan, buf, len);
         chan = sdscatlen(chan, "__:", 3);
-        chan = sdscatsds(chan, objectGetVal(eventobj));
+        chan = sdscatlen(chan, event, eventlen);
         chanobj = createObject(OBJ_STRING, chan);
         pubsubPublishMessage(chanobj, key, 0);
         decrRefCount(chanobj);
     }
-    decrRefCount(eventobj);
 }

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -290,6 +290,41 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
+    test "Keyspace notifications: events with no subscribers" {
+        r config set notify-keyspace-events KEA
+        r set foo{t} bar
+
+        set rd1 [valkey_deferring_client]
+        assert_equal {1} [psubscribe $rd1 *]
+        r set foo2{t} bar2
+        assert_equal "pmessage * __keyspace@${db}__:foo2{t} set" [$rd1 read]
+        assert_equal "pmessage * __keyevent@${db}__:set foo2{t}" [$rd1 read]
+        $rd1 close
+    }
+
+    test "Keyspace notifications: K/E bitmask selects emitted channels" {
+        set rd1 [valkey_deferring_client]
+        assert_equal {1} [psubscribe $rd1 *]
+
+        # Neither K nor E: string class fires but is dropped early.
+        r config set notify-keyspace-events $
+        r set foo bar
+        r publish fence hello ;# Fence: no keyspace notification may leak before it
+        assert_equal "pmessage * fence hello" [$rd1 read]
+
+        # Only K: keyspace channel only.
+        r config set notify-keyspace-events K$
+        r set foo bar
+        assert_equal "pmessage * __keyspace@${db}__:foo set" [$rd1 read]
+
+        # Only E: keyevent channel only.
+        r config set notify-keyspace-events E$
+        r set foo bar
+        assert_equal "pmessage * __keyevent@${db}__:set foo" [$rd1 read]
+
+        $rd1 close
+    }
+
     test "Keyspace notifications: we are able to mask events" {
         r config set notify-keyspace-events KEl
         r del mylist


### PR DESCRIPTION
Several minor optimizations in notifyKeyspaceEvent:

1. Return early when neither NOTIFY_KEYSPACE nor NOTIFY_KEYEVENT is
   enabled, or when there are no pub/sub subscribers at all. This
   avoids building the event object, the channel names and calling
   pubsubPublishMessage when nobody can receive the message.

2. Create eventobj only in the keyspace branch that publishes it; the
   keyevent channel name is built directly from the C string, so a
   keyevent-only configuration no longer allocates an extra robj.

3. Pre-size the channel sds with a single exact-sized allocation
   (SDS_NOINIT + sdsclear) so the subsequent concatenations never
   trigger a realloc.

Add tests covering the early-return path (events with no subscribers)
and the K/E bitmask selection of emitted channels (neither K nor E,
keyspace only, keyevent only).