### PR TITLE
Fix test_reclaimFilePageCache to avoid tmpfs

### DIFF
--- a/src/unit/test_util.cpp
+++ b/src/unit/test_util.cpp
@@ -296,10 +296,10 @@ TEST_F(UtilTest, TestReclaimFilePageCache) {
 #if defined(__linux__)
     struct statfs stats;
 
-    /* Check if /tmp is memory-backed (e.g., tmpfs) */
+    /* fadvise(FADV_DONTNEED) has no effect on memory-backed filesystems */
     if (statfs("/tmp", &stats) == 0) {
-        if (stats.f_type != TMPFS_MAGIC) { // Not tmpfs, use /tmp
-            GTEST_SKIP() << "Skipping test because /tmp is not tmpfs";
+        if (stats.f_type == TMPFS_MAGIC) {
+            GTEST_SKIP() << "Skipping test because /tmp is tmpfs";
         }
     }
 


### PR DESCRIPTION
Correct the condition introduced in #1379

In the original commit 0a987b2d7b5379d2f8e4a98e633614bfef48a05e, the fix was to avoid using `/tmp` directory when it is detected as tmpfs 

However in later refactoring (7892bf808b6f748684af7defa0c0a8611cc4be50) the intention of the check was reversed
- If tmpfs test will run & fail
- If not tmpfs test will be skipped 

fixes #897