### PR TITLE
Cluster: require a PONG on the current link before sending an automatic MEET

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2575,6 +2575,14 @@ int clusterBlacklistExists(char *nodeid, size_t len) {
  * CLUSTER messages exchange - PING/PONG and gossip
  * -------------------------------------------------------------------------- */
 
+/* Drop a sticky auto-MEET. The flag is only cleared when the peer answers, and
+ * clusterLinkConnectHandler sends MEET as the first packet of every new outbound
+ * link while it is set, so a recycled address would still receive it. The cron
+ * re-arms MEET if the peer returns and answers. Not called for HANDSHAKE. */
+static void clusterNodeClearMeetFlag(clusterNode *node) {
+    node->flags &= ~CLUSTER_NODE_MEET;
+}
+
 /* Marks a node as FAIL. Apart from clusterLoadConfig, this is the only way we mark a
  * node as FAIL during runtime. */
 void markNodeAsFailing(clusterNode *node) {
@@ -2583,6 +2591,7 @@ void markNodeAsFailing(clusterNode *node) {
     node->fail_time = mstime();
     /* Remove the PFAIL flag. */
     node->flags &= ~CLUSTER_NODE_PFAIL;
+    clusterNodeClearMeetFlag(node);
 
     /* Immediately check if the failing node is our primary node. */
     if (nodeIsReplica(myself) && myself->replicaof == node) {
@@ -4183,6 +4192,7 @@ int clusterProcessPacket(clusterLink *link) {
                           link->node->name, humanNodename(link->node), link->node->shard_id,
                           (int)(now - (link->node->ctime)), link->node->flags);
                 link->node->flags |= CLUSTER_NODE_NOADDR;
+                clusterNodeClearMeetFlag(link->node);
                 link->node->ip[0] = '\0';
                 link->node->tcp_port = 0;
                 link->node->tls_port = 0;
@@ -6146,13 +6156,27 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, long 
     }
     if (nodeInNormalState(node) && node->link != NULL && node->inbound_link == NULL &&
         now - node->inbound_link_freed_time > getHandshakeTimeout() &&
-        now - node->meet_sent > getHandshakeTimeout() &&
-        nodeSupportsMultiMeet(node)) {
+        now - node->meet_sent > getHandshakeTimeout() && nodeSupportsMultiMeet(node) &&
+        node->pong_received >= node->link->ctime && now - node->pong_received <= server.cluster_node_timeout) {
         /* Node has an outbound link, but no inbound link for more than the handshake timeout.
          * This probably means this node does not know us yet, whereas we know it.
          * So we send it a MEET packet to do a handshake with it and correct the inconsistent cluster view.
          * We make sure to not re-send a MEET packet more than once every handshake timeout period, so as to
-         * leave the other node time to complete the handshake. */
+         * leave the other node time to complete the handshake.
+         *
+         * We also require proof that the peer on *this* connection is the node we expect:
+         * a PONG received on the current link, and recently enough. nodeInNormalState() alone
+         * is not enough, it only says we have not declared the node failed *yet*, and the two
+         * clocks involved do not start together -- inbound_link_freed_time is initialized to
+         * node->ctime and, for a peer that never opened an inbound link to us, is long expired
+         * before the peer goes away, while the PFAIL clock only starts at the first unanswered
+         * ping. A node that simply died would otherwise still get a MEET armed for it. PFAIL/FAIL
+         * now drop CLUSTER_NODE_MEET, but the flag used to survive until the peer responded and
+         * was re-sent on every reconnect, so a recycled address could still receive it.
+         * Requiring pong_received >= link->ctime rules that out: the reconnect to the departed
+         * address creates a new link, and a peer answering on a reassigned address cannot
+         * satisfy it either, because a PONG carrying a mismatching sender ID frees the link and
+         * marks the node NOADDR before pong_received is updated. */
         node->flags |= CLUSTER_NODE_MEET;
         serverLog(LL_NOTICE, "Sending MEET packet to node %.40s (%s) because there is no inbound link for it",
                   node->name, humanNodename(node));
@@ -6377,6 +6401,7 @@ void clusterCron(void) {
             if (!(node->flags & (CLUSTER_NODE_PFAIL | CLUSTER_NODE_FAIL))) {
                 serverLog(LL_NOTICE, "NODE %.40s (%s) possibly failing.", node->name, humanNodename(node));
                 node->flags |= CLUSTER_NODE_PFAIL;
+                clusterNodeClearMeetFlag(node);
                 update_state = 1;
                 if (clusterNodeIsVotingPrimary(myself)) {
                     markNodeAsFailingIfNeeded(node);

--- a/tests/unit/cluster/cluster-reliable-meet.tcl
+++ b/tests/unit/cluster/cluster-reliable-meet.tcl
@@ -270,3 +270,52 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
         } ;# stop Node 0
     } ;# test
 } ;# stop cluster
+
+start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-node-timeout 2000 cluster-replica-no-failover yes}} {
+    test "Automatic MEET is not armed for a paused peer with no inbound link" {
+        # Node 0 observer, node 1 victim.
+        # start_cluster 2 0: R 0 == [srv 0] (last started), R 1 == [srv -1].
+        set victim_id [dict get [get_myself 1] id]
+
+        wait_for_cluster_state ok
+        wait_for_condition 50 100 {
+            [llength [R 0 CLUSTER LINKS]] == 2
+        } else {
+            fail "Observer never established inbound+outbound links with the victim"
+        }
+
+        set meet_before [count_log_message 0 "Sending MEET packet"]
+        set meet_sent_before [CI 0 cluster_stats_messages_meet_sent]
+
+        # pause_process SIGSTOPs the victim: TCP still accepts, nobody answers.
+        # That opens the two-clock window without a SYN blackhole.
+        # inbound_link_freed_time starts on CLUSTERLINK KILL FROM; PFAIL waits
+        # for ping_sent. Pause first so the victim cannot re-open the inbound link.
+        pause_process [srv -1 pid]
+        R 0 DEBUG CLUSTERLINK KILL FROM $victim_id
+
+        # Wait past cluster-node-timeout + handshake timeout slack (both 2000ms).
+        after 6000
+
+        set meet_after [count_log_message 0 "Sending MEET packet"]
+        set meet_sent_after [CI 0 cluster_stats_messages_meet_sent]
+        set victim [cluster_get_node_by_id 0 $victim_id]
+        set has_pfail [cluster_has_flag $victim {fail?}]
+        set has_fail [cluster_has_flag $victim fail]
+
+        resume_process [srv -1 pid]
+
+        assert_equal $meet_before $meet_after
+        # clusterLinkConnectHandler sends MEET with no NOTICE log; stats catch that path.
+        assert_equal $meet_sent_before $meet_sent_after
+        # 2 voting primaries, so PFAIL does not escalate to FAIL.
+        assert {$has_pfail || $has_fail}
+
+        wait_for_condition 50 200 {
+            [CI 0 cluster_state] eq {ok} && [CI 1 cluster_state] eq {ok} &&
+            [cluster_nodes_all_know_each_other 2]
+        } else {
+            fail "Cluster did not reconverge after resuming the paused peer"
+        }
+    }
+} ;# stop cluster


### PR DESCRIPTION
## Problem

Automatic MEET can go to a node that already died. If that IP is reused by another cluster (common on Kubernetes), the two clusters merge and the lower-epoch side loses its slots and keys.

## Fix

- Arm auto-MEET only if this link has a recent PONG (`pong_received >= link->ctime`).
- Drop `CLUSTER_NODE_MEET` on PFAIL, FAIL, and NOADDR, so a MEET armed while the node was alive is not resent after it dies.

#1251 is unchanged: a live peer that answers PINGs but has no inbound link still gets a MEET.

## Test

`tests/unit/cluster/cluster-reliable-meet.tcl`: pause the peer, kill the inbound link, wait past `cluster-node-timeout`, assert no auto-MEET, then resume and reconverge.
