### PR TITLE
Deflake diskless timeout replica count assertion

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1049,16 +1049,15 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                         }
                     }
                     if {$all_drop == "timeout"} {
-                        # The pipe can finish before the paused replica times out,
-                        # so both replicas may still be up at pipe-read time.
-                        if {[catch {
-                            wait_for_log_messages -2 {
-                                "*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"
-                                "*Diskless rdb transfer, done reading from pipe, 2 replicas still up*"
-                            } $loglines 1 1
-                        } err]} {
-                            fail "diskless timeout invariant failed: expected the pipe to finish with 1 or 2 replicas still up; original error: $err"
+                        # A full sync timeout removes the replica before pipe EOF,
+                        # while a streaming sync timeout happens after pipe EOF.
+                        if {[count_log_message -2 "Disconnecting timedout replica (full sync)"] == 1} {
+                            set expected_replicas 1
+                        } else {
+                            set expected_replicas 2
                         }
+                        set expected_pipe_log [list "*Diskless rdb transfer, done reading from pipe, $expected_replicas replicas still up*"]
+                        wait_for_log_messages -2 $expected_pipe_log $loglines 1 1
                         # master disconnected the slow replica, remove from array
                         set replicas_alive [lreplace $replicas_alive 0 0]
                         # release it

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1049,7 +1049,16 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                         }
                     }
                     if {$all_drop == "timeout"} {
-                        wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"} $loglines 1 1
+                        # The pipe can finish before the paused replica times out,
+                        # so both replicas may still be up at pipe-read time.
+                        if {[catch {
+                            wait_for_log_messages -2 {
+                                "*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"
+                                "*Diskless rdb transfer, done reading from pipe, 2 replicas still up*"
+                            } $loglines 1 1
+                        } err]} {
+                            fail "diskless timeout invariant failed: expected the pipe to finish with 1 or 2 replicas still up; original error: $err"
+                        }
                         # master disconnected the slow replica, remove from array
                         set replicas_alive [lreplace $replicas_alive 0 0]
                         # release it


### PR DESCRIPTION
## What changed

Correlate the diskless timeout branch with the exact pipe-completion count: `(full sync)` requires one replica still up, while `(streaming sync)` requires two. Keep the exact-one timeout guard and use `wait_for_log_messages` directly so its native diagnostic is preserved.

Fixes #4209.

## Why

The two timeout branches are both legitimate, but their pipe counts are not interchangeable. Accepting either count unconditionally could hide incorrect pipe bookkeeping for the branch that actually fired.

## Verification

On Linux, an intentionally inverted mapping failed at the derived pipe-log assertion. The corrected focused test passed, followed by 100/100 sequential repetitions; all local repetitions observed `(full sync)` with one replica still up. The macOS Daily test remains pending.
