### PR TITLE
Prevent double block path from processPendingCommandAndInputBuffer

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3994,6 +3994,10 @@ int processPendingCommandAndInputBuffer(client *c) {
      * So whenever we change the code here we need to consider if we need this change on module
      * blocked client as well */
     if (c->flag.pending_command) {
+        /* Return if client is already blocked */
+        if (c->flag.blocked) {
+            return C_OK;
+        }
         c->flag.pending_command = 0;
         if (processCommandAndResetClient(c) == C_ERR) {
             return C_ERR;


### PR DESCRIPTION
### Description

There have been recent test failures in daily workflow giving error `I/O error reading reply` in test suites with io-threads + tls enabled.

This is due to serverAsserts abruptly closing server making test suite give this error.

I analyzed this condition turns out it is due to client is being blocked a second time when already blocked which raises this serverAssert.
```
serverAssert(c->bstate->client_waiting_acks_list_node == NULL);
```
This path is reached as io-thread resumes execution from `processPendingCommandAndInputBuffer` which does not check if client is already blocked or not and proceeds to set `c->flag.pending_command` to 0, which proceeds to block client again via `processCommand` raising serverAssert.

### Fix 

Add a check inside `processPendingCommandAndInputBuffer` if client is already blocked, return with C_OK without processing command again. 

Added extra checks inside `blockPostponeClient` & `blockClientForReplicaAck` to early return in case of double block.

Set `c->flag.pending_command` to 1 to avoid reset client to drop argv of client causing null access later.

---
All 371 tests passed in ./runtest