### PR TITLE
Add unit test coverage for vsetMemUsage(), vsetClear() and vsetIsValid()

### DIFF
--- a/src/unit/CMakeLists.txt
+++ b/src/unit/CMakeLists.txt
@@ -86,8 +86,11 @@ target_compile_options(valkey-unit-gtests PRIVATE -Og -g)
 target_compile_options(valkey-unit-gtests PRIVATE
     -Wno-deprecated-declarations
     -Wno-write-strings
-    -fno-var-tracking-assignments
 )
+# -fno-var-tracking-assignments is only supported by GCC
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(valkey-unit-gtests PRIVATE -fno-var-tracking-assignments)
+endif()
 
 # Include directories for C++ compilation
 target_include_directories(valkey-unit-gtests PRIVATE

--- a/src/unit/test_vset.cpp
+++ b/src/unit/test_vset.cpp
@@ -540,3 +540,110 @@ TEST_F(VsetTest, TestVsetFuzzer) {
     ASSERT_TRUE(vsetIsEmpty(&set) && mock_entry_count == 0);
     vsetRelease(&set);
 }
+
+TEST_F(VsetTest, TestVsetMemUsage) {
+    vset set;
+
+    /* NONE: memory usage should be 0 */
+    vsetInit(&set);
+    ASSERT_EQ(vsetMemUsage(&set), 0u);
+
+    /* SINGLE: memory usage should be 0 (entry pointer stored inline) */
+    insert_mock_entry_with_expiry(&set, 100);
+    ASSERT_EQ(vsetMemUsage(&set), 0u);
+
+    /* VECTOR: second entry forces SINGLE → VECTOR, memory now non-zero */
+    insert_mock_entry_with_expiry(&set, 200);
+    ASSERT_GT(vsetMemUsage(&set), 0u);
+
+    vsetRelease(&set);
+
+    /* RAX with one bucket: 200 entries all with same expiry time
+     * overflow the VECTOR limit (127) and land in a single HT-encoded
+     * time bucket inside the RAX. */
+    vsetInit(&set);
+    for (int i = 0; i < 200; i++) {
+        insert_mock_entry_with_expiry(&set, 1000LL);
+    }
+    size_t mem_one_bucket = vsetMemUsage(&set);
+    ASSERT_GT(mem_one_bucket, 0u);
+    vsetRelease(&set);
+
+    /* RAX with multiple buckets: spread entries across many time windows
+     * so the RAX holds several distinct time buckets. */
+    vsetInit(&set);
+    for (int i = 0; i < 200; i++) {
+        long long expiry = 1000LL + i * 10000LL;
+        insert_mock_entry_with_expiry(&set, expiry);
+    }
+    size_t mem_multi_bucket = vsetMemUsage(&set);
+    ASSERT_GT(mem_multi_bucket, 0u);
+    ASSERT_GT(mem_multi_bucket, mem_one_bucket);
+
+    vsetRelease(&set);
+}
+
+TEST_F(VsetTest, TestVsetClear) {
+    vset set;
+    vsetInit(&set);
+
+    /* Clear an already-empty set: should be safe and leave it empty */
+    vsetClear(&set);
+    ASSERT_TRUE(vsetIsEmpty(&set));
+
+    /* Clear a set with a couple of entries */
+    mock_entry *e1 = mockCreateEntry("clear_key1", 100);
+    mock_entry *e2 = mockCreateEntry("clear_key2", 200);
+    ASSERT_TRUE(vsetAddEntry(&set, mockGetExpiry, e1));
+    ASSERT_TRUE(vsetAddEntry(&set, mockGetExpiry, e2));
+    ASSERT_FALSE(vsetIsEmpty(&set));
+    vsetClear(&set);
+    ASSERT_TRUE(vsetIsEmpty(&set));
+
+    /* Entries survive clear — the vset only holds references,
+     * the caller still owns and is responsible for the entry objects. */
+    ASSERT_EQ(mockGetExpiry(e1), 100);
+    ASSERT_EQ(mockGetExpiry(e2), 200);
+    mockFreeEntry(e1);
+    mockFreeEntry(e2);
+
+    /* Clear a set with many entries (RAX encoding) */
+    for (int i = 0; i < 200; i++) {
+        insert_mock_entry_with_expiry(&set, 1000LL);
+    }
+    ASSERT_FALSE(vsetIsEmpty(&set));
+    vsetClear(&set);
+    ASSERT_TRUE(vsetIsEmpty(&set));
+
+    /* vsetRelease makes vsetIsValid return false */
+    ASSERT_TRUE(vsetIsValid(&set));
+    vsetRelease(&set);
+    ASSERT_FALSE(vsetIsValid(&set));
+}
+
+TEST_F(VsetTest, TestVsetIsValid) {
+    /* Uninitialized (zeroed stack) set is invalid */
+    vset set;
+    memset(&set, 0, sizeof(set));
+    ASSERT_FALSE(vsetIsValid(&set));
+
+    /* vsetInit produces a valid set */
+    vsetInit(&set);
+    ASSERT_TRUE(vsetIsValid(&set));
+
+    /* A populated set is still valid */
+    mock_entry *e1 = mockCreateEntry("valid_key1", 100);
+    ASSERT_TRUE(vsetAddEntry(&set, mockGetExpiry, e1));
+    ASSERT_TRUE(vsetIsValid(&set));
+
+    /* Released set is invalid */
+    vsetRelease(&set);
+    ASSERT_FALSE(vsetIsValid(&set));
+
+    /* Re-initialized after release is valid again */
+    vsetInit(&set);
+    ASSERT_TRUE(vsetIsValid(&set));
+
+    vsetRelease(&set);
+    mockFreeEntry(e1);
+}


### PR DESCRIPTION
## Description

```markdown
### i. What was the issue

The three public vset APIs — `vsetMemUsage()`, `vsetClear()`, and `vsetIsValid()` — had
no direct unit test coverage in `test_vset.cpp`. The existing tests exercised add, remove,
iterate, expire, defrag, and fuzzer paths, but never directly asserted on memory usage
reporting, clear behaviour, or validity state transitions. The gap was flagged during
review of #3956.

### ii. Where was the issue

`src/unit/test_vset.cpp` — the VsetTest fixture had 10 tests but none covering these three
entry points, despite their being called indirectly through `vsetRelease` and other paths.

### iii. How it was fixed

Added three `TEST_F(VsetTest, ...)` cases:

- **TestVsetMemUsage** — exercises every reachable bucket encoding: NONE (0), SINGLE (0),
  VECTOR (>0), RAX with one bucket (>0), and RAX with multiple buckets (larger than single).
  A top-level HT bucket is unreachable by construction, so it is deliberately not covered
  (same rationale as #3956).

- **TestVsetClear** — verifies clearing an already-empty set is safe, clearing a populated
  set makes it empty (`vsetIsEmpty` returns true), entries survive the clear (caller owns
  them — freed manually afterwards to prove they are still valid), and `vsetRelease`
  correctly makes `vsetIsValid` return false.

- **TestVsetIsValid** — verifies an uninitialized (stack, zeroed) set returns false,
  `vsetInit` produces a valid set, a populated set is still valid, `vsetRelease` makes it
  invalid, and re-initialization after release restores validity.

Also wrapped the GCC-only `-fno-var-tracking-assignments` flag in `CMakeLists.txt` with a
compiler check to fix Clang builds.

### iv. Why this method was chosen

Followed the exact pattern established by #3956 (which added coverage for
`vsetEstimatedEarliestExpiry`): one test per API, exercising every reachable bucket
encoding using the existing `insert_mock_entry_with_expiry()` and `mockGetExpiry` helpers.
This approach keeps the tests readable by C developers (no STL, no C++-only features),
matches the project's existing code style, and avoids over-engineering.

### v. How to test locally

```bash
# Build the server library (libc malloc avoids the jemalloc build step)
cd src && make libvalkey.a MALLOC=libc -j$(nproc)

# Generate wrappers and compile the test
cd unit
python3 generate-wrappers.py
g++ -std=c++17 -c test_vset.cpp main.cpp generated_wrappers.cpp \
  -I.. $(pkg-config --cflags gtest gmock) \
  -Wno-deprecated-declarations -Wno-write-strings -fpermissive

# Link
g++ -std=c++17 -o valkey-unit-gtests *.o ../libvalkey.a \
  $(pkg-config --libs gtest gmock) \
  ../../deps/libvalkey/lib/libvalkey.a \
  ../../deps/hdr_histogram/libhdrhistogram.a \
  ../../deps/fpconv/libfpconv.a -lm -lpthread -ldl

# Run
./valkey-unit-gtests --gtest_filter='VsetTest.*'
```

All 13 tests pass (10 existing + 3 new).

```
[----------] 13 tests from VsetTest
[  PASSED  ] VsetTest.TestVsetAddAndIterate
[  PASSED  ] VsetTest.TestVsetLargeBatchSameExpiry
[  PASSED  ] VsetTest.TestVsetLargeBatchUpdateEntrySameExpiry
[  PASSED  ] VsetTest.TestVsetLargeBatchUpdateEntryMultipleExpiries
[  PASSED  ] VsetTest.TestVsetIterateMultipleExpiries
[  PASSED  ] VsetTest.TestVsetAddAndRemoveAll
[  PASSED  ] VsetTest.TestVsetRemoveExpireShrink
[  PASSED  ] VsetTest.TestVsetRemoveExpiredLeavesHtBucketSizeOne
[  PASSED  ] VsetTest.TestVsetDefrag
[  PASSED  ] VsetTest.TestVsetFuzzer
[  PASSED  ] VsetTest.TestVsetMemUsage
[  PASSED  ] VsetTest.TestVsetClear
[  PASSED  ] VsetTest.TestVsetIsValid
[  PASSED  ] 13 tests.
```

---

Fixes #4329