### PR TITLE
fix: resolve WATCHed key slot mismatch in cluster mode EXEC (#4343) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2154,6 +2154,17 @@ int keyIsExpired(serverDb *db, robj *key) {
     return keyIsExpiredWithDictIndex(db, key, dict_index);
 }
 
+/* Check if the key is expired, computing the KV store index from the key's
+ * own hash slot rather than the current client's cached slot. This is
+ * necessary when checking the expiry of keys that may reside in a different
+ * slot than the one the executing client is associated with, e.g. WATCHed
+ * keys during EXEC that may be in a different slot than the transaction. */
+int keyIsExpiredByKey(serverDb *db, robj *key) {
+    int dict_index = server.cluster_enabled ?
+        keyHashSlot((char *)objectGetVal(key), (int)sdslen(objectGetVal(key))) : 0;
+    return keyIsExpiredWithDictIndex(db, key, dict_index);
+}
+
 /* val is optional. Pass NULL if val is not yet fetched from the database. */
 static keyStatus expireIfNeededWithDictIndex(serverDb *db, robj *key, robj *val, int flags, int dict_index) {
     if (server.lazy_expire_disabled) return KEY_VALID;

--- a/src/multi.c
+++ b/src/multi.c
@@ -455,7 +455,7 @@ int isWatchedKeyExpired(client *c) {
     while ((ln = listNext(&li))) {
         wk = listNodeValue(ln);
         if (wk->expired) continue; /* was expired when WATCH was called */
-        if (keyIsExpired(wk->db, wk->key)) return 1;
+        if (keyIsExpiredByKey(wk->db, wk->key)) return 1;
     }
 
     return 0;

--- a/src/server.h
+++ b/src/server.h
@@ -3766,6 +3766,7 @@ void propagateDeletion(serverDb *db, robj *key, int lazy, int slot);
 int propagateFieldsDeletion(serverDb *db, robj *o, size_t n_fields, robj *fields[], int slot);
 size_t dbReclaimExpiredFields(robj *o, serverDb *db, mstime_t now, unsigned long max_entries, int didx);
 int keyIsExpired(serverDb *db, robj *key);
+int keyIsExpiredByKey(serverDb *db, robj *key);
 long long getExpire(serverDb *db, robj *key);
 robj *setExpire(client *c, serverDb *db, robj *key, long long when);
 int checkAlreadyExpired(mstime_t when);


### PR DESCRIPTION
## Problem

In cluster mode, `EXEC` checks whether each WATCHed key has expired by calling `keyIsExpired()`, which internally uses `getKeySlot()`. `getKeySlot()` returns the current client's cached slot when the `CLIENT_EXECUTING_COMMAND` flag is set. During `EXEC` this cached slot is the slot of the *queued commands*, but WATCHed keys may hash to a *different* slot.

This causes:
- **Debug builds** (`enable-debug-assert yes`): assertion failure inside `getKeySlot()` because `keyHashSlot(watched_key) != current_client->slot`
- **Non-debug builds**: the expiry check reads the wrong slot's keyspace, so an expired WATCHed key looks alive and `EXEC` commits a transaction it should have aborted

## Fix

Add `keyIsExpiredByKey(serverDb *db, robj *key)`, which computes the KV store index from the key's *own* hash slot rather than the cached client slot. `isWatchedKeyExpired()` now uses this function so each WATCHed key's expiry is checked against its correct slot.

## Verification

- `make` builds cleanly
- Fix mirrors how `getKVStoreIndexForKey` behaves for non-EXEC code paths (computes the slot from the key)

Fixes #4343