### PR TITLE
fix: guard against frozen TSC monotonic clock from unsynchronised cores (#4345)

### DIFF
--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -70,6 +70,9 @@ static void monotonicInit_x86linux(void) {
         clock_gettime(CLOCK_MONOTONIC, &end);
 
         uint64_t elapsed_us = (end.tv_sec - start.tv_sec) * 1000000ULL + (end.tv_nsec - start.tv_nsec) / 1000;
+        /* A thread migrated across cores whose TSCs disagree can read a lower
+         * end value; the unsigned difference would wrap. Discard the sample. */
+        if (tsc_end <= tsc_start) continue;
         uint64_t tsc_elapsed = tsc_end - tsc_start;
         double sample_ticks_per_us = (double)tsc_elapsed / (double)elapsed_us;
         uint64_t sample_mult = (uint64_t)((double)(1ULL << MONO_FPMULT_SHIFT) / sample_ticks_per_us);
@@ -98,7 +101,7 @@ static void monotonicInit_x86linux(void) {
     }
     regfree(&constTscRegex);
 
-    if (mono_ticks_speed == UINT64_MAX) {
+    if (mono_ticks_speed == UINT64_MAX || mono_ticks_speed == 0) {
         fprintf(stderr, "monotonic: x86 linux, unable to determine clock rate");
         return;
     }


### PR DESCRIPTION
Fixes #4345

## Root cause

`monotonicInit_x86linux()` in `src/monotonic.c` can produce a zero multiplier when a thread migrates across cores whose TSCs are not synchronised. The unsigned subtraction `tsc_end - tsc_start` wraps when `tsc_end < tsc_start`, yielding a division that rounds the multiplier to zero. `getMonotonicUs()` then returns 0 for the process lifetime, `serverCron` never runs, and keys with TTLs never expire — a silent data-retention hazard.

## Fix (two guards)

1. **Reject migrated samples**: if `tsc_end <= tsc_start` after the calibration sleep, the thread was moved across an unsynchronised TSC boundary. Discard the sample and continue to the next iteration.

2. **Reject zero multiplier**: after calibration, treat `mono_ticks_speed == 0` the same as `UINT64_MAX` (uninitialised) — fall through to the POSIX `clock_gettime` path.

Both failure paths already degrade to `monotonicInit_posix()`, so the guards simply redirect the same fallback to a path that is reliable.

## Diagnosis

A running server affected by this displays:
- `monotonic_clock:X86 TSC @ inf ticks/us`
- `uptime_in_seconds:0`
- `TIME` returns the same microsecond indefinitely

## Verification

- `monotonicInit_x86linux` now discards any calibration sample where TSC regression is detected
- Zero multiplier is caught by the same guard that handles the uninitialised case
- The POSIX fallback is tested and working on the same hardware