### PR TITLE
Don't re-run a blocked client's pending command in handleReadJobs()

### DIFF
--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -865,7 +865,11 @@ static void handleReadJobs(client **read_jobs, int read_count) {
             client *c = lookupClientByID(read_client_ids[i]);
             if (!c || !c->conn) continue;
 
-            if (processPendingCommandAndInputBuffer(c) == C_OK) beforeNextClient(c);
+            /* pending_command belongs to whoever blocked the client. BLOCKED_POSTPONE
+             * keeps it set across unblockClient(), hence the unblocked check too. */
+            if (!c->flag.blocked && !c->flag.unblocked &&
+                processPendingCommandAndInputBuffer(c) == C_OK)
+                beforeNextClient(c);
 
             c = lookupClientByID(read_client_ids[i]);
             if (!c || !c->conn) continue;

--- a/tests/unit/io-threads.tcl
+++ b/tests/unit/io-threads.tcl
@@ -171,3 +171,39 @@ start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overr
         assert_equal {PONG} [r ping]
     }
 }
+
+start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overrides {io-threads 5}} {
+    # handleReadJobs() used to re-run the pending command of a client that
+    # processClientsCommandsBatch() had just blocked, blocking it twice and
+    # leaking a server.blocked_clients reference per blocking command.
+    test {Blocking command offloaded to an IO thread blocks the client only once} {
+        assert_equal {OK} [r config set io-threads-always-active yes]
+        activate_io_threads_and_wait
+
+        set rd [valkey_deferring_client]
+        $rd blpop iothreads-blist 0
+        wait_for_blocked_clients_count 1
+
+        r lpush iothreads-blist foo
+        assert_equal {iothreads-blist foo} [$rd read]
+        wait_for_blocked_clients_count 0
+
+        $rd close
+        assert_equal {PONG} [r ping]
+    }
+
+    test {Blocking command offloaded to an IO thread does not leak blocked_clients on timeout} {
+        assert_equal {OK} [r config set io-threads-always-active yes]
+        activate_io_threads_and_wait
+
+        set rd [valkey_deferring_client]
+        $rd blpop iothreads-nolist 1
+        wait_for_blocked_clients_count 1
+
+        assert_equal {} [$rd read]
+        wait_for_blocked_clients_count 0
+
+        $rd close
+        assert_equal {PONG} [r ping]
+    }
+}


### PR DESCRIPTION
blockForKeys() sets pending_command so a blocking command is re-executed once the client is unblocked. handleReadJobs() calls processPendingCommandAndInputBuffer() after processClientsCommandsBatch(), which re-enters processCommand() on the client it just blocked, blocking it a second time.

With io-threads active a single in-flight BLPOP reports blocked_clients:2, and the counter leaks one reference per blocking command:

    valkey-server --io-threads 2 --io-threads-always-active yes
    # after 5 BLPOP timeouts, all those clients since disconnected:
    blocked_clients:5

Reproduction:
`./runtest --single unit/type/list --io-threads --only "Unblock fairness is kept while pipelining"`

Existing coverage only fails under --io-threads, which CI never passes; the new test in unit/io-threads.tcl pins 
io-threads itself so a default run covers this path.

Guard the call on the states that mean the client already owns an unprocessed command, matching processUnblockedClients(). Guarding the call rather than the loop iteration keeps blocked clients reaching connUpdateState().