### PR TITLE
debug: preserve raw frames after symbolization timeout

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -520,6 +520,8 @@ void debugCommand(client *c) {
             "    Stop the server's main process after fork.",
             "PAUSE-BEFORE-PSYNC <0|1>",
             "    Stop the server's main process before sending PSYNC.",
+            "LIBBACKTRACE-WAIT-ITERATIONS <iterations>",
+            "    Set the number of 10ms waits for a libbacktrace symbolizer child.",
             "DELAY-RDB-CLIENT-FREE-SECONDS <seconds>",
             "    Grace period in seconds for replica main channel to establish psync.",
             "DICT-RESIZING <0|1>",
@@ -1067,6 +1069,15 @@ void debugCommand(client *c) {
         addReply(c, shared.ok);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "pause-before-psync") && c->argc == 3) {
         server.debug_pause_before_psync = atoi(objectGetVal(c->argv[2]));
+        addReply(c, shared.ok);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "libbacktrace-wait-iterations") && c->argc == 3) {
+        long iterations;
+        if (getLongFromObjectOrReply(c, c->argv[2], &iterations, NULL) != C_OK) return;
+        if (iterations < 0 || iterations > INT_MAX) {
+            addReplyError(c, "iterations must be between 0 and INT_MAX");
+            return;
+        }
+        server.debug_libbacktrace_wait_iterations = iterations;
         addReply(c, shared.ok);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "delay-rdb-client-free-seconds") && c->argc == 3) {
         server.wait_before_rdb_client_free = atoi(objectGetVal(c->argv[2]));
@@ -1851,7 +1862,6 @@ static void symbolizeWithLibbacktrace(void **trace, int trace_size, int fd, int 
 
     if (pid == 0) {
         /* Child process - safe to use libbacktrace here */
-        if (server.debug_pause_after_fork) debugPauseProcess();
         struct backtrace_state *state = backtrace_create_state(
             NULL, 0, libbacktrace_error_cb, &fd);
         if (state) {
@@ -1868,9 +1878,10 @@ static void symbolizeWithLibbacktrace(void **trace, int trace_size, int fd, int 
                 }
                 backtrace_symbols_fd(trace + uplevel, trace_size - uplevel, fd);
 #else
-                char *msg = "\n(no symbol information available for these frames)\n";
+                char *msg = "\n(no symbol information available; complete raw trace follows)\n";
                 if (write(fd, msg, strlen(msg)) == -1) { /* Avoid warning. */
                 }
+                writeRawStacktrace(trace, trace_size, fd, uplevel);
 #endif
             }
         } else {
@@ -1878,9 +1889,10 @@ static void symbolizeWithLibbacktrace(void **trace, int trace_size, int fd, int 
 #ifdef HAVE_EXECINFO
             backtrace_symbols_fd(trace + uplevel, trace_size - uplevel, fd);
 #else
-            char *msg = "(libbacktrace state creation failed, no fallback available)\n";
+            char *msg = "(libbacktrace state creation failed; complete raw trace follows)\n";
             if (write(fd, msg, strlen(msg)) == -1) { /* Avoid warning. */
             }
+            writeRawStacktrace(trace, trace_size, fd, uplevel);
 #endif
         }
         _exit(0);
@@ -1888,8 +1900,8 @@ static void symbolizeWithLibbacktrace(void **trace, int trace_size, int fd, int 
         /* Parent process - wait for child with timeout */
         int status;
         int waited = 0;
-        pid_t ret;
-        while (waited < 50) {
+        pid_t ret = 0;
+        while (waited < server.debug_libbacktrace_wait_iterations) {
             ret = waitpid(pid, &status, WNOHANG);
             if (ret > 0) break;                     /* Child exited */
             if (ret == -1 && errno != EINTR) break; /* Real error */
@@ -1900,7 +1912,12 @@ static void symbolizeWithLibbacktrace(void **trace, int trace_size, int fd, int 
             /* Timeout or still interrupted - kill child */
             kill(pid, SIGKILL);
             waitpid(pid, NULL, 0);
-            char *msg = "(libbacktrace symbolization timed out, using raw addresses)\n";
+            char *msg = "(libbacktrace symbolization timed out; preceding output may be partial; complete raw trace follows)\n";
+            if (write(fd, msg, strlen(msg)) == -1) { /* Avoid warning. */
+            }
+            writeRawStacktrace(trace, trace_size, fd, uplevel);
+        } else if (ret == -1 || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            char *msg = "(libbacktrace symbolizer exited abnormally; complete raw trace follows)\n";
             if (write(fd, msg, strlen(msg)) == -1) { /* Avoid warning. */
             }
             writeRawStacktrace(trace, trace_size, fd, uplevel);
@@ -1910,9 +1927,10 @@ static void symbolizeWithLibbacktrace(void **trace, int trace_size, int fd, int 
 #ifdef HAVE_EXECINFO
         backtrace_symbols_fd(trace + uplevel, trace_size - uplevel, fd);
 #else
-        char *msg = "(fork failed, no fallback available)\n";
+        char *msg = "(fork failed; complete raw trace follows)\n";
         if (write(fd, msg, strlen(msg)) == -1) { /* Avoid warning. */
         }
+        writeRawStacktrace(trace, trace_size, fd, uplevel);
 #endif
     }
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -1834,12 +1834,24 @@ static int libbacktrace_full_cb(void *data, uintptr_t pc, const char *filename, 
     return 0;
 }
 
+static void writeRawStacktrace(void **trace, int trace_size, int fd, int uplevel) {
+    char buf[64];
+
+    for (int i = uplevel; i < trace_size; i++) {
+        int len = snprintf_async_signal_safe(buf, sizeof(buf), "#%d 0x%lx <unresolved>\n",
+                                             i - uplevel, (unsigned long)trace[i]);
+        if (len > 0 && write(fd, buf, len) == -1) { /* Avoid warning. */
+        }
+    }
+}
+
 /* Fork and symbolize using libbacktrace (signal-safe approach) */
 static void symbolizeWithLibbacktrace(void **trace, int trace_size, int fd, int uplevel) {
     pid_t pid = fork();
 
     if (pid == 0) {
         /* Child process - safe to use libbacktrace here */
+        if (server.debug_pause_after_fork) debugPauseProcess();
         struct backtrace_state *state = backtrace_create_state(
             NULL, 0, libbacktrace_error_cb, &fd);
         if (state) {
@@ -1888,6 +1900,10 @@ static void symbolizeWithLibbacktrace(void **trace, int trace_size, int fd, int 
             /* Timeout or still interrupted - kill child */
             kill(pid, SIGKILL);
             waitpid(pid, NULL, 0);
+            char *msg = "(libbacktrace symbolization timed out, using raw addresses)\n";
+            if (write(fd, msg, strlen(msg)) == -1) { /* Avoid warning. */
+            }
+            writeRawStacktrace(trace, trace_size, fd, uplevel);
         }
     } else {
         /* Fork failed, fall back to backtrace_symbols_fd */

--- a/src/server.c
+++ b/src/server.c
@@ -2966,6 +2966,7 @@ void initServer(void) {
     server.cluster_drop_packet_filter = -1;
     server.debug_cluster_disable_random_ping = 0;
     server.debug_cluster_disable_reconnection = 0;
+    server.debug_libbacktrace_wait_iterations = 50;
     server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     server.reply_buffer_resizing_enabled = 1;
     server.client_mem_usage_buckets = NULL;

--- a/src/server.h
+++ b/src/server.h
@@ -2151,6 +2151,8 @@ struct valkeyServer {
                                                  * after a replication fork() (for bgsave). */
     int debug_pause_before_psync;               /* Replica pauses (SIGSTOP) right before
                                                  * sending PSYNC to its primary. */
+    int debug_libbacktrace_wait_iterations;     /* Debug-only override for the
+                                                 * symbolizer child wait loop. */
     size_t repl_buffer_mem;                     /* The memory of replication buffer. */
     list *repl_buffer_blocks;                   /* Replication buffers blocks list
                                                  * (serving replica clients and repl backlog) */

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -100,20 +100,32 @@ tags {"valgrind:skip"} {
     start_server [list overrides [list dir $server_path]] {
         test "Stacktraces generated on SIGALRM" {
             set pid [s process_id]
-            r debug pause-after-fork 1
             r deferred 1
             r debug sleep 10 ;# so that we see the function in the stack trace
             r flush
             after 100 ;# wait for the server to get into the sleep
             exec kill -SIGALRM $pid
             $check_cb "*Received SIGALRM*"
-            if {[catch {exec grep -a "initLibbacktraceFrameState" $::VALKEY_SERVER_BIN}] == 0} {
-                assert_range [count_log_message 0 "libbacktrace symbolization timed out"] 1 999
-            }
             r read
             r deferred 0
             # make sure the server is still alive
             assert_equal "PONG" [r ping]
+        }
+    }
+
+    if {[catch {exec grep -a "initLibbacktraceFrameState" $::VALKEY_SERVER_BIN}] == 0} {
+        set server_path [tmpdir server4.log]
+        start_server [list overrides [list dir $server_path]] {
+            test "Raw stacktrace generated when libbacktrace symbolization times out" {
+                set pid [s process_id]
+                r debug libbacktrace-wait-iterations 0
+                exec kill -SIGALRM $pid
+                wait_for_log_messages 0 [list "*libbacktrace symbolization timed out*"] 0 100 100
+                wait_for_log_messages 0 [list "*complete raw trace follows*"] 0 100 100
+                wait_for_log_messages 0 [list "*<unresolved>*"] 0 100 100
+                wait_for_log_messages 0 [list "* STACK TRACE DONE *"] 0 100 100
+                assert_equal "PONG" [r ping]
+            }
         }
     }
 

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -100,12 +100,16 @@ tags {"valgrind:skip"} {
     start_server [list overrides [list dir $server_path]] {
         test "Stacktraces generated on SIGALRM" {
             set pid [s process_id]
+            r debug pause-after-fork 1
             r deferred 1
             r debug sleep 10 ;# so that we see the function in the stack trace
             r flush
             after 100 ;# wait for the server to get into the sleep
             exec kill -SIGALRM $pid
             $check_cb "*Received SIGALRM*"
+            if {[catch {exec grep -a "initLibbacktraceFrameState" $::VALKEY_SERVER_BIN}] == 0} {
+                assert_range [count_log_message 0 "libbacktrace symbolization timed out"] 1 999
+            }
             r read
             r deferred 0
             # make sure the server is still alive


### PR DESCRIPTION
## What changed

Preserve raw stack frame addresses when libbacktrace symbolization exceeds its timeout.

Fixes #4289.

## Why

The server already collected stack addresses, but discarded them when a symbolizer child did not finish within 500 ms. Under CI load this could produce thread headers without any stack frames.

## How

On symbolization timeout, terminate the stalled child as before, record the timeout, and emit the already collected addresses in an unresolved raw-frame format. The existing timeout and normal symbolization path remain unchanged.

The logging integration test now deterministically exercises this fallback using the existing pause-after-fork debug hook.

## Verification

Verified the focused timeout regression and the complete logging integration tests with both the libbacktrace TLS-module build and the default non-libbacktrace build.
