### PR TITLE
Clear the redaction bitmap between commands in a transaction

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -285,8 +285,11 @@ void execCommand(client *c) {
         c->mstate->commands[j].cmd = c->cmd;
 
         /* The original argv has already been processed for commandlog and monitor,
-         * so we can safely free it before proceeding to the next command. */
+         * so we can safely free it before proceeding to the next command. The
+         * redaction bitmap refers to the argv we just consumed, so it must be
+         * cleared as well or it will be applied to the next command's arguments. */
         freeClientOriginalArgv(c);
+        c->redact_arg_bitmap = 0;
     }
 
     // restore old DENY_BLOCKING value

--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -198,6 +198,21 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
         assert_match {* key 9 5000 AUTH2 (redacted) (redacted)} [lindex [lindex $slowlog_resp 0] 3]
     } {} {needs:repl}
 
+    test {COMMANDLOG slow - Redaction does not leak to later commands in a MULTI} {
+        r config set commandlog-execution-slower-than 0
+        r commandlog reset slow
+        r multi
+        r acl setuser commandlog-test-user +get
+        r set foo bar
+        r exec
+        r config set commandlog-execution-slower-than -1
+        set slowlog_resp [r commandlog get -1 slow]
+
+        # The ACL SETUSER redaction must not carry over to the following SET
+        assert_equal {set foo bar} [lindex [lindex $slowlog_resp 0] 3]
+        r acl deluser commandlog-test-user
+    }
+
     test {COMMANDLOG slow - Rewritten commands are logged as their original command} {
         r config set commandlog-execution-slower-than 0
 


### PR DESCRIPTION
`redactClientCommandArgument()` records the indices to redact in `c->redact_arg_bitmap`, which is only cleared by `resetClient()`. `execCommand()` doesn't call `resetClient()` between queued commands, so the bits set by one command are still set when the next one is logged.

`MULTI; ACL SETUSER u >secret; SET foo bar; EXEC` logs the `SET` as `set foo (redacted)` in the commandlog and MONITOR, since ACL SETUSER redacts index 2 onwards. This only ever over-redacts, so nothing sensitive is exposed, but it hides arguments operators expect to see.

Clear the bitmap alongside the existing `freeClientOriginalArgv()` at the end of each iteration.