### PR TITLE
Fix strict-aliasing miscompilation of the fbtree iterator under LTO

### DIFF
--- a/src/fbtree.c
+++ b/src/fbtree.c
@@ -27,7 +27,12 @@ typedef enum {
     ITER_PAST_END,     /* Positioned past last element (fbtreeNext returns NULL, fbtreePrev works) */
 } IterState;
 
-typedef struct {
+/* may_alias is required: fbtreeIterator is declared as uint64_t[3] and
+ * iteratorFromOpaque() accesses it through this struct type. Without the
+ * attribute that access violates strict aliasing, and gcc 15 with LTO
+ * miscompiles fbtreeSeekToRank on musl toolchains (seek stores elided,
+ * iterator behaves as never seeked). Do not remove. */
+typedef struct __attribute__((may_alias)) {
     fbtreeIndex *fbt;
     leafNode *current_leaf;
     uint8_t current_index;
@@ -2606,7 +2611,9 @@ size_t fbtreeEstimateStructureMemory(fbtreeIndex *fbt) {
     /* Leaf count is exact for small chains; for larger trees it is
      * extrapolated from the fill of the first leaves, which reflects how
      * sparse deletes have left the tree. */
-    enum { FILL_SAMPLE_LEAVES = 16 };
+    enum {
+        FILL_SAMPLE_LEAVES = 16
+    };
     size_t leaves_seen = 0, items_seen = 0;
     leafNode *leaf = fbt->leftmost_leaf;
     while (leaf && leaves_seen < FILL_SAMPLE_LEAVES) {


### PR DESCRIPTION
Fixes the three Daily CI failures on the zset-btree branch (run 31152425315): `ZRANGE basics - btree`, `ZREVRANGE basics - btree`, and `ZSETs ZRANK augmented skip list stress testing - btree` on test-alpine-jemalloc, test-alpine-libc-malloc, and test-alpine-32bit.

### Root cause

`fbtreeIterator` is declared as `typedef uint64_t fbtreeIterator[3]` and `fbtree.c` accesses it through the internal `iter` struct via `iteratorFromOpaque()` (fbtree.c line 61). That access violates strict aliasing, so it is UB in every build. It turns into a miscompilation when the optimizer sees both sides of the punning in one scope: the Makefile adds `-flto=auto` at `-O3`, which merges the `genericZrangebyrankCommand -> orderedIndexSeekToIndex -> fbtreeSeekToRank -> fbtreeNext` chain. Alpine gcc 15.2 concludes the seek stores through `iter *` cannot alias the `uint64_t[3]` stack object and elides them. The iterator behaves as never seeked, which matches the failures exactly: unseeked `fbtreeNext()` starts at the leftmost leaf (`ZRANGE ztmp 1 -1` returns `a b c`) and unseeked `fbtreePrev()` at the rightmost (`ZREVRANGE ztmp 1 -1` returns `d c b`). glibc jobs passing today is an inlining accident, not safety.

### Fix

`__attribute__((may_alias))` on the internal `iter` struct. Supported by gcc and clang, generates no code, changes no layout, and only exempts accesses through `iter *` inside fbtree.c from type-based alias analysis. A code comment explains why the attribute must stay.

### Validation (Docker, Alpine musl gcc 15.2.0, default `-O3 -flto` flags)

| Cell | Result |
|---|---|
| Unfixed, default flags | 3 zset failures identical to CI |
| Unfixed, `-fno-strict-aliasing` | 0 failures |
| Unfixed, `-O3 -fno-lto` | 0 failures (isolates the trigger to LTO + strict aliasing) |
| Union-based opaque typedef (alternative fix) | still 3 failures, rejected |
| This fix, 64-bit musl | full zset unit green (348 tests) |
| This fix, 32-bit musl, `-Werror` + `USE_LIBBACKTRACE=yes` | full zset unit green |
| This fix, gtest unit binary on Alpine (includes all of test_fbtree.cpp and test_ordered_index.cpp) | 598 pass, 3 skipped, 0 fail |
| This fix, Ubuntu 24.04 glibc | zset unit green, no regression |

### Notes on the other failing Daily jobs (not addressed here)

- test-ubuntu-32bit `Active defrag - AOF loading`: pre-existing flake tracked in #3954, occurrences predate this branch. The test loads plain SET commands so the zset defrag rewrite is not exercised.
- test-ubuntu-io-threads and test-ubuntu-tls-io-threads: fail identically on the unstable nightly baseline.
- test-alpine-32bit logging.tcl backtrace tests: likely a side effect of the miscompiled binary, worth rechecking after this lands.

Separate note: `hashtable.h` uses the same `uint64_t[N]` opaque idiom with the same cast pattern, so the same latent UB exists there. It has not miscompiled yet. I will file a separate issue for it.
