### PR TITLE
Reject non-migration clients for CLUSTER SYNCSLOTS FINISH

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -730,6 +730,15 @@ void clusterCommandSyncSlotsFailoverGranted(client *c) {
 /* Sent by a target primary to a replica in its shard to inform that an ongoing
  * slot import is now finished. */
 void clusterCommandSyncSlotsFinish(client *c) {
+    /* FINISH is sent within the slot migration replication stream, so it must
+     * originate from a slot migration client (primary/AOF). Reject any other
+     * client to prevent driving the import state machine to a terminal state. */
+    if (!mustObeyClient(c)) {
+        addReplyError(c, "CLUSTER SYNCSLOTS FINISH should only be used "
+                         "by slot migration clients");
+        return;
+    }
+
     char *name = NULL;
     char *state = NULL;
     char *message = NULL;

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -1475,6 +1475,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
             assert_error "*ERR CLUSTER SYNCSLOTS PAUSED should only be used by slot migration clients*" {R 0 CLUSTER SYNCSLOTS PAUSED}
             assert_error "*ERR CLUSTER SYNCSLOTS FAILOVER-GRANTED should only be used by slot migration clients*" {R 0 CLUSTER SYNCSLOTS FAILOVER-GRANTED}
             assert_error "*ERR CLUSTER SYNCSLOTS ACK should only be used by slot migration clients*" {R 0 CLUSTER SYNCSLOTS ACK}
+            assert_error "*ERR CLUSTER SYNCSLOTS FINISH should only be used by slot migration clients*" {R 0 CLUSTER SYNCSLOTS FINISH STATE failed NAME $fake_jobname}
             assert_error "*syntax error*" {R 0 CLUSTER SYNCSLOTS UNKNOWN}
 
             assert_causes_conn_drop 0 {


### PR DESCRIPTION
CLUSTER SYNCSLOTS FINISH is an internal message sent by a target primary to
its replicas within the slot migration replication stream, but had no guard
rejecting clients that are not part of that stream. A normal client could
therefore abuse it to drive the import state machine to a terminal state.

Reject any client that is not a primary, AOF or slot migration client via
mustObeyClient(). Note that mustObeyClient() is used here rather than the
c->slot_migration_job check used by the other subcommands, since FINISH is
propagated to replicas and the AOF rather than being received on the import
job connection.