### PR TITLE
Clear the redaction bitmap between commands in a transaction

### DIFF
--- a/src/commandlog.c
+++ b/src/commandlog.c
@@ -69,8 +69,11 @@ static commandlogEntry *commandlogCreateEntry(client *c, robj **argv, int argc, 
     ce->time = time(NULL);
     ce->value = value;
     ce->id = server.commandlog[type].entry_id++;
-    ce->peerid = sdsnew(getClientPeerId(c));
-    ce->cname = c->name ? sdsnew(objectGetVal(c->name)) : sdsempty();
+    /* For commands executed from a script, the executing client is a fake
+     * client with no connection, so attribute the entry to the calling client. */
+    client *caller = scriptIsRunning() ? scriptGetCaller() : c;
+    ce->peerid = sdsnew(getClientPeerId(caller));
+    ce->cname = caller->name ? sdsnew(objectGetVal(caller->name)) : sdsempty();
     return ce;
 }
 
@@ -154,21 +157,13 @@ void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd) {
     robj **argv = c->original_argv ? c->original_argv : c->argv;
     int argc = c->original_argv ? c->original_argc : c->argc;
 
-    /* In script, client will be replaced with its caller, so commandlog needs to use the metrics
-     * of the client that currently executing the command. */
-    long duration = c->duration;
-    unsigned long long net_input_bytes_curr_cmd = c->net_input_bytes_curr_cmd;
-    unsigned long long net_output_bytes_curr_cmd = c->net_output_bytes_curr_cmd;
-
-    /* If a script is currently running, the client passed in is a
-     * fake client. Or the client passed in is the original client
-     * if this is a EVAL or alike, doesn't matter. In this case,
-     * use the original client to get the client information. */
-    c = scriptIsRunning() ? scriptGetCaller() : c;
-
-    commandlogPushEntryIfNeeded(c, argv, argc, duration, COMMANDLOG_TYPE_SLOW);
-    commandlogPushEntryIfNeeded(c, argv, argc, net_input_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REQUEST);
-    commandlogPushEntryIfNeeded(c, argv, argc, net_output_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REPLY);
+    /* 'c' is the client that executed the command: for a command called from a
+     * script this is the fake client, whose argv, metrics and redaction bitmap
+     * describe the executed command. Entry creation resolves the calling client
+     * for the connection identity fields. */
+    commandlogPushEntryIfNeeded(c, argv, argc, c->duration, COMMANDLOG_TYPE_SLOW);
+    commandlogPushEntryIfNeeded(c, argv, argc, c->net_input_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REQUEST);
+    commandlogPushEntryIfNeeded(c, argv, argc, c->net_output_bytes_curr_cmd, COMMANDLOG_TYPE_LARGE_REPLY);
 }
 
 /* The SLOWLOG command. Implements all the subcommands needed to handle the

--- a/src/server.c
+++ b/src/server.c
@@ -3887,9 +3887,12 @@ void call(client *c, int flags) {
     c->flag.force_repl = 0;
     c->flag.prevent_prop = 0;
 
-    /* The redaction bitmap describes the argv of the executing command and is
-     * set on demand by the command itself. Clear any bits left by a previous
-     * command, since resetClient() does not run between queued MULTI commands. */
+    /* The redaction bitmap describes the argv of the command about to execute and
+     * is set on demand by the command itself. Clearing it here covers every case
+     * where one client executes several commands without an intervening
+     * resetClient(): the queued commands of a MULTI, RM_Call sequences issued on a
+     * reused module temp client, and the server.call() chain of a script. Stale
+     * bits would otherwise redact the wrong argument of a later command. */
     c->redact_arg_bitmap = 0;
 
     /* The server core is in charge of propagation when the first entry point

--- a/src/server.c
+++ b/src/server.c
@@ -3887,6 +3887,11 @@ void call(client *c, int flags) {
     c->flag.force_repl = 0;
     c->flag.prevent_prop = 0;
 
+    /* The redaction bitmap describes the argv of the executing command and is
+     * set on demand by the command itself. Clear any bits left by a previous
+     * command, since resetClient() does not run between queued MULTI commands. */
+    c->redact_arg_bitmap = 0;
+
     /* The server core is in charge of propagation when the first entry point
      * of call() is processCommand().
      * The only other option to get to call() without having processCommand

--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -218,7 +218,7 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
         r commandlog reset slow
         # MIGRATE on a missing key returns NOKEY before connecting anywhere,
         # but redacts its AUTH2 arguments while parsing them.
-        r eval {redis.call('migrate', '127.0.0.1', '9999', 'missingkey', '9', '100', 'AUTH2', 'user', 'password')} 0
+        r eval {server.call('migrate', '127.0.0.1', '9999', 'missingkey', '9', '100', 'AUTH2', 'user', 'password')} 0
         r config set commandlog-execution-slower-than -1
         set slowlog_resp [r commandlog get -1 slow]
 

--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -198,6 +198,35 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
         assert_match {* key 9 5000 AUTH2 (redacted) (redacted)} [lindex [lindex $slowlog_resp 0] 3]
     } {} {needs:repl}
 
+    test {COMMANDLOG slow - Redaction does not leak to later commands in a MULTI} {
+        r config set commandlog-execution-slower-than 0
+        r commandlog reset slow
+        r multi
+        r acl setuser commandlog-test-user +get
+        r set foo bar
+        r exec
+        r config set commandlog-execution-slower-than -1
+        set slowlog_resp [r commandlog get -1 slow]
+
+        # The ACL SETUSER redaction must not carry over to the following SET
+        assert_equal {set foo bar} [lindex [lindex $slowlog_resp 0] 3]
+        r acl deluser commandlog-test-user
+    }
+
+    test {COMMANDLOG slow - Redaction is applied to commands executed from scripts} {
+        r config set commandlog-execution-slower-than 0
+        r commandlog reset slow
+        # MIGRATE on a missing key returns NOKEY before connecting anywhere,
+        # but redacts its AUTH2 arguments while parsing them.
+        r eval {redis.call('migrate', '127.0.0.1', '9999', 'missingkey', '9', '100', 'AUTH2', 'user', 'password')} 0
+        r config set commandlog-execution-slower-than -1
+        set slowlog_resp [r commandlog get -1 slow]
+
+        # Entry 0 is the EVAL itself, entry 1 is the MIGRATE the script executed
+        assert_equal {migrate 127.0.0.1 9999 missingkey 9 100 AUTH2 (redacted) (redacted)} \
+            [lindex [lindex $slowlog_resp 1] 3]
+    }
+
     test {COMMANDLOG slow - Rewritten commands are logged as their original command} {
         r config set commandlog-execution-slower-than 0
 


### PR DESCRIPTION
In an earlier commit we didn't properly reset the redaction bitmap during exec, and used the wrong one for lua scripts. This fixes that to properly redact commands. Added new regression tests and all existing tests still pass. 