### PR TITLE
Fix NULL dereference in usUntilEarliestTimer when all timers are deleted

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -312,6 +312,8 @@ static int64_t usUntilEarliestTimer(aeEventLoop *eventLoop) {
         te = te->next;
     }
 
+    if (earliest == NULL) return -1;
+
     monotime now = getMonotonicUs();
     return (now >= earliest->when) ? 0 : earliest->when - now;
 }

--- a/src/unit/test_ae.cpp
+++ b/src/unit/test_ae.cpp
@@ -1,0 +1,86 @@
+/*
+ * Test: ae event loop survives when all time events are deleted.
+ *
+ * This test verifies that aeProcessEvents() does not crash when
+ * all time events have been lazy-deleted (id == AE_DELETED_EVENT_ID).
+ * The bug was a NULL dereference in usUntilEarliestTimer() when the
+ * scan loop found no valid time events.
+ */
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "../ae.h"
+#include "../anet.h"
+#include <unistd.h>
+}
+
+/* Simple time-event callback that self-deletes. */
+static long long selfDeletingProc(aeEventLoop *el, long long id, void *clientData) {
+    (void)el;
+    (void)id;
+    int *called = (int *)clientData;
+    *called = 1;
+    return AE_NOMORE;
+}
+
+static long long noopProc(aeEventLoop *el, long long id, void *clientData) {
+    (void)el;
+    (void)id;
+    (void)clientData;
+    return 1000000;
+}
+
+TEST(AeEventLoopTest, SurvivesWhenAllTimeEventsDeleted) {
+    aeEventLoop *el = aeCreateEventLoop(128);
+    ASSERT_NE(el, nullptr);
+
+    /* Create two time events that will self-delete on first fire. */
+    int called1 = 0, called2 = 0;
+    ASSERT_NE(aeCreateTimeEvent(el, 0, selfDeletingProc, &called1, NULL), -1);
+    ASSERT_NE(aeCreateTimeEvent(el, 0, selfDeletingProc, &called2, NULL), -1);
+
+    /*
+     * Process time events once. Both events should fire and self-delete,
+     * setting their id to AE_DELETED_EVENT_ID. The deletion is lazy --
+     * the nodes remain in the linked list until the next cleanup pass.
+     */
+    aeProcessEvents(el, AE_TIME_EVENTS);
+
+    EXPECT_EQ(called1, 1);
+    EXPECT_EQ(called2, 1);
+
+    /*
+     * Process time events again. With all events deleted, the scan
+     * loop in usUntilEarliestTimer() should find no valid events.
+     * Before the fix, this would dereference a NULL pointer and crash.
+     * After the fix, it should return -1 and the caller should handle it.
+     */
+    aeProcessEvents(el, AE_TIME_EVENTS);
+
+    /* If we reach here without crashing, the fix works. */
+    SUCCEED() << "Survived aeProcessEvents with all time events deleted";
+
+    aeDeleteEventLoop(el);
+}
+
+TEST(AeEventLoopTest, HandlesMixedDeletedAndActiveTimers) {
+    aeEventLoop *el = aeCreateEventLoop(128);
+    ASSERT_NE(el, nullptr);
+
+    int called1 = 0, called2 = 0;
+    ASSERT_NE(aeCreateTimeEvent(el, 0, selfDeletingProc, &called1, NULL), -1);
+    ASSERT_NE(aeCreateTimeEvent(el, 0, noopProc, &called2, NULL), -1);
+
+    /* First fire: event1 self-deletes, event2 reschedules. */
+    aeProcessEvents(el, AE_TIME_EVENTS);
+
+    EXPECT_EQ(called1, 1);
+
+    /* Second fire: only event2 is active, should not crash. */
+    aeProcessEvents(el, AE_TIME_EVENTS);
+
+    SUCCEED() << "Survived with mixed deleted and active timers";
+
+    aeDeleteEventLoop(el);
+}

--- a/src/unit/test_ae.cpp
+++ b/src/unit/test_ae.cpp
@@ -5,82 +5,114 @@
  * all time events have been lazy-deleted (id == AE_DELETED_EVENT_ID).
  * The bug was a NULL dereference in usUntilEarliestTimer() when the
  * scan loop found no valid time events.
+ *
+ * A permanently-readable pipe is registered as a file event so that
+ * aeApiPoll() returns immediately instead of blocking forever (the
+ * test would otherwise hang because there are no file events and no
+ * valid time events to wake the loop).
  */
 
 #include "gtest/gtest.h"
 
 extern "C" {
 #include "../ae.h"
-#include "../anet.h"
 #include <unistd.h>
 }
 
-/* Simple time-event callback that self-deletes. */
+/* File event callback for the always-readable pipe. */
+static void pipeFileProc(aeEventLoop *el, int fd, void *clientData, int mask) {
+    (void)el;
+    (void)fd;
+    (void)clientData;
+    (void)mask;
+    /* Intentionally do nothing; the pipe stays readable via the unread byte. */
+}
+
+/* Time-event callback that self-deletes on first fire. */
 static long long selfDeletingProc(aeEventLoop *el, long long id, void *clientData) {
     (void)el;
     (void)id;
     int *called = (int *)clientData;
     *called = 1;
-    return AE_NOMORE;
+    return AE_NOMORE;  /* delete this event */
 }
 
+/* Time-event callback that does nothing (stays active). */
 static long long noopProc(aeEventLoop *el, long long id, void *clientData) {
     (void)el;
     (void)id;
     (void)clientData;
-    return 1000000;
+    return 1000000;  /* reschedule in 1 second */
 }
 
 TEST(AeEventLoopTest, SurvivesWhenAllTimeEventsDeleted) {
+    int pipefds[2];
+    ASSERT_EQ(pipe(pipefds), 0);
+
     aeEventLoop *el = aeCreateEventLoop(128);
     ASSERT_NE(el, nullptr);
+
+    /* Register the always-readable pipe so aeApiPoll returns immediately. */
+    ASSERT_EQ(aeCreateFileEvent(el, pipefds[0], AE_READABLE, pipeFileProc, NULL), AE_OK);
+
+    /* Write a byte so the pipe is readable (aeApiPoll wakes on it). */
+    char byte = 'x';
+    ASSERT_EQ((int)write(pipefds[1], &byte, 1), 1);
 
     /* Create two time events that will self-delete on first fire. */
     int called1 = 0, called2 = 0;
     ASSERT_NE(aeCreateTimeEvent(el, 0, selfDeletingProc, &called1, NULL), -1);
     ASSERT_NE(aeCreateTimeEvent(el, 0, selfDeletingProc, &called2, NULL), -1);
 
-    /*
-     * Process time events once. Both events should fire and self-delete,
-     * setting their id to AE_DELETED_EVENT_ID. The deletion is lazy --
-     * the nodes remain in the linked list until the next cleanup pass.
-     */
-    aeProcessEvents(el, AE_TIME_EVENTS);
-
+    /* First pass: both events fire and self-delete. */
+    aeProcessEvents(el, AE_ALL_EVENTS);
     EXPECT_EQ(called1, 1);
     EXPECT_EQ(called2, 1);
 
     /*
-     * Process time events again. With all events deleted, the scan
-     * loop in usUntilEarliestTimer() should find no valid events.
-     * Before the fix, this would dereference a NULL pointer and crash.
-     * After the fix, it should return -1 and the caller should handle it.
+     * Second pass: with all time events deleted, the scan loop in
+     * usUntilEarliestTimer() finds no valid events. Before the fix this
+     * would dereference a NULL pointer and crash; after the fix it should
+     * return -1 and the caller handles it. The pipe keeps the loop alive.
      */
-    aeProcessEvents(el, AE_TIME_EVENTS);
+    aeProcessEvents(el, AE_ALL_EVENTS);
 
-    /* If we reach here without crashing, the fix works. */
-    SUCCEED() << "Survived aeProcessEvents with all time events deleted";
-
+    aeDeleteFileEvent(el, pipefds[0], AE_READABLE);
     aeDeleteEventLoop(el);
+    close(pipefds[0]);
+    close(pipefds[1]);
+
+    SUCCEED() << "Survived aeProcessEvents with all time events deleted";
 }
 
 TEST(AeEventLoopTest, HandlesMixedDeletedAndActiveTimers) {
+    int pipefds[2];
+    ASSERT_EQ(pipe(pipefds), 0);
+
     aeEventLoop *el = aeCreateEventLoop(128);
     ASSERT_NE(el, nullptr);
+
+    ASSERT_EQ(aeCreateFileEvent(el, pipefds[0], AE_READABLE, pipeFileProc, NULL), AE_OK);
+
+    /* Write a byte so the pipe is readable (aeApiPoll wakes on it). */
+    char byte = 'x';
+    ASSERT_EQ((int)write(pipefds[1], &byte, 1), 1);
 
     int called1 = 0, called2 = 0;
     ASSERT_NE(aeCreateTimeEvent(el, 0, selfDeletingProc, &called1, NULL), -1);
     ASSERT_NE(aeCreateTimeEvent(el, 0, noopProc, &called2, NULL), -1);
 
-    /* First fire: event1 self-deletes, event2 reschedules. */
-    aeProcessEvents(el, AE_TIME_EVENTS);
-
+    /* First pass: event1 self-deletes, event2 reschedules. */
+    aeProcessEvents(el, AE_ALL_EVENTS);
     EXPECT_EQ(called1, 1);
 
-    /* Second fire: only event2 is active, should not crash. */
-    aeProcessEvents(el, AE_TIME_EVENTS);
+    /* Second pass: only event2 is active, should not crash. */
+    aeProcessEvents(el, AE_ALL_EVENTS);
+
+    aeDeleteFileEvent(el, pipefds[0], AE_READABLE);
+    aeDeleteEventLoop(el);
+    close(pipefds[0]);
+    close(pipefds[1]);
 
     SUCCEED() << "Survived with mixed deleted and active timers";
-
-    aeDeleteEventLoop(el);
 }


### PR DESCRIPTION
## Problem

When all time events in the event loop are lazy-deleted (id == AE_DELETED_EVENT_ID),
`usUntilEarliestTimer()` in `src/ae.c` dereferences a NULL `earliest` pointer.

**Issue**: [#4349](https://github.com/valkey-io/valkey/issues/4349)

## Root Cause

The scan loop on lines 309-313 can leave `earliest` NULL when every remaining time event has `id == AE_DELETED_EVENT_ID`. The existing guard on line 307 handles the truly-empty list case (`te == NULL`), but the list can be non-empty yet contain only zombie events.

## Fix

Add a single-line NULL guard after the scan loop:

```c
if (earliest == NULL) return -1;
```

This is consistent with the existing empty-list guard on line 307 which also returns -1. The caller in `aeProcessEvents()` already handles -1 correctly (line 441: `if (usUntilTimer >= 0)`).

## Regression Test

Added `src/unit/test_ae.cpp` with two tests:
1. `SurvivesWhenAllTimeEventsDeleted` — creates time events, deletes them all, verifies no crash
2. `HandlesMixedDeletedAndActiveTimers` — mixed state of deleted and active timers

## Verification

- Build: `make -j4` succeeds
- The fix is a single added line with no behavioral change for the normal case
- The existing empty-list guard pattern validates the correctness of returning -1
- CI will run the full test suite

## Limitations

- gtest was not available in the local environment for unit test compilation
- The regression test (`test_ae.cpp`) is included but will be validated by CI
- Tested on Linux x86_64 only