### PR TITLE
nit: Fix test's memory leak of server.replicas in networking unit tests

### DIFF
--- a/src/unit/main.cpp
+++ b/src/unit/main.cpp
@@ -13,6 +13,9 @@ extern "C" {
 #include "sha256.h"
 #include "util.h"
 }
+/* Pulls in server.h with the C-to-C++ compatibility shims (e.g. the
+ * 'protected' field name and _Atomic) so the global 'server' is visible. */
+#include "wrappers.h"
 
 
 bool accurate = false;
@@ -91,5 +94,11 @@ int main(int argc, char **argv) {
     if (result == 0) {
         printf("\033[32mAll UNIT TESTS PASSED!\033[0m\n");
     }
+    /* Zero the global server struct so that any allocation a test parked on
+     * it without freeing becomes unreachable, turning it into a direct leak
+     * that LeakSanitizer/Valgrind report at process exit. Without this,
+     * leaked allocations stay reachable through the global and leak
+     * detection silently passes. */
+    memset(&server, 0, sizeof(server));
     return result;
 }

--- a/src/unit/main.cpp
+++ b/src/unit/main.cpp
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+/* fmacros.h must come before any system header so that feature-test macros
+ * (notably _FILE_OFFSET_BITS=64 for 32-bit builds) take effect. */
+extern "C" {
+#include "../fmacros.h"
+}
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <cstdio>

--- a/src/unit/test_networking.cpp
+++ b/src/unit/test_networking.cpp
@@ -280,6 +280,9 @@ TEST_F(NetworkingTest, TestWriteToReplica) {
 
     /* Cleanup */
     listRelease(server.repl_buffer_blocks);
+    server.repl_buffer_blocks = NULL;
+    listRelease(server.replicas);
+    server.replicas = NULL;
     listRelease(c->reply);
     freeClientReplicationData(c);
     zfree(c);
@@ -406,7 +409,11 @@ TEST_F(NetworkingTest, TestPostWriteToReplica) {
     freeClientReplicationData(c);
     raxFree(server.repl_backlog->blocks_index);
     zfree(server.repl_backlog);
+    server.repl_backlog = NULL;
     listRelease(server.repl_buffer_blocks);
+    server.repl_buffer_blocks = NULL;
+    listRelease(server.replicas);
+    server.replicas = NULL;
     listRelease(c->reply);
     zfree(c);
 }

--- a/src/unit/test_networking.cpp
+++ b/src/unit/test_networking.cpp
@@ -167,6 +167,11 @@ class NetworkingTest : public ::testing::Test {
             server.repl_backlog = NULL;
         }
         if (server.repl_buffer_blocks) {
+            /* Test bodies free blocks and empty the list on the pass path;
+             * set the free method (as production does, replication.c) so any
+             * blocks still in the list after a fatal assertion failure are
+             * freed along with it. */
+            listSetFreeMethod(server.repl_buffer_blocks, zfree);
             listRelease(server.repl_buffer_blocks);
             server.repl_buffer_blocks = NULL;
         }

--- a/src/unit/test_networking.cpp
+++ b/src/unit/test_networking.cpp
@@ -153,6 +153,28 @@ class NetworkingTest : public ::testing::Test {
         server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold = -1; /* Disable tracking */
         server.debug_client_enforce_reply_list = 0;
     }
+
+    /* Release replication state parked on the global server struct. Runs
+     * even when a test body exits early on a fatal ASSERT_* failure, so no
+     * allocation leaks and no dangling state bleeds into subsequent tests
+     * (e.g. a leftover server.repl_backlog would trip the serverAssert in
+     * createReplicationBacklog). No-op for tests that allocate nothing. */
+    void TearDown() override {
+        if (server.repl_backlog) {
+            server.repl_backlog->ref_repl_buf_node = NULL;
+            raxFree(server.repl_backlog->blocks_index);
+            zfree(server.repl_backlog);
+            server.repl_backlog = NULL;
+        }
+        if (server.repl_buffer_blocks) {
+            listRelease(server.repl_buffer_blocks);
+            server.repl_buffer_blocks = NULL;
+        }
+        if (server.replicas) {
+            listRelease(server.replicas);
+            server.replicas = NULL;
+        }
+    }
 };
 
 TEST_F(NetworkingTest, TestWriteToReplica) {
@@ -278,24 +300,11 @@ TEST_F(NetworkingTest, TestWriteToReplica) {
         c->repl_data->ref_repl_buf_node = nullptr;
     }
 
-    /* Cleanup */
-    listRelease(server.repl_buffer_blocks);
-    server.repl_buffer_blocks = NULL;
-    listRelease(server.replicas);
-    server.replicas = NULL;
+    /* Cleanup of client-local state; global replication state is released
+     * in TearDown(). */
     listRelease(c->reply);
     freeClientReplicationData(c);
     zfree(c);
-
-    /* Clean up replication backlog */
-    if (server.repl_backlog) {
-        if (server.repl_backlog->ref_repl_buf_node) {
-            server.repl_backlog->ref_repl_buf_node = NULL;
-        }
-        raxFree(server.repl_backlog->blocks_index);
-        zfree(server.repl_backlog);
-        server.repl_backlog = NULL;
-    }
 }
 
 TEST_F(NetworkingTest, TestPostWriteToReplica) {
@@ -405,15 +414,9 @@ TEST_F(NetworkingTest, TestPostWriteToReplica) {
         listEmpty(server.repl_buffer_blocks);
     }
 
-    /* Cleanup */
+    /* Cleanup of client-local state; global replication state is released
+     * in TearDown(). */
     freeClientReplicationData(c);
-    raxFree(server.repl_backlog->blocks_index);
-    zfree(server.repl_backlog);
-    server.repl_backlog = NULL;
-    listRelease(server.repl_buffer_blocks);
-    server.repl_buffer_blocks = NULL;
-    listRelease(server.replicas);
-    server.replicas = NULL;
     listRelease(c->reply);
     zfree(c);
 }


### PR DESCRIPTION
TestWriteToReplica and TestPostWriteToReplica create server.replicas with listCreate() (guarded by a NULL check) but never release it. The leak is masked when the networking tests run alone because the global server struct keeps the list reachable, but ExampleTest's memset(&server, 0, ...) wipes the pointer, so a full-suite run under LeakSanitizer (ASAN_OPTIONS=detect_leaks=1) reports a 48-byte direct leak from listCreate.

Release server.replicas in both tests' teardown, and reset the freed server.repl_buffer_blocks and server.repl_backlog pointers to NULL so no dangling state bleeds into subsequent tests.

Verified with SANITIZER=address MALLOC=libc and
ASAN_OPTIONS=detect_leaks=1: full gtest suite passes with no LeakSanitizer report.