### PR TITLE
Fix malformed AOF after a short read in MULTI

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1703,11 +1703,7 @@ int loadSingleAppendOnlyFile(char *filename) {
      * If the client is in the middle of a MULTI/EXEC, handle it as it was
      * a short read, even if technically the protocol is correct: we want
      * to remove the unprocessed tail and continue. */
-    if (fakeClient->flag.multi) {
-        serverLog(LL_WARNING, "Revert incomplete MULTI/EXEC transaction in AOF file %s", filename);
-        valid_up_to = valid_before_multi;
-        goto uxeof;
-    }
+    if (fakeClient->flag.multi) goto uxeof;
 
 loaded_ok: /* DB loaded, cleanup and return success (AOF_OK or AOF_TRUNCATED). */
     loadingIncrProgress(ftello(fp) - last_progress_report_size);
@@ -1722,6 +1718,10 @@ readerr: /* Read error. If feof(fp) is true, fall through to unexpected EOF. */
     }
 
 uxeof: /* Unexpected AOF end of file. */
+    if (fakeClient->flag.multi) {
+        serverLog(LL_WARNING, "Revert incomplete MULTI/EXEC transaction in AOF file %s", filename);
+        valid_up_to = valid_before_multi;
+    }
     if (server.aof_load_truncated) {
         serverLog(LL_WARNING, "!!! Warning: short read while loading the AOF file %s!!!", filename);
         serverLog(LL_WARNING, "!!! Truncating the AOF %s at offset %llu !!!", filename,

--- a/src/aof.c
+++ b/src/aof.c
@@ -1588,8 +1588,9 @@ int loadSingleAppendOnlyFile(char *filename) {
             ret = AOF_FAILED;
             goto cleanup;
         } else {
-            loadingAbsProgress(ftello(fp));
-            last_progress_report_size = ftello(fp);
+            valid_up_to = ftello(fp);
+            loadingAbsProgress(valid_up_to);
+            last_progress_report_size = valid_up_to;
             if (old_style) serverLog(LL_NOTICE, "Reading the remaining AOF tail...");
         }
     }

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -517,6 +517,7 @@ tags {"external:skip"} {
             wait_done_loading $client
             assert_equal rdb-value [$client get rdb-key]
             assert_equal {} [$client get transaction-key]
+            assert_equal OK [$client set post-recovery-key post-recovery-value]
 
             restart_server 0 true false
 
@@ -524,6 +525,7 @@ tags {"external:skip"} {
             wait_done_loading $client
             assert_equal rdb-value [$client get rdb-key]
             assert_equal {} [$client get transaction-key]
+            assert_equal post-recovery-value [$client get post-recovery-key]
         }
 
         clean_aof_persistence $aof_dirpath

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -494,6 +494,41 @@ tags {"external:skip"} {
         clean_aof_persistence $aof_dirpath
     }
 
+    test {Old-style RDB-preamble AOF preserves preamble on truncated MULTI} {
+        start_server {overrides {appendonly no aof-use-rdb-preamble yes save {}}} {
+            r select 0
+            r set rdb-key rdb-value
+
+            r config set appendonly yes
+            waitForBgrewriteaof r
+
+            file mkdir $server_path
+            file copy -force [get_base_aof_path r] $aof_old_name_old_path
+        }
+
+        set fp [open $aof_old_name_old_path a]
+        append_to_aof [formatCommand multi]
+        append_to_aof [formatCommand set transaction-key transaction-value]
+        append_to_aof [string range [formatCommand exec] 0 end-1]
+        close $fp
+
+        start_server_aof [list dir $server_path aof-load-truncated yes] {
+            set client [valkey [srv host] [srv port] 0 $::tls]
+            wait_done_loading $client
+            assert_equal rdb-value [$client get rdb-key]
+            assert_equal {} [$client get transaction-key]
+
+            restart_server 0 true false
+
+            set client [valkey [srv host] [srv port] 0 $::tls]
+            wait_done_loading $client
+            assert_equal rdb-value [$client get rdb-key]
+            assert_equal {} [$client get transaction-key]
+        }
+
+        clean_aof_persistence $aof_dirpath
+    }
+
     test {Multi Part AOF can continue the upgrade from the interrupted upgrade state} {
         create_aof $server_path $aof_old_name_old_path {
             append_to_aof [formatCommand set k1 v1]

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -29,6 +29,34 @@ tags {"aof external:skip logreqres:skip"} {
         }
     }
 
+    create_aof $aof_dirpath $aof_file {
+        append_to_aof [formatCommand set foo hello]
+        append_to_aof [formatCommand multi]
+        append_to_aof [formatCommand set bar world]
+        append_to_aof [string range [formatCommand exec] 0 end-1]
+    }
+
+    start_server_aof [list dir $server_path aof-load-truncated yes] {
+        test "Short read in MULTI: Discard incomplete transaction and preserve subsequent writes across restart" {
+            assert_equal 1 [is_alive [srv pid]]
+            set client [valkey [srv host] [srv port] 0 $::tls]
+            wait_done_loading $client
+            assert_equal "hello" [$client get foo]
+            assert_equal {} [$client get bar]
+            assert_equal "OK" [$client set baz survived]
+            assert_equal "survived" [$client get baz]
+
+            restart_server 0 true false
+
+            assert_equal 1 [is_alive [srv pid]]
+            set client [valkey [srv host] [srv port] 0 $::tls]
+            wait_done_loading $client
+            assert_equal "hello" [$client get foo]
+            assert_equal {} [$client get bar]
+            assert_equal "survived" [$client get baz]
+        }
+    }
+
     ## Should also start with truncated AOF without incomplete MULTI block.
     create_aof $aof_dirpath $aof_file {
         append_to_aof [formatCommand incr foo]


### PR DESCRIPTION
When a Lua script or a transaction produces multiple write operations, these operations are persisted to the AOF inside a `MULTI`/`EXEC` block.

In cases such as a machine power failure, only part of the block may be persisted:

```text
SET foo hello
MULTI
SET bar world
EX
```

With `aof-load-truncated yes`, the server previously removed only the
partial `EXEC`, leaving an incomplete `MULTI` block in the AOF:

```
SET foo hello
MULTI
SET bar world
```

New writes could then be lost after another restart.

This PR fixes the issue by truncating the AOF before `MULTI` and adds a
regression test for this case.