### PR TITLE
build: set _XOPEN_SOURCE on glibc rather than on Linux

### DIFF
--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -50,7 +50,7 @@
 #define _ALL_SOURCE
 #endif
 
-#if defined(__linux__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__OpenBSD__) || defined(__GLIBC__)
 #define _XOPEN_SOURCE 700
 /*
  * On NetBSD, _XOPEN_SOURCE undefines _NETBSD_SOURCE and


### PR DESCRIPTION
`src/fmacros.h` keys `_XOPEN_SOURCE 700` on `__linux__` and `__OpenBSD__`, but the
condition it's really after is glibc. On non-Linux glibc platforms — GNU/Hurd, and
GNU/kFreeBSD historically — it isn't set and the build fails on missing declarations.

```diff
-#if defined(__linux__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__OpenBSD__) || defined(__GLIBC__)
```

On Linux this is a no-op, since `__linux__` already satisfies the condition. I built
`unstable` with it to confirm nothing changes there.

Debian carries this as `0001-Fix-FTBFS-on-kFreeBSD.patch`. I've titled it after the glibc
condition since @guillemj noted in #1882 that it applies to GNU/* generally, but happy to
use the original name if you'd rather keep it consistent with Debian.

Original patch by @lamby.
