### PR TITLE
cluster: publish +switch-master Pub/Sub notification on failover

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5680,6 +5680,57 @@ void clusterFailoverReplaceYourPrimary(void) {
     /* Since we have became a new primary node, we may rely on auth_time to
      * determine whether a failover is in progress, so it is best to reset it. */
     server.cluster->failover_auth_time = 0;
+
+    /* 7) Publish a Pub/Sub notification on the '+switch-master' channel so that
+     * cluster-aware clients can immediately update their slot cache without
+     * waiting for the next periodic topology refresh or an error-driven refresh.
+     *
+     * Message format (compatible with Sentinel's +switch-master event):
+     *   <shard_id> <old_master_ip> <old_master_port> <new_master_ip> <new_master_port>
+     *
+     * The message is published locally and propagated to every cluster node via
+     * the cluster bus so that all connected clients receive it regardless of
+     * which node they are subscribed to.
+     *
+     * Use the client-facing (announced) address and port when available so that
+     * the coordinates in the notification are usable by clients even behind NAT
+     * or a load balancer (cluster-announce-client-ipv4 / cluster-announce-client-port). */
+    {
+        /* Prefer the client-facing announced IP; fall back to the cluster-bus IP. */
+        const char *old_ip = (sdslen(old_primary->announce_client_ipv4) != 0)
+                                 ? old_primary->announce_client_ipv4
+                                 : (old_primary->ip[0] ? old_primary->ip : "?");
+        const char *new_ip = (sdslen(myself->announce_client_ipv4) != 0)
+                                 ? myself->announce_client_ipv4
+                                 : (myself->ip[0] ? myself->ip : "?");
+        /* Prefer the client-facing announced port; fall back to the cluster-bus port. */
+        int old_port = old_primary->announce_client_tcp_port
+                           ? old_primary->announce_client_tcp_port
+                           : (server.tls_cluster ? old_primary->tls_port : old_primary->tcp_port);
+        int new_port = myself->announce_client_tcp_port
+                           ? myself->announce_client_tcp_port
+                           : (server.tls_cluster ? myself->tls_port : myself->tcp_port);
+        char msg_buf[512];
+        int msg_len = snprintf(msg_buf, sizeof(msg_buf),
+                               "%.40s %s %d %s %d",
+                               old_primary->shard_id,
+                               old_ip, old_port,
+                               new_ip, new_port);
+        if (msg_len > 0 && msg_len < (int)sizeof(msg_buf)) {
+            /* Use sizeof()-1 to derive the length from the literal, avoiding
+             * hard-coded values that can silently go out of sync. */
+            robj *channel = createStringObject("+switch-master",
+                                               sizeof("+switch-master") - 1);
+            robj *message = createStringObject(msg_buf, msg_len);
+            /* Publish locally and propagate to all cluster nodes. */
+            pubsubPublishMessageAndPropagateToCluster(channel, message, 0);
+            serverLog(LL_NOTICE,
+                      "Cluster failover: published '+switch-master' notification: %s",
+                      msg_buf);
+            decrRefCount(channel);
+            decrRefCount(message);
+        }
+    }
 }
 
 /* This function is called if we are a replica node and our primary serving


### PR DESCRIPTION
## Summary

This PR implements a Pub/Sub failover notification mechanism for Valkey Cluster, addressing [issue #3881](https://github.com/valkey-io/valkey/issues/3881).

When a replica is promoted to master via `clusterFailoverReplaceYourPrimary()`, the node now publishes a `+switch-master` message on the global Pub/Sub channel. This allows cluster-aware clients to update their slot cache immediately, rather than waiting for the next periodic topology refresh or an error-driven `MOVED`/`ASK` redirect.

## Changes

**`src/cluster_legacy.c`** — step 7 added to `clusterFailoverReplaceYourPrimary()`:

- Constructs a `+switch-master` message in the same format as Sentinel:
  ```
  <shard_id> <old_master_ip> <old_master_port> <new_master_ip> <new_master_port>
  ```
- Calls `pubsubPublishMessageAndPropagateToCluster()` which:
  - Publishes the message locally to all subscribers on this node.
  - Propagates the message via the cluster bus to every other node, so clients connected to any node receive the notification.
- Logs the notification at `LL_NOTICE` level.

## Motivation

Currently, cluster clients discover master role changes only through indirect signals such as `MOVED`, `ASK`, `READONLY` errors, connection failures, or periodic `CLUSTER SLOTS` refreshes. This introduces latency proportional to the refresh interval or the next failed command.

Sentinel already provides a well-established `+switch-master` event. Adding the same mechanism to Cluster mode provides a consistent, event-driven way for clients, proxies, and monitoring tools to react to failovers in real time.

## Compatibility

- No protocol changes; uses the existing `PUBLISH`/`CLUSTERMSG_TYPE_PUBLISH` path.
- No new configuration options required.
- Clients that do not subscribe to `+switch-master` are unaffected.
- The channel name `+switch-master` is intentionally identical to the Sentinel channel so that client libraries can reuse the same handler.

## Testing

- Syntax verified with `gcc -fsyntax-only`.
- Manual testing with a 3-node cluster: after `CLUSTER FAILOVER`, the `+switch-master` message was received by a subscriber connected to a different node within milliseconds.

relate client pr： https://github.com/valkey-io/valkey-java/pull/27
