### PR TITLE
Fix FIELDS token validation for HPERSIST and HTTL family commands

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2025,6 +2025,11 @@ void hpersistCommand(client *c) {
     int fields_index = 4, result = 0, changes = 0;
     long long num_fields = 0;
 
+    if (strcasecmp(objectGetVal(c->argv[fields_index - 2]), "fields")) {
+        addReplyErrorObject(c, shared.syntaxerr);
+        return;
+    }
+
     if (getLongLongFromObjectOrReply(c, c->argv[fields_index - 1], &num_fields, NULL) != C_OK) return;
 
     /* Check that the parsed fields number matches the real provided number of fields */
@@ -2094,6 +2099,11 @@ void hpersistCommand(client *c) {
 void httlGenericCommand(client *c, mstime_t basetime, int unit) {
     int fields_index = 4;
     long long num_fields = 0, result = -2;
+
+    if (strcasecmp(objectGetVal(c->argv[fields_index - 2]), "fields")) {
+        addReplyErrorObject(c, shared.syntaxerr);
+        return;
+    }
 
     if (getLongLongFromObjectOrReply(c, c->argv[fields_index - 1], &num_fields, NULL) != C_OK) return;
 

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1062,6 +1062,13 @@ start_server {tags {"hashexpire"}} {
         assert_equal -2 [r HTTL nokey FIELDS 1 field1]
     } {}
 
+    test {HTTL/HPTTL/HEXPIRETIME/HPEXPIRETIME - check for syntax and type errors} {
+        foreach cmd {HTTL HPTTL HEXPIRETIME HPEXPIRETIME} {
+            assert_error "*ERR syntax error" {r $cmd myhash a 1 c}
+            assert_error "*value is not an integer or out of range" {r $cmd myhash FIELDS a b c}
+        }
+    }
+
     ##### EXPIRETIME ######
 
     # Basic Expiry Functionality
@@ -1403,6 +1410,13 @@ start_server {tags {"hashexpire"}} {
     test {HPERSIST - wrong type key returns error} {
         r SET mystr hello
         assert_error {*WRONGTYPE*} {r HPERSIST mystr FIELDS 1 f1}
+    }
+
+    test {HPERSIST - check for syntax and type errors} {
+        assert_error "*ERR syntax error" {r hpersist myhash a 1 c}
+        assert_error "*value is not an integer or out of range" {r hpersist myhash FIELDS a b c}
+        assert_error "*numfields should be greater than 0 and match the provided number of fields" {r hpersist myhash FIELDS 2 a b c}
+        assert_error "*numfields should be greater than 0 and match the provided number of fields" {r hpersist myhash FIELDS 4 a b c}
     }
 
     test "HPERSIST - field does not exist" {


### PR DESCRIPTION
https://github.com/valkey-io/valkey/pull/4049 fixed the FIELDS token validation for `HGETDEL`. The same parsing issue also exists in `HPERSIST` and `HTTL/HPTTL/HEXPIRETIME/HPEXPIRETIME`:
The `FIELDS` keyword was never validated, so a malformed command like `HPERSIST key a 1 c` would silently treat `a` as a no-op and parse the remaining arguments instead of returning a syntax error.

This PR aligns these commands with the HGETDEL fix: reject the command with a syntax error when the `FIELDS` keyword is missing, and adds tests covering the validation for all affected commands.