### PR TITLE
Add base64 field decoding for benchmark datasets

### DIFF
--- a/src/valkey-benchmark-dataset.c
+++ b/src/valkey-benchmark-dataset.c
@@ -26,23 +26,22 @@ static const char *PLACEHOLDERS[PLACEHOLDER_COUNT] = {
 
 /* Base64 decoding lookup table */
 static const unsigned char b64_decode_table[256] = {
-    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-    255,255,255,255,255,255,255,255,255,255,255, 62,255,255,255, 63,
-     52, 53, 54, 55, 56, 57, 58, 59, 60, 61,255,255,255,  0,255,255,
-    255,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-     15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,255,255,255,255,255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 62, 255, 255, 255, 63,
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 255, 255, 255, 0, 255, 255,
+    255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 255, 255, 255, 255, 255,
     255, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-     41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,255,255,255,255,255,
-    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255
-};
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255};
 
 /* Forward declarations */
 static bool datasetBuildFieldMap(dataset *ds, sds *template_argv, int template_argc);
@@ -284,7 +283,7 @@ static unsigned char *base64Decode(const char *input, size_t input_len, size_t *
         return zmalloc(1);
     }
 
-    /* Calculate output length, accounting for padding. */
+    /* Padding ('=') is only ever valid as the last one or two characters. */
     size_t padding = 0;
     if (input[input_len - 1] == '=') padding++;
     if (input[input_len - 2] == '=') padding++;
@@ -294,11 +293,17 @@ static unsigned char *base64Decode(const char *input, size_t input_len, size_t *
     size_t i = 0, j = 0;
 
     while (i < input_len) {
+        int last_quartet = (i + 4 == input_len);
         unsigned char raw[4];
         for (int k = 0; k < 4; k++) {
             unsigned char ch = (unsigned char)input[i++];
-            /* '=' padding only decodes to 0 and only in the final group. */
             if (ch == '=') {
+                int valid_pad = last_quartet && ((padding == 1 && k == 3) || (padding == 2 && k >= 2));
+                if (!valid_pad) {
+                    fprintf(stderr, "Warning: skipping :base64 field, misplaced '=' padding\n");
+                    zfree(output);
+                    return zmalloc(1);
+                }
                 raw[k] = 0;
                 continue;
             }
@@ -306,10 +311,15 @@ static unsigned char *base64Decode(const char *input, size_t input_len, size_t *
             if (v == 255) {
                 fprintf(stderr, "Warning: skipping :base64 field, invalid character '%c'\n", ch);
                 zfree(output);
-                *out_len = 0;
                 return zmalloc(1);
             }
             raw[k] = v;
+        }
+
+        if (last_quartet && ((padding == 2 && (raw[1] & 0x0f) != 0) || (padding == 1 && (raw[2] & 0x03) != 0))) {
+            fprintf(stderr, "Warning: skipping :base64 field, non-canonical padding bits\n");
+            zfree(output);
+            return zmalloc(1);
         }
 
         if (j < capacity) output[j++] = (raw[0] << 2) | (raw[1] >> 4);
@@ -472,9 +482,16 @@ static sds replaceOccurrence(sds processed_arg, const char *pos, const char *rep
 static sds processFieldsInArg(dataset *ds, sds arg, int record_index) {
     if (!strstr(arg, FIELD_PREFIX)) return arg;
 
-    /* Loop through all field placeholders in the argument */
-    while (strstr(arg, FIELD_PREFIX)) {
-        const char *field_pos = strstr(arg, FIELD_PREFIX);
+    /* Scan the original (text) template once with a moving cursor and build the
+     * result sequentially.  */
+    sds result = sdsempty();
+    const char *cursor = arg;
+    const char *arg_end = arg + sdslen(arg);
+
+    while (cursor < arg_end) {
+        const char *field_pos = strstr(cursor, FIELD_PREFIX);
+        if (!field_pos) break;
+
         const char *field_start = field_pos + FIELD_PREFIX_LEN;
         const char *field_end = strstr(field_start, FIELD_SUFFIX);
         if (!field_end) break;
@@ -485,11 +502,10 @@ static sds processFieldsInArg(dataset *ds, sds arg, int record_index) {
         int field_idx = findFieldIndex(ds, field_start, field_name_len);
         if (field_idx == -1) break;
 
-        const char *field_value = extractDatasetFieldValue(ds, field_idx, record_index);
-        size_t before_len = field_pos - arg;
-        const char *after_start = field_end + FIELD_SUFFIX_LEN;
+        /* Emit the literal text between the cursor and this placeholder. */
+        result = sdscatlen(result, cursor, field_pos - cursor);
 
-        sds result = sdsnewlen(arg, before_len);
+        const char *field_value = extractDatasetFieldValue(ds, field_idx, record_index);
         if (needs_decode) {
             size_t decoded_len;
             unsigned char *decoded = base64Decode(field_value, sdslen(field_value), &decoded_len);
@@ -498,13 +514,16 @@ static sds processFieldsInArg(dataset *ds, sds arg, int record_index) {
         } else {
             result = sdscatlen(result, field_value, sdslen(field_value));
         }
-        result = sdscat(result, after_start);
 
-        sdsfree(arg);
-        arg = result;
+        cursor = field_end + FIELD_SUFFIX_LEN;
     }
 
-    return arg;
+    /* Append whatever text remains after the last substitution (or the whole
+     * unmodified tail if we stopped early on an unresolved placeholder). */
+    result = sdscatlen(result, cursor, arg_end - cursor);
+
+    sdsfree(arg);
+    return result;
 }
 
 static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key, int replace_placeholders, long long keyspacelen, int sequential_replacement) {

--- a/src/valkey-benchmark-dataset.c
+++ b/src/valkey-benchmark-dataset.c
@@ -146,6 +146,9 @@ bool datasetBuildFieldMap(dataset *ds, sds *template_argv, int template_argc) {
             if (!field_end) break;
 
             size_t field_name_len = field_end - field_start;
+            if (field_name_len > 7 && !memcmp(field_start + field_name_len - 7, ":base64", 7)) {
+                field_name_len -= 7;
+            }
             sds field_name = sdsnewlen(field_start, field_name_len);
 
             int field_idx = -1;

--- a/src/valkey-benchmark-dataset.c
+++ b/src/valkey-benchmark-dataset.c
@@ -24,9 +24,30 @@ static const char *PLACEHOLDERS[PLACEHOLDER_COUNT] = {
     "__rand_int__", "__rand_1st__", "__rand_2nd__", "__rand_3rd__", "__rand_4th__",
     "__rand_5th__", "__rand_6th__", "__rand_7th__", "__rand_8th__", "__rand_9th__"};
 
+/* Base64 decoding lookup table */
+static const unsigned char b64_decode_table[256] = {
+    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+    255,255,255,255,255,255,255,255,255,255,255, 62,255,255,255, 63,
+     52, 53, 54, 55, 56, 57, 58, 59, 60, 61,255,255,255,  0,255,255,
+    255,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+     15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,255,255,255,255,255,
+    255, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+     41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,255,255,255,255,255,
+    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255
+};
+
 /* Forward declarations */
 static bool datasetBuildFieldMap(dataset *ds, sds *template_argv, int template_argc);
 static sds getFieldValue(const char *row, int column_index, char delimiter);
+static unsigned char *base64Decode(const char *input, size_t input_len, size_t *out_len);
 static bool csvDiscoverFields(dataset *ds);
 static bool csvLoadDocuments(dataset *ds, int verbose);
 static bool shouldStopLoading(dataset *ds);
@@ -170,7 +191,12 @@ sds datasetGenerateCommand(dataset *ds, int record_index, sds *template_argv, in
     }
 
     char *cmd = NULL;
-    int len = valkeyFormatCommandArgv(&cmd, template_argc, (const char **)processed_argv, NULL);
+    size_t *argvlen = zmalloc(template_argc * sizeof(size_t));
+    for (int i = 0; i < template_argc; i++) {
+        argvlen[i] = sdslen(processed_argv[i]);
+    }
+    int len = valkeyFormatCommandArgv(&cmd, template_argc, (const char **)processed_argv, argvlen);
+    zfree(argvlen);
     if (len == -1) {
         for (int i = 0; i < template_argc; i++) {
             sdsfree(processed_argv[i]);
@@ -236,6 +262,35 @@ static sds getFieldValue(const char *row, int column_index, char delimiter) {
     }
 
     return sdsempty();
+}
+
+static unsigned char *base64Decode(const char *input, size_t input_len, size_t *out_len) {
+    if (input_len == 0) {
+        *out_len = 0;
+        return zmalloc(1);
+    }
+
+    /* Calculate output length, accounting for padding */
+    size_t padding = 0;
+    if (input_len >= 1 && input[input_len - 1] == '=') padding++;
+    if (input_len >= 2 && input[input_len - 2] == '=') padding++;
+    *out_len = (input_len / 4) * 3 - padding;
+
+    unsigned char *output = zmalloc(*out_len);
+    size_t i = 0, j = 0;
+
+    while (i < input_len) {
+        unsigned char a = b64_decode_table[(unsigned char)input[i++]];
+        unsigned char b = (i < input_len) ? b64_decode_table[(unsigned char)input[i++]] : 0;
+        unsigned char c = (i < input_len) ? b64_decode_table[(unsigned char)input[i++]] : 0;
+        unsigned char d = (i < input_len) ? b64_decode_table[(unsigned char)input[i++]] : 0;
+
+        if (j < *out_len) output[j++] = (a << 2) | (b >> 4);
+        if (j < *out_len) output[j++] = (b << 4) | (c >> 2);
+        if (j < *out_len) output[j++] = (c << 6) | d;
+    }
+
+    return output;
 }
 
 static bool csvDiscoverFields(dataset *ds) {
@@ -397,6 +452,13 @@ static sds processFieldsInArg(dataset *ds, sds arg, int record_index) {
         if (!field_end) break;
 
         size_t field_name_len = field_end - field_start;
+
+        bool needs_decode = false;
+        if (field_name_len > 7 && !memcmp(field_start + field_name_len - 7, ":base64", 7)) {
+            needs_decode = true;
+            field_name_len -= 7;
+        }
+
         int field_idx = findFieldIndex(ds, field_start, field_name_len);
         if (field_idx == -1) break;
 
@@ -405,7 +467,14 @@ static sds processFieldsInArg(dataset *ds, sds arg, int record_index) {
         const char *after_start = field_end + FIELD_SUFFIX_LEN;
 
         sds result = sdsnewlen(arg, before_len);
-        result = sdscat(result, field_value);
+        if (needs_decode) {
+            size_t decoded_len;
+            unsigned char *decoded = base64Decode(field_value, sdslen(field_value), &decoded_len);
+            result = sdscatlen(result, decoded, decoded_len);
+            zfree(decoded);
+        } else {
+            result = sdscatlen(result, field_value, sdslen(field_value));
+        }
         result = sdscat(result, after_start);
 
         sdsfree(arg);
@@ -458,3 +527,5 @@ static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key,
 
     return cmd;
 }
+
+

--- a/src/valkey-benchmark-dataset.c
+++ b/src/valkey-benchmark-dataset.c
@@ -48,6 +48,7 @@ static const unsigned char b64_decode_table[256] = {
 static bool datasetBuildFieldMap(dataset *ds, sds *template_argv, int template_argc);
 static sds getFieldValue(const char *row, int column_index, char delimiter);
 static unsigned char *base64Decode(const char *input, size_t input_len, size_t *out_len);
+static bool fieldStripBase64Suffix(const char *field_start, size_t *field_name_len);
 static bool csvDiscoverFields(dataset *ds);
 static bool csvLoadDocuments(dataset *ds, int verbose);
 static bool shouldStopLoading(dataset *ds);
@@ -146,9 +147,7 @@ bool datasetBuildFieldMap(dataset *ds, sds *template_argv, int template_argc) {
             if (!field_end) break;
 
             size_t field_name_len = field_end - field_start;
-            if (field_name_len > 7 && !memcmp(field_start + field_name_len - 7, ":base64", 7)) {
-                field_name_len -= 7;
-            }
+            fieldStripBase64Suffix(field_start, &field_name_len);
             sds field_name = sdsnewlen(field_start, field_name_len);
 
             int field_idx = -1;
@@ -194,12 +193,11 @@ sds datasetGenerateCommand(dataset *ds, int record_index, sds *template_argv, in
     }
 
     char *cmd = NULL;
-    size_t *argvlen = zmalloc(template_argc * sizeof(size_t));
+    size_t argvlen[template_argc];
     for (int i = 0; i < template_argc; i++) {
         argvlen[i] = sdslen(processed_argv[i]);
     }
     int len = valkeyFormatCommandArgv(&cmd, template_argc, (const char **)processed_argv, argvlen);
-    zfree(argvlen);
     if (len == -1) {
         for (int i = 0; i < template_argc; i++) {
             sdsfree(processed_argv[i]);
@@ -267,32 +265,59 @@ static sds getFieldValue(const char *row, int column_index, char delimiter) {
     return sdsempty();
 }
 
+static bool fieldStripBase64Suffix(const char *field_start, size_t *field_name_len) {
+    if (*field_name_len > BASE64_SUFFIX_LEN &&
+        !memcmp(field_start + *field_name_len - BASE64_SUFFIX_LEN, BASE64_SUFFIX, BASE64_SUFFIX_LEN)) {
+        *field_name_len -= BASE64_SUFFIX_LEN;
+        return true;
+    }
+    return false;
+}
+
 static unsigned char *base64Decode(const char *input, size_t input_len, size_t *out_len) {
-    if (input_len == 0) {
-        *out_len = 0;
+    *out_len = 0;
+
+    if (input_len == 0 || input_len % 4 != 0) {
+        if (input_len != 0) {
+            fprintf(stderr, "Warning: skipping :base64 field, length %zu is not a multiple of 4\n", input_len);
+        }
         return zmalloc(1);
     }
 
-    /* Calculate output length, accounting for padding */
+    /* Calculate output length, accounting for padding. */
     size_t padding = 0;
-    if (input_len >= 1 && input[input_len - 1] == '=') padding++;
-    if (input_len >= 2 && input[input_len - 2] == '=') padding++;
-    *out_len = (input_len / 4) * 3 - padding;
+    if (input[input_len - 1] == '=') padding++;
+    if (input[input_len - 2] == '=') padding++;
+    size_t capacity = (input_len / 4) * 3 - padding;
 
-    unsigned char *output = zmalloc(*out_len);
+    unsigned char *output = zmalloc(capacity ? capacity : 1);
     size_t i = 0, j = 0;
 
     while (i < input_len) {
-        unsigned char a = b64_decode_table[(unsigned char)input[i++]];
-        unsigned char b = (i < input_len) ? b64_decode_table[(unsigned char)input[i++]] : 0;
-        unsigned char c = (i < input_len) ? b64_decode_table[(unsigned char)input[i++]] : 0;
-        unsigned char d = (i < input_len) ? b64_decode_table[(unsigned char)input[i++]] : 0;
+        unsigned char raw[4];
+        for (int k = 0; k < 4; k++) {
+            unsigned char ch = (unsigned char)input[i++];
+            /* '=' padding only decodes to 0 and only in the final group. */
+            if (ch == '=') {
+                raw[k] = 0;
+                continue;
+            }
+            unsigned char v = b64_decode_table[ch];
+            if (v == 255) {
+                fprintf(stderr, "Warning: skipping :base64 field, invalid character '%c'\n", ch);
+                zfree(output);
+                *out_len = 0;
+                return zmalloc(1);
+            }
+            raw[k] = v;
+        }
 
-        if (j < *out_len) output[j++] = (a << 2) | (b >> 4);
-        if (j < *out_len) output[j++] = (b << 4) | (c >> 2);
-        if (j < *out_len) output[j++] = (c << 6) | d;
+        if (j < capacity) output[j++] = (raw[0] << 2) | (raw[1] >> 4);
+        if (j < capacity) output[j++] = (raw[1] << 4) | (raw[2] >> 2);
+        if (j < capacity) output[j++] = (raw[2] << 6) | raw[3];
     }
 
+    *out_len = capacity;
     return output;
 }
 
@@ -455,12 +480,7 @@ static sds processFieldsInArg(dataset *ds, sds arg, int record_index) {
         if (!field_end) break;
 
         size_t field_name_len = field_end - field_start;
-
-        bool needs_decode = false;
-        if (field_name_len > 7 && !memcmp(field_start + field_name_len - 7, ":base64", 7)) {
-            needs_decode = true;
-            field_name_len -= 7;
-        }
+        bool needs_decode = fieldStripBase64Suffix(field_start, &field_name_len);
 
         int field_idx = findFieldIndex(ds, field_start, field_name_len);
         if (field_idx == -1) break;
@@ -530,5 +550,3 @@ static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key,
 
     return cmd;
 }
-
-

--- a/src/valkey-benchmark-dataset.h
+++ b/src/valkey-benchmark-dataset.h
@@ -22,6 +22,8 @@
 #define FIELD_PREFIX_LEN 8
 #define FIELD_SUFFIX "__"
 #define FIELD_SUFFIX_LEN 2
+#define BASE64_SUFFIX ":base64"
+#define BASE64_SUFFIX_LEN 7
 
 /* Dataset format types */
 typedef enum datasetFormat {

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -482,6 +482,59 @@ tags {"benchmark network external:skip logreqres:skip"} {
             file delete $csv_file
         }
 
+        test {benchmark: two placeholders in one arg, first decodes to a null byte} {
+            # Two placeholders in ONE arg token. First decodes to 0x0100030109 (\x00
+            # at byte 2); if the loop rescanned the rebuilt binary, strstr would stop
+            # there and the second placeholder would be left unsubstituted.
+            set csv_data "id,vector,label\n1,AQADAQk=,hello"
+            set csv_file [tmpfile "base64_multi.csv"]
+            set fd [open $csv_file w]
+            puts $fd $csv_data
+            close $fd
+
+            set cmd [valkeybenchmark $master_host $master_port \
+                "--dataset $csv_file -n 2 -r 10 -- SET doc:__rand_int__ __field:vector:base64____field:label__"]
+            common_bench_setup $cmd
+            assert_match {*calls=2,*} [cmdstat set]
+
+            set keys [r keys "doc:*"]
+            assert {[llength $keys] > 0}
+            set actual [r get [lindex $keys 0]]
+
+            # 5 decoded bytes + "hello"; the literal "__field:label__" must be gone
+            assert_equal 10 [string length $actual]
+            binary scan $actual H* hex_value
+            assert_equal "0100030109" [string range $hex_value 0 9]
+            assert_equal "hello" [string range $actual 5 end]
+
+            file delete $csv_file
+        }
+
+        test {benchmark: decoded base64 spelling a placeholder is not re-substituted} {
+            # "X19maWVsZDp2ZWN0b3JfXw==" decodes to the literal text "__field:vector__".
+            # If the loop rescanned the rebuilt buffer it would re-expand that against
+            # the mapped "vector" field and corrupt the value.
+            set csv_data "id,vector\n1,X19maWVsZDp2ZWN0b3JfXw=="
+            set csv_file [tmpfile "base64_selfplaceholder.csv"]
+            set fd [open $csv_file w]
+            puts $fd $csv_data
+            close $fd
+
+            set cmd [valkeybenchmark $master_host $master_port \
+                "--dataset $csv_file -n 2 -r 10 -- SET doc:__rand_int__ __field:vector:base64__"]
+            common_bench_setup $cmd
+            assert_match {*calls=2,*} [cmdstat set]
+
+            set keys [r keys "doc:*"]
+            assert {[llength $keys] > 0}
+            set actual [r get [lindex $keys 0]]
+
+            # Decoded bytes stored verbatim, not re-expanded as a placeholder
+            assert_equal "__field:vector__" $actual
+
+            file delete $csv_file
+        }
+
         test {benchmark: dataset base64 field with malformed length is skipped safely} {
             # "A=" length 2 is not a multiple of 4; the length guard must reject it
             # (else the out_len math underflows size_t). Field is stored empty, no crash.
@@ -524,6 +577,54 @@ tags {"benchmark network external:skip logreqres:skip"} {
             assert_equal 0 [string length $actual]
 
             file delete $csv_file
+        }
+
+        test {benchmark: dataset base64 field with misplaced padding is skipped safely} {
+            # '=' is only legal in the final quartet's trailing slots. All three
+            # inputs violate that and must be rejected (stored empty), not decoded.
+            foreach bad {A=AA AA=A ====} {
+                set csv_data "id,vector\n1,$bad\n2,$bad"
+                set csv_file [tmpfile "base64_badpad.csv"]
+                set fd [open $csv_file w]
+                puts $fd $csv_data
+                close $fd
+
+                set cmd [valkeybenchmark $master_host $master_port \
+                    "--dataset $csv_file -n 2 -r 10 -- HSET doc:__rand_int__ vector __field:vector:base64__"]
+                common_bench_setup $cmd
+                assert_match {*calls=2,*} [cmdstat hset]
+
+                set keys [r keys "doc:*"]
+                assert {[llength $keys] > 0}
+                set actual [r hget [lindex $keys 0] vector]
+                assert_equal 0 [string length $actual]
+
+                file delete $csv_file
+            }
+        }
+
+        test {benchmark: dataset base64 field with non-canonical padding bits is skipped safely} {
+            # RFC 4648: bits discarded by padding must be zero. "AB==" leaves stray
+            # bits in raw[1], "AAB=" in raw[2] -- both must be rejected.
+            foreach bad {AB== AAB=} {
+                set csv_data "id,vector\n1,$bad\n2,$bad"
+                set csv_file [tmpfile "base64_noncanon.csv"]
+                set fd [open $csv_file w]
+                puts $fd $csv_data
+                close $fd
+
+                set cmd [valkeybenchmark $master_host $master_port \
+                    "--dataset $csv_file -n 2 -r 10 -- HSET doc:__rand_int__ vector __field:vector:base64__"]
+                common_bench_setup $cmd
+                assert_match {*calls=2,*} [cmdstat hset]
+
+                set keys [r keys "doc:*"]
+                assert {[llength $keys] > 0}
+                set actual [r hget [lindex $keys 0] vector]
+                assert_equal 0 [string length $actual]
+
+                file delete $csv_file
+            }
         }
 
         test {benchmark: dataset base64 field without suffix stays as text} {

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -415,6 +415,100 @@ tags {"benchmark network external:skip logreqres:skip"} {
             file delete $csv_file
         }
 
+        test {benchmark: dataset with base64 field decoding} {
+            # Create CSV with a base64-encoded binary field
+            # "AQIDBA==" decodes to bytes: 0x01 0x02 0x03 0x04 (4 bytes)
+            set csv_data "id,title,embedding\n1,laptop,AQIDBA==\n2,phone,BQYHCAkK"
+            set csv_file [tmpfile "base64_dataset.csv"]
+            set fd [open $csv_file w]
+            puts $fd $csv_data
+            close $fd
+
+            set cmd [valkeybenchmark $master_host $master_port \
+                "--dataset $csv_file -n 2 -r 10 -- HSET doc:__rand_int__ title __field:title__ embedding __field:embedding:base64__"]
+            common_bench_setup $cmd
+            assert_match {*calls=2,*} [cmdstat hset]
+
+            # Verify data was stored
+            set keys [r keys "doc:*"]
+            assert {[llength $keys] > 0}
+
+            # Verify the hash field names are "title" and "embedding" (not "embedding:base64")
+            set sample_key [lindex $keys 0]
+            set fields [lsort [r hkeys $sample_key]]
+            assert_equal [lsort {embedding title}] $fields
+
+            # Verify the title field is plain text
+            set title [r hget $sample_key title]
+            assert {$title eq "laptop" || $title eq "phone"}
+
+            # Verify the embedding field has correct decoded binary length
+            set actual_emb [r hget $sample_key embedding]
+            if {$title eq "laptop"} {
+                # "AQIDBA==" → 4 bytes: \x01\x02\x03\x04
+                assert_equal 4 [string length $actual_emb]
+                binary scan $actual_emb H* hex_value
+                assert_equal "01020304" $hex_value
+            } else {
+                # "BQYHCAkK" → 6 bytes: \x05\x06\x07\x08\x09\x0a
+                assert_equal 6 [string length $actual_emb]
+                binary scan $actual_emb H* hex_value
+                assert_equal "05060708090a" $hex_value
+            }
+
+            file delete $csv_file
+        }
+
+        test {benchmark: dataset base64 field preserves null bytes} {
+            # "AQADAQk=" decodes to 5 bytes: \x01\x00\x03\x01\x09
+            # Contains \x00 at byte 2, which would truncate if strlen() were used
+            set csv_data "id,vector\n1,AQADAQk="
+            set csv_file [tmpfile "base64_nullbyte.csv"]
+            set fd [open $csv_file w]
+            puts $fd $csv_data
+            close $fd
+
+            set cmd [valkeybenchmark $master_host $master_port \
+                "--dataset $csv_file -n 2 -r 10 -- HSET doc:__rand_int__ vector __field:vector:base64__"]
+            common_bench_setup $cmd
+            assert_match {*calls=2,*} [cmdstat hset]
+
+            # Verify the full binary is preserved past the null byte
+            set keys [r keys "doc:*"]
+            assert {[llength $keys] > 0}
+            set sample_key [lindex $keys 0]
+            set actual [r hget $sample_key vector]
+
+            # Must be 5 bytes, not 1 (which is what strlen would give)
+            assert_equal 5 [string length $actual]
+            binary scan $actual H* hex_value
+            assert_equal "0100030109" $hex_value
+
+            file delete $csv_file
+        }
+
+        test {benchmark: dataset base64 field without suffix stays as text} {
+            # Same CSV but command does NOT use :base64 suffix
+            # Field should be stored as raw base64 text (not decoded)
+            set csv_data "id,embedding\n1,AAAAAAAAAD8AAABAAACAQQ=="
+            set csv_file [tmpfile "base64_text.csv"]
+            set fd [open $csv_file w]
+            puts $fd $csv_data
+            close $fd
+
+            set cmd [valkeybenchmark $master_host $master_port \
+                "--dataset $csv_file -n 2 -r 10 -- SET doc:__rand_int__ __field:embedding__"]
+            common_bench_setup $cmd
+
+            # Without :base64, the value should be the literal base64 string (24 chars)
+            set keys [r keys "doc:*"]
+            assert {[llength $keys] > 0}
+            set value [r get [lindex $keys 0]]
+            assert_equal "AAAAAAAAAD8AAABAAACAQQ==" $value
+
+            file delete $csv_file
+        }
+
         test {benchmark: sequential zadd results in expected number of keys} {
             set cmd [valkeybenchmark $master_host $master_port "-r 50 -n 50 --sequential -t zadd"]
             common_bench_setup $cmd

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -416,8 +416,7 @@ tags {"benchmark network external:skip logreqres:skip"} {
         }
 
         test {benchmark: dataset with base64 field decoding} {
-            # Create CSV with a base64-encoded binary field
-            # "AQIDBA==" decodes to bytes: 0x01 0x02 0x03 0x04 (4 bytes)
+            # "AQIDBA==" -> 0x01020304 (4 bytes), "BQYHCAkK" -> 0x05060708090a (6 bytes)
             set csv_data "id,title,embedding\n1,laptop,AQIDBA==\n2,phone,BQYHCAkK"
             set csv_file [tmpfile "base64_dataset.csv"]
             set fd [open $csv_file w]
@@ -433,24 +432,22 @@ tags {"benchmark network external:skip logreqres:skip"} {
             set keys [r keys "doc:*"]
             assert {[llength $keys] > 0}
 
-            # Verify the hash field names are "title" and "embedding" (not "embedding:base64")
+            # ":base64" suffix must be stripped from the field name
             set sample_key [lindex $keys 0]
             set fields [lsort [r hkeys $sample_key]]
             assert_equal [lsort {embedding title}] $fields
 
-            # Verify the title field is plain text
+            # title stays plain text
             set title [r hget $sample_key title]
             assert {$title eq "laptop" || $title eq "phone"}
 
-            # Verify the embedding field has correct decoded binary length
+            # embedding is decoded to binary
             set actual_emb [r hget $sample_key embedding]
             if {$title eq "laptop"} {
-                # "AQIDBA==" → 4 bytes: \x01\x02\x03\x04
                 assert_equal 4 [string length $actual_emb]
                 binary scan $actual_emb H* hex_value
                 assert_equal "01020304" $hex_value
             } else {
-                # "BQYHCAkK" → 6 bytes: \x05\x06\x07\x08\x09\x0a
                 assert_equal 6 [string length $actual_emb]
                 binary scan $actual_emb H* hex_value
                 assert_equal "05060708090a" $hex_value
@@ -460,8 +457,7 @@ tags {"benchmark network external:skip logreqres:skip"} {
         }
 
         test {benchmark: dataset base64 field preserves null bytes} {
-            # "AQADAQk=" decodes to 5 bytes: \x01\x00\x03\x01\x09
-            # Contains \x00 at byte 2, which would truncate if strlen() were used
+            # "AQADAQk=" -> 0x0100030109 (5 bytes); the \x00 would truncate under strlen()
             set csv_data "id,vector\n1,AQADAQk="
             set csv_file [tmpfile "base64_nullbyte.csv"]
             set fd [open $csv_file w]
@@ -473,13 +469,12 @@ tags {"benchmark network external:skip logreqres:skip"} {
             common_bench_setup $cmd
             assert_match {*calls=2,*} [cmdstat hset]
 
-            # Verify the full binary is preserved past the null byte
+            # Full binary must survive past the null byte (5 bytes, not 1)
             set keys [r keys "doc:*"]
             assert {[llength $keys] > 0}
             set sample_key [lindex $keys 0]
             set actual [r hget $sample_key vector]
 
-            # Must be 5 bytes, not 1 (which is what strlen would give)
             assert_equal 5 [string length $actual]
             binary scan $actual H* hex_value
             assert_equal "0100030109" $hex_value
@@ -487,9 +482,52 @@ tags {"benchmark network external:skip logreqres:skip"} {
             file delete $csv_file
         }
 
+        test {benchmark: dataset base64 field with malformed length is skipped safely} {
+            # "A=" length 2 is not a multiple of 4; the length guard must reject it
+            # (else the out_len math underflows size_t). Field is stored empty, no crash.
+            set csv_data "id,vector\n1,A=\n2,A="
+            set csv_file [tmpfile "base64_badlen.csv"]
+            set fd [open $csv_file w]
+            puts $fd $csv_data
+            close $fd
+
+            set cmd [valkeybenchmark $master_host $master_port \
+                "--dataset $csv_file -n 2 -r 10 -- HSET doc:__rand_int__ vector __field:vector:base64__"]
+            common_bench_setup $cmd
+            assert_match {*calls=2,*} [cmdstat hset]
+
+            # Malformed input decodes to an empty value
+            set keys [r keys "doc:*"]
+            assert {[llength $keys] > 0}
+            set actual [r hget [lindex $keys 0] vector]
+            assert_equal 0 [string length $actual]
+
+            file delete $csv_file
+        }
+
+        test {benchmark: dataset base64 field with invalid characters is skipped safely} {
+            # '!' and '@' are outside the base64 alphabet; field is stored empty, no crash.
+            set csv_data "id,vector\n1,AQ!@\n2,AQ!@"
+            set csv_file [tmpfile "base64_badchar.csv"]
+            set fd [open $csv_file w]
+            puts $fd $csv_data
+            close $fd
+
+            set cmd [valkeybenchmark $master_host $master_port \
+                "--dataset $csv_file -n 2 -r 10 -- HSET doc:__rand_int__ vector __field:vector:base64__"]
+            common_bench_setup $cmd
+            assert_match {*calls=2,*} [cmdstat hset]
+
+            set keys [r keys "doc:*"]
+            assert {[llength $keys] > 0}
+            set actual [r hget [lindex $keys 0] vector]
+            assert_equal 0 [string length $actual]
+
+            file delete $csv_file
+        }
+
         test {benchmark: dataset base64 field without suffix stays as text} {
-            # Same CSV but command does NOT use :base64 suffix
-            # Field should be stored as raw base64 text (not decoded)
+            # No ":base64" suffix -> value stored as the literal base64 string, not decoded
             set csv_data "id,embedding\n1,AAAAAAAAAD8AAABAAACAQQ=="
             set csv_file [tmpfile "base64_text.csv"]
             set fd [open $csv_file w]
@@ -500,7 +538,7 @@ tags {"benchmark network external:skip logreqres:skip"} {
                 "--dataset $csv_file -n 2 -r 10 -- SET doc:__rand_int__ __field:embedding__"]
             common_bench_setup $cmd
 
-            # Without :base64, the value should be the literal base64 string (24 chars)
+            # Value should be the literal 24-char base64 string
             set keys [r keys "doc:*"]
             assert {[llength $keys] > 0}
             set value [r get [lindex $keys 0]]


### PR DESCRIPTION
### Summary
Extends valkey-benchmark's structured dataset support to decode base64-encoded
fields into raw binary before sending them to the server. This lets a benchmark load
binary payloads — most importantly vector embeddings — from a CSV/TSV dataset, which the
existing text-only field substitution could not do.

A dataset field is decoded by adding a `:base64` suffix to the field placeholder:

    valkey-benchmark --dataset vectors.csv -n 1000 -- \
        HSET doc:__rand_int__ title __field:title__ embedding __field:embedding:base64__

Here `title` is substituted as plain text and `embedding` is base64-decoded to its raw
bytes. Fields without the `:base64` suffix are unchanged.

### Changes
- **Base64 decoder** (`base64Decode`) — standard RFC 4648 decoding via a 256-entry lookup
  table. Rejects malformed input safely: input whose length isn't a multiple of 4 (which
  would otherwise underflow the output-length math) and invalid characters both log a
  warning, skip the field, and store an empty value rather than crashing.
- **Suffix handling** (`fieldStripBase64Suffix`) — strips `:base64` from the placeholder so
  the field name resolves correctly and the stored hash field is `embedding`, not
  `embedding:base64`.
- **Binary-safe command formatting** — build an explicit `argvlen[]` from `sdslen()` and
  pass it to `valkeyFormatCommandArgv`, so values with embedded `0x00` are sent intact.

### Testing
Added 5 integration tests in `tests/integration/valkey-benchmark.tcl`:
- base64 field decodes to correct bytes; `:base64` suffix stripped from field name
- decoded binary preserves embedded null bytes (regression guard for the strlen truncation)
- malformed length is skipped safely (no crash / no size_t underflow)
- invalid base64 characters are skipped safely
- a field without the `:base64` suffix is stored as literal text

All integration tests pass. Also verified manually end-to-end: `AQIDBA==` → 4 bytes
`0x01020304`, `BQYHCAkK` → 6 bytes, and `AQADAQk=` → 5 bytes with a `0x00` mid-value
stored intact (`hstrlen` returns 5, not 1).
