### PR TITLE
Route security/auth crypto through the OpenSSL 3 provider API

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -3295,7 +3295,10 @@ void aclCommand(client *c) {
         }
 
         long chars = (bits + 3) / 4; /* Round to number of characters to emit. */
-        getRandomHexChars(pass, chars);
+        if (!getSecureRandomHexChars(pass, chars)) {
+            addReplyError(c, "The crypto provider could not supply random bytes");
+            return;
+        }
         addReplyBulkCBuffer(c, pass, chars);
     } else if (!strcasecmp(sub, "log") && (c->argc == 2 || c->argc == 3)) {
         long count = 10; /* Number of entries to emit by default. */

--- a/src/server.c
+++ b/src/server.c
@@ -7530,7 +7530,16 @@ __attribute__((weak)) int main(int argc, char **argv) {
     umask(server.umask = umask(0777));
 
     uint8_t hashseed[16];
-    getRandomBytes(hashseed, sizeof(hashseed));
+    if (!getSecureRandomBytes(hashseed, sizeof(hashseed))) {
+        /* This runs before initServerConfig(), so server.logfile is still NULL
+         * and serverLog()/serverPanic() would crash before printing anything.
+         * Write the diagnostic directly and refuse to start. */
+        fprintf(stderr,
+                "FATAL: could not obtain secure random bytes for the hash seed.\n"
+                "The configured OpenSSL provider did not supply randomness. Check that the\n"
+                "provider named in openssl.cnf is installed, loadable, and passing its self tests.\n");
+        exit(1);
+    }
     hashtableSetHashFunctionSeed(hashseed);
 
     char *exec_name = strrchr(argv[0], '/');

--- a/src/unit/test_util.cpp
+++ b/src/unit/test_util.cpp
@@ -347,3 +347,49 @@ TEST_F(UtilTest, TestWritePointerWithPadding) {
         ASSERT_EQ(buf[i], 0u);
     }
 }
+
+/* getSecureRandomHexChars() must emit only [0-9a-f] and must not write past
+ * len. The charset is the documented contract, so it is an oracle independent
+ * of whichever generator backs the call. */
+TEST_F(UtilTest, TestSecureRandomHexCharsCharset) {
+    char buf[128];
+    const size_t len = sizeof(buf) - 1;
+
+    buf[len] = '#'; /* Canary. */
+    ASSERT_EQ(getSecureRandomHexChars(buf, len), 1);
+
+    for (size_t i = 0; i < len; i++) {
+        ASSERT_TRUE((buf[i] >= '0' && buf[i] <= '9') || (buf[i] >= 'a' && buf[i] <= 'f'))
+            << "byte " << i << " outside the documented charset";
+    }
+    ASSERT_EQ(buf[len], '#') << "wrote past len";
+}
+
+/* Every byte position must actually be written. Prefill with a canary and draw
+ * repeatedly: a position left untouched keeps the canary in every draw, which
+ * catches a partial fill or a chunking loop that stops short. A working CSPRNG
+ * leaves a given position equal to the canary in all 24 draws with probability
+ * 2^-192, so a false failure is not a practical concern.
+ *
+ * A plain memcmp against the canary buffer would not catch this: memcmp stops
+ * at the first difference, so a half-filled buffer still compares unequal. */
+TEST_F(UtilTest, TestSecureRandomBytesFillsEveryPosition) {
+    const size_t kLen = 64;
+    const unsigned char kCanary = 0xA5;
+    const int kDraws = 24;
+    unsigned char probe[kLen + 1];
+    bool differed[kLen] = {false};
+
+    for (int draw = 0; draw < kDraws; draw++) {
+        memset(probe, kCanary, sizeof(probe));
+        ASSERT_EQ(getSecureRandomBytes(probe, kLen), 1);
+        ASSERT_EQ(probe[kLen], kCanary) << "wrote past len";
+        for (size_t i = 0; i < kLen; i++) {
+            if (probe[i] != kCanary) differed[i] = true;
+        }
+    }
+
+    for (size_t i = 0; i < kLen; i++) {
+        ASSERT_TRUE(differed[i]) << "byte " << i << " was never written in " << kDraws << " draws";
+    }
+}

--- a/src/util.c
+++ b/src/util.c
@@ -55,6 +55,20 @@
 #include "valkey_strtod.h"
 #include "monotonic.h"
 
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+#include <openssl/rand.h>
+/* Drawing secret material from a configured provider needs the OpenSSL 3
+ * provider APIs and config-driven provider selection. Older OpenSSL and
+ * LibreSSL have neither, so those builds keep the bundled generator.
+ *
+ * USE_OPENSSL == 1 means BUILD_TLS=yes. BUILD_TLS=module compiles the server
+ * with USE_OPENSSL == 2 but does not link libcrypto into it (src/Makefile),
+ * so a module build keeps the bundled generator as well. */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(LIBRESSL_VERSION_NUMBER)
+#define USE_OPENSSL_PROVIDER_CRYPTO 1
+#endif
+#endif
+
 #if HAVE_X86_SIMD
 #include <immintrin.h>
 #endif
@@ -1144,7 +1158,12 @@ void getRandomSeedCString(char *buff, size_t len) {
  * the uses a one way hash function in counter mode to generate a random
  * stream. However if /dev/urandom is not available, a weaker seed is used.
  *
- * This function is not thread safe, since the state is global. */
+ * This function is not thread safe, since the state is global.
+ *
+ * This is the non-secret entry point: run ids, replication ids, cluster node
+ * names and shard ids, the RDB EOF mark, migrate slot job names, the sentinel
+ * id, and ValkeyModule_GetRandomBytes(). Secret material uses
+ * getSecureRandomBytes() below. */
 void getRandomBytes(unsigned char *p, size_t len) {
     static uint64_t counter = 0; /* The counter we hash with the seed. */
 
@@ -1198,6 +1217,59 @@ void getRandomHexChars(char *p, size_t len) {
 
     getRandomBytes((unsigned char *)p, len);
     for (j = 0; j < len; j++) p[j] = charset[p[j] & 0x0F];
+}
+
+/* Get random bytes for secret material. Returns 1 on success, 0 on failure.
+ *
+ * When built with TLS against OpenSSL 3 this draws from the RAND provider via
+ * RAND_priv_bytes(), so the provider configured in openssl.cnf supplies the
+ * secret. RAND_priv_bytes() rather than RAND_bytes() because OpenSSL keeps a
+ * separate DRBG for private material; the two in-tree callers here, ACL
+ * GENPASS and the hash function seed, are both secret, so the private one is
+ * the correct source.
+ *
+ * A failure returns 0 and the caller must fail closed. There is deliberately
+ * no fallback to getRandomBytes() in a provider build: its seed degrades to
+ * clock and pid entropy when /dev/urandom cannot be read, which is not an
+ * acceptable substitute for a secret.
+ *
+ * Builds that cannot reach a provider (no TLS, OpenSSL below 3, LibreSSL, and
+ * BUILD_TLS=module, which does not link libcrypto into the server) use
+ * getRandomBytes() and always return 1. That is what these call sites used
+ * before provider support existed, so those builds are unchanged.
+ *
+ * RAND_priv_bytes() takes an int length, so draw in INT_MAX sized chunks. */
+int getSecureRandomBytes(unsigned char *p, size_t len) {
+#ifdef USE_OPENSSL_PROVIDER_CRYPTO
+    while (len) {
+        int chunk = len > (size_t)INT_MAX ? INT_MAX : (int)len;
+
+        if (RAND_priv_bytes(p, chunk) != 1) return 0;
+        p += chunk;
+        len -= (size_t)chunk;
+    }
+    return 1;
+#else
+    getRandomBytes(p, len);
+    return 1;
+#endif
+}
+
+/* Like getSecureRandomBytes() but the output is restricted to the hex charset
+ * [0-9a-f]. Returns 1 on success, 0 on failure. On failure the buffer contents
+ * are unspecified, so callers must not read it; ACL GENPASS returns an error
+ * without touching it.
+ *
+ * As with getRandomHexChars() each byte yields one hex character, so this is 4
+ * bits of entropy per byte written; callers size the buffer for the strength
+ * they want, which is what ACL GENPASS's (bits + 3) / 4 does. */
+int getSecureRandomHexChars(char *p, size_t len) {
+    char *charset = "0123456789abcdef";
+    size_t j;
+
+    if (!getSecureRandomBytes((unsigned char *)p, len)) return 0;
+    for (j = 0; j < len; j++) p[j] = charset[p[j] & 0x0F];
+    return 1;
 }
 
 /* Given the filename, return the absolute path as an SDS string, or NULL

--- a/src/util.h
+++ b/src/util.h
@@ -119,6 +119,8 @@ void getRandomSeedCString(char *buff, size_t len);
 void setRandomSeedCString(char *seed_str, size_t len);
 void getRandomHexChars(char *p, size_t len);
 void getRandomBytes(unsigned char *p, size_t len);
+int getSecureRandomHexChars(char *p, size_t len);
+int getSecureRandomBytes(unsigned char *p, size_t len);
 long long ustime(void);
 mstime_t mstime(void);
 void writePointerWithPadding(unsigned char *buf, const void *ptr);

--- a/valkey.conf
+++ b/valkey.conf
@@ -1215,6 +1215,27 @@ replica-priority 100
 # For more information about ACL configuration please refer to
 # the Valkey web site at https://valkey.io/topics/acl
 
+# CRYPTO PROVIDER FOR SECRET RANDOMNESS
+#
+# When built with TLS against OpenSSL 3, the random bytes behind ACL GENPASS
+# and the hash function seed are drawn from the OpenSSL provider selected in
+# openssl.cnf, rather than from the generator bundled with Valkey. This makes
+# it possible to have those values come from a validated cryptographic module.
+#
+# No Valkey configuration selects the provider; that is done entirely in
+# openssl.cnf.
+#
+# If the configured provider cannot supply randomness, Valkey fails closed: it
+# refuses to start when the hash seed cannot be drawn, and ACL GENPASS returns
+# an error. It never silently falls back to the bundled generator for these.
+#
+# Non-secret randomness, such as run ids, replication ids, cluster node names
+# and the RDB EOF marker, continues to use the bundled generator and is
+# unaffected.
+#
+# Builds without TLS, against OpenSSL older than 3.0, against LibreSSL, or
+# with TLS built as a module all keep the bundled generator.
+
 # ACL LOG
 #
 # The ACL Log tracks failed commands and authentication events associated


### PR DESCRIPTION
## What this changes

Two call sites draw their random bytes from OpenSSL instead of from the generator bundled with Valkey:

- `ACL GENPASS` (`src/acl.c`)
- the hash function seed at startup (`src/server.c`)

Nothing else changes. `getRandomBytes()` is byte-identical to master and still serves run ids, replication ids, cluster node names and shard ids, the RDB EOF mark, migrate slot job names and the sentinel id.

## Why it needs a code change

Valkey ships its own SHA-256 and its own random generator in `src/sha256.c` and `src/util.c`. Neither calls into OpenSSL, so no `openssl.cnf` setting can affect them. An operator who has configured OpenSSL to use a particular cryptographic module still gets Valkey's bundled generator for `ACL GENPASS`.

That matters to deployments that have to show their secrets came from a specific validated module, which is a procurement requirement in a fair number of government and finance environments. Today Valkey cannot be used in those deployments regardless of how OpenSSL is configured.

The change is narrow because only two values in the server are secret. Everything else `getRandomBytes()` produces is an identifier that gets published in `INFO` or sent over the wire, so there is no reason to move it.

## Why `RAND_priv_bytes()` and not `RAND_bytes()`

OpenSSL keeps two DRBGs: a public one and a private one intended for material that is never disclosed. Both are equally strong; the split exists so that output an attacker can observe is not drawn from the same instance as material that stays secret.

Both call sites here are secret, so the private one is the correct source. This is also why the change is deliberately not exposed through the module API: that would let arbitrary modules call it for public values, and the reason for choosing the private DRBG would no longer hold.

## Failure behavior

If the configured provider cannot supply randomness, both call sites fail closed rather than falling back:

- `ACL GENPASS` returns an error to the client.
- The startup seed draw prints a diagnostic to stderr and exits.

Falling back would be worse than failing. The bundled generator seeds from `/dev/urandom`, but when that cannot be read it degrades to a mix of `gettimeofday()` and the pid, which is not a reasonable source for a password. An operator who asked for provider-supplied secrets should get an error, not a quietly weaker secret.

The startup path writes to stderr rather than calling `serverLog()` because it runs before `initServerConfig()`, where `server.logfile` is still NULL and `serverLogRaw()` would dereference it.

## Builds that are not affected

The code is gated on `USE_OPENSSL == 1`. Builds without TLS, against OpenSSL older than 3.0, against LibreSSL, or with `BUILD_TLS=module` all keep the bundled generator and behave exactly as they do today.

`BUILD_TLS=module` is excluded deliberately: `src/Makefile` compiles the server with `USE_OPENSSL=2` in that configuration but does not link `libcrypto` into the server binary, so the provider calls would not link.

## Testing

`src/unit/test_util.cpp` covers the charset contract of `getSecureRandomHexChars()` and checks that every byte position of the buffer is actually written, using a canary prefill across repeated draws. A plain `memcmp` would not catch a partial fill, because it stops at the first difference.

Not covered: the provider-failure path. Exercising it means making `RAND_priv_bytes()` fail, and the `--wrap` harness in `src/unit/wrappers.h` compiles for non-TLS builds too, where that symbol does not exist. I did not want to make the harness conditional for this. Happy to add it if you would rather have it.

## Notes

- `valkey.conf` gains a comment block describing the behavior, since this changes what `ACL GENPASS` depends on.
- No public function changes signature. `getRandomBytes()`, `getRandomHexChars()`, `setRandomSeedCString()` and `getHashSeedFromString()` are all byte-identical to master.
- Password hashing is a separate question and is not in this PR. `ACLHashPassword()` still uses the bundled SHA-256. Routing that through a provider changes behavior on the AUTH path and deserves its own review; I will send it separately if there is interest.
