### PR TITLE
Deflake: run_solo tests once in a dedicated job instead of across the full matrix

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -118,7 +118,7 @@ jobs:
         run: sudo apt-get install tcl8.6 tclx
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --failures-output test-failures/moduleapi.json --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -159,6 +159,52 @@ jobs:
         run: |
           sudo apt-get install tcl8.6 tclx
           ./runtest --verbose --tags compatible-redis --dump-logs --other-server-path tests/tmp/redis-7.0.15/src/redis-server
+      - name: Upload test failures
+        if: always()
+        uses: ./.github/actions/upload-test-failures
+        with:
+          job-name: ${{ github.job }}
+  test-solo:
+    # Runs the run_solo tests (defrag, fuzzer, and cluster resharding/failover2/
+    # replica-migration-slow) once, on jemalloc arm. These tests execute alone
+    # after the parallel phase drains; the rest of the matrix passes --skip-solo
+    # so they are not duplicated across every platform/config.
+    runs-on: ubuntu-24.04-arm
+    if: |
+      (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
+        (github.event_name == 'pull_request' &&
+          (github.event.pull_request.base.ref != 'unstable' ||
+            contains(github.event.pull_request.labels.*.name, 'run-extra-tests')) &&
+          (github.event.action != 'labeled' ||
+            (github.event.pull_request.base.ref == 'unstable' && github.event.label.name == 'run-extra-tests'))
+        )) &&
+      !contains(github.event.inputs.skipjobs, 'solo')
+    timeout-minutes: 1440
+    steps:
+      - name: prep
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+        run: |
+          echo "GITHUB_REPOSITORY=${{inputs.use_repo || github.event.inputs.use_repo}}" >> $GITHUB_ENV
+          echo "GITHUB_HEAD_REF=${{inputs.use_git_ref || github.event.inputs.use_git_ref}}" >> $GITHUB_ENV
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.use_repo || github.event.inputs.use_repo || github.repository }}
+          ref: ${{ inputs.use_git_ref || github.event.inputs.use_git_ref || github.ref }}
+      - name: Install libbacktrace
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ianlancetaylor/libbacktrace
+          ref: b9e40069c0b47a722286b94eb5231f7f05c08713
+          path: libbacktrace
+      - run: cd libbacktrace && ./configure && make && sudo make install
+      - name: make
+        run: make SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes
+      - name: testprep
+        run: sudo apt-get install tcl8.6 tclx
+      - name: solo tests
+        if: true && !contains(github.event.inputs.skiptests, 'valkey')
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --single unit/memefficiency --single unit/fuzzer --single unit/cluster/resharding --single unit/cluster/failover2 --single unit/cluster/replica-migration-slow ${{github.event.inputs.test_args}}
       - name: Upload test failures
         if: always()
         uses: ./.github/actions/upload-test-failures
@@ -206,7 +252,7 @@ jobs:
         run: sudo apt-get install tcl8.6 tclx
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --failures-output test-failures/moduleapi.json --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -314,7 +360,7 @@ jobs:
         run: apt-get install -y tcl8.6 tclx procps
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --failures-output test-failures/moduleapi.json --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -374,7 +420,7 @@ jobs:
         run: sudo apt-get install tcl8.6 tclx
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --failures-output test-failures/moduleapi.json --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -426,7 +472,7 @@ jobs:
         run: sudo apt-get install tcl8.6 tclx
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --failures-output test-failures/moduleapi.json --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -499,7 +545,7 @@ jobs:
         run: sudo apt-get install tcl8.6 tclx
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: |
@@ -566,7 +612,7 @@ jobs:
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
         run: |
-          ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --tls ${{github.event.inputs.test_args}}
+          ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo --tls ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: |
@@ -623,7 +669,7 @@ jobs:
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
         run: |
-          ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+          ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: |
@@ -1436,7 +1482,7 @@ jobs:
         run: sudo apt-get install tcl8.6 tclx
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --failures-output test-failures/moduleapi.json --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -1513,7 +1559,7 @@ jobs:
         run: dnf -y install tcl tcltls
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --failures-output test-failures/moduleapi.json --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -1593,7 +1639,7 @@ jobs:
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
         run: |
-          ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --tls-module ${{github.event.inputs.test_args}}
+          ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo --tls-module ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: |
@@ -1670,7 +1716,7 @@ jobs:
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
         run: |
-          ./runtest --accurate --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+          ./runtest --accurate --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: |
@@ -1936,7 +1982,7 @@ jobs:
         run: apk add tcl procps tclx
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --failures-output test-failures/moduleapi.json --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -1991,7 +2037,7 @@ jobs:
         run: apk add tcl procps tclx
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
         run: CFLAGS='-Werror' ./runtest-moduleapi --failures-output test-failures/moduleapi.json --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -2152,6 +2198,7 @@ jobs:
       actions: write
     needs:
       - test-ubuntu-jemalloc
+      - test-solo
       - test-ubuntu-arm
       - test-ubuntu-jemalloc-fortify
       - test-ubuntu-libc-malloc
@@ -2253,6 +2300,7 @@ jobs:
     if: always() && github.event_name == 'schedule' && github.repository == 'valkey-io/valkey'
     needs:
       - test-ubuntu-jemalloc
+      - test-solo
       - test-ubuntu-arm
       - test-s390x
       - test-ubuntu-jemalloc-fortify

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -16,7 +16,7 @@ on:
     inputs:
       skipjobs:
         description: "jobs to skip (delete the ones you wanna keep, do not leave empty)"
-        default: "valgrind,sanitizer,tls,freebsd,macos,alpine,32bit,iothreads,ubuntu,rpm-distros,malloc,specific,fortify,reply-schema,arm,s390x,lttng"
+        default: "valgrind,sanitizer,tls,freebsd,macos,alpine,32bit,iothreads,ubuntu,rpm-distros,malloc,specific,fortify,reply-schema,arm,s390x,lttng,solo"
       skiptests:
         description: "tests to skip (delete the ones you wanna keep, do not leave empty)"
         default: "valkey,modules,sentinel,cluster,unittest,large-memory"
@@ -168,7 +168,11 @@ jobs:
     # Runs the run_solo tests (defrag, fuzzer, and cluster resharding/failover2/
     # replica-migration-slow) once, on jemalloc arm. These tests execute alone
     # after the parallel phase drains; the rest of the matrix passes --skip-solo
-    # so they are not duplicated across every platform/config.
+    # so they are not duplicated across every platform/config. The cluster solo
+    # tests also run once under --tls to cover the TLS-specific code paths
+    # (e.g. resharding dual-listener + MOVED-over-plaintext).
+    # Sanitizer, valgrind, and force-defrag jobs still run solo tests where the
+    # memory/UB checker or forced defrag adds coverage this job does not.
     runs-on: ubuntu-24.04-arm
     if: |
       (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' ||
@@ -199,12 +203,17 @@ jobs:
           path: libbacktrace
       - run: cd libbacktrace && ./configure && make && sudo make install
       - name: make
-        run: make SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes
+        run: make BUILD_TLS=yes SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes
       - name: testprep
-        run: sudo apt-get install tcl8.6 tclx
+        run: |
+          sudo apt-get install tcl8.6 tclx tcl-tls
+          ./utils/gen-test-certs.sh
       - name: solo tests
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
         run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey.json --verbose --dump-logs --single unit/memefficiency --single unit/fuzzer --single unit/cluster/resharding --single unit/cluster/failover2 --single unit/cluster/replica-migration-slow ${{github.event.inputs.test_args}}
+      - name: solo cluster tests - TLS
+        if: true && !contains(github.event.inputs.skiptests, 'valkey')
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --failures-output test-failures/valkey-tls.json --verbose --dump-logs --tls --single unit/cluster/resharding --single unit/cluster/failover2 --single unit/cluster/replica-migration-slow ${{github.event.inputs.test_args}}
       - name: Upload test failures
         if: always()
         uses: ./.github/actions/upload-test-failures
@@ -2108,7 +2117,7 @@ jobs:
 
               case "${SKIPTESTS:-}" in
                 *valkey*) ;;
-                *) ./runtest ${RUN_ACCURATE:-} --failures-output test-failures/valkey.json --verbose --dump-logs ${TEST_ARGS:-} ;;
+                *) ./runtest ${RUN_ACCURATE:-} --failures-output test-failures/valkey.json --verbose --dump-logs --skip-solo ${TEST_ARGS:-} ;;
               esac
 
               case "${SKIPTESTS:-}" in

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -797,6 +797,7 @@ proc print_help_screen {} {
         "--ignore-encoding  Don't validate object encoding."
         "--ignore-digest    Don't use debug digest validations."
         "--large-memory     Run tests using over 100mb."
+        "--skip-solo        Skip tests wrapped in run_solo."
         "--debug-defrag     Indicate the test is running against server compiled with"
         "                   DEBUG_FORCE_DEFRAG option."
         "--help             Print this help screen."

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -333,6 +333,7 @@ proc get_field_in_client_list {id client_list filed} {
 proc run_solo {name code} {
     if {$::skip_solo} {
         # Solo tests are consolidated into a dedicated CI job; skip them here.
+        send_data_packet $::test_server_fd skip $name
         return
     }
     if {$::numclients == 1 || $::loop || $::external} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -93,6 +93,7 @@ set ::cluster_mode 0
 set ::ignoreencoding 0
 set ::ignoredigest 0
 set ::large_memory 0
+set ::skip_solo 0
 set ::log_req_res 0
 set ::force_resp3 0
 set ::solo_tests_count 0
@@ -330,6 +331,10 @@ proc get_field_in_client_list {id client_list filed} {
 # test server, so that the test server will send them again to
 # clients once the clients are idle.
 proc run_solo {name code} {
+    if {$::skip_solo} {
+        # Solo tests are consolidated into a dedicated CI job; skip them here.
+        return
+    }
     if {$::numclients == 1 || $::loop || $::external} {
         # run_solo is not supported in these scenarios, just run the code.
         eval $code
@@ -950,6 +955,8 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         set ::cluster_mode 1
     } elseif {$opt eq {--large-memory}} {
         set ::large_memory 1
+    } elseif {$opt eq {--skip-solo}} {
+        set ::skip_solo 1
     } elseif {$opt eq {--ignore-encoding}} {
         set ::ignoreencoding 1
     } elseif {$opt eq {--ignore-digest}} {


### PR DESCRIPTION
## Summary

`run_solo` tests run alone, after a job's parallel phase drains. Today the same solo test executes in ~25 full-suite jobs per daily — and since each execution is an independent chance to flake on a loaded runner, those ~25 rolls **compound** a small per-run flake probability into a much larger per-daily red rate. For example, `cluster/failover2` flakes only ~0.15% per execution but turns ~3.6% of dailies red.

This PR **de-compounds** that. It adds a `--skip-solo` harness flag, drops solo execution from the broad matrix, and runs each solo test once in a dedicated `test-solo` job — so a daily rolls the dice ~once per solo test instead of ~25 times, with no loss of coverage. Companion to #4179, which makes the defrag latency checks deterministic gtests.

Consolidated here: `memefficiency` (defrag), `fuzzer`, and the three cluster solo tests (`cluster/resharding`, `cluster/failover2`, `cluster/replica-migration-slow`). Left as-is: the large-memory solo tests and `violations`, which already run only in the two large-memory jobs.

## Why these tests flake

Not test-logic bugs, and not the engine being slow — these tests are marked `run_solo` because they're resource-hungry or timing-delicate, which makes them sensitive to a loaded, shared runner. Flake rates from daily-run history:

- `memefficiency` defrag latency assert (see #2444): red in ~1% of dailies.
- `cluster/failover2`: ~3.6% of dailies — a cluster-convergence timing check; the largest single functional-test flake.
- `cluster/resharding`: ~0.4% of dailies.
- `fuzzer`, `cluster/replica-migration-slow`: no meaningful flake history — moved just to shed matrix duplication.

For defrag, #4179 has the full data: across ~4,500 units on uncontended hosts the worst latency was 2 ms vs the 5 ms limit (zero breaches); on the same commit, 16 parallel clients gave 124 failures while 4 gave 0 — the wall-clock assert is measuring the scheduler, not the engine. (Per single execution these flake only ~0.04% for defrag to ~0.15% for `failover2`; the ~25-way duplication is what inflates them to the per-daily rates above.)

## What changes

- `tests/test_helper.tcl`: `--skip-solo` flag + a one-line guard in `run_solo` (reuses the existing `numclients==1` / `--loops` no-op path).
- `.github/workflows/daily.yml`: `--skip-solo` on the full-suite jobs whose solo runs are pure duplication; a new `test-solo` job (ubuntu-24.04-arm, jemalloc) runs the solo tests once, at default parallelism (so deferral still works) and without `--tags -slow`.
- Solo runs kept on the sanitizer (ASan/UBSan) and force-defrag jobs, where they add instrumentation coverage the plain job doesn't.
- Non-solo tests are unaffected.

## Cost / benefit

- **Fewer red dailies:** collectively, these solo tests' contribution to the per-daily flake rate is estimated to drop from ~5% to ~0.7% from each running ~1× (defrag) or ~4× (cluster tests) instead of ~25×.
- **Compute:** solo tests run ~1× instead of ~25× — roughly **150 job-minutes saved per daily**.
- **Flake isolation:** a solo flake now re-runs a ~15-min `test-solo` job, not a ~30-min matrix job.
- **Daily wall-clock is unchanged** — it's gated by the ~5h valgrind jobs, which this PR doesn't touch. This is a duplication/isolation change, not a critical-path one.

## Testing

- Local: `./runtest --single unit/memefficiency --skip-solo` skips the defrag solo block and passes; without the flag it runs as before. Same for `fuzzer`.
- Fork CI ([run](https://github.com/valkey-rainfall/valkey/actions/runs/30383602351)): dispatched the daily with only `test-solo` enabled — passed, with the defrag, fuzzer, and cluster solo blocks all executed (non-vacuous, confirmed in the job log).