### PR TITLE
fix(cluster): resolve 32-bit compilation failures

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3671,7 +3671,10 @@ int clusterIsValidPacket(clusterLink *link) {
 
     if (type < CLUSTERMSG_TYPE_COUNT) {
         server.cluster->stats_bus_messages_received[type]++;
-        clusterBusAddNetworkBytesByType(type, totlen, 0);
+        /* FIX: Explicitly cast 32-bit unsigned totlen to uint64_t to satisfy 
+         * strict C11 _Generic atomic macro typing on 32-bit architectures. */
+        uint64_t bytes_received = (uint64_t)totlen;
+        clusterBusAddNetworkBytesByType(type, bytes_received, 0);
     }
 
     if (is_light && !messageTypeSupportsLightHdr(type)) {
@@ -4510,7 +4513,11 @@ void clusterWriteHandler(connection *conn) {
             handleLinkIOError(link);
             return;
         }
-        clusterBusAddNetworkBytesByType(ntohs(msg->type) & ~CLUSTERMSG_MODIFIER_MASK, nwritten, 1);
+        
+        /* FIX: Explicitly cast the ssize_t nwritten payload length to uint64_t 
+         * before passing into the strictly-typed cluster telemetry pipeline. */
+        uint64_t bytes_written = (uint64_t)nwritten;
+        clusterBusAddNetworkBytesByType(ntohs(msg->type) & ~CLUSTERMSG_MODIFIER_MASK, bytes_written, 1);
         if (msg_offset + nwritten < msg_len) {
             /* If full message wasn't written, record the offset
              * and continue sending from this point next time */

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -141,7 +141,10 @@ void clusterSlotStatsAddNetworkBytesOutForSlot(int slot, unsigned long long net_
 
 /* Accumulates egress bytes upon sending RESP responses back to user clients. */
 void clusterSlotStatsAddNetworkBytesOutForUserClient(client *c) {
-    clusterSlotStatsAddNetworkBytesOutForSlot(c->slot, c->net_output_bytes_curr_cmd);
+    /* FIX: Cast the size_t net_output_bytes_curr_cmd to uint64_t to prevent 
+     * 32-bit compilation failures when interfacing with 64-bit slot telemetry structures. */
+    uint64_t out_bytes = (uint64_t)c->net_output_bytes_curr_cmd;
+    clusterSlotStatsAddNetworkBytesOutForSlot(c->slot, out_bytes);
 }
 
 /* Accumulates egress bytes upon sending replication stream. This only applies for primary nodes. */
@@ -181,7 +184,11 @@ void clusterSlotStatsAddNetworkBytesOutForShardedPubSubInternalPropagation(clien
     if (!clusterSlotStatsEnabled(slot)) return;
 
     serverAssert(slot >= 0 && slot < CLUSTER_SLOTS);
-    server.cluster->slot_stats[slot].network_bytes_out += c->net_output_bytes_curr_cmd;
+    
+    /* FIX: Cast the size_t net_output_bytes_curr_cmd to uint64_t for strict
+     * 32-bit architecture type-matching when adding to the 64-bit cluster stats accumulator. */
+    uint64_t out_bytes = (uint64_t)c->net_output_bytes_curr_cmd;
+    server.cluster->slot_stats[slot].network_bytes_out += out_bytes;
 
     /* For sharded pubsub, the client's network bytes metrics must be reset here,
      * as resetClient() is not called until subscription ends. */


### PR DESCRIPTION
Resolves 32-bit atomic size_t mismatch.