### PR TITLE
Fix CTZ fallback operator precedence

### DIFF
--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -10,7 +10,7 @@ static inline int32_t builtin_ctzll(uint64_t value) {
     return __builtin_ctzll(value);
 #else
     int bitpos = 0;
-    while (value & 1 == 0) {
+    while ((value & 1) == 0) {
         value >>= 1;
         ++bitpos;
     }

--- a/src/unit/test_intrinsics.cpp
+++ b/src/unit/test_intrinsics.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+
+#include <stdint.h>
+
+#if defined(__GNUC__) || defined(__clang__)
+#define INTRINSICS_TEST_HAS_DIAGNOSTIC_PRAGMA
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wparentheses"
+#endif
+
+#undef __GNUC__
+#undef __clang__
+
+extern "C" {
+#include "intrinsics.h"
+}
+
+#ifdef INTRINSICS_TEST_HAS_DIAGNOSTIC_PRAGMA
+#pragma GCC diagnostic pop
+#endif
+
+class IntrinsicsTest : public ::testing::Test {};
+
+TEST_F(IntrinsicsTest, TestBuiltinCtzllFallback) {
+    ASSERT_EQ(64, builtin_ctzll(0));
+
+    for (int i = 0; i < 64; i++) {
+        uint64_t value = ((uint64_t)1) << i;
+        ASSERT_EQ(i, builtin_ctzll(value));
+    }
+}

--- a/src/unit/test_intrinsics.cpp
+++ b/src/unit/test_intrinsics.cpp
@@ -8,22 +8,16 @@
 
 #include <stdint.h>
 
-#if defined(__GNUC__) || defined(__clang__)
-#define INTRINSICS_TEST_HAS_DIAGNOSTIC_PRAGMA
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wparentheses"
+#ifdef __INTRINSICS_H
+#error "intrinsics.h must not be included before this point, or the fallback path is not compiled"
 #endif
 
 #undef __GNUC__
 #undef __clang__
 
 extern "C" {
-#include "intrinsics.h"
+#include "../intrinsics.h"
 }
-
-#ifdef INTRINSICS_TEST_HAS_DIAGNOSTIC_PRAGMA
-#pragma GCC diagnostic pop
-#endif
 
 class IntrinsicsTest : public ::testing::Test {};
 


### PR DESCRIPTION
## Summary

Fix the non-builtin `builtin_ctzll()` fallback so its loop tests the low bit correctly. Add a unit test that forces the fallback path and covers zero plus every single-bit position.

Fixes #2284

## Testing

- Forced-fallback unit test
- HyperLogLog integration tests
- Makefile and CMake TLS builds
