### PR TITLE
Guard against malformed failure artifacts

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2229,11 +2229,35 @@ jobs:
           merge-multiple: false
 
       - name: Merge into single file
+        id: merge
         run: |
           python3 << 'EOF'
           import json, glob, os
 
           merged = {}
+          damaged = []
+
+          # Every field the Tcl writers emit for a failure. A file can parse as
+          # JSON yet still be damaged: a run killed mid-write can leave a null or
+          # a half-built object in the list. Those publish as real failures the
+          # detector then reads as empty, so the entry shape is checked too, not
+          # just the list around it.
+          REQUIRED_FAILURE_FIELDS = ("test_name", "test_file", "status", "error")
+
+          def invalid_entry_reason(entry, index):
+              """Why *entry* is not a usable failure object, or None if it is."""
+              if not isinstance(entry, dict):
+                  return f"entry {index} is {type(entry).__name__}, expected an object"
+              missing = [f for f in REQUIRED_FAILURE_FIELDS if f not in entry]
+              if missing:
+                  return f"entry {index} is missing {', '.join(missing)}"
+              nonstring = [
+                  f for f in REQUIRED_FAILURE_FIELDS
+                  if not isinstance(entry[f], str)
+              ]
+              if nonstring:
+                  return f"entry {index} has non-string {', '.join(nonstring)}"
+              return None
 
           for job_dir in sorted(glob.glob("individual-failures/test-failures-*")):
               job_name = os.path.basename(job_dir).replace("test-failures-", "")
@@ -2241,8 +2265,34 @@ jobs:
 
               for suite_file in glob.glob(os.path.join(job_dir, "*.json")):
                   suite_name = os.path.splitext(os.path.basename(suite_file))[0]
-                  with open(suite_file) as f:
-                      data = json.load(f)
+                  # Read each suite independently. A damaged file (a job killed
+                  # mid-write, a truncated upload) must not abort the merge: the
+                  # artifact carries every other job's failures too.
+                  try:
+                      with open(suite_file, encoding="utf-8") as f:
+                          data = json.load(f)
+                  except (OSError, ValueError) as exc:
+                      damaged.append(f"{job_name}/{suite_name}: {exc}")
+                      print(f"{job_name}/{suite_name}: unreadable, skipped ({exc})")
+                      continue
+                  # A suite file is a list of failures. Anything else parses but
+                  # has no length, so treat it as damaged rather than letting it
+                  # raise past this loop and lose the whole artifact.
+                  if not isinstance(data, list):
+                      reason = f"expected a JSON list, got {type(data).__name__}"
+                      damaged.append(f"{job_name}/{suite_name}: {reason}")
+                      print(f"{job_name}/{suite_name}: unreadable, skipped ({reason})")
+                      continue
+                  entry_reasons = [
+                      r for r in (
+                          invalid_entry_reason(e, i) for i, e in enumerate(data)
+                      ) if r
+                  ]
+                  if entry_reasons:
+                      reason = "; ".join(entry_reasons)
+                      damaged.append(f"{job_name}/{suite_name}: {reason}")
+                      print(f"{job_name}/{suite_name}: unreadable, skipped ({reason})")
+                      continue
                   merged[job_name][suite_name] = data
                   count = len(data)
                   if count:
@@ -2252,6 +2302,23 @@ jobs:
 
           with open("all-test-failures.json", "w") as f:
               json.dump(merged, f, indent=2)
+
+          if damaged:
+              # Record the loss for the step that fails this job after the
+              # upload. The artifact is still worth publishing because it holds
+              # every readable job's failures, but it is incomplete, so the job
+              # must not report success.
+              print(f"::error::{len(damaged)} suite file(s) could not be read "
+                    f"and are missing from the artifact: {'; '.join(damaged)}")
+              with open("consolidation-damage.txt", "w") as f:
+                  f.write("\n".join(damaged))
+
+          # Signal damage to later steps so the per-job artifacts that fed the
+          # merge are kept for inspection rather than deleted.
+          step_output = os.environ.get("GITHUB_OUTPUT")
+          if step_output:
+              with open(step_output, "a") as f:
+                  f.write(f"damaged={'true' if damaged else 'false'}\n")
           EOF
 
       - name: Upload consolidated failures
@@ -2261,7 +2328,11 @@ jobs:
           path: all-test-failures.json
           retention-days: 30
 
+      # Skip the cleanup when a suite file was damaged, so the per-job
+      # artifacts survive for inspection. The parse-error string alone is not
+      # enough to reconstruct a file killed mid-write or truncated on upload.
       - name: Delete individual artifacts
+        if: steps.merge.outputs.damaged != 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
@@ -2286,6 +2357,17 @@ jobs:
               }
             }
             console.log('Done. Individual artifacts deleted.');
+
+      # Last step, so the consolidated artifact is published and any healthy
+      # per-job artifacts are cleaned up first. An artifact missing some suites
+      # must not leave this job green.
+      - name: Fail if any suite file was unreadable
+        run: |
+          if [ -f consolidation-damage.txt ]; then
+            echo "Suite files missing from the artifact:"
+            cat consolidation-damage.txt
+            exit 1
+          fi
   notify-about-job-results:
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'schedule' && github.repository == 'valkey-io/valkey'
@@ -2324,6 +2406,7 @@ jobs:
       - test-alpine-libc-malloc
       - test-alpine-32bit
       - reply-schemas-validator
+      - consolidate-test-failures
     steps:
       - name: Collect job status
         run: |

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -578,9 +578,9 @@ proc write_test_failures {} {
         set test_file [lindex $entry 1]
         set error_msg [lindex $entry 2]
 
-        set test_name [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $test_name]
-        set test_file [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $test_file]
-        set error_msg [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $error_msg]
+        set test_name [json_escape_string $test_name]
+        set test_file [json_escape_string $test_file]
+        set error_msg [json_escape_string $error_msg]
 
         lappend failures "\{\"test_name\":\"$test_name\",\"test_file\":\"$test_file\",\"status\":\"err\",\"error\":\"$error_msg\"\}"
     }
@@ -590,6 +590,8 @@ proc write_test_failures {} {
         file mkdir $outdir
     }
     set fp [open $::failures_output_file w]
+    # JSON is UTF-8, so do not leave the channel on the system encoding.
+    fconfigure $fp -encoding utf-8
     puts $fp "\[[join $failures ","]\]"
     close $fp
 }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1320,3 +1320,27 @@ proc memcmp {string1 string2} {
     }
     return [expr {$len1 - $len2}]
 }
+
+# Escape a string for use as a JSON string value.
+#
+# Beyond the characters with a short escape, every C0 control character has to
+# be escaped: JSON forbids them raw, and one raw byte makes the whole file
+# unparsable, taking every failure in the run with it. Failure messages carry
+# server output and memory-tool reports, which do contain control bytes, and an
+# incomplete ANSI sequence survives colour stripping.
+proc json_escape_string {s} {
+    set s [string map {
+        "\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r"
+        "\t" "\\t" "\b" "\\b" "\f" "\\f"
+    } $s]
+    set out ""
+    foreach ch [split $s ""] {
+        scan $ch %c code
+        if {$code < 0x20} {
+            append out [format {\u%04x} $code]
+        } else {
+            append out $ch
+        }
+    }
+    return $out
+}

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -655,10 +655,9 @@ proc write_test_failures {} {
             set error_msg $failed
         }
 
-        set test_name [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $test_name]
-        set test_file [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $test_file]
-        set error_msg [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $error_msg]
-        set status [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $status]
+        foreach var {test_name test_file error_msg status} {
+            set $var [json_escape_string [set $var]]
+        }
 
         lappend failures "\{\"test_name\":\"$test_name\",\"test_file\":\"$test_file\",\"status\":\"$status\",\"error\":\"$error_msg\"\}"
     }
@@ -668,6 +667,10 @@ proc write_test_failures {} {
         file mkdir $outdir
     }
     set fp [open $::failures_output_file w]
+    # JSON is UTF-8. Left on the system encoding, which some CI containers set
+    # to a single-byte locale, a non-ASCII byte in a message is written in that
+    # encoding and the consumer cannot decode the file.
+    fconfigure $fp -encoding utf-8
     puts $fp "\[[join $failures ","]\]"
     close $fp
 }


### PR DESCRIPTION
This PR is one of two reworks to guard against artifact failure. The consumer side is handled in the valkey-ci-agent [PR 77](https://github.com/valkey-io/valkey-ci-agent/pull/77), which survives a damaged artifact zip and reports when a run was only partly analyzed. The two are independent and can merge in either order.

## Purpose

The Daily workflow consolidates each job's test failures into `all-test-failures.json` and uploads it as the `all-test-failures` artifact, which the Test Failure Detector in `valkey-ci-agent` consumes.

The Tcl runner escaped only the seven characters with a JSON short escape, so a failure message containing any other C0 control byte produced an unparsable file. Since the file is one array, a single raw byte discarded every failure in the run. Failure messages routinely carry such bytes: server output, memory-tool reports, and incomplete ANSI sequences that survive colour stripping.

The consolidate step then read every suite file with one unguarded `json.load` in a loop, so one damaged file raised and no artifact was written at all, taking every other job's failures with it.

See the Daily CI artifact consolidation failure [here](https://github.com/valkey-io/valkey/actions/runs/30181268954/job/89757611681)

## Changes

Add `json_escape_string` in `tests/support/util.tcl`, which escapes every C0 control character, and use it in both failure writers (`tests/test_helper.tcl` and `tests/instances.tcl`). Both now also write with `fconfigure -encoding utf-8`, since a channel left on the system encoding writes non-ASCII bytes in a locale the consumer cannot decode.

Read each suite file independently during consolidation. A damaged file is skipped and named in an `::error::` annotation, so the rest of the artifact still publishes.

Add a `Fail if any suite file was unreadable` step after the upload and before the delete step. The partial artifact is still worth publishing, but an incomplete one must not leave the job green, and the per-job artifacts that fed it are kept for inspection.