### PR TITLE
Bump fast-uri and redis-py in utils/ to clear known CVEs

### DIFF
--- a/utils/reply-schema-linter/package-lock.json
+++ b/utils/reply-schema-linter/package-lock.json
@@ -32,9 +32,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/utils/req-res-validator/requirements.txt
+++ b/utils/req-res-validator/requirements.txt
@@ -1,2 +1,2 @@
 jsonschema==4.17.3
-redis==4.5.1
+redis==8.0.1


### PR DESCRIPTION
utils/reply-schema-linter pulls fast-uri 3.1.0 transitively via ajv, and utils/req-res-validator pins redis 4.5.1. Both are flagged by SBOM vulnerability scanners (fast-uri: GHSA-q3j6-qgpj-74h6, -v39h-62p7-jpjc, -4c8g-83qw-93j6, -v2hh-gcrm-f6hx; redis-py: GHSA-8fww-64cx-x8p5, GHSA-24wv-mv5m-xv4h). Neither is compiled into valkey-server, but they surface as CVEs in any SBOM scan of the source tree.

Bump fast-uri to 3.1.4 (lockfile only, still within ajv's ^3.0.1 range) and redis to 8.0.1. Verified: the reply-schema linter still compiles every schema, and the req-res validator (which only uses redis.Redis().ping() and basic commands) works against a live valkey server.