### PR TITLE
Fix frozen monotonic clock on unsynchronised TSC hosts

### DIFF
--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -48,9 +48,9 @@ static monotime getMonotonicUs_x86(void) {
     return ((__uint128_t)__rdtsc() * mono_ticks_speed) >> MONO_FPMULT_SHIFT;
 }
 
-/* Reject TSC when the kernel is not using it as clocksource (e.g. after a
- * cross-core sync failure). If sysfs is unavailable, return 0 and defer. */
-static int kernelClocksourceRejectsTsc(void) {
+/* Return 1 only when the kernel is using TSC as clocksource. Fail closed if
+ * sysfs is unreadable: constant_tsc alone does not prove cross-core sync. */
+static int kernelClocksourceIsTsc(void) {
     char buf[64];
     size_t len;
     FILE *f = fopen("/sys/devices/system/clocksource/clocksource0/current_clocksource", "r");
@@ -64,7 +64,7 @@ static int kernelClocksourceRejectsTsc(void) {
     len = strlen(buf);
     while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r' || buf[len - 1] == ' '))
         buf[--len] = '\0';
-    return strcmp(buf, "tsc") != 0;
+    return strcmp(buf, "tsc") == 0;
 }
 
 static void monotonicInit_x86linux(void) {
@@ -76,7 +76,7 @@ static void monotonicInit_x86linux(void) {
     int constantTsc = 0;
     int rc;
 
-    if (kernelClocksourceRejectsTsc()) {
+    if (!kernelClocksourceIsTsc()) {
         fprintf(stderr, "monotonic: x86 linux, kernel clocksource is not tsc");
         return;
     }

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -2,6 +2,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 #include "serverassert.h"
 
@@ -31,6 +32,7 @@ static char monotonic_info_string[32];
  *   USE_PROCESSOR_CLOCK: processor clock usage not explicitly disabled
  *   __x86_64__: requires 64-bit x86 architecture (for rdtsc instruction and 128-bit arithmetic)
  *   __linux__: needed to access /proc/cpuinfo for verifying 'constant_tsc' CPU flag
+ *              and the kernel clocksource sysfs node for cross-core TSC trust
  *   __SIZEOF_INT128__: requires compiler support for 128-bit integers to prevent wraparound
  */
 #if defined(USE_PROCESSOR_CLOCK) && defined(__x86_64__) && defined(__linux__) && defined(__SIZEOF_INT128__)
@@ -46,6 +48,25 @@ static monotime getMonotonicUs_x86(void) {
     return ((__uint128_t)__rdtsc() * mono_ticks_speed) >> MONO_FPMULT_SHIFT;
 }
 
+/* Reject TSC when the kernel is not using it as clocksource (e.g. after a
+ * cross-core sync failure). If sysfs is unavailable, return 0 and defer. */
+static int kernelClocksourceRejectsTsc(void) {
+    char buf[64];
+    size_t len;
+    FILE *f = fopen("/sys/devices/system/clocksource/clocksource0/current_clocksource", "r");
+    if (f == NULL) return 0;
+    if (fgets(buf, sizeof(buf), f) == NULL) {
+        fclose(f);
+        return 0;
+    }
+    fclose(f);
+
+    len = strlen(buf);
+    while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r' || buf[len - 1] == ' '))
+        buf[--len] = '\0';
+    return strcmp(buf, "tsc") != 0;
+}
+
 static void monotonicInit_x86linux(void) {
     const int bufflen = 256;
     char buf[bufflen];
@@ -54,6 +75,11 @@ static void monotonicInit_x86linux(void) {
     regmatch_t pmatch[nmatch];
     int constantTsc = 0;
     int rc;
+
+    if (kernelClocksourceRejectsTsc()) {
+        fprintf(stderr, "monotonic: x86 linux, kernel clocksource is not tsc");
+        return;
+    }
 
     /* Calibrate TSC ticks per microsecond against CLOCK_MONOTONIC.
      * This determines the actual TSC frequency regardless of what
@@ -70,13 +96,16 @@ static void monotonicInit_x86linux(void) {
         clock_gettime(CLOCK_MONOTONIC, &end);
 
         uint64_t elapsed_us = (end.tv_sec - start.tv_sec) * 1000000ULL + (end.tv_nsec - start.tv_nsec) / 1000;
+        /* Discard if TSC went backwards (core migration across unsynced TSCs). */
+        if (tsc_end <= tsc_start || elapsed_us == 0) continue;
         uint64_t tsc_elapsed = tsc_end - tsc_start;
         double sample_ticks_per_us = (double)tsc_elapsed / (double)elapsed_us;
         uint64_t sample_mult = (uint64_t)((double)(1ULL << MONO_FPMULT_SHIFT) / sample_ticks_per_us);
 
         /* Use the minimum out of TSC_CALIBRATION_ITERATIONS iterations for accuracy
-         * because mono_ticks_speed represents an inverse relationship of ticks_per_us. */
-        if (sample_mult < mono_ticks_speed) {
+         * because mono_ticks_speed represents an inverse relationship of ticks_per_us.
+         * Skip a zero multiplier: it would always win the minimum and freeze the clock. */
+        if (sample_mult != 0 && sample_mult < mono_ticks_speed) {
             mono_ticks_speed = sample_mult;
         }
     }
@@ -98,7 +127,7 @@ static void monotonicInit_x86linux(void) {
     }
     regfree(&constTscRegex);
 
-    if (mono_ticks_speed == UINT64_MAX) {
+    if (mono_ticks_speed == UINT64_MAX || mono_ticks_speed == 0) {
         fprintf(stderr, "monotonic: x86 linux, unable to determine clock rate");
         return;
     }

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -2,7 +2,6 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
 #include <time.h>
 #include "serverassert.h"
 
@@ -32,7 +31,6 @@ static char monotonic_info_string[32];
  *   USE_PROCESSOR_CLOCK: processor clock usage not explicitly disabled
  *   __x86_64__: requires 64-bit x86 architecture (for rdtsc instruction and 128-bit arithmetic)
  *   __linux__: needed to access /proc/cpuinfo for verifying 'constant_tsc' CPU flag
- *              and the kernel clocksource sysfs node for cross-core TSC trust
  *   __SIZEOF_INT128__: requires compiler support for 128-bit integers to prevent wraparound
  */
 #if defined(USE_PROCESSOR_CLOCK) && defined(__x86_64__) && defined(__linux__) && defined(__SIZEOF_INT128__)
@@ -48,25 +46,6 @@ static monotime getMonotonicUs_x86(void) {
     return ((__uint128_t)__rdtsc() * mono_ticks_speed) >> MONO_FPMULT_SHIFT;
 }
 
-/* Return 1 only when the kernel is using TSC as clocksource. Fail closed if
- * sysfs is unreadable: constant_tsc alone does not prove cross-core sync. */
-static int kernelClocksourceIsTsc(void) {
-    char buf[64];
-    size_t len;
-    FILE *f = fopen("/sys/devices/system/clocksource/clocksource0/current_clocksource", "r");
-    if (f == NULL) return 0;
-    if (fgets(buf, sizeof(buf), f) == NULL) {
-        fclose(f);
-        return 0;
-    }
-    fclose(f);
-
-    len = strlen(buf);
-    while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r' || buf[len - 1] == ' '))
-        buf[--len] = '\0';
-    return strcmp(buf, "tsc") == 0;
-}
-
 static void monotonicInit_x86linux(void) {
     const int bufflen = 256;
     char buf[bufflen];
@@ -75,11 +54,6 @@ static void monotonicInit_x86linux(void) {
     regmatch_t pmatch[nmatch];
     int constantTsc = 0;
     int rc;
-
-    if (!kernelClocksourceIsTsc()) {
-        fprintf(stderr, "monotonic: x86 linux, kernel clocksource is not tsc");
-        return;
-    }
 
     /* Calibrate TSC ticks per microsecond against CLOCK_MONOTONIC.
      * This determines the actual TSC frequency regardless of what

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -6,19 +6,6 @@ start_server {tags {"other"}} {
         } {ok}
     }
 
-    # Regression for #4345: a zero TSC calibration multiplier freezes
-    # getMonotonicUs() at 0, so serverCron never runs and TIME stalls.
-    test {Monotonic clock is not frozen} {
-        set mono [status r monotonic_clock]
-        assert_no_match {*inf*} $mono
-        set t1 [r time]
-        after 200
-        set t2 [r time]
-        set delta_us [expr {([lindex $t2 0] - [lindex $t1 0]) * 1000000 +
-                            ([lindex $t2 1] - [lindex $t1 1])}]
-        assert {$delta_us >= 100000}
-    }
-
     test {Coverage: HELP commands} {
         assert_match "*OBJECT <subcommand> *" [r OBJECT HELP]
         assert_match "*MEMORY <subcommand> *" [r MEMORY HELP]

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -6,6 +6,19 @@ start_server {tags {"other"}} {
         } {ok}
     }
 
+    # Regression for #4345: a zero TSC calibration multiplier freezes
+    # getMonotonicUs() at 0, so serverCron never runs and TIME stalls.
+    test {Monotonic clock is not frozen} {
+        set mono [status r monotonic_clock]
+        assert_no_match {*inf*} $mono
+        set t1 [r time]
+        after 200
+        set t2 [r time]
+        set delta_us [expr {([lindex $t2 0] - [lindex $t1 0]) * 1000000 +
+                            ([lindex $t2 1] - [lindex $t1 1])}]
+        assert {$delta_us >= 100000}
+    }
+
     test {Coverage: HELP commands} {
         assert_match "*OBJECT <subcommand> *" [r OBJECT HELP]
         assert_match "*MEMORY <subcommand> *" [r MEMORY HELP]


### PR DESCRIPTION
## Summary

- On hosts with unsynchronised TSC, `monotonicInit_x86linux()` can calibrate to a zero multiplier (`tsc_end < tsc_start` wraps unsigned). `getMonotonicUs()` then returns 0 for the process lifetime, so `serverCron` never runs and keys with TTL never expire.
- Discard backwards / invalid calibration samples and reject a zero multiplier so we fall back to POSIX `clock_gettime`.

Fixes #4345

## Test plan

- [ ] On a healthy host: `INFO server` shows a finite `monotonic_clock` (e.g. `X86 TSC @ ... ticks/us`) and advancing `TIME` / uptime
- [ ] (If available) On a host whose kernel uses non-`tsc` clocksource: server starts with `POSIX clock_gettime` instead of a frozen TSC clock