### PR TITLE
fix: guard against NULL dereference in usUntilEarliestTimer when all time events are pending deletion

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -312,6 +312,9 @@ static int64_t usUntilEarliestTimer(aeEventLoop *eventLoop) {
         te = te->next;
     }
 
+    /* If all time events are pending deletion, return -1. */
+    if (earliest == NULL) return -1;
+
     monotime now = getMonotonicUs();
     return (now >= earliest->when) ? 0 : earliest->when - now;
 }


### PR DESCRIPTION
## Description

`usUntilEarliestTimer()` (src/ae.c) scans the time-event list for the earliest timer that is not pending deletion. When **every** remaining time event is a lazy-deleted zombie (`id == AE_DELETED_EVENT_ID`), the scan finds nothing, `earliest` stays `NULL`, and the function dereferences it.

The empty-list case is guarded (`if (te == NULL) return -1;`), the all-zombies case is not.

## Fix

Add a NULL check for `earliest` after the while loop, returning `-1` when all events are pending deletion (same semantics as the empty-list case).

## Background

This is the identical bug that Redis fixed in redis/redis#15391 (June 2026). Valkey did not have the guard.

Closes #4349