### PR TITLE
Skip static Lua engine loading in Sentinel mode

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -7768,8 +7768,10 @@ __attribute__((weak)) int main(int argc, char **argv) {
     }
 
 #if defined(LUA_ENABLED) && STATIC_LUA
-    /* Initialize the LUA scripting engine on-startup only when LUA is built statically */
-    if (scriptingEngineManagerFind("lua") == NULL) {
+    /* Initialize the LUA scripting engine on-startup only when LUA is built statically.
+     * Sentinel does not support SCRIPTING commands nor the MODULE commands, so the Lua
+     * engine is not needed here. */
+    if (!server.sentinel_mode && scriptingEngineManagerFind("lua") == NULL) {
         if (moduleLoadStatic("lua", NULL, 0, 0) != C_OK) {
             serverPanic("Lua engine initialization failed, check the server logs.");
         }


### PR DESCRIPTION
Previously we will load the Lua engine under the Sentinel mode.
Its OnLoad then probed `CONFIG GET lua-enable-insecure-api`, which
Sentinel rejects, producing a warning log (added in #3548):
```
<lua> Unable to determine 'lua-enable-insecure-api' configuration value:
ERR unknown command 'CONFIG', with args beginning with: 'GET' 'lua-enable-insecure-api'
```

Sentinel does not support SCRIPTING commands (EVAL/SCRIPT) nor the
MODULE commands, so the statically linked Lua engine is not needed
here. Skip moduleLoadStatic("lua") when server.sentinel_mode is set.