### PR TITLE
fix: check hash-max-listpack-value when loading hash listpack from RDB

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2593,7 +2593,26 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 goto emptykey;
             }
 
-            if (hashTypeLength(o) > server.hash_max_listpack_entries) hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
+            if (hashTypeLength(o) > server.hash_max_listpack_entries) {
+                hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
+            } else {
+                /* Check if any field or value exceeds hash_max_listpack_value.
+                 * This mirrors the runtime check in hashTypeSet() and the
+                 * per-element check in the RDB_TYPE_HASH loading path. */
+                unsigned char *lp = objectGetVal(o);
+                unsigned char *p = lpFirst(lp);
+                while (p) {
+                    unsigned int slen;
+                    long long lval;
+                    unsigned char *vstr = lpGetValue(p, &slen, &lval);
+                    size_t len = vstr ? slen : (size_t)sdigits10(lval);
+                    if (len > server.hash_max_listpack_value) {
+                        hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
+                        break;
+                    }
+                    p = lpNext(lp, p);
+                }
+            }
             break;
         default:
             /* totally unreachable */

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -938,4 +938,22 @@ start_server {tags {"hash"}} {
         assert_error "*value is NaN or Infinity*" {r hincrbyfloat hfoo field +inf}
         assert_equal 0 [r exists hfoo]
     } {} {valgrind:skip}
+
+    test {Hash listpack loaded via RDB respects hash-max-listpack-value} {
+        r del k kk
+        # A value at the default hash-max-listpack-value (8) stays listpack-encoded.
+        r hset k f [string repeat a 8]
+        assert_encoding listpack k
+        set dump [r dump k]
+
+        # Lower hash-max-listpack-entries and hash-max-listpack-value so the
+        # existing value now exceeds the value threshold. The load path must
+        # convert the listpack to a hashtable, just like the runtime path does
+        # when a new value exceeds the threshold.
+        config_set hash-max-listpack-entries 2
+        config_set hash-max-listpack-value 2
+        r restore kk 0 $dump
+        assert_encoding hashtable kk
+        assert_equal [r hget kk f] [string repeat a 8]
+    }
 }


### PR DESCRIPTION
The `RDB_TYPE_HASH_LISTPACK` load path only checked `hash_max_listpack_entries` when deciding whether to convert a loaded hash to a hashtable. This made the load behave asymmetrically relative to the runtime path (`hashTypeSet`) and the per-element `RDB_TYPE_HASH` loading path, both of which also convert when a field or value exceeds `hash_max_listpack_value`.

As a result, a hash that was saved as a listpack could stay listpack-encoded after reload even when `hash_max_listpack_value` was lowered below the size of its field/value, diverging from what would happen if the key were modified at runtime.

**Fix:** Scan the listpack in the `RDB_TYPE_HASH_LISTPACK` load path and convert to a hashtable when any field or value exceeds `hash_max_listpack_value`.

**Test:** Added a regression test that dumps a listpack-encoded hash, lowers `hash-max-listpack-value`, restores the key, and verifies the encoding is `hashtable` with the data intact.

Closes #4203