### PR TITLE
Don't vote for a zero-offset replica when a better candidate exists

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5371,6 +5371,22 @@ void clusterSendMFStart(clusterNode *node) {
     clusterMsgSendBlockDecrRefCount(msgblock);
 }
 
+/* Returns 1 if 'primary' has a replica, other than 'candidate', that is a viable
+ * failover candidate and is known to have processed part of the primary's
+ * replication stream, that is, its replication offset is not zero.
+ *
+ * Replicas that can't win an election instead of 'candidate' are not considered,
+ * so that a shard is never left without a possible failover. */
+static int betterFailoverCandidateExists(clusterNode *primary, clusterNode *candidate) {
+    for (int i = 0; i < primary->num_replicas; i++) {
+        clusterNode *replica = primary->replicas[i];
+        if (replica == candidate) continue;
+        if (nodeFailed(replica) || nodeTimedOut(replica) || nodeCantFailover(replica)) continue;
+        if (replica->repl_offset != 0) return 1;
+    }
+    return 0;
+}
+
 /* Vote for the node asking for our vote if there are the conditions. */
 void clusterSendFailoverAuthIfNeeded(clusterNode *node, clusterMsg *request) {
     clusterNode *primary = node->replicaof;
@@ -5425,6 +5441,28 @@ void clusterSendFailoverAuthIfNeeded(clusterNode *node, clusterMsg *request) {
             serverLog(LL_WARNING, "Failover auth denied to %.40s (%s) for epoch %llu: its primary is up", node->name,
                       humanNodename(node), (unsigned long long)requestCurrentEpoch);
         }
+        return;
+    }
+
+    /* Don't vote for a replica that has a zero replication offset, that is, a
+     * replica that never processed anything from the replication stream of the
+     * failed primary, as long as some other replica of the same primary is a
+     * viable candidate with a non-zero offset.
+     *
+     * Such a replica has no data of its own and would cause a full data loss if
+     * it won the election. It also self-penalizes its election delay, so it only
+     * asks for votes this early when it hasn't learned about its siblings yet.
+     * Granting it a vote splits the votes with the better ranked replica, and
+     * since only one vote per epoch is allowed, the good candidate can lose the
+     * election it should have won.
+     *
+     * This is bypassed for manual failovers, where the user explicitly asked
+     * for this specific replica to be promoted. */
+    if (!force_ack && ntohu64(request->offset) == 0 && betterFailoverCandidateExists(primary, node)) {
+        serverLog(LL_WARNING,
+                  "Failover auth denied to %.40s (%s) for epoch %llu: "
+                  "its replication offset is zero and a better candidate exists",
+                  node->name, humanNodename(node), (unsigned long long)requestCurrentEpoch);
         return;
     }
 

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -352,6 +352,67 @@ start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 
     test_sub_replica "sigstop"
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster
 
+start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999 shutdown-timeout 0}} {
+    test "Zero repl offset replica can still win the election when it is the only candidate" {
+        # Write a key to primary 0 so that it has a non-zero repl_offset.
+        set value [string repeat "x" 1024]
+        R 0 set key_991803 $value
+        assert_equal $value [R 0 get key_991803]
+
+        # Move server 4 away from primary 0, so that primary 0 is left without
+        # any replica. Wait until primary 0 sees it has no replica anymore.
+        R 4 cluster replicate [R 1 cluster myid]
+        wait_for_condition 1000 50 {
+            [s 0 connected_slaves] eq 0
+        } else {
+            puts "R 0 role: [R 0 role]"
+            fail "Primary 0 still has replicas"
+        }
+
+        # 10s, make sure primary 0 will hang in the save, so that the new
+        # replica never completes the full sync and keeps a zero repl offset.
+        R 0 config set rdb-key-save-delay 100000000
+
+        # Make server 7 the only replica of primary 0.
+        R 7 config set cluster-replica-validity-factor 0
+        R 7 cluster replicate [R 0 cluster myid]
+        wait_for_condition 1000 50 {
+            [get_my_primary_peer 7] eq "[srv 0 host]:[srv 0 port]"
+        } else {
+            puts "R 7 role: [R 7 role]"
+            fail "Server 7 did not become a replica of primary 0"
+        }
+
+        # Pause primary 0.
+        set primary0_pid [s 0 process_id]
+        pause_process $primary0_pid
+
+        # Server 7 has a zero repl offset, but since it is the only candidate
+        # of primary 0, the other primaries must still vote for it, otherwise
+        # this shard would never be able to fail over.
+        wait_for_condition 1000 50 {
+            [s -7 role] eq {master}
+        } else {
+            puts "s -7 role: [s -7 role]"
+            puts "R 7: [R 7 cluster info]"
+            fail "Failover does not happened"
+        }
+
+        # Make sure it really was an election with a zero offset, i.e. that we
+        # exercised the only-candidate path and not some other code path.
+        verify_log_message -7 "*Start of election*offset 0*" 0
+
+        resume_process $primary0_pid
+
+        # Wait for the old primary to go online and become a replica.
+        wait_for_condition 1000 50 {
+            [s 0 role] eq {slave}
+        } else {
+            fail "The old primary was not converted into replica"
+        }
+    }
+} my_slot_allocation cluster_allocate_replicas ;# start_cluster
+
 proc test_cluster_setslot {type} {
     test "valkey-cli make source node ignores NOREPLICAS error when doing the last CLUSTER SETSLOT - $type" {
         R 3 config set cluster-allow-replica-migration no


### PR DESCRIPTION
## Problem

When a primary fails, all of its replicas can start an election at about the
same time. A replica whose replication offset is zero never received any data
from the failed primary, so promoting it throws away everything in that shard.

Nothing reliably prevents that:

1. Each replica delays its election to favor the one holding the most data,
   including an extra 500 ms if its offset is zero. But each replica measures
   that delay from when it personally noticed the primary was down, and there is
   no shared starting point, so an empty replica that noticed earlier can still
   go first.

2. A voting primary grants its vote to the first eligible request that arrives,
   without checking how much data the asking replica has. It gets one vote per
   round, so once it votes it cannot help a better replica that asks a moment
   later.

So the outcome depends on message arrival order, and with several replicas
asking, the votes split and nobody reaches a majority.

That is the CI failure in #4265. Shard 0 had three replicas: server 4, which
held the data, plus servers 3 and 7, both at offset zero because they had just
been attached and never finished copying. Server 2 voted for server 4; server 1
voted for server 3 a millisecond later. Each then refused the other candidate,
having already voted. Server 4 got neither of the two votes it needed and gave
up, and empty server 7 won the next round.

The reported error "Failover does not happened" is misleading. A failover did
finish, but the wrong replica won; the test only waits for the roles it expects,
so it cannot tell those apart.

## Fix

Refuse the vote when the asking replica reports an offset of zero and another
usable replica of the same primary has data. The check now sits with the voter,
so the result no longer depends on which request arrives first.

- Refusing does not use up the vote, so the primary can still vote for the
  replica that holds the data.
- Replicas that could not win anyway (failed, unreachable, or configured not to
  fail over) do not count as alternatives, so a shard whose only replica has
  offset zero can still fail over and is never left stuck.
- Manual failovers are unaffected, since there the user named the replica.

## Tests

Added a test in `tests/unit/cluster/replica-migration.tcl` for the case that
carries the real risk: a shard whose only replica has offset zero must still
fail over. It checks the server log to confirm the election ran at offset zero,
so it cannot pass by another route. Forcing the new condition to always refuse
makes it the only failure in the suite, so it does catch a regression.

Passing: `replica-migration` (125, over 4 runs), the failover and
replica-selection suites (407), the failure-detection suites (139), and
`replica-migration-slow` plus related cluster suites (118).
`clang-format-18` reports no changes.

## Caveat

The original vote split depends on timing under load and I could not reproduce
it locally, so the account above comes from reading the CI logs rather than a
local failing run. The new test covers the single-replica case, not the split.

Fixes #4265
