### PR TITLE
Optimize stream node tombstone garbage collection

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3345,6 +3345,7 @@ standardConfig static_configs[] = {
     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, server.rdb_compression, 1, NULL, NULL),
     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
     createBoolConfig("activerehashing", NULL, MODIFIABLE_CONFIG, server.activerehashing, 1, NULL, NULL),
+    createBoolConfig("stream-node-gc-enabled", NULL, MODIFIABLE_CONFIG, server.stream_node_gc_enabled, 1, NULL, NULL),
     createBoolConfig("stop-writes-on-bgsave-error", NULL, MODIFIABLE_CONFIG, server.stop_writes_on_bgsave_err, 1, NULL, NULL),
     createBoolConfig("set-proc-title", NULL, IMMUTABLE_CONFIG, server.set_proc_title, 1, NULL, NULL), /* Should setproctitle be used? */
     createBoolConfig("lazyfree-lazy-eviction", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_eviction, 1, NULL, NULL),

--- a/src/server.h
+++ b/src/server.h
@@ -2238,6 +2238,7 @@ struct valkeyServer {
     size_t hll_sparse_max_bytes;
     size_t stream_node_max_bytes;
     long long stream_node_max_entries;
+    int stream_node_gc_enabled;
     /* List parameters */
     int list_max_listpack_size;
     int list_compress_depth;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4108,12 +4108,14 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size) {
     p = next;
     if (!lpValidateNext(lp, &next, size)) return 0;
 
+    int64_t actual_deleted_count = 0;
     entry_count += deleted_count;
     while (entry_count--) {
         if (!p) return 0;
         int64_t fields = primary_fields, extra_fields = 3;
         int64_t flags = lpGetIntegerIfValid(p, &valid_record);
         if (!valid_record) return 0;
+        if (flags & STREAM_ITEM_FLAG_DELETED) actual_deleted_count++;
         p = next;
         if (!lpValidateNext(lp, &next, size)) return 0;
 
@@ -4157,7 +4159,7 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size) {
         if (!lpValidateNext(lp, &next, size)) return 0;
     }
 
-    if (next) return 0;
+    if (next || actual_deleted_count != deleted_count) return 0;
 
     return 1;
 }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -53,6 +53,10 @@
  * will return NULL. */
 #define STREAM_LISTPACK_MAX_SIZE (1 << 30)
 
+/* Compact only when the node has more than this many physical entries. */
+#define STREAM_LISTPACK_GC_MIN_ENTRIES 10
+#define STREAM_LISTPACK_GC_LIVE_DIVISOR 2
+
 void streamFreeCG(streamCG *cg);
 void streamFreeCGVoid(void *cg);
 void streamFreeNACK(streamNACK *na);
@@ -403,6 +407,17 @@ void streamGetEdgeID(stream *s, int first, int skip_tombstones, streamID *edge_i
     streamIteratorStop(&si);
 }
 
+/* Return the number of listpack elements in an entry, excluding the trailing
+ * lp-count element itself. */
+static int64_t streamListpackEntryCount(int64_t flags, int64_t numfields) {
+    int64_t lp_count = numfields + 3; /* flags + ms-diff + seq-diff. */
+    if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) {
+        /* Non-compressed entries also store each field and num-fields. */
+        lp_count += numfields + 1;
+    }
+    return lp_count;
+}
+
 /* Adds a new item into the stream 's' having the specified number of
  * field-value pairs as specified in 'numfields' and stored into 'argv'.
  * Returns the new entry ID populating the 'added_id' structure.
@@ -640,15 +655,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) lp = lpAppend(lp, (unsigned char *)field, sdslen(field));
         lp = lpAppend(lp, (unsigned char *)value, sdslen(value));
     }
-    /* Compute and store the lp-count field. */
-    int64_t lp_count = numfields;
-    lp_count += 3; /* Add the 3 fixed fields flags + ms-diff + seq-diff. */
-    if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) {
-        /* If the item is not compressed, it also has the fields other than
-         * the values, and an additional num-fields field. */
-        lp_count += numfields + 1;
-    }
-    lp = lpAppendInteger(lp, lp_count);
+    lp = lpAppendInteger(lp, streamListpackEntryCount(flags, numfields));
 
     /* Insert back into the tree in order to update the listpack pointer. */
     if (ri.data != lp) raxInsert(s->rax, (unsigned char *)&rax_key, sizeof(rax_key), lp, NULL);
@@ -686,6 +693,73 @@ typedef struct {
 #define TRIM_STRATEGY_NONE 0
 #define TRIM_STRATEGY_MAXLEN 1
 #define TRIM_STRATEGY_MINID 2
+
+/* Rebuild a stream listpack without entries that were marked as deleted.
+ * The listpack header counters must be updated before calling this function. */
+static unsigned char *streamListpackCompact(unsigned char *lp) {
+    unsigned char *p = lpFirst(lp);
+    int64_t entries = lpGetInteger(p);
+    int64_t copied_entries = 0;
+    p = lpNext(lp, p); /* Skip entries count. */
+    p = lpNext(lp, p); /* Skip deleted entries count. */
+    int64_t primary_fields_count = lpGetInteger(p);
+
+    unsigned char *new_lp = lpNew(lpBytes(lp));
+    new_lp = lpAppendInteger(new_lp, entries);
+    new_lp = lpAppendInteger(new_lp, 0);
+    new_lp = lpAppendInteger(new_lp, primary_fields_count);
+
+    p = lpNext(lp, p);
+    for (int64_t i = 0; i < primary_fields_count; i++) {
+        unsigned int slen;
+        long long lval;
+        unsigned char *sval = lpGetValue(p, &slen, &lval);
+        new_lp = sval ? lpAppend(new_lp, sval, slen) : lpAppendInteger(new_lp, lval);
+        p = lpNext(lp, p);
+    }
+    new_lp = lpAppendInteger(new_lp, 0);
+    p = lpNext(lp, p); /* Skip the primary entry terminator. */
+
+    while (p) {
+        int64_t flags = lpGetInteger(p);
+        unsigned char *scan = lpNext(lp, p); /* Skip flags. */
+        scan = lpNext(lp, scan);             /* Skip ID ms delta. */
+        scan = lpNext(lp, scan);             /* Skip ID seq delta. */
+
+        int64_t numfields;
+        if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
+            numfields = primary_fields_count;
+        } else {
+            numfields = lpGetInteger(scan);
+        }
+        int64_t lp_count = streamListpackEntryCount(flags, numfields);
+
+        if (!(flags & STREAM_ITEM_FLAG_DELETED)) {
+            copied_entries++;
+            /* lp-count excludes its own element, so copy lp_count + 1. */
+            for (int64_t i = 0; i <= lp_count; i++) {
+                unsigned int slen;
+                long long lval;
+                unsigned char *sval = lpGetValue(p, &slen, &lval);
+                new_lp = sval ? lpAppend(new_lp, sval, slen) : lpAppendInteger(new_lp, lval);
+                p = lpNext(lp, p);
+            }
+        } else {
+            for (int64_t i = 0; i <= lp_count; i++) p = lpNext(lp, p);
+        }
+    }
+
+    /* Loaded listpacks are validated by streamValidateListpackIntegrity(), and
+     * both callers update the header before compaction. A mismatch therefore
+     * indicates an internal invariant violation rather than recoverable data. */
+    serverAssert(copied_entries == entries);
+    return lpShrinkToFit(new_lp);
+}
+
+static int streamListpackShouldCompact(int64_t entries, int64_t deleted) {
+    return server.stream_node_gc_enabled && entries + deleted > STREAM_LISTPACK_GC_MIN_ENTRIES &&
+           deleted > entries / STREAM_LISTPACK_GC_LIVE_DIVISOR;
+}
 
 /* Trim the stream 's' according to args->trim_strategy, and return the
  * number of elements removed from the stream. The 'approx' option, if non-zero,
@@ -766,6 +840,8 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
         /* Now we have to trim entries from within 'lp' */
         int64_t deleted_from_lp = 0;
+        int64_t deleted_prefix_entries = 0;
+        unsigned long deleted_prefix_elements = 0;
 
         p = lpNext(lp, p); /* Skip deleted field. */
         p = lpNext(lp, p); /* Skip num-of-fields in the primary entry. */
@@ -818,7 +894,9 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
             }
 
             while (to_skip--) p = lpNext(lp, p); /* Skip the whole entry. */
-            p = lpNext(lp, p);                   /* Skip the final lp-count field. */
+            deleted_prefix_elements += lpGetInteger(p) + 1;
+            deleted_prefix_entries++;
+            p = lpNext(lp, p); /* Skip the final lp-count field. */
 
             /* Mark the entry as deleted. */
             if (!(flags & STREAM_ITEM_FLAG_DELETED)) {
@@ -840,15 +918,17 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         lp = lpReplaceInteger(lp, &p, marked_deleted + deleted_from_lp);
         p = lpNext(lp, p); /* Skip num-of-fields in the primary entry. */
 
-        /* Here we should perform garbage collection in case at this point
-         * there are too many entries deleted inside the listpack. */
         entries -= deleted_from_lp;
         marked_deleted += deleted_from_lp;
-        if (entries + marked_deleted > 10 && marked_deleted > entries / 2) {
-            /* TODO: perform a garbage collection. */
+        if (deleted_prefix_entries > 0 && streamListpackShouldCompact(entries, marked_deleted)) {
+            /* Exact trimming visits a contiguous prefix of the listpack.
+             * Delete that prefix directly instead of rebuilding all the
+             * entries that remain. */
+            lp = lpDeleteRange(lp, primary_fields_count + 4, deleted_prefix_elements);
+            p = lpFirst(lp);
+            p = lpNext(lp, p); /* Seek deleted field. */
+            lp = lpReplaceInteger(lp, &p, marked_deleted - deleted_prefix_entries);
         }
-
-        /* Update the listpack with the new pointer. */
         raxInsert(s->rax, ri.key, ri.key_len, lp, NULL);
 
         break; /* If we are here, there was enough to delete in the current
@@ -1282,13 +1362,24 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
         raxRemove(si->stream->rax, si->ri.key, si->ri.key_len, NULL);
     } else {
         /* In the base case we alter the counters of valid/deleted entries. */
-        lp = lpReplaceInteger(lp, &p, aux - 1);
+        int64_t entries = aux - 1;
+        lp = lpReplaceInteger(lp, &p, entries);
         p = lpNext(lp, p); /* Seek deleted field. */
         aux = lpGetInteger(p);
-        lp = lpReplaceInteger(lp, &p, aux + 1);
+        int64_t deleted = aux + 1;
+        lp = lpReplaceInteger(lp, &p, deleted);
 
-        /* Update the listpack with the new pointer. */
-        if (si->lp != lp) raxInsert(si->stream->rax, si->ri.key, si->ri.key_len, lp, NULL);
+        if (streamListpackShouldCompact(entries, deleted)) {
+            unsigned char *old_lp = lp;
+            lp = streamListpackCompact(lp);
+            raxInsert(si->stream->rax, si->ri.key, si->ri.key_len, lp, NULL);
+            lpFree(old_lp);
+            si->lp = lp;
+            si->ri.data = lp;
+        } else if (si->lp != lp) {
+            /* Update the listpack with the new pointer. */
+            raxInsert(si->stream->rax, si->ri.key, si->ri.key_len, lp, NULL);
+        }
     }
 
     /* Update the number of entries counter. */
@@ -1305,9 +1396,6 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     }
     streamIteratorStop(si);
     streamIteratorStart(si, si->stream, &start, &end, si->rev);
-
-    /* TODO: perform a garbage collection here if the ratio between
-     * deleted and valid goes over a certain limit. */
 }
 
 /* Stop the stream iterator. The only cleanup we need is to free the rax

--- a/src/unit/test_t_stream.cpp
+++ b/src/unit/test_t_stream.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 
 extern "C" {
+#include "listpack.h"
 #include "stream.h"
 }
 
@@ -74,4 +75,21 @@ TEST_F(StreamIdTest, TestStreamIDLexicographicOrdering) {
     streamEncodeID(buf_d, &id_d);
 
     ASSERT_LT(memcmp(buf_c, buf_d, 16), 0);
+}
+
+TEST_F(StreamIdTest, TestStreamListpackRejectsDeletedCountMismatch) {
+    unsigned char *lp = lpNew(0);
+    lp = lpAppendInteger(lp, 1); /* One live entry according to the header. */
+    lp = lpAppendInteger(lp, 0);
+    lp = lpAppendInteger(lp, 1);
+    lp = lpAppend(lp, (unsigned char *)"field", 5);
+    lp = lpAppendInteger(lp, 0);
+    lp = lpAppendInteger(lp, 3); /* SAMEFIELDS | DELETED */
+    lp = lpAppendInteger(lp, 0);
+    lp = lpAppendInteger(lp, 0);
+    lp = lpAppend(lp, (unsigned char *)"value", 5);
+    lp = lpAppendInteger(lp, 4);
+
+    EXPECT_FALSE(streamValidateListpackIntegrity(lp, lpBytes(lp)));
+    lpFree(lp);
 }

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -601,7 +601,10 @@ start_server {
     }
 
     test {Stream node GC compacts listpacks with many deleted entries} {
-        r del somestream somestream-copy trimstream trimstream-copy
+        r del somestream
+        r del somestream-copy
+        r del trimstream
+        r del trimstream-copy
         set old_node_max_bytes [lindex [r config get stream-node-max-bytes] 1]
         set old_node_max_entries [lindex [r config get stream-node-max-entries] 1]
         set old_gc_enabled [lindex [r config get stream-node-gc-enabled] 1]
@@ -667,7 +670,10 @@ start_server {
             r restore trimstream-copy 0 $trim_payload
             assert_equal $trim_forward [r xrange trimstream-copy - +]
         } finally {
-            r del somestream somestream-copy trimstream trimstream-copy
+            r del somestream
+            r del somestream-copy
+            r del trimstream
+            r del trimstream-copy
             r config set stream-node-max-bytes $old_node_max_bytes
             r config set stream-node-max-entries $old_node_max_entries
             r config set stream-node-gc-enabled $old_gc_enabled

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -599,6 +599,81 @@ start_server {
         assert {[dict get [lindex $result 0 1] b] eq {2}}
         assert {[dict get [lindex $result 1 1] c] eq {3}}
     }
+
+    test {Stream node GC compacts listpacks with many deleted entries} {
+        r del somestream somestream-copy trimstream trimstream-copy
+        set old_node_max_bytes [lindex [r config get stream-node-max-bytes] 1]
+        set old_node_max_entries [lindex [r config get stream-node-max-entries] 1]
+        set old_gc_enabled [lindex [r config get stream-node-gc-enabled] 1]
+        r config set stream-node-max-bytes 1000000
+        r config set stream-node-max-entries 100
+        r config set stream-node-gc-enabled no
+
+        try {
+            set deleted_ids {}
+            set value [string repeat x 256]
+            for {set j 1} {$j <= 100} {incr j} {
+                switch [expr {$j % 3}] {
+                    0 {r xadd somestream $j-0 a $value b $value c $value}
+                    1 {r xadd somestream $j-0 a $value}
+                    2 {r xadd somestream $j-0 b $value c $value}
+                }
+                if {$j < 70} {
+                    lappend deleted_ids $j-0
+                }
+            }
+
+            set memory_before [r memory usage somestream]
+            assert_equal 69 [r xdel somestream {*}$deleted_ids]
+            set memory_gc_disabled [r memory usage somestream]
+            assert {$memory_gc_disabled > $memory_before / 2}
+
+            r config set stream-node-gc-enabled yes
+            assert_equal 1 [r xdel somestream 70-0]
+            set memory_after [r memory usage somestream]
+            assert {$memory_after < $memory_before / 2}
+
+            set forward [r xrange somestream - +]
+            set reverse [r xrevrange somestream + -]
+            assert_equal 30 [llength $forward]
+            assert_equal [lreverse $forward] $reverse
+            assert_equal 71-0 [lindex $forward 0 0]
+            assert_equal 100-0 [lindex $reverse 0 0]
+            assert_equal 101-0 [r xadd somestream 101-0 a added]
+            assert_equal {a added} [lindex [r xrange somestream 101-0 101-0] 0 1]
+
+            set payload [r dump somestream]
+            r restore somestream-copy 0 $payload
+            assert_equal [r xrange somestream - +] [r xrange somestream-copy - +]
+
+            for {set j 1} {$j <= 100} {incr j} {
+                switch [expr {$j % 3}] {
+                    0 {r xadd trimstream $j-0 a $value b $value c $value}
+                    1 {r xadd trimstream $j-0 a $value}
+                    2 {r xadd trimstream $j-0 b $value c $value}
+                }
+            }
+            set trim_memory_before [r memory usage trimstream]
+            assert_equal 70 [r xtrim trimstream maxlen = 30]
+            set trim_memory_after [r memory usage trimstream]
+            assert {$trim_memory_after < $trim_memory_before / 2}
+            set trim_forward [r xrange trimstream - +]
+            set trim_reverse [r xrevrange trimstream + -]
+            assert_equal 30 [llength $trim_forward]
+            assert_equal [lreverse $trim_forward] $trim_reverse
+            assert_equal 71-0 [lindex $trim_forward 0 0]
+
+            set trim_payload [r dump trimstream]
+            r restore trimstream-copy 0 $trim_payload
+            assert_equal $trim_forward [r xrange trimstream-copy - +]
+        } finally {
+            r del somestream somestream-copy trimstream trimstream-copy
+            r config set stream-node-max-bytes $old_node_max_bytes
+            r config set stream-node-max-entries $old_node_max_entries
+            r config set stream-node-gc-enabled $old_gc_enabled
+        }
+    }
+
     # Here the idea is to check the consistency of the stream data structure
     # as we remove all the elements down to zero elements.
     test {XDEL fuzz test} {
@@ -631,6 +706,48 @@ start_server {
                 set res [r xrange somestream - +]
                 assert {[llength $res] == $x}
             }
+        }
+    }
+
+    test {XDEL fuzz test with frequent stream node GC} {
+        set old_node_max_bytes [lindex [r config get stream-node-max-bytes] 1]
+        set old_node_max_entries [lindex [r config get stream-node-max-entries] 1]
+        set old_gc_enabled [lindex [r config get stream-node-gc-enabled] 1]
+        r config set stream-node-max-bytes 1000000
+        r config set stream-node-max-entries 12
+
+        try {
+            foreach gc_enabled {yes no} {
+                r config set stream-node-gc-enabled $gc_enabled
+                r del somestream
+                set ids {}
+                for {set j 0} {$j < 600} {incr j} {
+                    switch [expr {$j % 3}] {
+                        0 {set id [r xadd somestream * a $j]}
+                        1 {set id [r xadd somestream * a $j b $j]}
+                        2 {set id [r xadd somestream * c $j d $j e $j]}
+                    }
+                    lappend ids $id
+                }
+
+                set ids [lshuffle $ids]
+                set remaining 600
+                foreach id $ids {
+                    assert_equal 1 [r xdel somestream $id]
+                    incr remaining -1
+                    if {$remaining % 25 == 0} {
+                        set forward [r xrange somestream - +]
+                        set reverse [r xrevrange somestream + -]
+                        assert_equal $remaining [llength $forward]
+                        assert_equal [lreverse $forward] $reverse
+                    }
+                }
+            }
+        } finally {
+            r del somestream
+            r config set stream-node-max-bytes $old_node_max_bytes
+            r config set stream-node-max-entries $old_node_max_entries
+            r config set stream-node-gc-enabled $old_gc_enabled
         }
     }
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -2393,6 +2393,11 @@ hll-sparse-max-bytes 3000
 stream-node-max-bytes 4096
 stream-node-max-entries 100
 
+# Reclaim entries marked as deleted inside stream listpacks. Disabling this
+# avoids the additional work on stream writes, but may retain more memory and
+# make stream iteration slower until the containing listpack is removed.
+stream-node-gc-enabled yes
+
 # Active rehashing uses 1% of the CPU time to help perform incremental rehashing
 # of the main server hash tables, the ones mapping top-level keys to values.
 #


### PR DESCRIPTION
## Motivation

  `XDEL` and exact `XTRIM` mark stream entries as deleted inside their
  listpacks, but the tombstones remain until the entire radix-tree node is
  removed.

  Streams managed primarily with `XDEL` can therefore retain significantly
  more memory than their live entry count suggests. Commands such as `XRANGE`
  and `XREVRANGE` must also scan these tombstones, making sparse streams
  increasingly expensive to iterate.

  Exact trimming can repeatedly scan tombstones remaining at the start of a
  listpack. This is especially costly when an application performs exact
  trimming on every append, for example with `XADD ... MAXLEN = ...`. Each
  operation may revisit the same tombstone prefix before deleting a small
  number of live entries. Periodically removing that prefix reduces the work
  performed by subsequent trim operations.

  ## Changes

  This PR adds garbage collection for tombstones stored inside stream
  listpacks.

  A stream node is compacted when:

  - stream node GC is enabled;
  - the total number of physical entries (`live + deleted`) is greater than 10;
    and
  - the number of deleted entries is greater than half the number of live
    entries.

  The deletion paths use different compaction strategies:

  - `XDEL` can leave tombstones anywhere in a listpack, so it rebuilds the
    listpack by copying only live entries.
  - Exact `XTRIM` always processes a contiguous listpack prefix, so it removes
    that prefix directly with `lpDeleteRange()`.
  - Approximate `XTRIM` already removes complete radix-tree nodes and does not
    require additional compaction.

  This PR also adds the `stream-node-gc-enabled` configuration option. It is
  enabled by default and can be changed at runtime using `CONFIG SET`.

  The option provides an escape hatch for write-latency-sensitive workloads.
  The operation that crosses the GC threshold performs compaction
  synchronously and can therefore be slower than the same operation with GC
  disabled. Disabling GC avoids that compaction work at the cost of retaining
  more memory and making subsequent stream iteration and exact trimming more
  expensive.

  ## Compaction threshold

  Compaction starts when tombstones exceed half the number of live entries.
  For a 100-entry node, this causes the first rebuild after approximately 34
  entries have been deleted.

  This threshold intentionally favors reclaiming tombstones before they
  dominate a node. It limits the amount of stale data scanned by subsequent
  stream operations while avoiding compaction after only a small number of
  deletions.

  A less aggressive threshold that waited until deleted entries outnumbered
  live entries was also evaluated. It reduced the frequency of compaction, but
  also reduced the improvements for frequent exact trimming and
  `XADD ... MAXLEN = ...`. In the controlled comparison, it did not improve
  the latency of an otherwise identical 51-ID `XDEL`.

  The half-live threshold was therefore retained. Stream nodes are small by
  default—4,096 bytes or at most 100 entries—and users with workloads that
  prioritize individual write latency can disable GC using
  `stream-node-gc-enabled no`.

  ## Performance

  The measurements use server-side execution time from `INFO commandstats`.
  The workloads were executed from Lua through a local Unix socket to exclude
  network round-trip and response transfer costs.

  Each result is the average of five runs on Linux.

  ### Periodic exact `XTRIM`

  The benchmark inserted 50,000 entries while retaining a maximum stream
  length of 1,000 entries. Exact `XTRIM` was issued periodically.

  Command:

  `XTRIM key MAXLEN = 1000`

  | XADD interval | GC disabled | GC enabled | Difference |
  |---:|---:|---:|---:|
  | Every 1 XADD | 1.174 µs/XTRIM | 0.515 µs/XTRIM | 56.2% faster |
  | Every 10 XADDs | 1.177 µs/XTRIM | 0.718 µs/XTRIM | 39.0% faster |
  | Every 100 XADDs | 0.494 µs/XTRIM | 0.531 µs/XTRIM | No meaningful change |
  | Every 1,000 XADDs | 1.788 µs/XTRIM | 1.696 µs/XTRIM | 5.1% faster |
  | Every 2,000 XADDs | 3.168 µs/XTRIM | 3.128 µs/XTRIM | 1.3% faster |

  Frequently issuing exact `XTRIM` leaves tombstones at the listpack boundary.
  GC avoids repeatedly scanning those tombstones during subsequent trim
  operations. When trimming is less frequent, complete radix-tree nodes account
  for more of the removed entries and listpack GC has less effect.

  The difference at the 100-XADD interval was within run-to-run variation and
  is reported as no meaningful change.

  ### `XADD` with exact trimming

  Command:

  `XADD key MAXLEN = 1000 * field value`

  | Metric | GC disabled | GC enabled | Difference |
  |---|---:|---:|---:|
  | Execution time | 1.425 µs/XADD | 0.763 µs/XADD | 46.4% faster |

  When exact trimming is performed on every append, GC periodically removes the
  tombstones at the listpack boundary and reduces the work required by
  subsequent operations.

  ### `XADD` with approximate trimming

  Command:

  `XADD key MAXLEN ~ 1000 * field value`

  | Metric | GC disabled | GC enabled | Difference |
  |---|---:|---:|---:|
  | Execution time | 0.456 µs/XADD | 0.458 µs/XADD | No meaningful change |

  Approximate trimming removes complete radix-tree nodes and does not create
  tombstones inside listpacks, so GC does not affect this workload.

  ### Sequential `XDEL`

  The benchmark inserted 100,000 entries and sequentially deleted 99 entries
  out of every 100, leaving 1,000 live entries.

  | Metric | GC disabled | GC enabled | Difference |
  |---|---:|---:|---:|
  | `XDEL` execution time | 0.623 µs/call | 0.510 µs/call | 18.2% faster |
  | Memory usage after deletion | 1,593,696 B | 183,136 B | 88.5% reduction |
  | `XRANGE` over 1,000 live entries | 890.2 µs | 212.6 µs | 4.19x faster |

  Without GC, `XRANGE` must scan approximately 99,000 tombstones to return
  1,000 live entries. Compacting sparse nodes both reduces memory usage and
  avoids that additional iteration work.

  Sequential `XDEL` also becomes faster overall because later deletions operate
  on smaller listpacks after earlier nodes have been compacted.

  ### Multi-ID `XDEL` crossing the GC threshold

  This benchmark measures a single multi-ID `XDEL` that crosses the compaction
  threshold and rebuilds the listpack during that call.

  | Metric | GC disabled | GC enabled | Difference |
  |---|---:|---:|---:|
  | `XDEL` execution time | 22.6 µs/call | 34.0 µs/call | 11.4 µs slower |

  The operation that crosses the threshold is slower because it performs the
  listpack rebuild synchronously. Subsequent deletions and iterations benefit
  from the smaller listpack.

  This one-time cost is also why GC can be disabled with
  `stream-node-gc-enabled no` for workloads that prioritize individual write
  latency over memory usage and subsequent stream iteration performance.

  ## Testing

  This PR adds two tests:

  - `Stream node GC compacts listpacks with many deleted entries` covers:
    - `XDEL` compaction with mixed field layouts;
    - exact `XTRIM` prefix compaction;
    - forward and reverse iteration after compaction;
    - appending entries after compaction; and
    - dump and restore of compacted streams.
  - `XDEL fuzz test with frequent stream node GC` deletes mixed-layout entries
    in randomized order with small stream nodes, exercising frequent
    compaction with GC both enabled and disabled.

  The existing `XDEL fuzz test` also continues deleting entries until the
  stream becomes empty and now exercises the default-enabled GC path.