### PR TITLE
Fix use-after-free crash when cluster messages arrive after module unload

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -13311,6 +13311,30 @@ void moduleUnregisterCommands(struct ValkeyModule *module) {
     invalidateCommandCache();
 }
 
+/* Remove every cluster message receiver that belongs to the given module. */
+static void moduleUnregisterClusterReceivers(ValkeyModule *module) {
+    if (!server.cluster_enabled) return;
+
+    for (int type = 0; type < UINT8_MAX; type++) {
+        moduleClusterReceiver *r = clusterReceivers[type], *prev = NULL;
+        while (r) {
+            if (r->module == module) {
+                /* Unlink the receiver node from the linked list. A module
+                 * registers at most one receiver per type, so we can stop
+                 * scanning this type as soon as we removed it. */
+                if (prev)
+                    prev->next = r->next;
+                else
+                    clusterReceivers[type] = r->next;
+                zfree(r);
+                break;
+            }
+            prev = r;
+            r = r->next;
+        }
+    }
+}
+
 /* We parse argv to add sds "NAME VALUE" pairs to the server.module_configs_queue list of configs.
  * We also increment the module_argv pointer to just after ARGS if there are args, otherwise
  * we set it to NULL */
@@ -13363,6 +13387,7 @@ void moduleUnregisterCleanup(ValkeyModule *module) {
     moduleUnsubscribeAllServerEvents(module);
     moduleRemoveConfigs(module);
     moduleUnregisterAuthCBs(module);
+    moduleUnregisterClusterReceivers(module);
 }
 
 /* Common helper for moduleLoad and moduleLoadStatic.

--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -67,7 +67,7 @@ int test_cluster_shards(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
 #define MSGTYPE_DING 1
 #define MSGTYPE_DONG 2
 #define MSGTYPE_TEST_UAF 3
-#define MSGTYPE_TEST_UAF_2 254
+#define MSGTYPE_TEST_MAX 254
 
 /* test.pingall */
 int PingallCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
@@ -95,7 +95,7 @@ int test_register_receiver(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int 
     UNUSED(argv);
     UNUSED(argc);
     ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_UAF, DingReceiver);
-    ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_UAF_2, DingReceiver);
+    ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_MAX, DingReceiver);
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
 }
 
@@ -103,15 +103,15 @@ int test_unregister_receiver(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, in
     UNUSED(argv);
     UNUSED(argc);
     ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_UAF, NULL);
-    ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_UAF_2, NULL);
+    ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_MAX, NULL);
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
 }
 
-int test_send_msg_type3(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+int test_send_msg_uaf(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     UNUSED(argv);
     UNUSED(argc);
     ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_TEST_UAF, "TestUAF", 7);
-    ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_TEST_UAF_2, "TestUAF2", 8);
+    ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_TEST_MAX, "TestMAX", 7);
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
 }
 
@@ -139,7 +139,7 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
         return VALKEYMODULE_ERR;
     if (ValkeyModule_CreateCommand(ctx, "test.unregister_receiver", test_unregister_receiver, "", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
-    if (ValkeyModule_CreateCommand(ctx, "test.send_msg_type3", test_send_msg_type3, "", 0, 0, 0) == VALKEYMODULE_ERR)
+    if (ValkeyModule_CreateCommand(ctx, "test.send_msg_uaf", test_send_msg_uaf, "", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
     /* Register our handlers for different message types. */

--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -67,6 +67,7 @@ int test_cluster_shards(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
 #define MSGTYPE_DING 1
 #define MSGTYPE_DONG 2
 #define MSGTYPE_TEST_UAF 3
+#define MSGTYPE_TEST_UAF_2 254
 
 /* test.pingall */
 int PingallCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
@@ -94,6 +95,7 @@ int test_register_receiver(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int 
     UNUSED(argv);
     UNUSED(argc);
     ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_UAF, DingReceiver);
+    ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_UAF_2, DingReceiver);
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
 }
 
@@ -101,6 +103,7 @@ int test_unregister_receiver(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, in
     UNUSED(argv);
     UNUSED(argc);
     ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_UAF, NULL);
+    ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_TEST_UAF_2, NULL);
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
 }
 
@@ -108,6 +111,7 @@ int test_send_msg_type3(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     UNUSED(argv);
     UNUSED(argc);
     ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_TEST_UAF, "TestUAF", 7);
+    ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_TEST_UAF_2, "TestUAF2", 8);
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
 }
 

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -334,6 +334,28 @@ start_cluster 3 0 [list config_lines $modules] {
         }
         verify_log_message 0 "*DING (type 3) RECEIVED*TestUAF*" 0
     }
+
+    test "VM_RegisterClusterMessageReceiver - dangling callback after MODULE UNLOAD" {
+        # Register a receiver for type 3 on node1
+        assert_equal OK [$node1 test.register_receiver]
+
+        # Unload the module on node1
+        assert_equal OK [$node1 MODULE UNLOAD cluster]
+
+        # Another node sends a type 3 packet; node1 receives it and, on the
+        # buggy code, would invoke the dangling callback and crash. After the
+        # fix the entry is gone, so the packet is simply ignored.
+        R 0 CONFIG RESETSTAT
+        assert_equal OK [$node2 test.send_msg_type3]
+
+        # Verify node1 is still alive (the receiving node must not have crashed).
+        wait_for_condition 50 100 {
+            [CI 0 cluster_stats_messages_module_received] >= 1
+        } else {
+            fail "node1 didn't receive cluster module message"
+        }
+        assert_equal PONG [$node1 PING]
+    }
 }
 
 start_cluster 2 0 {overrides {cluster-node-timeout 1000}} {

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -314,10 +314,10 @@ start_cluster 3 0 [list config_lines $modules] {
     }
 
     test "VM_RegisterClusterMessageReceiver - unregister head and re-register does not crash" {
-        # Register a receiver for type 3 on node1
+        # Register the receivers on node1
         assert_equal OK [$node1 test.register_receiver]
 
-        # Unregister it (this is the head of the list for type 3)
+        # Unregister it (the head of the list)
         assert_equal OK [$node1 test.unregister_receiver]
 
         # Re-register - on the buggy code this traverses freed memory and crashes
@@ -325,35 +325,40 @@ start_cluster 3 0 [list config_lines $modules] {
 
         # Send from node2 so node1 receives it via the re-registered receiver
         R 0 CONFIG RESETSTAT
-        assert_equal OK [$node2 test.send_msg_type3]
+        assert_equal OK [$node2 test.send_msg_uaf]
 
         wait_for_condition 50 100 {
-            [CI 0 cluster_stats_messages_module_received] >= 1
+            [CI 0 cluster_stats_messages_module_received] >= 2
         } else {
             fail "node1 didn't receive cluster module message after re-registration"
         }
         verify_log_message 0 "*DING (type 3) RECEIVED*TestUAF*" 0
+        verify_log_message 0 "*DING (type 254) RECEIVED*TestMAX*" 0
     }
 
     test "VM_RegisterClusterMessageReceiver - dangling callback after MODULE UNLOAD" {
-        # Register a receiver for type 3 on node1
+        set loglines [count_log_lines 0]
+
+        # Register the receivers on node1
         assert_equal OK [$node1 test.register_receiver]
 
         # Unload the module on node1
         assert_equal OK [$node1 MODULE UNLOAD cluster]
 
-        # Another node sends a type 3 packet; node1 receives it and, on the
-        # buggy code, would invoke the dangling callback and crash. After the
-        # fix the entry is gone, so the packet is simply ignored.
+        # Another node sends a packet; node1 receives it and, on the buggy code,
+        # would invoke the dangling callback and crash. After the fix the entry
+        # is gone, so the packet is simply ignored.
         R 0 CONFIG RESETSTAT
-        assert_equal OK [$node2 test.send_msg_type3]
+        assert_equal OK [$node2 test.send_msg_uaf]
 
         # Verify node1 is still alive (the receiving node must not have crashed).
         wait_for_condition 50 100 {
-            [CI 0 cluster_stats_messages_module_received] >= 1
+            [CI 0 cluster_stats_messages_module_received] >= 2
         } else {
             fail "node1 didn't receive cluster module message"
         }
+        verify_no_log_message 0 "*DING (type 3) RECEIVED*TestUAF*" $loglines
+        verify_no_log_message 0 "*DING (type 254) RECEIVED*TestMAX*" $loglines
         assert_equal PONG [$node1 PING]
     }
 }


### PR DESCRIPTION
moduleUnregisterCleanup did not remove the module's cluster message
receivers. The stale entries kept pointing at the freed ValkeyModule,
so a later cluster message of that type dereferenced r->module in
moduleCallClusterReceivers, causing a use-after-free.

Added a MODULE UNLOAD test to verify the fix, and also added type=254
to allow us to verify the correctness of the loop logic.