### PR TITLE
Deflake HRANDFIELD CASE 4 test with expired hash fields

### DIFF
--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1549,13 +1549,19 @@ start_server {tags {"hashexpire"}} {
 
         # Now write a persistent elements
         assert_equal {3} [r HSET myhash f8 v8 f9 v9 f10 v10]
-        # make sure this is the elements we will get all the time
+        # The hash still holds 8 expired but not yet reclaimed fields, so CASE 4
+        # picks fields by random sampling over all 11 of them. Sampling gives up
+        # after a bounded number of tries, so the reply may hold fewer than the
+        # requested 3 fields even though 3 valid fields exist. See #4208.
+        # Assert only what is guaranteed: whatever comes back is distinct and is
+        # one of the valid fields.
         for {set i 1} {$i <= 50} {incr i} {
             set result [r hrandfield myhash 3]
-            assert_equal 3 [llength [split $result]]
-            assert_match {*f8*} $result
-            assert_match {*f9*} $result
-            assert_match {*f10*} $result
+            assert_lessthan_equal [llength $result] 3
+            assert_equal [llength $result] [llength [lsort -unique $result]]
+            foreach field $result {
+                assert {$field in {f8 f9 f10}}
+            }
         }
     }
 

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1549,8 +1549,9 @@ start_server {tags {"hashexpire"}} {
 
         # Now write a persistent elements
         assert_equal {3} [r HSET myhash f8 v8 f9 v9 f10 v10]
-        # The hash still holds 8 expired but not yet reclaimed fields, so CASE 4
-        # picks fields by random sampling over all 11 of them. Sampling gives up
+        # HSET on the expired f8 clears its TTL, so the hash now holds 7 expired
+        # but not yet reclaimed fields plus the 3 valid ones, 10 entries in total.
+        # CASE 4 picks fields by random sampling over all 10 of them, and gives up
         # after a bounded number of tries, so the reply may hold fewer than the
         # requested 3 fields even though 3 valid fields exist. See #4208.
         # Assert only what is guaranteed: whatever comes back is distinct and is


### PR DESCRIPTION
Expired hash fields are not reclaimed immediately, so hashTypeLength() still counts them. That inflated size makes hrandfieldWithCountCommand pick CASE 4, which collects fields by random sampling.

The sampler then mostly draws expired entries. hashTypeRandomElement() gives up after 100 internal tries, and the outer loop is capped by maxtries. When expired fields dominate, both budgets can run out before 'count' distinct live fields are collected, so the reply comes back short.

The test used 8 expired and 3 live fields and required all 3 fields on every call, which fails roughly once per 100k calls. Assert only what is guaranteed instead: the reply holds at most 'count' fields, contains no duplicates, and contains only live fields. This keeps coverage of the part of the contract that does hold, in particular that expired fields are never returned.

Fixes: #4208