### PR TITLE
bgIteration: unpause rehashing before flush

### DIFF
--- a/src/bgiteration.c
+++ b/src/bgiteration.c
@@ -592,7 +592,11 @@ static void fullScanIteratorFlushDb(genericIterator *genIt, int cur_dbid) {
     int orig_db = (cur_dbid == -1) ? it->iter_db : it->cur_to_orig_db[cur_dbid];
     if (orig_db == it->iter_db) {
         // We are currently iterating on the DB that's being flushed.
-        it->kvs = NULL;
+        if (it->kvs) {
+            // If it->kvs is set, we're actively scanning and have paused rehash
+            resumeRehashForKvsHashtable(it->kvs, it->kvs_didx);
+            it->kvs = NULL;
+        }
         // Iteration will continue with the next DB.
     }
 }


### PR DESCRIPTION
Minor bug.  When scanning, the full scan iterator pauses rehashing on the hashtable.  When a FLUSHDB occurs, we need to unpause, so that if the hashtable is emptied (but not released/replaced) it doesn't remain paused.

https://github.com/valkey-io/valkey/pull/3648#issuecomment-5160134468