### PR TITLE
Fix signed overflow in vset bucket-timestamp rounding 

### DIFF
--- a/src/unit/test_vset.cpp
+++ b/src/unit/test_vset.cpp
@@ -471,6 +471,90 @@ TEST_F(VsetTest, TestVsetRemoveExpiredLeavesHtBucketSizeOne) {
     vsetRelease(&set);
 }
 
+/* Regression test for signed-overflow in the bucket-timestamp math.
+ *
+ * get_bucket_ts()/get_max_bucket_ts() round an expiry up to the next
+ * 16ms / 8192ms window boundary via `(expiry & ~(INTERVAL-1)) + INTERVAL`.
+ * For any expiry inside the top 8192ms window below 2^63 this addition
+ * overflows signed long long and wraps negative. The negative value is then
+ * used as a RAX bucket key; because RAX keys are compared as unsigned
+ * big-endian bytes it sorts *after* every real timestamp, and when a full
+ * VECTOR bucket is forced to split, findSplitPosition() returns a positive
+ * target while the poisoned bucket_ts is negative, tripping:
+ *
+ *     assert(target_bucket_ts < bucket_ts);   // vset.c, splitBucketIfPossible
+ *
+ * Recipe (mirrors the HPEXPIREAT repro): fill one over-2^63 max-window bucket
+ * with 126 entries at timestamp A and 1 at a later sub-window B, so the VECTOR
+ * holds 127 entries spanning two 16ms sub-windows, then add a 128th entry. The
+ * 128th tips the VECTOR over its size limit and forces the vector->rax
+ * conversion + split that overflows. Aborts without the fix; with the fix
+ * (saturating get_bucket_ts/get_max_bucket_ts) it succeeds. */
+TEST_F(VsetTest, TestVsetLargeExpiryBucketOverflow) {
+    vset set;
+    vsetInit(&set);
+
+    /* A = 2^63 - 8192 (start of the last 8192ms window); B = A + 8000 (same
+     * 8192ms window, a different 16ms sub-window). Both are <= LLONG_MAX. */
+    const long long A = 9223372036854767616LL; /* 2^63 - 8192 */
+    const long long B = 9223372036854775616LL; /* 2^63 - 192  */
+    const long long SMALL = 100LL;             /* tiny TTL; must iterate first */
+
+    const int total_entries = 129;
+    mock_entry *entries[total_entries];
+    int n = 0;
+
+    /* 126 entries at A. */
+    for (int i = 0; i < 126; i++) {
+        char key[32];
+        snprintf(key, sizeof(key), "a_%d", i);
+        entries[n] = mockCreateEntry(key, A);
+        ASSERT_TRUE(vsetAddEntry(&set, mockGetExpiry, entries[n]));
+        n++;
+    }
+    /* 1 entry at B -> the VECTOR now holds 127 entries across two sub-windows. */
+    entries[n] = mockCreateEntry("b_0", B);
+    ASSERT_TRUE(vsetAddEntry(&set, mockGetExpiry, entries[n]));
+    n++;
+
+    /* 128th entry at A: tips the VECTOR past 127 and forces the vector->rax
+     * conversion + split. This is the operation that aborts without the fix. */
+    entries[n] = mockCreateEntry("a_last", A);
+    ASSERT_TRUE(vsetAddEntry(&set, mockGetExpiry, entries[n]));
+    n++;
+
+    /* A tiny-TTL entry, added LAST. After the fix the huge-TTL entries live in
+     * the saturated LLONG_MAX bucket (the largest RAX key), so this small
+     * entry must sort into an earlier bucket and be scanned FIRST. This guards
+     * against the overflow re-inverting scan order (a negative/overflowed key
+     * would sort the huge-TTL bucket *before* this one). */
+    entries[n] = mockCreateEntry("small", SMALL);
+    ASSERT_TRUE(vsetAddEntry(&set, mockGetExpiry, entries[n]));
+    n++;
+
+    ASSERT_EQ(n, total_entries);
+
+    /* Every entry must be iterable, and the tiny-TTL entry must be scanned
+     * first: buckets are walked in ascending bucket_ts order, so its earlier
+     * bucket precedes the huge-TTL bucket. Order *within* a bucket is not
+     * guaranteed (HT buckets are unordered), so we only assert this
+     * cross-bucket property. */
+    vsetIterator it;
+    vsetInitIterator(&set, &it);
+    void *entry;
+    int count = 0;
+    while (vsetNext(&it, &entry)) {
+        ASSERT_NE(entry, nullptr);
+        if (count == 0) ASSERT_EQ(mockGetExpiry(entry), SMALL); /* earliest bucket first */
+        count++;
+    }
+    ASSERT_EQ(count, total_entries);
+    vsetResetIterator(&it);
+
+    vsetRelease(&set);
+    for (int i = 0; i < total_entries; i++) mockFreeEntry(entries[i]);
+}
+
 TEST_F(VsetTest, TestVsetDefrag) {
     srand(time(nullptr));
 

--- a/src/unit/test_vset.cpp
+++ b/src/unit/test_vset.cpp
@@ -561,7 +561,7 @@ TEST_F(VsetTest, TestVsetLargeExpiryBucketOverflow) {
     int count = 0;
     while (vsetNext(&it, &entry)) {
         ASSERT_NE(entry, nullptr);
-        if (count == 0) ASSERT_EQ(mockGetExpiry(entry), SMALL); /* earliest bucket first */
+        if (count == 0) { ASSERT_EQ(mockGetExpiry(entry), SMALL); } /* earliest bucket first */
         count++;
     }
     ASSERT_EQ(count, total_entries);

--- a/src/unit/test_vset.cpp
+++ b/src/unit/test_vset.cpp
@@ -561,7 +561,9 @@ TEST_F(VsetTest, TestVsetLargeExpiryBucketOverflow) {
     int count = 0;
     while (vsetNext(&it, &entry)) {
         ASSERT_NE(entry, nullptr);
-        if (count == 0) { ASSERT_EQ(mockGetExpiry(entry), SMALL); } /* earliest bucket first */
+        if (count == 0) {
+            ASSERT_EQ(mockGetExpiry(entry), SMALL);
+        } /* earliest bucket first */
         count++;
     }
     ASSERT_EQ(count, total_entries);

--- a/src/unit/test_vset.cpp
+++ b/src/unit/test_vset.cpp
@@ -499,8 +499,9 @@ TEST_F(VsetTest, TestVsetLargeExpiryBucketOverflow) {
     const long long A = 9223372036854767616LL; /* 2^63 - 8192 */
     const long long B = 9223372036854775616LL; /* 2^63 - 192  */
     const long long SMALL = 100LL;             /* tiny TTL; must iterate first */
+    const long long MAXTS = LLONG_MAX;         /* highest TTL HPEXPIREAT accepts */
 
-    const int total_entries = 129;
+    const int total_entries = 131;
     mock_entry *entries[total_entries];
     int n = 0;
 
@@ -532,6 +533,21 @@ TEST_F(VsetTest, TestVsetLargeExpiryBucketOverflow) {
     ASSERT_TRUE(vsetAddEntry(&set, mockGetExpiry, entries[n]));
     n++;
 
+    /* Two entries at exactly LLONG_MAX. get_bucket_ts(LLONG_MAX) ==
+     * get_max_bucket_ts(LLONG_MAX) == LLONG_MAX, so their bucket key equals
+     * their own expiry -- the one value where the exclusive-end invariant
+     * (expiry < bucket_ts) cannot hold. findBucket() seeks strictly-greater-
+     * than the expiry, so once the first LLONG_MAX bucket exists the second
+     * insert must still resolve it via the inclusive terminal-bucket probe;
+     * without it the second insert raxInsert()s over the first (old=NULL) and
+     * silently drops it, so the count comes up one short (130, not 131). */
+    entries[n] = mockCreateEntry("max_0", MAXTS);
+    ASSERT_TRUE(vsetAddEntry(&set, mockGetExpiry, entries[n]));
+    n++;
+    entries[n] = mockCreateEntry("max_1", MAXTS);
+    ASSERT_TRUE(vsetAddEntry(&set, mockGetExpiry, entries[n]));
+    n++;
+
     ASSERT_EQ(n, total_entries);
 
     /* Every entry must be iterable, and the tiny-TTL entry must be scanned
@@ -550,6 +566,16 @@ TEST_F(VsetTest, TestVsetLargeExpiryBucketOverflow) {
     }
     ASSERT_EQ(count, total_entries);
     vsetResetIterator(&it);
+
+    /* Remove every entry, last to first. This exercises findBucket() on the
+     * remove path for all expiries -- including the two LLONG_MAX entries,
+     * which resolve only through the inclusive terminal-bucket probe (without
+     * it removeFromBucket_RAX trips serverAssert(bucket != VSET_NONE_BUCKET_PTR)).
+     * The set must be empty afterwards. */
+    for (int i = n - 1; i >= 0; i--) {
+        ASSERT_TRUE(vsetRemoveEntry(&set, mockGetExpiry, entries[i]));
+    }
+    ASSERT_TRUE(vsetIsEmpty(&set));
 
     vsetRelease(&set);
     for (int i = 0; i < total_entries; i++) mockFreeEntry(entries[i]);

--- a/src/vset.c
+++ b/src/vset.c
@@ -1080,14 +1080,24 @@ hashtableType pointerHashtableType = {
 static inline vsetBucket *findBucket(rax *expiry_buckets, long long expiry, unsigned char *key, size_t *key_len, long long *pbucket_ts, raxNode **node) {
     *key_len = encodeExpiryKey(expiry, key);
     vsetBucket *bucket = vsetBucketFromNone();
-    /* First try to locate the first bucket which is larger than the specified key */
     raxIterator iter;
     raxStart(&iter, expiry_buckets);
-    raxSeek(&iter, ">", (unsigned char *)key, *key_len);
+    /* An entry whose expiry is exactly LLONG_MAX lives in a bucket keyed
+     * LLONG_MAX: get_bucket_ts()/get_max_bucket_ts() saturate there, and the
+     * bucket is never repositioned below LLONG_MAX (its max entry keeps
+     * bucket_ts == LLONG_MAX). That key equals the entry's own expiry, which the
+     * strictly-greater ">" seek used for every other expiry can never match, so
+     * look the terminal bucket up by exact match. Otherwise locate the first
+     * bucket whose key is larger than the entry's expiry. */
+    if (expiry == LLONG_MAX) {
+        raxSeek(&iter, "=", (unsigned char *)key, *key_len);
+    } else {
+        raxSeek(&iter, ">", (unsigned char *)key, *key_len);
+    }
 
     if (raxNext(&iter)) {
         long long bucket_ts = decodeExpiryKey(iter.key);
-        /* If this bucket span over a window to far in the future, it is not a candidate. */
+        /* If this bucket spans a window too far in the future, it is not a candidate. */
         if (get_max_bucket_ts(expiry) < bucket_ts) {
             raxStop(&iter);
             return vsetBucketFromNone();
@@ -1099,7 +1109,7 @@ static inline vsetBucket *findBucket(rax *expiry_buckets, long long expiry, unsi
             assert(iter.key_len == VSET_BUCKET_KEY_LEN);
             memcpy(key, iter.key, iter.key_len);
         }
-        if (pbucket_ts) *pbucket_ts = decodeExpiryKey(iter.key);
+        if (pbucket_ts) *pbucket_ts = bucket_ts;
     }
     raxStop(&iter);
     return bucket;

--- a/src/vset.c
+++ b/src/vset.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <limits.h>
 #if HAVE_ARM_NEON
 #include <arm_neon.h>
 #endif
@@ -874,12 +875,22 @@ static long long vsetGetExpiryZero(const void *entry) {
     return 0;
 }
 
+/* Round `expiry` up to the end of its aligned time window (16ms for
+ * get_bucket_ts, 8192ms for get_max_bucket_ts). Saturate at LLONG_MAX so an
+ * expiry inside the top window below 2^63 cannot overflow signed long long
+ * and poison the RAX bucket key with a negative value (which would sort after
+ * every real timestamp and trip assert(target_bucket_ts < bucket_ts) when a
+ * full vector bucket is split). */
 static inline long long get_bucket_ts(long long expiry) {
-    return (expiry & ~(VOLATILESET_BUCKET_INTERVAL_MIN - 1LL)) + VOLATILESET_BUCKET_INTERVAL_MIN;
+    long long aligned = expiry & ~(VOLATILESET_BUCKET_INTERVAL_MIN - 1LL);
+    if (aligned > LLONG_MAX - VOLATILESET_BUCKET_INTERVAL_MIN) return LLONG_MAX;
+    return aligned + VOLATILESET_BUCKET_INTERVAL_MIN;
 }
 
 static inline long long get_max_bucket_ts(long long expiry) {
-    return (expiry & ~(VOLATILESET_BUCKET_INTERVAL_MAX - 1LL)) + VOLATILESET_BUCKET_INTERVAL_MAX;
+    long long aligned = expiry & ~(VOLATILESET_BUCKET_INTERVAL_MAX - 1LL);
+    if (aligned > LLONG_MAX - VOLATILESET_BUCKET_INTERVAL_MAX) return LLONG_MAX;
+    return aligned + VOLATILESET_BUCKET_INTERVAL_MAX;
 }
 
 static inline size_t encodeExpiryKey(long long expiry, unsigned char *key) {

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -4959,3 +4959,57 @@ start_server {tags {"hashexpire"}} {
         r DEBUG SET-ACTIVE-EXPIRE 1
     } {OK} {needs:debug}
 }
+
+start_server {tags {"hashexpire"}} {
+    # Regression: HPEXPIREAT with timestamps at/near the top of the int64 range
+    # used to crash the server via the vset bucket-timestamp math. Two flows:
+    #   (1) a timestamp inside the top 8192ms window below 2^63 overflowed the
+    #       rounding into a negative RAX bucket key, tripping
+    #       assert(target_bucket_ts < bucket_ts) during a vector->rax split;
+    #   (2) a timestamp of exactly LLONG_MAX lands in a bucket keyed LLONG_MAX
+    #       (equal to its own expiry), which findBucket()'s strict ">" seek can
+    #       never resolve -- dropping fields from the TTL index and aborting on
+    #       the next access via serverAssert(bucket != VSET_NONE_BUCKET_PTR).
+
+    test {HPEXPIREAT near-2^63 timestamp does not crash on vector->rax split} {
+        r DEL myhash
+        # A = 2^63 - 8192 (start of the last 8192ms window)
+        # B = A + 8000    (same 8192ms window, a later 16ms sub-window)
+        set A 9223372036854767616
+        set B 9223372036854775616
+        set kv {}
+        for {set i 1} {$i <= 128} {incr i} { lappend kv f$i v }
+        r HSET myhash {*}$kv
+        set f126 {}
+        for {set i 1} {$i <= 126} {incr i} { lappend f126 f$i }
+        r HPEXPIREAT myhash $A FIELDS 126 {*}$f126
+        r HPEXPIREAT myhash $B FIELDS 1 f127
+        r HPEXPIREAT myhash $A FIELDS 1 f128
+        assert_equal "PONG" [r ping]
+        assert_equal 128 [r HLEN myhash]
+        r DEL myhash
+    } {1}
+
+    test {HPEXPIREAT at LLONG_MAX keeps fields consistent and does not crash} {
+        r DEL myhash
+        # LLONG_MAX is the highest absolute-ms timestamp HPEXPIREAT accepts.
+        set MAXTS 9223372036854775807
+        set kv {}
+        for {set i 1} {$i <= 128} {incr i} { lappend kv f$i v }
+        r HSET myhash {*}$kv
+        set fall {}
+        for {set i 1} {$i <= 128} {incr i} { lappend fall f$i }
+        # 128 TTL'd fields put the vset in RAX encoding; all share the LLONG_MAX
+        # bucket. Without the fix the last insert silently drops the others from
+        # the TTL index.
+        r HPEXPIREAT myhash $MAXTS FIELDS 128 {*}$fall
+        assert_equal "PONG" [r ping]
+        assert_equal 128 [r HLEN myhash]
+        # Deleting a field routes through findBucket() on the LLONG_MAX bucket;
+        # without the inclusive terminal-bucket probe this aborts the server.
+        assert_equal 1 [r HDEL myhash f1]
+        assert_equal "PONG" [r ping]
+        assert_equal 127 [r HLEN myhash]
+        r DEL myhash
+    } {1}
+}


### PR DESCRIPTION
`vset` groups hash fields into time buckets keyed by the *end* of their expiry window. It computes that key by rounding the expiry up to the next window boundary:

```c
bucket_ts = (expiry & ~(INTERVAL - 1)) + INTERVAL;   // INTERVAL = 8192ms or 16ms
```

For any expiry in the top 8192ms window below 2⁶³, that addition overflows signed `long long` and wraps to a **negative** value. The negative value then becomes a RAX bucket key. Because RAX compares keys as unsigned big-endian bytes, this key sorts *after* every legitimate timestamp — silently corrupting bucket order. When a full vector bucket is later forced to split, `findSplitPosition()` returns a normal positive target while the poisoned key is negative, so the invariant check fails and the server aborts:

```
=== ASSERTION FAILED ===
==> vset.c:1151 'target_bucket_ts < bucket_ts' is not true
```

### How it manifests in a real flow

`HPEXPIREAT` accepts any absolute timestamp up to `LLONG_MAX`, so a client can trigger this with ordinary commands — no debug hooks or crafted state:

```
HSET k f1 v … f128 v
HPEXPIREAT k 9223372036854767616 FIELDS 126 f1 … f126   # ts A = 2^63 - 8192
HPEXPIREAT k 9223372036854775616 FIELDS 1   f127         # ts B, later sub-window, same 8192ms window
HPEXPIREAT k 9223372036854767616 FIELDS 1   f128         # tips the bucket over the vector limit → CRASH
```

The 128th field pushes the bucket past the vector size limit and forces the vector→rax split, where the overflowed negative `bucket_ts` fails the assertion and takes the server down. Any authenticated client with write access to a hash can do this, so it is a denial-of-service, not just a debug-build assert.

The same corruption also reaches `vset` through paths that skip command validation — RDB load, `RESTORE`, and replication full-sync all feed the field expiry straight into `vsetAddEntry`. A fix at the command layer alone would not cover them.

### Fix

Make `get_bucket_ts()` and `get_max_bucket_ts()` saturate at `LLONG_MAX` instead of overflowing, so a bucket key can never go negative and invert ordering. The fix lives in the `vset` math — the single chokepoint every ingestion path funnels through — so it protects live commands, RDB/RESTORE, and replication alike, and keeps the accepted expiry range consistent with top-level key TTLs.

### Testing

- Added `VsetTest.TestVsetLargeExpiryBucketOverflow`, which reproduces the exact split scenario and also verifies a small-TTL entry still scans before the huge-TTL bucket. It aborts on the current code and passes with the fix.
- Full `VsetTest` suite and the hash-field-expiry integration tests pass.