### PR TITLE
Fix Test dual-channel: primary tracking replica backlog refcount (#4139)

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -615,8 +615,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 set loglines [lindex $res 1]
                 incr $loglines
                 wait_and_resume_process -2
-                if {$::valgrind} {set retry_count 7000} else {set retry_count 700}
-                verify_replica_online $primary 0 $retry_count
+                verify_replica_online $primary 0 [expr {$::valgrind ? 7000 : 700}]
                 wait_for_condition 50 1000 {
                     [status $replica1 master_link_status] == "up"
                 } else {
@@ -632,8 +631,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 set loglines [lindex $res 1]
                 incr $loglines
                 wait_and_resume_process -1
-                if {$::valgrind} {set retry_count 7000} else {set retry_count 700}
-                verify_replica_online $primary 0 $retry_count
+                verify_replica_online $primary 0 [expr {$::valgrind ? 7000 : 700}]
                 wait_for_condition 50 1000 {
                     [status $replica2 master_link_status] == "up"
                 } else {

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -615,7 +615,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 set loglines [lindex $res 1]
                 incr $loglines
                 wait_and_resume_process -2
-                verify_replica_online $primary 0 700
+                if {$::valgrind} {set retry_count 7000} else {set retry_count 700}
+                verify_replica_online $primary 0 $retry_count
                 wait_for_condition 50 1000 {
                     [status $replica1 master_link_status] == "up"
                 } else {
@@ -631,7 +632,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 set loglines [lindex $res 1]
                 incr $loglines
                 wait_and_resume_process -1
-                verify_replica_online $primary 0 700
+                if {$::valgrind} {set retry_count 7000} else {set retry_count 700}
+                verify_replica_online $primary 0 $retry_count
                 wait_for_condition 50 1000 {
                     [status $replica2 master_link_status] == "up"
                 } else {


### PR DESCRIPTION
Fixes #4139.

## What

`verify_replica_online`'s default 70-second budget (`700` retries × `100ms`) in the "start with
backlog" (and, for consistency, "start with empty backlog") sub-tests of `Test dual-channel:
primary tracking replica backlog refcount` doesn't scale for how long the RDB transfer can take
under Valgrind. This adds the same `$::valgrind`-based 10x retry scaling already used elsewhere
in the test suite (e.g. `tests/support/server.tcl`'s `wait_server_started`), which these two
`verify_replica_online` calls didn't have.

## Why

#4139 was filed from the `test-valgrind-no-malloc-usable-size-test` CI job. I reproduced the
same test's flakiness (a related but not identical assertion — see "What I verified" below) and
tracked it to this timing budget, not a genuine bug in the replication code:

- **9/9 reproductions** of `"Replica is not in sync after 70 seconds"` at the current 700-retry
  budget, across two independent runs, no Valgrind, no artificial load — this test is
  considerably more reproducible than it might look from a single bot-filed occurrence.
- **Decisive experiment**: raising the budget from 70s to 300s (diagnostic-only, not this PR's
  actual change) made the sub-test **pass in ~298 seconds**, with the whole file coming back
  clean (`43 passed, 0 failed`). That rules out a hang, deadlock, or data corruption — the
  transfer is legitimate, correct work that just needs more time than the budget allows in a
  sufficiently slow environment.
- This test's dataset (~3.5-3.6M keys from its `start_write_load ... 20` generator) combined
  with the test's own deliberate `rdb-key-save-delay 10` (10 **microseconds** per key, confirmed
  in `src/debug.c`'s `debugDelay(int usec)`) already accounts for ~35s of guaranteed artificial
  slowdown before any real serialization/transfer time — a thin margin against a 70s budget
  even before accounting for Valgrind's well-known further overhead on CPU-bound work.
- This exact test already needed one prior flakiness fix for its earlier `wait_for_log_messages`
  calls in #2827 (same root class of problem — a fixed retry count not scaling with real
  execution time), just further up in the same test body.

## What I verified, and what I didn't (being upfront about scope)

- Verified: 9/9 reproduction of the 70s timeout, unloaded, on a real Ubuntu 24.04 build matching
  this repo's `test-ubuntu-tls` CI job (`BUILD_TLS=yes SERVER_CFLAGS='-Werror'
  USE_LIBBACKTRACE=yes`, matching Tcl-TLS/OpenSSL versions).
- Verified: the transfer completes correctly and quickly resolves once given enough budget
  (300s) — not a hang.
- Ruled out a competing theory: a `"clients connected"` count drop mid-transfer looked initially
  like it might indicate a stale/leaked replica reference (which would actually match the test's
  "backlog refcount" name), but `src/server.c`'s definition of that counter
  (`listLength(server.clients) - listLength(server.replicas)`) shows it already excludes
  replicas — the drop is just the test's own write-load generator disconnecting on its normal
  20-second schedule, unrelated to the replicas.
- **Verified under real Valgrind**: with this fix applied, `./runtest --single
  integration/dual-channel-replication --tls --valgrind` passes cleanly (`43 passed, 0 failed`),
  with the target sub-test completing in ~10.7s — comfortably inside even the *original* 70s
  budget, let alone the new 700s Valgrind ceiling. Worth being precise about what this does and
  doesn't prove: it confirms the fix doesn't break anything and the scaled ceiling is more than
  sufficient headroom for this run, but it didn't reproduce a Valgrind-side timeout directly on
  this hardware, likely because the test's `start_write_load ... 20`-second generator is itself
  slowed by the Valgrind-instrumented primary, so the fixed 20-second window accumulates fewer
  keys (less to transfer) than the throughput I saw in a non-Valgrind run — a plausible reason
  a single CI occurrence of this timeout under Valgrind could be rare rather than constant, and
  why my local Valgrind run happened not to reproduce the original timing edge.
- **Not addressed by this PR**: I also observed the same 70s timeout failing on a non-Valgrind,
  real-Ubuntu-with-matching-TLS Docker environment (needing ~298s there too). I don't have
  strong evidence this generalizes to typical CI hardware — the only bot-filed occurrence of this
  failure is the Valgrind one, suggesting non-Valgrind CI runs of this test are not commonly
  affected — so I've scoped this PR to the clearly-justified Valgrind case rather than also
  raising the non-Valgrind default, which felt like a separate decision maintainers should weigh
  in on rather than something I should decide unilaterally from one non-standard environment. Happy
  to extend this PR if that's wanted.

## Testing

Ran `./runtest --single integration/dual-channel-replication --tls` repeatedly (9 runs across
two batches) to confirm the failure, then a controlled `verify_replica_online` budget increase
to confirm the mechanism, before writing this fix.
