### PR TITLE
Expansion of Failure Detector

### DIFF
--- a/.github/actions/extract-gtest-failures/action.yml
+++ b/.github/actions/extract-gtest-failures/action.yml
@@ -1,0 +1,172 @@
+name: 'Extract GTest Failures'
+description: 'Parse gtest-parallel JSON results into the test-failures schema'
+inputs:
+  results-file:
+    description: 'Path to the gtest-parallel JSON dump, relative to the workspace'
+    required: false
+    default: 'gtest-results.json'
+runs:
+  using: 'composite'
+  steps:
+    - name: Extract gtest failures to JSON
+      shell: bash
+      env:
+        GTEST_RESULTS_FILE: ${{ inputs.results-file }}
+      run: |
+        python3 << 'EOF'
+        import glob, json, os, re
+
+        os.makedirs("test-failures", exist_ok=True)
+        results_file = "test-failures/unittest.json"
+        failures = []
+
+        # Largest per-failure error text carried in the artifact, matching the
+        # Tcl side's ::max_failure_error_chars. A verbose ASAN/UBSAN dump can run
+        # to megabytes; the head holds the assertion and first stack that
+        # identify the failure. Keeping the rest bloats the artifact and can push
+        # a filed issue past GitHub's 65536-char body limit.
+        _MAX_ERROR_CHARS = 65536
+
+        # gtest-parallel keeps each test's console log under
+        # <output_dir>/gtest-parallel-logs/<outcome>/, named
+        # <binary>-<test_name>-<n>.log with non-alphanumerics replaced by "_".
+        # The Makefile sets --output_dir to the results file's directory, so the
+        # logs sit beside it. The dump records only PASS/FAIL/TIMEOUT, so the
+        # failure text comes from these logs.
+        _NORMALIZE_RE = re.compile(r"[^A-Za-z0-9]")
+        _EXECUTION_NUMBER_RE = re.compile(r"-(\d+)\.log$")
+
+        # gtest-parallel files each attempt's log by how that attempt ended: a
+        # failure lands in failed/, a test the watchdog killed in timed_out/,
+        # and one still running when the run stopped in interrupted/. All three
+        # are searched, since a timeout's log is never in failed/ and its
+        # verdict is reported the same way. Each attempt is filed separately, so
+        # a test that failed once and then timed out has a log in two of these.
+        _LOG_DIRS = ("failed", "timed_out", "interrupted")
+
+        def failed_log_text(gtest_json, test_name):
+            """Return the console log for a failed test, or "" if not found.
+
+            The execution number in the filename varies with retries, so match
+            the normalized test name and take the highest-numbered log (the
+            last attempt). Reading is best-effort: a missing or unreadable log
+            leaves the error text empty rather than failing extraction.
+            """
+            logs_root = os.path.join(
+                os.path.dirname(gtest_json) or ".", "gtest-parallel-logs"
+            )
+            token = _NORMALIZE_RE.sub("_", test_name)
+            matches = []
+            for outcome in _LOG_DIRS:
+                matches.extend(
+                    glob.glob(os.path.join(logs_root, outcome, f"*-{token}-*.log"))
+                )
+            if not matches:
+                return ""
+
+            # Order by the trailing execution number, not by path: the numbers
+            # are unpadded, so "-10.log" sorts before "-2.log" as text, and the
+            # candidates now come from several directories.
+            def execution_number(path):
+                match = _EXECUTION_NUMBER_RE.search(os.path.basename(path))
+                return int(match.group(1)) if match else 0
+
+            last_attempt = max(matches, key=execution_number)
+            try:
+                with open(last_attempt, encoding="utf-8", errors="replace") as f:
+                    text = f.read().strip()
+            except OSError:
+                return ""
+            if len(text) > _MAX_ERROR_CHARS:
+                text = text[:_MAX_ERROR_CHARS] + "\n... (truncated)"
+            return text
+
+        def write_and_exit(message):
+            """Record no failures and stop, leaving the suite file in place.
+
+            The consolidate step reads each suite file, so bailing out without
+            one would drop the unittest suite with nothing to say why.
+            """
+            with open(results_file, "w") as f:
+                json.dump([], f)
+            print(message)
+            exit(0)
+
+        gtest_json = os.environ.get("GTEST_RESULTS_FILE") or "gtest-results.json"
+        if not os.path.exists(gtest_json):
+            # Some jobs run the unit tests without asking for a dump. Writing an
+            # empty suite for them would report a unittest suite that passed when
+            # its results were never collected, so leave the suite absent.
+            print("No gtest results file; this job collected no unit-test results.")
+            exit(0)
+
+        # gtest-parallel writes the dump only once, after every test finishes,
+        # so a run killed partway through (OOM, job timeout) leaves it empty or
+        # truncated. That says nothing about whether tests failed, so report it
+        # and move on rather than failing the step.
+        try:
+            with open(gtest_json) as f:
+                data = json.load(f)
+        except (OSError, ValueError) as exc:
+            write_and_exit(f"Could not read {gtest_json}: {exc}")
+
+        if not isinstance(data, dict):
+            write_and_exit(
+                f"Unexpected {gtest_json} format: expected an object, got "
+                f"{type(data).__name__}."
+            )
+
+        # gtest-parallel --dump_json_test_results produces:
+        # {"tests": {"TestSuite.TestName": {"actual": "PASS|FAIL|TIMEOUT", ...}, ...}}
+        # or nested: {"tests": {"Suite": {"Test": {"actual": "...", ...}}}}
+        # gtest-parallel records one of PASS, FAIL, or TIMEOUT per attempt.
+        FAILURE_TYPES = {"FAIL": "unittest", "TIMEOUT": "timeout"}
+
+        def walk_tests(node, prefix=""):
+            """Recursively walk the test results structure."""
+            for key, value in node.items():
+                if not isinstance(value, dict):
+                    continue
+                if "actual" not in value:
+                    new_prefix = f"{prefix}{key}." if prefix else f"{key}."
+                    walk_tests(value, new_prefix)
+                    continue
+                full_name = f"{prefix}{key}" if prefix else key
+                # "actual" accumulates one token per attempt ("FAIL FAIL
+                # PASS"); the last token is the final outcome, so a test that
+                # passed on retry is not reported. It can be empty for a test
+                # interrupted before any attempt, and a non-string if the dump
+                # is damaged; neither may abort the whole extraction.
+                actual_field = value.get("actual")
+                if not isinstance(actual_field, str):
+                    continue
+                outcomes = actual_field.split()
+                if not outcomes:
+                    continue
+                ftype = FAILURE_TYPES.get(outcomes[-1])
+                if ftype is None:
+                    continue
+                error = failed_log_text(gtest_json, full_name)
+                failures.append({
+                    "test_name": full_name,
+                    "test_file": "src/unit/valkey-unit-gtests",
+                    "type": ftype,
+                    "error": error or f"gtest {outcomes[-1]}",
+                })
+
+        tests = data.get("tests", data)
+        if not isinstance(tests, dict):
+            write_and_exit(
+                f"Unexpected {gtest_json} tests field: expected an object, got "
+                f"{type(tests).__name__}."
+            )
+        walk_tests(tests)
+
+        with open(results_file, "w") as f:
+            json.dump(failures, f, indent=2)
+
+        if failures:
+            print(f"Found {len(failures)} gtest failure(s)")
+        else:
+            print("No gtest failures")
+        EOF

--- a/.github/actions/extract-valgrind-failures/action.yml
+++ b/.github/actions/extract-valgrind-failures/action.yml
@@ -1,0 +1,130 @@
+name: 'Extract Valgrind Failures'
+description: 'Parse valgrind logs from the gtest unit-test run into the test-failures schema'
+inputs:
+  # The default covers both shapes the unittest step writes: err.<pid>.txt for
+  # the gtest binary under gtest-parallel, and err.txt for the older
+  # valkey-unit-tests fallback.
+  log-glob:
+    description: 'Space-separated globs matching the valgrind logs, relative to the workspace'
+    required: false
+    default: 'err.*.txt err.txt'
+  suite-name:
+    description: 'Suite file to write under test-failures/'
+    required: false
+    default: 'valgrind-unittest'
+runs:
+  using: 'composite'
+  steps:
+    - name: Extract valgrind failures to JSON
+      shell: bash
+      env:
+        VALGRIND_LOG_GLOB: ${{ inputs.log-glob }}
+        VALGRIND_SUITE_NAME: ${{ inputs.suite-name }}
+      run: |
+        python3 << 'EOF'
+        import glob, json, os, re
+
+        # The unittest step runs the gtest binary under valgrind with
+        # --log-file=err.%p.txt, then greps those logs and exits non-zero when
+        # one holds an error. That makes the job red, but the logs are not part
+        # of the failures artifact, so a valgrind error found while every gtest
+        # verdict passed reached no issue: the detector saw a red run whose
+        # artifact named no failure. This step carries those reports across.
+
+        os.makedirs("test-failures", exist_ok=True)
+        suite_name = os.environ.get("VALGRIND_SUITE_NAME") or "valgrind-unittest"
+        results_file = os.path.join("test-failures", f"{suite_name}.json")
+
+        # Largest per-failure error text carried in the artifact, matching the
+        # Tcl side's ::max_failure_error_chars. A valgrind buffer can run to
+        # megabytes; the head holds the diagnostic and first stack that identify
+        # the failure, and the consumer caps an issue body at 65536 anyway.
+        _MAX_ERROR_CHARS = 65536
+
+        # The same signals tests/support/util.tcl's find_valgrind_errors looks
+        # for, so a log this step reports is one the Tcl harness would report
+        # too. Kept deliberately in step with that proc: a divergence would mean
+        # the same buffer is a failure in one path and clean in the other.
+        _ERROR_SIGNALS = (
+            re.compile(r" at 0x"),
+            re.compile(r"Invalid"),
+            re.compile(r"Mismatched"),
+            re.compile(r"uninitialized"),
+            re.compile(r"has a fishy"),
+            re.compile(r"overlap"),
+        )
+
+        # "set address range perms" warnings are routine and not a concern; every
+        # other warning is, which is how find_valgrind_errors reads them.
+        _WARNING_RE = re.compile(r"^(?=.*Warning)(?:(?!set address range perms).)*$", re.M)
+
+        # A run that ended cleanly says so. Absent, the process did not
+        # terminate properly and the buffer is reported.
+        _CLEAN_SIGNALS = (
+            re.compile(r"definitely lost: 0 bytes"),
+            re.compile(r"no leaks are possible"),
+        )
+
+        def valgrind_error_in(text):
+            """The buffer when it reports an error, else "" — mirrors the Tcl proc."""
+            if any(signal.search(text) for signal in _ERROR_SIGNALS):
+                return text
+            if _WARNING_RE.search(text):
+                return text
+            if not any(signal.search(text) for signal in _CLEAN_SIGNALS):
+                return text
+            return ""
+
+        def truncate(text):
+            if len(text) <= _MAX_ERROR_CHARS:
+                return text
+            return text[:_MAX_ERROR_CHARS] + "\n... (truncated)"
+
+        log_glob = os.environ.get("VALGRIND_LOG_GLOB") or "err.*.txt err.txt"
+        # Sorted and deduped so the artifact is stable across runs: the pid in
+        # each filename varies, an unordered glob would reorder entries between
+        # runs, and the globs can overlap on one file.
+        logs = sorted({
+            path
+            for pattern in log_glob.split()
+            for path in glob.glob(pattern)
+        })
+        if not logs:
+            # No logs means the unittest step did not run the gtest binary under
+            # valgrind (the binary was absent, or the step was skipped). Writing
+            # an empty suite would report a suite that passed when it never ran,
+            # so leave the file absent.
+            print("No valgrind logs; this job collected no valgrind results.")
+            raise SystemExit(0)
+
+        failures = []
+        for path in logs:
+            try:
+                with open(path, encoding="utf-8", errors="replace") as f:
+                    text = f.read()
+            except OSError as exc:
+                # Best effort: an unreadable log must not fail the step, which
+                # would drop the readable ones with it.
+                print(f"{path}: unreadable, skipped ({exc})")
+                continue
+            error = valgrind_error_in(text).strip()
+            if not error:
+                continue
+            # Prefixed exactly as check_valgrind_errors does, so the consumer
+            # classifies and fingerprints this the same as a harness-reported
+            # valgrind failure rather than treating it as a new shape.
+            failures.append({
+                "test_name": "",
+                "test_file": "src/unit/valkey-unit-gtests",
+                "type": "valgrind",
+                "error": truncate(f"Valgrind error: {error}"),
+            })
+
+        with open(results_file, "w") as f:
+            json.dump(failures, f, indent=2)
+
+        if failures:
+            print(f"Found {len(failures)} valgrind failure(s) in {len(logs)} log(s)")
+        else:
+            print(f"No valgrind failures in {len(logs)} log(s)")
+        EOF

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -134,13 +134,16 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
         run: ./runtest-sentinel --failures-output test-failures/sentinel.json ${{github.event.inputs.cluster_test_args}}
       - name: unittest
-        if: true && !contains(github.event.inputs.skiptests, 'unittest')
+        if: always() && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            make test-unit accurate=1
+            make test-unit accurate=1 json_results=$GITHUB_WORKSPACE/gtest-results.json
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate
           fi
+      - name: Extract gtest failures
+        if: always()
+        uses: ./.github/actions/extract-gtest-failures
       - name: install Redis OSS 6.2 server for compatibility testing
         run: |
           cd tests/tmp
@@ -222,13 +225,16 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
         run: ./runtest-sentinel --failures-output test-failures/sentinel.json ${{github.event.inputs.cluster_test_args}}
       - name: unittest
-        if: true && !contains(github.event.inputs.skiptests, 'unittest')
+        if: always() && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            make test-unit accurate=1
+            make test-unit accurate=1 json_results=$GITHUB_WORKSPACE/gtest-results.json
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate
           fi
+      - name: Extract gtest failures
+        if: always()
+        uses: ./.github/actions/extract-gtest-failures
       - name: Upload test failures
         if: always()
         uses: ./.github/actions/upload-test-failures
@@ -330,13 +336,16 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
         run: ./runtest-sentinel --failures-output test-failures/sentinel.json ${{github.event.inputs.cluster_test_args}}
       - name: unittest
-        if: true && !contains(github.event.inputs.skiptests, 'unittest')
+        if: always() && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            make test-unit accurate=1
+            make test-unit accurate=1 json_results=$GITHUB_WORKSPACE/gtest-results.json
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate
           fi
+      - name: Extract gtest failures
+        if: always()
+        uses: ./.github/actions/extract-gtest-failures
       - name: Upload test failures
         if: always()
         uses: ./.github/actions/upload-test-failures
@@ -517,15 +526,18 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
         run: ./runtest-sentinel --failures-output test-failures/sentinel.json ${{github.event.inputs.cluster_test_args}}
       - name: unittest
-        if: true && !contains(github.event.inputs.skiptests, 'unittest')
+        if: always() && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            make test-unit accurate=1 \
+            make test-unit accurate=1 json_results=$GITHUB_WORKSPACE/gtest-results.json \
               GTEST_CFLAGS="-I/usr/src/googletest/googletest/include -I/usr/src/googletest/googlemock/include" \
               GTEST_LIBS="/usr/lib32/libgtest.a /usr/lib32/libgmock.a"
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate
           fi
+      - name: Extract gtest failures
+        if: always()
+        uses: ./.github/actions/extract-gtest-failures
       - name: Upload test failures
         if: always()
         uses: ./.github/actions/upload-test-failures
@@ -928,15 +940,24 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --valgrind --no-latency --failures-output test-failures/moduleapi.json --verbose --clients 1 --timeout 2400 --dump-logs ${{github.event.inputs.test_args}}
       - name: unittest
-        if: true && !contains(github.event.inputs.skiptests, 'unittest')
+        if: always() && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            ./deps/gtest-parallel/gtest-parallel valgrind -- --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.%p.txt ./src/unit/valkey-unit-gtests --valgrind
+            ./deps/gtest-parallel/gtest-parallel --dump_json_test_results $GITHUB_WORKSPACE/gtest-results.json --output_dir $GITHUB_WORKSPACE valgrind -- --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.%p.txt ./src/unit/valkey-unit-gtests --valgrind
             if grep -qlE '0x[0-9A-Fa-f]+:' err.*.txt 2>/dev/null; then grep -lE '0x[0-9A-Fa-f]+:' err.*.txt | xargs cat; exit 1; fi
           elif [ -f ./src/valkey-unit-tests ]; then
             valgrind --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.txt ./src/valkey-unit-tests --valgrind
             if grep -q 0x err.txt; then cat err.txt; exit 1; fi
           fi
+      - name: Extract gtest failures
+        if: always()
+        uses: ./.github/actions/extract-gtest-failures
+      # The step above carries only gtest verdicts. A valgrind error found while
+      # every verdict passed reddens the job through the grep on err.*.txt but
+      # reaches no issue, so those logs are extracted too.
+      - name: Extract valgrind failures
+        if: always()
+        uses: ./.github/actions/extract-valgrind-failures
       - name: Upload test failures
         if: always()
         uses: ./.github/actions/upload-test-failures
@@ -1041,15 +1062,23 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --valgrind --no-latency --failures-output test-failures/moduleapi.json --verbose --clients 1 --timeout 2400 --dump-logs ${{github.event.inputs.test_args}}
       - name: unittest
-        if: true && !contains(github.event.inputs.skiptests, 'unittest')
+        if: always() && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            ./deps/gtest-parallel/gtest-parallel valgrind -- --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.%p.txt ./src/unit/valkey-unit-gtests --valgrind
+            ./deps/gtest-parallel/gtest-parallel --dump_json_test_results $GITHUB_WORKSPACE/gtest-results.json --output_dir $GITHUB_WORKSPACE valgrind -- --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.%p.txt ./src/unit/valkey-unit-gtests --valgrind
             if grep -qlE '0x[0-9A-Fa-f]+:' err.*.txt 2>/dev/null; then grep -lE '0x[0-9A-Fa-f]+:' err.*.txt | xargs cat; exit 1; fi
           elif [ -f ./src/valkey-unit-tests ]; then
             valgrind --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.txt ./src/valkey-unit-tests --valgrind
             if grep -q 0x err.txt; then cat err.txt; exit 1; fi
           fi
+      - name: Extract gtest failures
+        if: always()
+        uses: ./.github/actions/extract-gtest-failures
+      # Same gap as the misc valgrind job above: a valgrind error with no
+      # failing gtest verdict would otherwise reach no issue.
+      - name: Extract valgrind failures
+        if: always()
+        uses: ./.github/actions/extract-valgrind-failures
       - name: Upload test failures
         if: always()
         uses: ./.github/actions/upload-test-failures
@@ -1113,13 +1142,16 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
         run: ./runtest-sentinel --failures-output test-failures/sentinel.json ${{github.event.inputs.cluster_test_args}}
       - name: unittest
-        if: true && !contains(github.event.inputs.skiptests, 'unittest')
+        if: always() && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            make test-unit
+            make test-unit json_results=$GITHUB_WORKSPACE/gtest-results.json
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests
           fi
+      - name: Extract gtest failures
+        if: always()
+        uses: ./.github/actions/extract-gtest-failures
       - name: Upload test failures
         if: always()
         uses: ./.github/actions/upload-test-failures
@@ -1182,13 +1214,16 @@ jobs:
           done) &
           echo $! > /tmp/memmon.pid
       - name: unittest
-        if: true && !contains(github.event.inputs.skiptests, 'unittest')
+        if: always() && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            make test-unit large_memory=1
+            make test-unit large_memory=1 json_results=$GITHUB_WORKSPACE/gtest-results.json
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --large-memory
           fi
+      - name: Extract gtest failures
+        if: always()
+        uses: ./.github/actions/extract-gtest-failures
       - name: large memory tests
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
         run: ./runtest --accurate --failures-output test-failures/valkey.json --verbose --dump-logs --clients 1 --large-memory --tags large-memory ${{github.event.inputs.test_args}}
@@ -1268,13 +1303,16 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
         run: ./runtest-sentinel --failures-output test-failures/sentinel.json ${{github.event.inputs.cluster_test_args}}
       - name: unittest
-        if: true && !contains(github.event.inputs.skiptests, 'unittest')
+        if: always() && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            make test-unit accurate=1
+            make test-unit accurate=1 json_results=$GITHUB_WORKSPACE/gtest-results.json
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate
           fi
+      - name: Extract gtest failures
+        if: always()
+        uses: ./.github/actions/extract-gtest-failures
       - name: Upload test failures
         if: always()
         uses: ./.github/actions/upload-test-failures
@@ -1337,13 +1375,16 @@ jobs:
           done) &
           echo $! > /tmp/memmon.pid
       - name: unittest
-        if: true && !contains(github.event.inputs.skiptests, 'unittest')
+        if: always() && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            make test-unit accurate=1 large_memory=1
+            make test-unit accurate=1 large_memory=1 json_results=$GITHUB_WORKSPACE/gtest-results.json
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate --large-memory
           fi
+      - name: Extract gtest failures
+        if: always()
+        uses: ./.github/actions/extract-gtest-failures
       - name: large memory tests
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
         run: ./runtest --accurate --failures-output test-failures/valkey.json --verbose --dump-logs --clients 1 --large-memory --tags large-memory ${{github.event.inputs.test_args}}
@@ -1419,13 +1460,16 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
         run: ./runtest-sentinel --failures-output test-failures/sentinel.json ${{github.event.inputs.cluster_test_args}}
       - name: unittest
-        if: true && !contains(github.event.inputs.skiptests, 'unittest')
+        if: always() && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            make test-unit
+            make test-unit json_results=$GITHUB_WORKSPACE/gtest-results.json
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests
           fi
+      - name: Extract gtest failures
+        if: always()
+        uses: ./.github/actions/extract-gtest-failures
       - name: Upload test failures
         if: always()
         uses: ./.github/actions/upload-test-failures
@@ -2237,12 +2281,16 @@ jobs:
           merged = {}
           damaged = []
 
-          # Every field the Tcl writers emit for a failure. A file can parse as
-          # JSON yet still be damaged: a run killed mid-write can leave a null or
-          # a half-built object in the list. Those publish as real failures the
+          # Every field the writers emit for a failure. A file can parse as JSON
+          # yet still be damaged: a run killed mid-write can leave a null or a
+          # half-built object in the list. Those publish as real failures the
           # detector then reads as empty, so the entry shape is checked too, not
           # just the list around it.
-          REQUIRED_FAILURE_FIELDS = ("test_name", "test_file", "status", "error")
+          #
+          # "type" replaces the old "status": every writer here (both Tcl
+          # harnesses and the gtest extraction) now names the failure type, and
+          # the detector keys its per-type handling off it.
+          REQUIRED_FAILURE_FIELDS = ("test_name", "test_file", "type", "error")
 
           def invalid_entry_reason(entry, index):
               """Why *entry* is not a usable failure object, or None if it is."""

--- a/src/unit/Makefile
+++ b/src/unit/Makefile
@@ -237,8 +237,14 @@ all: valkey-unit-gtests
 
 .PHONY: test-unit
 TEST_ARGS = $(if $(accurate),--accurate) $(if $(large_memory),--large-memory) $(if $(valgrind),--valgrind) $(if $(seed),--seed $(seed))
+# Set json_results=<path> to dump per-test outcomes and preserve each test's
+# console log. CI points json_results at a file, and --output_dir keeps the
+# per-test logs beside it; the extract-gtest-failures action reads the failing
+# ones for the full failure text. gtest-parallel writes both before returning
+# the test exit code, so they survive a failing run.
+GTEST_JSON_ARGS = $(if $(json_results),--dump_json_test_results $(json_results) --output_dir $(dir $(json_results)))
 test-unit: valkey-unit-gtests
-	python3 ../../deps/gtest-parallel/gtest_parallel.py ./valkey-unit-gtests --gtest_filter=$(UNIT_TEST_PATTERN)* -- $(TEST_ARGS)
+	python3 ../../deps/gtest-parallel/gtest_parallel.py ./valkey-unit-gtests --gtest_filter=$(UNIT_TEST_PATTERN)* $(GTEST_JSON_ARGS) -- $(TEST_ARGS)
 	@printf '\033[32mAll UNIT TESTS PASSED!\033[0m\n'
 
 .PHONY: valgrind

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -578,11 +578,15 @@ proc write_test_failures {} {
         set test_file [lindex $entry 1]
         set error_msg [lindex $entry 2]
 
+        set error_msg [truncate_failure_error $error_msg $::max_failure_error_chars]
+
         set test_name [json_escape_string $test_name]
         set test_file [json_escape_string $test_file]
         set error_msg [json_escape_string $error_msg]
 
-        lappend failures "\{\"test_name\":\"$test_name\",\"test_file\":\"$test_file\",\"status\":\"err\",\"error\":\"$error_msg\"\}"
+        # Every entry reaching here came from the assertion branch of `test`;
+        # this harness's other failure paths bump ::failed without recording one.
+        lappend failures "\{\"test_name\":\"$test_name\",\"test_file\":\"$test_file\",\"type\":\"assertion\",\"error\":\"$error_msg\"\}"
     }
 
     set outdir [file dirname $::failures_output_file]
@@ -590,8 +594,9 @@ proc write_test_failures {} {
         file mkdir $outdir
     }
     set fp [open $::failures_output_file w]
-    # JSON is UTF-8, so do not leave the channel on the system encoding.
-    fconfigure $fp -encoding utf-8
+    # Write the failure text as the bytes it already is, not through an encoding
+    # that would re-encode them.
+    fconfigure $fp -translation binary
     puts $fp "\[[join $failures ","]\]"
     close $fp
 }

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -370,14 +370,16 @@ proc spawn_server {executable config_file stdout stderr args} {
     return $pid
 }
 
-# Wait for actual startup, return 1 if port is busy, 0 otherwise
+# Wait for actual startup. Returns "started" once the server is up,
+# "port_busy" if the port was taken so the caller can retry on another one, or
+# "reported" if startup failed and the failure was already sent to the test
+# server. The caller must not report a "reported" failure again.
 proc wait_server_started {executable config_file stdout stderr pid} {
     set checkperiod 100; # Milliseconds
     set maxiter [expr {120*1000/$checkperiod}] ; # Wait up to 2 minutes.
-    set port_busy 0
     while 1 {
         if {[regexp -- " PID: $pid.*Server initialized" [exec cat $stdout]]} {
-            break
+            return "started"
         }
         after $checkperiod
         incr maxiter -1
@@ -386,24 +388,24 @@ proc wait_server_started {executable config_file stdout stderr pid} {
             puts "--- LOG CONTENT ---"
             puts [exec cat $stdout]
             puts "-------------------"
-            break
+            return "reported"
         }
 
         # Check if the port is actually busy and the server failed
         # for this reason.
         if {[regexp {Failed listening on port} [exec cat $stdout]]} {
-            set port_busy 1
-            break
+            return "port_busy"
         }
 
         # Configuration errors are unexpected, but it's helpful to fail fast
-        # to give the feedback to the test runner.
+        # to give the feedback to the test runner. The server's own stderr is
+        # reported rather than a fixed message because it names the offending
+        # directive; a fixed one is identical for every cause.
         if {[regexp {FATAL CONFIG FILE ERROR} [exec cat $stderr]]} {
-            start_server_error $executable $config_file "Configuration issue prevented Valkey startup"
-            break
+            start_server_error $executable $config_file [exec cat $stderr]
+            return "reported"
         }
     }
-    return $port_busy
 }
 
 proc dump_server_log {srv} {
@@ -671,12 +673,22 @@ proc start_server {options {code undefined}} {
         set pid [spawn_server $executable $config_file $stdout $stderr $args]
 
         # check that the server actually started
-        set port_busy [wait_server_started $executable $config_file $stdout $stderr $pid]
+        set startup_status [wait_server_started $executable $config_file $stdout $stderr $pid]
+
+        # The failure is already reported; reporting it again here would file a
+        # second issue for the same dead server. Restore the globals this proc
+        # appended to, as the other early returns do, or the leaked tags apply
+        # to every later server in the file.
+        if {$startup_status eq "reported"} {
+            set ::singledb $old_singledb
+            set ::tags [lrange $::tags 0 end-[llength $tags]]
+            return
+        }
 
         # Sometimes we have to try a different port, even if we checked
         # for availability. Other test clients may grab the port before we
         # are able to do it for example.
-        if {$port_busy} {
+        if {$startup_status eq "port_busy"} {
             puts "Port $port was already busy, trying another port..."
             set port [find_available_port $::baseport $::portcount]
             if {$::tls} {
@@ -890,8 +902,19 @@ proc restart_server {level wait_ready rotate_logs {reconnect 1} {shutdown sigter
 
     set pid [spawn_server $executable $config_file $stdout $stderr {}]
 
-    # check that the server actually started
-    wait_server_started $executable $config_file $stdout $stderr $pid
+    # check that the server actually started. A restart has no second port to
+    # fall back on, so anything but a start is fatal here: continuing would
+    # record a pid for a dead server and fail later in reconnect, attributing
+    # the failure to whichever test ran next. Raising is deliberate even for
+    # "reported", whose failure wait_server_started already sent: a plain return
+    # would hand the caller a dead server to keep testing against, and the "err"
+    # packet that status sends does not stop the run on its own. The exception
+    # handler in test_helper.tcl drops this raise from ::failed_tests for the
+    # "reported" status, so stopping the client here costs no second issue.
+    set startup_status [wait_server_started $executable $config_file $stdout $stderr $pid]
+    if {$startup_status ne "started"} {
+        error "Restarted server did not come up: $startup_status"
+    }
 
     # update the pid in the servers list
     dict set srv "pid" $pid

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1326,26 +1326,76 @@ proc memcmp {string1 string2} {
     return [expr {$len1 - $len2}]
 }
 
-# Escape a string for use as a JSON string value.
+# Every C0 control character needs escaping, not just the ones with a short
+# form: JSON forbids them raw, and one anywhere in the file makes the whole file
+# unparsable, discarding every failure in the run. Server output and memory-tool
+# reports do carry them. Built once, since the map is walked per character and
+# the strings being escaped run to megabytes.
+set ::json_escape_map {
+    "\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r"
+    "\t" "\\t" "\b" "\\b" "\f" "\\f"
+}
+foreach code {0 1 2 3 4 5 6 7 11 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31} {
+    lappend ::json_escape_map [format %c $code] [format {\u%04x} $code]
+}
+
+# Reduce a string to UTF-8 bytes, whichever form it arrived in.
 #
-# Beyond the characters with a short escape, every C0 control character has to
-# be escaped: JSON forbids them raw, and one raw byte makes the whole file
-# unparsable, taking every failure in the run with it. Failure messages carry
-# server output and memory-tool reports, which do contain control bytes, and an
-# incomplete ANSI sequence survives colour stripping.
-proc json_escape_string {s} {
-    set s [string map {
-        "\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r"
-        "\t" "\\t" "\b" "\\b" "\f" "\\f"
-    } $s]
-    set out ""
-    foreach ch [split $s ""] {
-        scan $ch %c code
-        if {$code < 0x20} {
-            append out [format {\u%04x} $code]
-        } else {
-            append out $ch
-        }
+# Failure text reaches the harness two ways and they are not the same type: over
+# a -translation binary socket it is already UTF-8 bytes, while [exec cat] of a
+# log decodes into a real Tcl string. Writing either one out assuming the other
+# corrupts it, so both are normalized here. A byte that is not part of a valid
+# UTF-8 sequence (a latin-1 log) is converted rather than passed through, so the
+# artifact always decodes.
+proc utf8_bytes {s} {
+    # All-ASCII text is already both forms at once and is the overwhelmingly
+    # common case, so it short-circuits the conversions below; those cost several
+    # passes over a report that can run to megabytes.
+    if {[string is ascii $s]} {
+        return $s
     }
-    return $out
+    # A codepoint above 255 cannot be a byte, so the string is a decoded one.
+    if {[regexp {[^\u0000-\u00ff]} $s]} {
+        return [encoding convertto utf-8 $s]
+    }
+    # Every codepoint fits a byte. If those bytes already form valid UTF-8, they
+    # came off the binary socket and must pass through untouched; otherwise the
+    # text is latin-1 and needs converting. Tcl 9's strict encoding profile
+    # raises on an invalid sequence rather than substituting, so the decode is
+    # caught: a failure means the bytes are not valid UTF-8, which is the
+    # latin-1 case, and only a clean decode is worth the round-trip comparison.
+    if {![catch {encoding convertfrom utf-8 $s} decoded]
+        && [encoding convertto utf-8 $decoded] eq $s} {
+        return $s
+    }
+    return [encoding convertto utf-8 $s]
+}
+
+# Largest per-failure error text the artifact carries, in bytes.
+set ::max_failure_error_chars 65536
+
+# Cap a failure's error text, in bytes, on a UTF-8 character boundary.
+#
+# A memory-tool report is the tool's whole stderr buffer and can run to tens of
+# megabytes. The head holds the diagnostic and the first stack, which is what
+# identifies the failure; keeping the rest makes the artifact too large to upload
+# and slows the write enough for a job timeout to truncate it mid-file. Cutting
+# inside a multi-byte sequence would leave the whole artifact undecodable.
+proc truncate_failure_error {s limit} {
+    set s [utf8_bytes $s]
+    if {[string length $s] <= $limit} {
+        return $s
+    }
+    set cut $limit
+    while {$cut > 0} {
+        scan [string index $s $cut] %c code
+        if {$code eq "" || ($code & 0xC0) != 0x80} break
+        incr cut -1
+    }
+    return "[string range $s 0 [expr {$cut - 1}]]\n... (truncated)"
+}
+
+# Escape a string for use as a JSON string value.
+proc json_escape_string {s} {
+    return [string map $::json_escape_map [utf8_bytes $s]]
 }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -400,23 +400,34 @@ proc test_server_cron {} {
         set err "\[[colorstr red TIMEOUT]\]: clients state report follows."
         puts $err
         foreach fd $::active_clients {
-            if {[info exist ::active_clients_task($fd)]} {
-                set task $::active_clients_task($fd)
-                set test_name [regsub {^\([^)]*\)\s*} $task {}]
-                set test_name [regsub {\s*\(pid\s+\d+\)\s*$} $test_name {}]
-                if {![string length [string trim $test_name]] && \
-                    [regexp {\(([^()]*)\)$} $task -> tn]} {
-                    set test_name $tn
-                }
-                set test_name [string trim $test_name]
-                if {[string length $test_name]} {
-                    set file {}
-                    if {[info exist ::active_clients_file($fd)]} {
-                        set file $::active_clients_file($fd)
-                    }
-                    lappend ::failed_tests "\[[colorstr red TIMEOUT]\]: $test_name in $file"
-                    incr ::err_count
-                }
+            if {![info exist ::active_clients_task($fd)]} {
+                continue
+            }
+            set task $::active_clients_task($fd)
+            set file {}
+            if {[info exist ::active_clients_file($fd)]} {
+                set file $::active_clients_file($fd)
+            }
+            if {[regexp {^\(IN PROGRESS\)\s*(.+)$} $task -> test_name]} {
+                # A test body was running: attribute the timeout to it.
+                # Strip the volatile "(pid N)" suffix some test names carry
+                # so the same timeout has a stable identity across runs.
+                set test_name [string trim [regsub {\s*\(pid\s+\d+\)\s*$} $test_name {}]]
+                lappend ::failed_tests [list "\[[colorstr red TIMEOUT]\]: $test_name in $file" "timeout" $file]
+                incr ::err_count
+            } elseif {[string match {(ERR)*} $task]} {
+                # This client's failure is already in ::failed_tests; the
+                # hang is a consequence of it, not a separate failure. Its
+                # payload is an error blob, not a test name.
+            } elseif {[string length $file]} {
+                # No test body was running (server spawn/kill, between tests).
+                # The task payload (pids, fds) is too volatile to be a test
+                # name, so the hang is reported against the file. The state goes
+                # in the message after the file, where the consumer keeps it as
+                # error text; before it, the name regex would capture the word
+                # "hang" and drop the state entirely.
+                lappend ::failed_tests [list "\[[colorstr red TIMEOUT]\]: hang in $file last state: $task" "timeout" $file]
+                incr ::err_count
             }
         }
         show_clients_state
@@ -487,7 +498,11 @@ proc read_from_test_client fd {
     } elseif {$status eq {err}} {
         set err "\[[colorstr red $status]\]: $data"
         puts $err
-        lappend ::failed_tests $err
+        set ctx_file ""
+        if {[info exist ::active_clients_file($fd)]} {
+            set ctx_file $::active_clients_file($fd)
+        }
+        lappend ::failed_tests [list $err "" $ctx_file]
         incr ::err_count
         set ::active_clients_task($fd) "(ERR) $data"
         if {$::exit_on_failure} {
@@ -501,9 +516,24 @@ proc read_from_test_client fd {
         }
     } elseif {$status eq {exception}} {
         puts "\[[colorstr red $status]\]: $data"
+        # restart_server raises on a startup status it cannot recover from, to
+        # stop the client rather than hand it a dead server. When that status is
+        # "reported", wait_server_started already sent the err packet naming the
+        # cause, so recording this raise too would file a second entry for one
+        # dead server: a "startup" against the test file and an "exception"
+        # against none. Those get different identities, so the detector reports
+        # them as two failures. Same reasoning as the "(ERR)" timeout branch
+        # above: a consequence of a recorded failure is not itself one.
+        if {![string match {*Restarted server did not come up: reported*} $data]} {
+            lappend ::failed_tests [list "\[[colorstr red exception]\]: $data" "exception" ""]
+        }
+        incr ::err_count
         if {[catch {write_test_failures} err]} {
             puts "Warning: Failed to write test failures: $err"
         }
+        # This path exits without reaching the_end, so print the summary here or
+        # the run's last word is the raw exception and the count goes unreported.
+        print_test_summary
         kill_clients
         force_kill_all_servers
         exit 1
@@ -635,31 +665,104 @@ proc write_test_failures {} {
     }
 
     set failures {}
-    foreach failed $::failed_tests {
-        if {[string match {*\[*TIMEOUT*\]*} $failed]} continue
-        if {[string match {*Sanitizer error*} $failed]} continue
-        if {[string match {*Valgrind error*} $failed]} continue
-        if {[string match {*Can't start*} $failed]} continue
-        if {[string match {*Check for memory leaks*} $failed]} continue
+    foreach record $::failed_tests {
+        # Each record is {message type-hint file}. The type hint and file are
+        # captured at failure time; classification below refines the type by
+        # matching on the message.
+        set failed [lindex $record 0]
+        set ctx_type [lindex $record 1]
+        set ctx_file [lindex $record 2]
 
-        set status "err"
+        # Strip ANSI color codes so pattern matching and the regexes below
+        # work whether or not the message was colorized (color_term is on
+        # under an xterm TERM, e.g. local runs).
+        set failed [regsub -all {\x1b\[[0-9;]*m} $failed {}]
+
+        set type "assertion"
         set test_name ""
         set test_file ""
         set error_msg ""
 
-        if {[regexp {\[(\w+)\]:\s*(.+?)\s+in\s+(tests/\S+\.tcl)\s*(.*)} $failed -> status test_name test_file error_msg]} {
-            # Successfully parsed
+        # Strip the leading status tag, e.g. "[err]: ". The character class
+        # matters: with a non-greedy ".*?" the shortest overall match wins and
+        # the trailing "\s*" matches nothing, leaving the separator space at
+        # the front of every stripped message.
+        set stripped [regsub {^\[[^\]]*\]:\s*} $failed {}]
+
+        # Classify the failure. The type hint captured at failure time is
+        # authoritative and is checked first: an exception's message text can
+        # contain any of the markers below.
+        #
+        # Markers are anchored to the start of the message, never globbed. A
+        # loose glob also matches a test whose own name or output contains one:
+        # two tests in tests/unit/moduleapi/blockonkeys.tcl carry TIMEOUT, and
+        # tests/modules/blockonbackground.c replies "Can't start thread". Those
+        # would be filed under the marker's type and lose their test identity.
+        if {$ctx_type eq "exception"} {
+            set type "exception"
+            set test_name ""
+            set test_file ""
+            set error_msg $stripped
+        } elseif {[regexp {^\[TIMEOUT\]:} $failed]} {
+            set type "timeout"
+            if {[regexp {\[TIMEOUT\]:\s*(.+?)\s+in\s+(tests/\S+\.tcl)\s*(.*)} $failed -> test_name test_file tail]} {
+                # Anything after the file is the runner's last-known state for a
+                # hang with no test body running. Keep it: it is the only clue
+                # to what the client was doing.
+                set error_msg [expr {$tail eq "" ? "Test timed out" : "Test timed out, $tail"}]
+            } else {
+                set test_name ""
+                set test_file $ctx_file
+                set error_msg $failed
+            }
+        } elseif {[regexp {^Valgrind error:} $stripped]} {
+            set type "valgrind"
+            set test_name ""
+            set test_file $ctx_file
+            set error_msg $stripped
+        } elseif {[regexp {^Sanitizer error:} $stripped]} {
+            set type "sanitizer"
+            set test_name ""
+            set test_file $ctx_file
+            set error_msg $stripped
+        } elseif {[regexp {^Can't start\s} $stripped]} {
+            set type "startup"
+            set test_name ""
+            set test_file $ctx_file
+            set error_msg $stripped
+        } elseif {[regexp {\[(\w+)\]:\s*(.+?)\s+in\s+(tests/\S+\.tcl)\s*(.*)} $failed -> _status test_name test_file error_msg]} {
+            # Standard assertion failure: [err]: <test_name> in <test_file>.
+            # The leak check is one of these, but its name is the same for every
+            # server a file starts ("Check for memory leaks (pid N)"), so it
+            # identifies the check rather than the leak. Dropping the pid alone
+            # would leave one name shared by every leak in the file, collapsing
+            # distinct leaks into one report. Emit it nameless instead: the
+            # detector then keys on the report's own root allocation site, which
+            # is the only part that says which code path leaked.
+            if {[string match {Check for memory leaks*} $test_name]} {
+                set type "memory-leak"
+                set test_name ""
+            } else {
+                set type "assertion"
+            }
         } else {
-            set test_name $failed
-            set test_file "unknown"
-            set error_msg $failed
+            # No known pattern and not the standard assertion format:
+            # classify as exception (the catch-all for unexpected errors)
+            # with no test identity, so the detector groups recurrences by
+            # normalized error text rather than the volatile raw string.
+            set type "exception"
+            set test_name ""
+            set test_file $ctx_file
+            set error_msg $stripped
         }
 
-        foreach var {test_name test_file error_msg status} {
+        set error_msg [truncate_failure_error $error_msg $::max_failure_error_chars]
+
+        foreach var {test_name test_file error_msg type} {
             set $var [json_escape_string [set $var]]
         }
 
-        lappend failures "\{\"test_name\":\"$test_name\",\"test_file\":\"$test_file\",\"status\":\"$status\",\"error\":\"$error_msg\"\}"
+        lappend failures "\{\"test_name\":\"$test_name\",\"test_file\":\"$test_file\",\"type\":\"$type\",\"error\":\"$error_msg\"\}"
     }
 
     set outdir [file dirname $::failures_output_file]
@@ -667,10 +770,11 @@ proc write_test_failures {} {
         file mkdir $outdir
     }
     set fp [open $::failures_output_file w]
-    # JSON is UTF-8. Left on the system encoding, which some CI containers set
-    # to a single-byte locale, a non-ASCII byte in a message is written in that
-    # encoding and the consumer cannot decode the file.
-    fconfigure $fp -encoding utf-8
+    # Failure text arrives over a -translation binary socket, so it is already a
+    # byte string. Writing it through an encoding would re-encode each byte and
+    # corrupt any non-ASCII the server logged; passing the bytes through leaves
+    # the UTF-8 the server emitted intact, which is what the consumer expects.
+    fconfigure $fp -translation binary
     puts $fp "\[[join $failures ","]\]"
     close $fp
 }
@@ -691,8 +795,8 @@ proc the_end {} {
 
     if {[llength $::failed_tests]} {
         puts "\n[colorstr bold-red {!!! WARNING}] The following tests failed:\n"
-        foreach failed $::failed_tests {
-            puts "*** $failed"
+        foreach record $::failed_tests {
+            puts "*** [lindex $record 0]"
         }
         if {!$::dont_clean} cleanup
         exit 1


### PR DESCRIPTION
## Purpose

The Daily workflow records per-job test failures into `all-test-failures.json` and uploads the `all-test-failures` artifact, which the Test Failure Detector in [`valkey-ci-agent`](https://github.com/valkey-io/valkey-ci-agent) reads to create and update GitHub issues.

Currently, the artifact holds only assertion failures. `write_test_failures` skips timeouts, sanitizer, valgrind, startup, and memory-leak reports, and gtest results are not in the artifact at all, so a failing unit test shows only as a red job. This PR records every failure type so the detector can report them. The consumer side is [valkey-ci-agent PR 78](https://github.com/valkey-io/valkey-ci-agent/pull/78).

## Summary

**A failure type for every failure**
  
`::failed_tests` entries become `{message type-hint file}` triples, since a valgrind or sanitizer message carries no test name. `write_test_failures` emits a `type` field, replacing `status`, with one of seven values: assertion, sanitizer, valgrind, timeout, startup, exception, memory-leak; the gtest action contributes an eighth, unittest. A record matching no marker becomes `exception` rather than being dropped.

Markers are anchored to the start of the message rather than globbed, and the assertion pattern is matched first, so a test whose own name or output contains a marker word (e.g. `TIMEOUT`, `Can't start thread`) is not misclassified. The macOS leak check is itself a named test, so it keeps its name and file and takes only its type from the marker. Timeout attribution keys off the `(IN PROGRESS)` task prefix; a client already in `(ERR)` state is skipped, since its hang follows from a failure already recorded.

**Extract gtest failures**

`src/unit/Makefile` accepts `json_results=<path>`, passing `--dump_json_test_results` and `--output_dir` to gtest-parallel; the default invocation is unchanged, and the dump and per-test logs are written before the exit code returns, so they survive a failed run. `.github/actions/extract-gtest-failures` turns the dump into a `test-failures/unittest.json` entry, pairing each verdict with the failing test's console log to carry the assertion text into the issue. It reads the last token of the `actual` field, so a test that passes on retry is not reported, and an unreadable, truncated, or empty dump degrades to an empty or absent suite file. `daily.yml` runs the extraction in the 11 jobs that build the gtest binary, with their `unittest` steps moved to `if: always() &&` so a prior red step no longer skips them.

**Supporting changes**
  
- `json_escape_string` escapes every C0 control byte, not just the seven with short escapes — one raw byte previously made the whole artifact unparsable. Failure text is normalized to UTF-8 and written on a binary channel, and per-failure text is capped on a character boundary so a multi-byte sequence is never split.
- `tests/instances.tcl` gets the same `type` field, escaping, truncation, and binary output for sentinel and cluster runs (all `assertion`).
- `wait_server_started` now returns `started`/`port_busy`/`reported` instead of a boolean, so a startup failure is reported once (not twice) and with the server's own stderr. `restart_server` treats anything but `started` as fatal.

## Testing

  - Merge step keeps healthy jobs and exits 0 when one suite file is damaged (previously exited 1 with no artifact).
  - Artifact round-trips as UTF-8 JSON for quotes, backslashes, newlines, all 32 C0 bytes, an incomplete ANSI escape, non-ASCII text, and Tcl list metacharacters; truncation stays on a character boundary.
  - Injected failures per marker case classify correctly, and an assertion quoting a marker keeps `type=assertion` and its test name.
  - gtest action exercised against normal, truncated, and missing dumps: failures and timeouts are reported, a retry-then-pass is not, and the no-results case leaves no suite file.