### PR TITLE
Deflake test: fix race causing missing manual failover timeout log

### DIFF
--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -171,6 +171,15 @@ proc test_replica_config_epoch_failover {type} {
         pause_process [srv 0 pid]
         R 3 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_NONE
         R 3 DEBUG CLOSE-CLUSTER-LINK-ON-PACKET-DROP 0
+
+        # For manual failover, trigger the failover IMMEDIATELY while the replica
+        # still has an outdated config epoch. This guarantees the first attempt
+        # will fail with a timeout.
+        if {$type == "manual"} {
+            R 3 cluster failover force
+            wait_for_log_messages -3 {"*Manual failover timed out*"} 0 1200 50
+        }
+
         wait_for_condition 1000 50 {
             [CI 1 cluster_state] == "fail" &&
             [CI 2 cluster_state] == "fail" &&
@@ -179,12 +188,8 @@ proc test_replica_config_epoch_failover {type} {
             fail "Cluster does not fail"
         }
 
-        # Make sure both the automatic and the manual failover will fail in the first time.
         if {$type == "automatic"} {
             wait_for_log_messages -3 {"*Failover attempt expired*"} 0 1200 50
-        } elseif {$type == "manual"} {
-            R 3 cluster failover force
-            wait_for_log_messages -3 {"*Manual failover timed out*"} 0 1200 50
         }
 
         # Make sure the primaries prints the relevant logs.

--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -172,12 +172,13 @@ proc test_replica_config_epoch_failover {type} {
         R 3 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_NONE
         R 3 DEBUG CLOSE-CLUSTER-LINK-ON-PACKET-DROP 0
 
-        # For manual failover, trigger the failover IMMEDIATELY while the replica
-        # still has an outdated config epoch. This guarantees the first attempt
-        # will fail with a timeout.
-        if {$type == "manual"} {
-            R 3 cluster failover force
-            wait_for_log_messages -3 {"*Manual failover timed out*"} 0 1200 50
+        # Wait until the replica's cluster links to R1 and R2 are connected.
+        # This ensures retries of the failover command can be delivered.
+        wait_for_condition 2000 50 {
+            [llength [split [R 3 cluster links] "\n"]] >= 2 &&
+            [string match "*connected*" [R 3 cluster links]]
+        } else {
+            fail "Replica did not re-establish cluster links"
         }
 
         wait_for_condition 1000 50 {
@@ -190,6 +191,20 @@ proc test_replica_config_epoch_failover {type} {
 
         if {$type == "automatic"} {
             wait_for_log_messages -3 {"*Failover attempt expired*"} 0 1200 50
+        } elseif {$type == "manual"} {
+            # Retry the manual failover until both primaries have actually seen
+            # (and denied) the request. This handles the case where the initial
+            # broadcast is dropped because cluster links were still being rebuilt.
+            wait_for_condition 50 100 {
+                catch {R 3 cluster failover force}
+                # Use count_log_message to avoid resetting log cursors.
+                [count_log_message -1 "reqConfigEpoch"] > 0 &&
+                [count_log_message -2 "reqConfigEpoch"] > 0
+            } else {
+                fail "The primaries did not receive the failover auth request"
+            }
+            # Now the timeout message must appear in R3's log.
+            wait_for_log_messages -3 {"*Manual failover timed out*"} 0 1200 50
         }
 
         # Make sure the primaries prints the relevant logs.
@@ -200,7 +215,7 @@ proc test_replica_config_epoch_failover {type} {
 
         # Make sure the replica has updated the config epoch.
         wait_for_condition 1000 10 {
-            $R0_config_epoch == [dict get [cluster_get_node_by_id 1 $R0_nodeid] config_epoch]
+            $R0_config_epoch == [dict get [cluster_get_node_by_id 3 $R0_nodeid] config_epoch]
         } else {
             fail "The replica does not update the config epoch"
         }


### PR DESCRIPTION
## Problem
#4310 The test Replica can update the config epoch when trigger the failover - manual intermittently failed with the error:
log message of '"*Manual failover timed out*"' not found

## Cause
**A race condition between re-enabling cluster gossip and issuing `CLUSTER FAILOVER FORCE`.**

After removing the packet filter, the test waited for the cluster to become fail before sending the failover command. During that wait, gossip messages from other primaries could update the replica's currentEpoch, making its first failover attempt succeed immediately, therefore the expected timeout log was not being generated.

## Fix
Fix the manual failover case by:
1. Waiting for replica cluster links to reconnect after removing the packet filter.
2. Retrying the manual failover until both primaries log the denial request, then confirming the timeout log.
3. Fixing the replica epoch-update guard to check the replica (node 3) instead of a primary.