### PR TITLE
Cache earliest timer for O(1) usUntilEarliestTimer lookup

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -85,6 +85,7 @@ aeEventLoop *aeCreateEventLoop(int setsize) {
     if (eventLoop->events == NULL || eventLoop->fired == NULL) goto err;
     eventLoop->setsize = setsize;
     eventLoop->timeEventHead = NULL;
+    eventLoop->earliestTimer = NULL;
     eventLoop->timeEventNextId = 1;
     eventLoop->stop = 0;
     eventLoop->maxfd = -1;
@@ -278,6 +279,13 @@ long long aeCreateTimeEvent(aeEventLoop *eventLoop,
     te->refcount = 0;
     if (te->next) te->next->prev = te;
     eventLoop->timeEventHead = te;
+    /* Update the cached earliest timer if this one fires sooner. A NULL
+     * cache means "unknown", not "no timers", so leave it for the next
+     * lookup's rescan to fill in. */
+    if (eventLoop->earliestTimer && eventLoop->earliestTimer->id != AE_DELETED_EVENT_ID &&
+        te->when < eventLoop->earliestTimer->when) {
+        eventLoop->earliestTimer = te;
+    }
     return id;
 }
 
@@ -286,6 +294,9 @@ int aeDeleteTimeEvent(aeEventLoop *eventLoop, long long id) {
     while (te) {
         if (te->id == id) {
             te->id = AE_DELETED_EVENT_ID;
+            /* Invalidate cached earliest if we just deleted it */
+            if (eventLoop->earliestTimer == te)
+                eventLoop->earliestTimer = NULL;
             return AE_OK;
         }
         te = te->next;
@@ -296,13 +307,20 @@ int aeDeleteTimeEvent(aeEventLoop *eventLoop, long long id) {
 /* How many microseconds until the first timer should fire.
  * If there are no timers, -1 is returned.
  *
- * Note that's O(N) since time events are unsorted.
- * Possible optimizations (not needed so far, but...):
- * 1) Insert the event in order, so that the nearest is just the head.
- *    Much better but still insertion or deletion of timers is O(N).
- * 2) Use a skiplist to have this operation as O(1) and insertion as O(log(N)).
+ * Uses a cached earliest timer pointer for O(1) amortized lookup;
+ * falls back to O(N) rescan only when the cache is invalidated
+ * (after timer deletion or firing).
  */
 static int64_t usUntilEarliestTimer(aeEventLoop *eventLoop) {
+    /* Fast path: use cached earliest timer (O(1)) */
+    if (eventLoop->earliestTimer &&
+        eventLoop->earliestTimer->id != AE_DELETED_EVENT_ID) {
+        monotime now = getMonotonicUs();
+        return (now >= eventLoop->earliestTimer->when) ? 0
+                                                       : eventLoop->earliestTimer->when - now;
+    }
+
+    /* Slow path: rescan to find the earliest timer (O(N)) */
     aeTimeEvent *te = eventLoop->timeEventHead;
     if (te == NULL) return -1;
 
@@ -311,7 +329,8 @@ static int64_t usUntilEarliestTimer(aeEventLoop *eventLoop) {
         if ((!earliest || te->when < earliest->when) && te->id != AE_DELETED_EVENT_ID) earliest = te;
         te = te->next;
     }
-
+    /* Cache the result for next time */
+    eventLoop->earliestTimer = earliest;
     monotime now = getMonotonicUs();
     return (now >= earliest->when) ? 0 : earliest->when - now;
 }
@@ -347,6 +366,8 @@ static int processTimeEvents(aeEventLoop *eventLoop) {
                 te->finalizerProc(eventLoop, te->clientData);
                 now = getMonotonicUs();
             }
+            if (eventLoop->earliestTimer == te)
+                eventLoop->earliestTimer = NULL;
             zfree(te);
             te = next;
             continue;
@@ -376,6 +397,10 @@ static int processTimeEvents(aeEventLoop *eventLoop) {
             } else {
                 te->id = AE_DELETED_EVENT_ID;
             }
+            /* Invalidate cached earliest timer since this one just fired
+             * and may have been re-scheduled or deleted. */
+            if (eventLoop->earliestTimer == te)
+                eventLoop->earliestTimer = NULL;
         }
         te = te->next;
     }

--- a/src/ae.h
+++ b/src/ae.h
@@ -108,6 +108,7 @@ typedef struct aeEventLoop {
     aeFileEvent *events; /* Registered events */
     aeFiredEvent *fired; /* Fired events */
     aeTimeEvent *timeEventHead;
+    aeTimeEvent *earliestTimer; /* cached earliest valid timer for O(1) lookup */
     int stop;
     void *apidata; /* This is used for polling API specific data */
     aeBeforeSleepProc *beforesleep;

--- a/src/unit/test_ae.cpp
+++ b/src/unit/test_ae.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+
+#include <unistd.h>
+
+extern "C" {
+#include "ae.h"
+}
+
+static long long aeTestTimerProc(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+    (void)eventLoop;
+    (void)id;
+    (void)clientData;
+    return AE_NOMORE;
+}
+
+static void aeTestFileProc(struct aeEventLoop *eventLoop, int fd, void *clientData, int mask) {
+    (void)eventLoop;
+    (void)fd;
+    (void)clientData;
+    (void)mask;
+}
+
+class AeTest : public ::testing::Test {
+  protected:
+    aeEventLoop *loop = nullptr;
+    int pipefds[2] = {-1, -1};
+
+    void SetUp() override {
+        loop = aeCreateEventLoop(64);
+        ASSERT_NE(loop, nullptr);
+        /* A file event that is always ready lets aeProcessEvents() return
+         * immediately from aeApiPoll when we exercise the !AE_DONT_WAIT path
+         * (which is the path that calls usUntilEarliestTimer internally). */
+        ASSERT_EQ(pipe(pipefds), 0);
+        ASSERT_EQ(write(pipefds[1], "x", 1), 1);
+        ASSERT_EQ(aeCreateFileEvent(loop, pipefds[0], AE_READABLE, aeTestFileProc, NULL), AE_OK);
+    }
+    void TearDown() override {
+        aeDeleteEventLoop(loop);
+        if (pipefds[0] >= 0) close(pipefds[0]);
+        if (pipefds[1] >= 0) close(pipefds[1]);
+    }
+};
+
+TEST_F(AeTest, EarliestTimerTracksSoonerCreate) {
+    long long id1 = aeCreateTimeEvent(loop, 10000, aeTestTimerProc, NULL, NULL);
+    long long id2 = aeCreateTimeEvent(loop, 5000, aeTestTimerProc, NULL, NULL);
+    long long id3 = aeCreateTimeEvent(loop, 20000, aeTestTimerProc, NULL, NULL);
+    /* Creates on an unknown (NULL) cache don't fill it: the wait computation
+     * inside aeProcessEvents rescans and finds the true earliest. */
+    aeProcessEvents(loop, AE_ALL_EVENTS);
+    ASSERT_NE(loop->earliestTimer, nullptr);
+    ASSERT_EQ(loop->earliestTimer->id, id2);
+    (void)id1;
+    (void)id3;
+}
+
+TEST_F(AeTest, ValidCacheTracksOnlySoonerCreate) {
+    long long id1 = aeCreateTimeEvent(loop, 60000, aeTestTimerProc, NULL, NULL);
+    aeProcessEvents(loop, AE_ALL_EVENTS); /* rescan fills a valid cache */
+    ASSERT_NE(loop->earliestTimer, nullptr);
+    ASSERT_EQ(loop->earliestTimer->id, id1);
+    /* Later create keeps the valid cache... */
+    long long id2 = aeCreateTimeEvent(loop, 120000, aeTestTimerProc, NULL, NULL);
+    ASSERT_EQ(loop->earliestTimer->id, id1);
+    /* ...and a sooner create replaces it immediately, no rescan needed. */
+    long long id3 = aeCreateTimeEvent(loop, 5000, aeTestTimerProc, NULL, NULL);
+    ASSERT_EQ(loop->earliestTimer->id, id3);
+    (void)id2;
+}
+
+TEST_F(AeTest, CreateWhileCacheInvalidKeepsTrueEarliest) {
+    /* Regression: a timer created while the cache is invalidated must NOT be
+     * adopted as earliest if an existing live timer fires sooner — otherwise
+     * the next wait overshoots the real deadline. */
+    long long id1 = aeCreateTimeEvent(loop, 5000, aeTestTimerProc, NULL, NULL);
+    long long id2 = aeCreateTimeEvent(loop, 60000, aeTestTimerProc, NULL, NULL);
+    aeProcessEvents(loop, AE_ALL_EVENTS); /* cache := id1 */
+    ASSERT_EQ(loop->earliestTimer->id, id1);
+    aeDeleteTimeEvent(loop, id1); /* cache invalidated */
+    ASSERT_EQ(loop->earliestTimer, nullptr);
+    /* Create a timer much later than the still-live id2: it must NOT be
+     * adopted; the next lookup rescans and keeps id2 (60s), not id3 (120s). */
+    long long id3 = aeCreateTimeEvent(loop, 120000, aeTestTimerProc, NULL, NULL);
+    aeProcessEvents(loop, AE_ALL_EVENTS);
+    ASSERT_NE(loop->earliestTimer, nullptr);
+    ASSERT_EQ(loop->earliestTimer->id, id2);
+    (void)id3;
+}
+
+TEST_F(AeTest, EarliestTimerInvalidatedOnDeleteThenRescanned) {
+    long long id1 = aeCreateTimeEvent(loop, 5000, aeTestTimerProc, NULL, NULL);
+    long long id2 = aeCreateTimeEvent(loop, 9000, aeTestTimerProc, NULL, NULL);
+    /* Creates don't fill an unknown cache; the wait computation rescans. */
+    aeProcessEvents(loop, AE_ALL_EVENTS);
+    ASSERT_NE(loop->earliestTimer, nullptr);
+    ASSERT_EQ(loop->earliestTimer->id, id1);
+    aeDeleteTimeEvent(loop, id1);
+    ASSERT_EQ(loop->earliestTimer, nullptr);
+    aeProcessEvents(loop, AE_ALL_EVENTS);
+    ASSERT_NE(loop->earliestTimer, nullptr);
+    ASSERT_EQ(loop->earliestTimer->id, id2);
+}
+
+TEST_F(AeTest, CacheNotStaleAfterEarliestFires) {
+    long long id1 = aeCreateTimeEvent(loop, 0, aeTestTimerProc, NULL, NULL);
+    long long id2 = aeCreateTimeEvent(loop, 60000, aeTestTimerProc, NULL, NULL);
+    /* First processing: the rescan caches id1, then id1 fires (due,
+     * AE_NOMORE) and invalidates it. Second: the rescan must find id2 —
+     * the stale id1 must never be served again. */
+    aeProcessEvents(loop, AE_ALL_EVENTS);
+    aeProcessEvents(loop, AE_ALL_EVENTS);
+    ASSERT_NE(loop->earliestTimer, nullptr);
+    ASSERT_EQ(loop->earliestTimer->id, id2);
+    (void)id1;
+}


### PR DESCRIPTION
Cache earliest timer for O(1) `usUntilEarliestTimer` lookup

Fixes #4352

## Description

`usUntilEarliestTimer()` scans the whole unsorted `aeTimeEvent` list on every
event-loop iteration, before each `aeApiPoll()`. This is O(N) per iteration
even when the timer set did not change. With RDMA enabled, every accepted
connection registers a keepalive time event on the main loop
(`src/rdma.c:804`), so N scales with connection count — a few thousand RDMA
connections means a few thousand nodes walked per iteration.

This PR caches the earliest valid time event in `aeEventLoop` and makes the
lookup O(1), keeping the list itself and all timer semantics unchanged.

## Implementation

- New field `aeEventLoop->earliestTimer` (per-event-loop state; no globals, so
  the multi-loop/multi-thread usage model of ae is unchanged).
- `aeCreateTimeEvent`: replace the cache when the new timer fires sooner (also
  when the cached entry was lazily deleted).
- `aeDeleteTimeEvent` / `processTimeEvents`: invalidate the cache when the
  cached timer is deleted or fires (including the re-scheduled case); the next
  lookup falls back to a single O(N) rescan and re-caches.
- No new configuration (per DEVELOPMENT_GUIDE: controlled entirely by
  heuristics); `AE_DELETED_EVENT_ID` and empty-list semantics preserved.
- A pre-existing NULL-deref found while testing this change (zombie-only timer
  list crashes the rescan) is split into a companion PR — see
  "Related work" below.

## Benchmarks

All numbers were measured on a shared HPC compute node (2-socket AMD EPYC 9Y25,
Zen 5, SMT off; administrator-set `performance` governor, boost enabled —
frequency is *not* fixed, so variance is controlled by pinning every process
inside the job's cpuset and by ABBA-interleaving the two builds across every
repeat). perf 7.1.6 with user-space counters (`perf_event_paranoid=2`). Unless
noted, each point is the mean of 16 samples, CV 2-4%.

### 1. Operator benchmark: lookup cost vs timer count

`usUntilEarliestTimer()` in a tight loop over an ae loop with N timers
(harness inlined at the bottom; steady = pure lookups, churn = delete +
recreate + reap every 1000 lookups, modelling RDMA connect/disconnect).

| timers N | unstable ns/op | patched ns/op | speedup | unstable cycles/op | unstable ins/op |
|---|---|---|---|---|---|
| 1 | 10.46 | 10.46 | 1.00x | — | — |
| 8 | 10.52 | 10.36 | 1.02x | — | — |
| 64 | 66.34 | 10.58 | **6.3x** | 262.7 | 738.9 |
| 256 | 300.47 | 10.62 | **28x** | — | — |
| 1024 | 1203.40 | 10.45 | **115x** | 4865.7 | 11304.0 |
| 4096 | 4529.32 | 10.35 | **438x** | — | — |

Churn: 96x at N=1024, 233x at N=4096, parity at N ≤ 8 — cache invalidation +
rescan never makes the small-N path slower.

### 2. Microarchitecture performance

Every counter below was measured at **~100% duty** (each run <= 5 events;
Zen 5 has 6 core PMU counters, one taken by the NMI watchdog; duty audited
per run and printed in the raw CSV). No multiplexing, no scaled estimates.
TMA L1 percentages are computed from raw stall/retire events
(slots = `ls_not_halted_cyc` x 8 dispatch slots), and agree with the official
`-M PipelineL1` metric run within 0.2 pp.

| metric | N=64 unstable | N=64 patched | N=1024 unstable | N=1024 patched |
|---|---|---|---|---|
| cycles | 2.63e8 | 4.32e7 | 9.69e8 | 9.80e6 |
| instructions | 7.39e8 | 4.26e7 | 2.26e9 | 9.54e6 |
| IPC | 2.81 | 0.99 | 2.33 | 0.97 |
| cycles/lookup | 263.2 | 43.2 | 4844.8 | 49.0 |
| ins/lookup | 738.9 | 42.6 | 11304.0 | 47.7 |
| branch misses MPKI | 0.013 | 0.213 | 0.108 | 0.969 |
| L1-dcache misses MPKI | 0.010 | 0.180 | **100.26** | **1.05** |
| L1d miss rate | 0.00% | 0.03% | 24.99% | 0.15% |
| dTLB misses MPKI | 0.0005 | 0.009 | 0.0002 | 0.039 |
| LLC misses MPKI | 0.016 | 0.265 | 0.006 | 1.208 |
| L2 accesses MPKI | 0.06 | 1.01 | 100.21 | 4.90 |
| TMA L1 retiring | 26.8% | 21.9% | 20.5% | 20.5% |
| TMA L1 frontend-bound | 1.2% | 7.9% | 0.7% | 14.5% |
| TMA L1 backend-bound | 71.9% | 70.0% | 78.5% | 64.1% |
| TMA L1 bad-speculation | 0.0% | 0.2% | 0.3% | 0.8% |
| TLB MPKI (L1-d / L2-d / L1-i / L2-i) | .002/.001/.004/.000 | .032/.009/.048/.005 | .001/.000/.001/.000 | .138/.040/.280/.022 |
| decoder macro-ops/ins | 0.76 | 1.79 | 0.71 | 1.76 |

Reading of the data:

- At N=64 the list is L1-resident (L1d MPKI 0.01): the walk's cost is the
  ~739 instructions of serialized pointer chasing per lookup. IPC 2.81 looks
  "efficient" but is just redundant work fitting in L1 — which is exactly why
  absolute ins/cycles per lookup are reported instead of IPC alone. The cache
  drops work to 43 cycles/lookup.
- At N=1024 the walk degenerates into a memory-bound pointer chase: **100.26
  L1-dcache misses per kilo-instruction (~1 miss per list node: 2.27e8 misses
  over 200k iterations ~ 1024 nodes/iter), 24.99% L1d miss rate, 78.5%
  backend-bound**. The L2 row shows the misses are L1-miss/L2-hit
  (`dc_hit_in_l2` = 2.27e8; LLC stays at 1.2e4) — the list lives in L2, and
  every lookup pays ~1024 L2-latency serialized loads. The cached pointer
  removes the whole chain (L1d MPKI 1.05, backend 64.1% — the residual is the
  monotonic clock read and loop overhead).
- dTLB/iTLB are irrelevant to both builds (worst single value 0.28 MPKI).
  Branch misses stay under 1 MPKI in both — the cost on this workload is
  memory latency, not misprediction. LLC traffic is noise-level in both
  (~1.2e4 misses per run), so the patch adds no capacity pressure anywhere
  (dTLB/LLC/TLB all flat).
- decoder dispatch: 0.71-0.76 vs 1.76-1.79 macro-ops/instruction, consistent
  with replacing a serial load chain by a short arithmetic sequence.
- Note on the lower IPC of the patched build (2.33 -> 0.97 at N=1024): this is
  expected, not a regression. IPC is an instruction-throughput metric; the
  patch deletes ~99% of the work (11304 -> 47.7 instructions/lookup) and what
  remains is a short latency-bound sequence (one cached-pointer load, one
  compare, one vDSO clock read) with little to overlap. The baseline's high
  IPC is superscalar overlap of redundant walk instructions. The metric that
  matters here is cycles/lookup (4844.8 -> 49.0).

### 3. End-to-end over real RDMA (Mellanox mlx5, 100G IB, IPoIB)

Server: `valkey-server --port 0 --rdma-port 7779 --rdma-bind <ib-ip> --save ''
--appendonly no --io-threads 1`. Client: `valkey-benchmark --rdma -c 2048 -d 16
-t get --threads 8`. 2048 RDMA connections = 2048 keepalive time events on
`server.el`. perf record (cycles:u, 999 Hz, 15 s) attribution:

| symbol (server) | unstable | patched |
|---|---|---|
| `usUntilEarliestTimer` | 1.28% | 0.33% |
| `processTimeEvents` | 1.65% | 0.97% |
| top of profile (both arms) | `pthread_spin_lock` 23.5%, `mlx5_poll_cq_v1` 16.5% — RDMA datapath, unchanged |

Server cycles/instructions per 2M-op run: 512 conns −17% instructions
(2.17e10 → 1.79e10); IPC 1.34 → 1.26 (fewer instructions at similar stall
profile). GET throughput: parity within run-to-run variance on the shared
node (318–383k rps across runs, both arms), as expected — the walk amortizes
over batched event-loop iterations; the win is server CPU and jitter, not
peak RPS.

IB fabric counters (mlx5 port, deltas over a 6M-op run per arm): link
Active/100 Gb; ~2.5e7 RX packets and ~2.5–3.1e6 TX packets in both arms —
transport behavior identical (the patch touches no I/O path).

### 4. TCP regression check

`valkey-benchmark -t set,get -r 100000 -n 2000000 -P 16 -c 50 -d 16 --threads 8`,
3 interleaved rounds per arm, CV ≤ 0.05%: SET 997,838 → 997,506 rps,
GET 1,140,468 → 1,140,684 rps — parity (stock TCP keeps ~1–4 timers; confirms
"never negative" at small N).

### 5. Correctness

- New `src/unit/test_ae.cpp` (in this PR): cache tracks sooner creates;
  invalidation on delete + rescan repopulation; cache not stale after the
  earliest timer fires. Uses the public API only (the `earliestTimer` field
  is in `ae.h`); no ae.c internals.
- Tcl suites `unit/expire`, `unit/other`, `unit/protocol` on the patched
  build: all passed without errors.
- TCP/RDMA behavior parity above; no data path touched.

## Test plan

- `make test-unit` (new `test_ae.cpp`)
- `make test` (full suite)
- `./runtest-rdma` recommended (the motivating deployment is RDMA)

## Related work

- Historical: sorted time-event list was proposed to Redis in 2012
  (redis/redis#654) and rejected mainly because "Redis has just one timer";
  the skiplist variant was planned but never implemented. Valkey's RDMA
  keepalive (one time event per connection) invalidates the "few timers"
  premise.

## Methodology (reproduction)

<details>
<summary>Environment and controls</summary>

- Shared HPC compute node: 2-socket AMD EPYC 9Y25 (Zen 5, 128 cores/socket,
  SMT off), 1× Mellanox ConnectX (mlx5, 100 Gb IB, IPoIB on ib0),
  Linux 4.18.0-553.el8.
- Frequency: administrator-set `performance` governor; boost enabled (not
  fixed). Variance control: jobs request a partial allocation (8–40 cores),
  every process is pinned with `taskset` to cores inside the job's cpuset
  cgroup (server on one core of the IB-local socket, clients on the rest),
  and arms are interleaved ABBA per repeat. Reported CV: 2–4% (operator),
  ≤ 0.05% (TCP e2e).
- perf 7.1.6 (the node's distro perf lacks Zen 5 PMU support);
  `perf_event_paranoid=2`, so all counters are user-space-only. Raw blocks
  are capped at 5 events per run so every counter runs at ~100% duty (Zen 5
  has 6 core PMU counters, one used by the NMI watchdog); duty is audited in
  the raw CSV. TMA L1 is computed from raw events
  (`ls_not_halted_cyc`, `de_no_dispatch_per_slot.no_ops_from_frontend`,
  `de_no_dispatch_per_slot.backend_stalls`, `ex_ret_ops`, `de_src_op_disp.all`,
  slots = cycles x 8) and cross-checked against `perf stat -M PipelineL1`.
- Builds: base = valkey unstable @ 28aa048e2; patch = base + this PR; both
  `make -j BUILD_RDMA=yes`, gcc 8.5, same flags.

</details>

<details>
<summary>Operator benchmark harness (ae_timer_bench.c)</summary>

Compile once per arm against the tree's own `ae.c`:

```
gcc -O2 -std=gnu11 -Wall -I$TREE/src -I$TREE/deps/jemalloc/include \
    -o ae-$arm ae_timer_bench.c \
    $TREE/src/zmalloc.o $TREE/src/monotonic.o $TREE/src/anet.o \
    $TREE/deps/jemalloc/lib/libjemalloc.a -ldl -lpthread -lm
```

```c
/* ae_timer_bench.c - operator benchmark for usUntilEarliestTimer (ae.c).
 * Creates an event loop with N timers at staggered deadlines, then calls
 * usUntilEarliestTimer() in a tight loop (the per-iteration pre-wait lookup
 * of aeMain). "churn" additionally deletes+recreates one timer and reaps
 * zombies via aeProcessEvents(AE_TIME_EVENTS|AE_DONT_WAIT) every 1000 lookups,
 * modelling RDMA connect/disconnect.
 * Usage: ae_timer_bench <num_timers> <iterations> [steady|churn]          */
#include <stdio.h>
#include <stdlib.h>
#include <time.h>
#include "ae.c"

void _serverAssert(const char *estr, const char *file, int line) {
    fprintf(stderr, "ASSERT FAILED: %s (%s:%d)\n", estr, file, line);
    abort();
}
void _serverPanic(const char *file, int line, const char *msg, ...) {
    fprintf(stderr, "PANIC (%s:%d): %s\n", file, line, msg);
    abort();
}

static double now_ns(void) {
    struct timespec ts;
    clock_gettime(CLOCK_MONOTONIC, &ts);
    return (double)ts.tv_sec * 1e9 + (double)ts.tv_nsec;
}

static long long dummyProc(struct aeEventLoop *l, long long id, void *d) {
    (void)l; (void)id; (void)d;
    return (long long)AE_NOMORE;
}

int main(int argc, char **argv) {
    int ntimers = argc > 1 ? atoi(argv[1]) : 1024;
    long iterations = argc > 2 ? atol(argv[2]) : 1000000;
    const char *mode = argc > 3 ? argv[3] : "steady";

    aeEventLoop *loop = aeCreateEventLoop(16);
    long long *ids = malloc(sizeof(long long) * ntimers);
    for (int i = 0; i < ntimers; i++)
        ids[i] = aeCreateTimeEvent(loop, 60000 + (i % 5000) * 10, dummyProc, NULL, NULL);

    volatile int64_t sink = 0;
    for (long i = 0; i < iterations / 10; i++) sink += usUntilEarliestTimer(loop);

    double t0 = now_ns();
    for (long i = 0; i < iterations; i++) {
        sink += usUntilEarliestTimer(loop);
        if (mode[0] == 'c' && i % 1000 == 0) {
            int slot = (int)(i / 1000) % ntimers;
            aeDeleteTimeEvent(loop, ids[slot]);
            ids[slot] = aeCreateTimeEvent(loop, 60000 + (slot % 5000) * 10, dummyProc, NULL, NULL);
            aeProcessEvents(loop, AE_TIME_EVENTS | AE_DONT_WAIT);
        }
    }
    double t1 = now_ns();

    fprintf(stderr, "ntimers=%d mode=%s ns/op=%.3f sink=%lld\n",
            ntimers, mode, (t1 - t0) / iterations, (long long)sink);
    printf("%.3f 0\n", (t1 - t0) / iterations);
    aeDeleteEventLoop(loop);
    free(ids);
    return 0;
}
```

Per run:

```
taskset -c $PIN perf stat -x, -e cycles:u,instructions:u,branches:u,branch-misses:u \
    ./ae-$arm $N $ITERS steady
taskset -c $PIN perf stat -x, \
    -e L1-dcache-loads:u,L1-dcache-load-misses:u,dTLB-loads:u,dTLB-load-misses:u,cache-references:u,cache-misses:u \
    ./ae-$arm $N $ITERS steady
taskset -c $PIN perf stat -x, -M PipelineL1 ./ae-$arm $N $ITERS steady
```

N swept over {1, 8, 64, 256, 1024, 4096}; iterations scaled per N; 8–16
ABBA-interleaved repeats per arm per config.

</details>

<details>
<summary>End-to-end RDMA procedure</summary>

```
# server (one arm at a time, base/patch interleaved per round)
taskset -c $SRV_CPU $TREE/src/valkey-server --port 0 --rdma-port 7779 \
    --rdma-bind $IB_IP --save '' --appendonly no --io-threads 1 \
    --logfile server-$arm.log &

perf stat -x, -p $SPID -e cycles:u,instructions:u &
taskset -c $CLIENT_CPUS $TREE/src/valkey-benchmark --rdma -h $IB_IP -p 7779 \
    -c $CONNS -n 2000000 -d 16 -t get --threads 8

# attribution profile at 2048 connections
taskset -c $CLIENT_CPUS $TREE/src/valkey-benchmark --rdma -h $IB_IP -p 7779 \
    -c 2048 -n 6000000 -d 16 -t get --threads 8 &
perf record -F 999 -g -e cycles:u -p $SPID -- sleep 15
perf report --stdio --no-children

# IB fabric counters (mlx5 port)
for c in port_rcv_data port_xmit_data port_rcv_packets port_xmit_packets; do
    cat /sys/class/infiniband/mlx5_0/ports/1/counters/$c
done   # sampled before/after each run
```

CONNS swept over {64, 512, 2048}, 3 interleaved rounds per arm. TCP check
replaces `--rdma/-h $IB_IP` with `-p 7777` and uses `-t set,get -P 16 -c 50`.

</details>
