### PR TITLE
Skip bad-arity commands when prefetching queued command keys

### DIFF
--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -274,7 +274,9 @@ int addCommandToBatchAndProcessIfFull(client *c) {
     /* Commands in the queue. */
     for (int j = c->cmd_queue.off; j < c->cmd_queue.len && batch->key_count < batch->max_prefetch_size; j++) {
         parsedCommand *p = &c->cmd_queue.cmds[j];
-        if (!p->cmd) continue; /* Error or incomplete command. */
+        /* Error, incomplete command, or a command whose argc violates its arity. The latter must be
+         * skipped because getKeysFromCommand() assumes the arity check has already passed. */
+        if (!p->cmd || p->read_flags & READ_FLAGS_BAD_ARITY) continue;
         p->read_flags |= READ_FLAGS_PREFETCHED;
         addCommandToBatch(p->cmd, p->argv, p->argc, c->db, p->slot);
     }

--- a/tests/unit/io-threads.tcl
+++ b/tests/unit/io-threads.tcl
@@ -138,3 +138,36 @@ start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overr
         }
     }
 }
+
+start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overrides {io-threads 5}} {
+    # A queued command whose argc violates its arity used to be handed to
+    # getKeysFromCommand() by the prefetch path, which assumes the arity check
+    # has already passed. GET with argc 1 panicked on the legacy range spec;
+    # EVAL and MIGRATE read past the end of argv.
+    test {Pipelined commands with bad arity do not reach the key prefetcher} {
+        assert_equal {OK} [r config set io-threads-always-active yes]
+        activate_io_threads_and_wait
+
+        set server_pid [s process_id]
+        set rd [valkey_deferring_client]
+
+        # Suspend the server so the whole pipeline arrives in a single read and
+        # is parsed into the client's command queue, which is the path that
+        # skipped the arity check.
+        pause_process $server_pid
+        $rd ping
+        $rd get
+        $rd eval x
+        $rd migrate a b
+        $rd flush
+        resume_process $server_pid
+
+        assert_equal {PONG} [$rd read]
+        assert_error "ERR wrong number of arguments*" {$rd read}
+        assert_error "ERR wrong number of arguments*" {$rd read}
+        assert_error "ERR wrong number of arguments*" {$rd read}
+        $rd close
+
+        assert_equal {PONG} [r ping]
+    }
+}


### PR DESCRIPTION
## Problem

`addCommandToBatchAndProcessIfFull()` correctly skips the client's *current* command when `READ_FLAGS_BAD_ARITY` is set, but the loop over `c->cmd_queue` only checks for a NULL `cmd`:

```c
/* Client's next command */
if (c->parsed_cmd && !(c->read_flags & READ_FLAGS_BAD_ARITY)) {   /* guarded */
    ...
}

/* Commands in the queue. */
for (int j = c->cmd_queue.off; j < c->cmd_queue.len && ...; j++) {
    parsedCommand *p = &c->cmd_queue.cmds[j];
    if (!p->cmd) continue;              /* no BAD_ARITY check */
    p->read_flags |= READ_FLAGS_PREFETCHED;
    addCommandToBatch(p->cmd, p->argv, p->argc, c->db, p->slot);
}
```

`prepareCommandGeneric()` sets `*cmd` from `lookupCommand()` and only *then* flags `READ_FLAGS_BAD_ARITY`, so `p->cmd` stays non-NULL and the command reaches `getKeysFromCommand()`, which assumes the arity check has already passed.

`prefetchCommandQueueKeys()` in `networking.c:4131` — added by the same commit, #2092 — gets this right, so this looks like a straight divergence rather than an intentional difference.

## Impact

With `io-threads > 1`, a single pipelined write panics the server:

```
# Guru Meditation: Valkey built-in command declared keys positions
# not matching the arity requirements. #db.c:2636
0  getKeysUsingLegacyRangeSpec + 276
1  addCommandToBatchAndProcessIfFull + 736
2  processClientIOReadsDone + 212
3  processIOThreadsResponses + 448
4  beforeSleep + 1240
```

A queued `GET` with `argc == 1` hits the panic in `getKeysUsingLegacyRangeSpec()`. Queued `EVAL` (`genericGetKeys()` reads `argv[2]` with no argc bound) and `MIGRATE` (`migrateGetKeys()` returns a key position past `argc`) reach out-of-bounds `robj *` dereferences on the same path rather than a clean panic.

## Reachability

**Not pre-auth.** `processInputBuffer()` returns before the pipelined-parsing loop when `READ_FLAGS_AUTH_REQUIRED` is set:

```c
if (c->read_flags & READ_FLAGS_AUTH_REQUIRED) {
    /* Execute client's AUTH command before parsing more, ... */
    return;
}

/* Try parsing pipelined commands. */
cmdQueue *queue = &c->cmd_queue;
serverAssert(queue->len == 0);
```

So an unauthenticated client's `cmd_queue` is never populated and the buggy loop has nothing to iterate. Measured on a server with `requirepass` set, `io-threads 4`, under load:

| client state | result |
|---|---|
| never authenticated | survived 500 payloads |
| `AUTH` pipelined in the same write as the payload | survived 500 payloads |
| `AUTH` completed in a prior round trip | panicked on attempt 1 |

Two caveats worth being explicit about:

- `authRequired()` is false when the default user is `nopass` and enabled — i.e. a server with no `requirepass` and no ACLs, which is the default config. There every client is effectively authenticated from the first byte, so any client that can open a connection triggers it. That is not an auth bypass, since nothing requires credentials on such a server.
- It **is** reachable before *authorization*. The prefetch runs in `beforeSleep()`, well before `processCommand()` enforces ACLs. I confirmed a user created with `ACL SETUSER lowpriv on >pw` and no command permissions — one that gets `NOPERM ... no permissions to run the 'get' command` for a plain `GET` — still panics the server on the first attempt. ACL restrictions do not mitigate it.

## Fix

Skip queued commands flagged `READ_FLAGS_BAD_ARITY`, matching the current-command guard directly above and the `networking.c` implementation.

## Test

Added a regression test to `unit/io-threads`, using the existing `activate_io_threads_and_wait` helper and the `pause_process` trick so the whole pipeline lands in one read and is parsed into `cmd_queue`. It reproduces the panic deterministically on unmodified unstable (`exception: I/O error reading reply`, with the Guru Meditation above in the server log) and passes with the fix; ran it 3x for flakiness. `unit/protocol`, `unit/multi`, `unit/keyspace` and `unit/networking` also pass.

Note that the test leans on `pause_process`/`resume_process` and on the I/O threads being awake, so it is more timing-shaped than most of the suite. It is tagged `valgrind:skip` like the existing block. Happy to trim it to just the `GET` case, which reproduces most reliably, if that is preferred.