### PR TITLE
Fix out-of-bounds read in getNodeByQuery's cross-DB COPY check

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1199,14 +1199,21 @@ clusterNode *getNodeByQuery(client *c, int *error_code) {
 
             /* Block the COPY command if it's cross-DB to keep the code simple.
              * Allowing cross-DB COPY is possible, but it would require looking up the second key in the target DB.
-             * The command should only be allowed if the key exists. We may revisit this decision in the future. */
-            if (mcmd->proc == copyCommand &&
-                margc >= 4 && !strcasecmp(objectGetVal(margv[3]), "db")) {
-                long long value;
-                if (getLongLongFromObject(margv[4], &value) != C_OK || value != currentDb->id) {
-                    if (error_code) *error_code = CLUSTER_REDIR_UNSTABLE;
-                    getKeysFreeResult(&result);
-                    return NULL;
+             * The command should only be allowed if the key exists. We may revisit this decision in the future.
+             *
+             * The DB and REPLACE tokens are optional and order-independent, and DB may appear more than once, so
+             * scan every DB clause the way copyCommand does. A DB token without a value is left to copyCommand to
+             * reject as a syntax error. */
+            if (mcmd->proc == copyCommand) {
+                for (int k = 3; k + 1 < margc; k++) {
+                    if (strcasecmp(objectGetVal(margv[k]), "db")) continue;
+                    long long value;
+                    if (getLongLongFromObject(margv[k + 1], &value) != C_OK || value != currentDb->id) {
+                        if (error_code) *error_code = CLUSTER_REDIR_UNSTABLE;
+                        getKeysFreeResult(&result);
+                        return NULL;
+                    }
+                    k++; /* Consume the dbid. */
                 }
             }
 

--- a/tests/unit/cluster/slot-migration.tcl
+++ b/tests/unit/cluster/slot-migration.tcl
@@ -663,10 +663,21 @@ start_cluster 3 3 {tags {external:skip cluster} } {
         set result [catch {assert_error [R $primary_id_src COPY "{3560}key1" "{3560}key1" DB 7 REPLACE]} err]
         assert_match "TRYAGAIN Multiple keys request during rehashing of slot" $err
 
+        # A DB token with no value is a syntax error, not an out-of-range read.
+        assert_error "ERR syntax error" {R $primary_id_src COPY "{3560}key1" "{3560}key2" DB}
+        assert_error "ERR syntax error" {R $primary_id_src COPY "{3560}key1" "{3560}key2" REPLACE DB}
+        assert_equal {PONG} [R $primary_id_src PING]
+
+        # DB and REPLACE are order-independent, so a cross-DB COPY must be blocked
+        # no matter where the DB clause appears.
+        assert_error "TRYAGAIN*" {R $primary_id_src COPY "{3560}key1" "{3560}key2" REPLACE DB 7}
+        assert_error "TRYAGAIN*" {R $primary_id_src COPY "{3560}key1" "{3560}key2" DB 0 DB 7}
+
         # Both keys exist, should work, but both keys must exist.
         R $primary_id_src COPY "{3560}key1" "{3560}key2"
         # And it should work if DB param is provided, as long as it matches the selected DB
         R $primary_id_src COPY "{3560}key1" "{3560}key2" DB 0 REPLACE
+        R $primary_id_src COPY "{3560}key1" "{3560}key2" REPLACE DB 0
 
     }
 


### PR DESCRIPTION
## Problem

The cross-DB `COPY` guard in `getNodeByQuery()` (added in #1671) checks `margc >= 4` but then dereferences `margv[4]`:

```c
if (mcmd->proc == copyCommand &&
    margc >= 4 && !strcasecmp(objectGetVal(margv[3]), "db")) {
    long long value;
    if (getLongLongFromObject(margv[4], &value) != C_OK || ...
```

`COPY` has arity `-3`, so `COPY k1 k2 DB` (`argc == 4`) passes the arity check in `processCommand()` and reaches `getNodeByQuery()` — which runs *before* `copyCommand()`'s own parser would reject it as a syntax error. The read is one past the end of the argument vector, and the resulting garbage `robj *` is dereferenced.

Reproduced on a two-node cluster (`cluster_state:ok`) with one slot `MIGRATING`:

```
control:  COPY {b}k1 {b}k2 DB 0   -> TRYAGAIN ...               (server survives)
trigger:  COPY {b}k1 {b}k2 DB     -> Server closed the connection
```

```
=== VALKEY BUG REPORT START ===
crashed by signal: 11, si_code: 2
0  valkey-server  getLongLongFromObject + 28
1  valkey-server  getNodeByQuery + 1312
2  valkey-server  processCommand + 1128
```

Reaching the check requires the slot to be in migrating or importing state (`cluster.c` short-circuits otherwise), i.e. during a resharding.

## Second issue in the same guard

`COPY`'s `DB` and `REPLACE` tokens are optional and order-independent, and `DB` may appear more than once (`copyCommand()` keeps the last value — see the note above `copyDbIdArgs()`), but the guard only inspected `argv[3]`. So the check was silently skipped whenever `REPLACE` came first.

On the same cluster, both keys present, slot migrating:

```
COPY {b}k1 {b}k2 DB 1 REPLACE  -> TRYAGAIN ...   (correctly blocked)
COPY {b}k1 {b}k2 REPLACE DB 1  -> 1              (cross-DB copy went through)
```

The second form performed exactly the cross-DB copy during slot migration that this guard exists to prevent.

## Fix

Scan every `DB` clause the way `copyCommand()` does, instead of hardcoding `argv[3]`/`argv[4]`. A `DB` token with no value is left alone so `copyCommand()` reports the syntax error.

Behavior with the fix, same setup:

| command | before | after |
|---|---|---|
| `COPY k1 k2 DB` | **SIGSEGV** | `ERR syntax error` |
| `COPY k1 k2 REPLACE DB` | `ERR syntax error` | `ERR syntax error` |
| `COPY k1 k2 REPLACE DB 1` | `1` (cross-DB copy) | `TRYAGAIN ...` |
| `COPY k1 k2 DB 1 REPLACE` | `TRYAGAIN ...` | `TRYAGAIN ...` |
| `COPY k1 k2 DB 0 DB 1` | `1` (cross-DB copy) | `TRYAGAIN ...` |
| `COPY k1 k2 DB 0 REPLACE` | `1` | `1` |
| `COPY k1 k2 REPLACE DB 0` | `1` | `1` |

## Tests

Extended the existing "Cross-DB COPY command should not be allow during slot migration" test. Verified the new assertions fail on unstable without the code change and pass with it; `unit/cluster/slot-migration`, `unit/cluster/multidb` and `unit/keyspace` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)