### PR TITLE
Apply *-max-listpack-value symmetrically on RDB load

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1767,6 +1767,28 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename) {
     return createStringObject("module-dummy-value", 18);
 }
 
+/* Return the maximum byte length of string entries in a listpack.
+ * step=1 inspects every entry (sets, hashes); step=2 skips every second
+ * entry (zsets: skip scores). Integer-encoded entries are ignored.
+ * Used by the RDB load path to enforce *-max-listpack-value symmetrically
+ * with the runtime conversion. */
+static unsigned int lpMaxElementLength(unsigned char *lp, int step) {
+    unsigned int maxlen = 0, slen;
+    long long lval;
+    unsigned char *p = lpFirst(lp);
+    int idx = 0;
+    while (p) {
+        if (step != 2 || (idx % 2 == 0)) {
+            if (lpGetValue(p, &slen, &lval) != NULL) {
+                if (slen > maxlen) maxlen = slen;
+            }
+        }
+        p = lpNext(lp, p);
+        idx++;
+    }
+    return maxlen;
+}
+
 /* callback for hashZiplistConvertAndValidateIntegrity.
  * Check that the ziplist doesn't have duplicate hash field names.
  * The ziplist element pointed by 'p' will be converted and stored into listpack. */
@@ -2482,7 +2504,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 decrRefCount(o);
                 goto emptykey;
             }
-            if (setTypeSize(o) > server.set_max_listpack_entries) setTypeConvert(o, OBJ_ENCODING_HASHTABLE);
+            if (setTypeSize(o) > server.set_max_listpack_entries ||
+                lpMaxElementLength(objectGetVal(o), 1) > server.set_max_listpack_value) setTypeConvert(o, OBJ_ENCODING_HASHTABLE);
             break;
         case RDB_TYPE_ZSET_ZIPLIST: {
             unsigned char *lp = lpNew(encoded_len);
@@ -2549,7 +2572,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 goto emptykey;
             }
 
-            if (zsetLength(o) > server.zset_max_listpack_entries) zsetConvert(o, OBJ_ENCODING_SKIPLIST);
+            if (zsetLength(o) > server.zset_max_listpack_entries ||
+                lpMaxElementLength(objectGetVal(o), 2) > server.zset_max_listpack_value) zsetConvert(o, OBJ_ENCODING_SKIPLIST);
             break;
         case RDB_TYPE_HASH_ZIPLIST: {
             unsigned char *lp = lpNew(encoded_len);
@@ -2593,7 +2617,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 goto emptykey;
             }
 
-            if (hashTypeLength(o) > server.hash_max_listpack_entries) hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
+            /* Apply both the entries and the value threshold, symmetric with
+             * the runtime conversion. */
+            if (hashTypeLength(o) > server.hash_max_listpack_entries ||
+                lpMaxElementLength(objectGetVal(o), 1) > server.hash_max_listpack_value)
+                hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
             break;
         default:
             /* totally unreachable */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2539,7 +2539,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 goto emptykey;
             }
 
-            if (zsetLength(o) > server.zset_max_listpack_entries)
+            if (zsetLength(o) > server.zset_max_listpack_entries ||
+                lpMaxElementLength(objectGetVal(o), 2) > server.zset_max_listpack_value)
                 zsetConvert(o, OBJ_ENCODING_SKIPLIST);
             else
                 objectSetVal(o, lpShrinkToFit(objectGetVal(o)));
@@ -2595,7 +2596,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 goto emptykey;
             }
 
-            if (hashTypeLength(o) > server.hash_max_listpack_entries)
+            if (hashTypeLength(o) > server.hash_max_listpack_entries ||
+                lpMaxElementLength(objectGetVal(o), 1) > server.hash_max_listpack_value)
                 hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
             else
                 objectSetVal(o, lpShrinkToFit(objectGetVal(o)));

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1767,21 +1767,24 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename) {
     return createStringObject("module-dummy-value", 18);
 }
 
-/* Return the maximum byte length of string entries in a listpack.
+/* Return the maximum byte length of the entries in a listpack, measured as
+ * the length of their string form so that integer-encoded entries count the
+ * same as they do at runtime (runtime uses ll2string before comparing against
+ * *-max-listpack-value, see t_set.c/t_hash.c/t_zset.c).
  * step=1 inspects every entry (sets, hashes); step=2 skips every second
- * entry (zsets: skip scores). Integer-encoded entries are ignored.
+ * entry (zsets: skip scores).
  * Used by the RDB load path to enforce *-max-listpack-value symmetrically
  * with the runtime conversion. */
 static unsigned int lpMaxElementLength(unsigned char *lp, int step) {
-    unsigned int maxlen = 0, slen;
-    long long lval;
+    unsigned char intbuf[LP_INTBUF_SIZE];
+    unsigned int maxlen = 0;
+    int64_t slen;
     unsigned char *p = lpFirst(lp);
     int idx = 0;
     while (p) {
         if (step != 2 || (idx % 2 == 0)) {
-            if (lpGetValue(p, &slen, &lval) != NULL) {
-                if (slen > maxlen) maxlen = slen;
-            }
+            lpGet(p, &slen, intbuf);
+            if ((unsigned int)slen > maxlen) maxlen = (unsigned int)slen;
         }
         p = lpNext(lp, p);
         idx++;
@@ -2390,9 +2393,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
         /* Fix the object encoding, and make sure to convert the encoded
          * data type into the base type if accordingly to the current
          * configuration there are too many elements in the encoded data
-         * type. Note that we only check the length and not max element
-         * size as this is an O(N) scan. Eventually everything will get
-         * converted. */
+         * type, or the elements are too large (checked for most encoded
+         * types; see lpMaxElementLength and the zipmap path). */
         switch (rdbtype) {
         case RDB_TYPE_HASH_ZIPMAP:
             /* Since we don't keep zipmaps anymore, the rdb loading for these

--- a/tests/integration/convert-ziplist-hash-on-load.tcl
+++ b/tests/integration/convert-ziplist-hash-on-load.tcl
@@ -25,4 +25,15 @@ start_server [list overrides [list "dir" $server_path "dbfilename" "hash-ziplist
     }
 }
 
+exec cp -f tests/assets/hash-ziplist.rdb $server_path
+start_server [list overrides [list "dir" $server_path "dbfilename" "hash-ziplist.rdb" "hash-max-ziplist-value" 1]] {
+    test "RDB load ziplist hash: converts to hash table when hash-max-ziplist-value is exceeded" {
+        r select 0
+
+        assert_encoding hashtable hash
+        assert_equal 2 [r hlen hash]
+        assert_match {v1 v2} [r hmget hash f1 f2]
+    }
+}
+
 }

--- a/tests/integration/convert-ziplist-zset-on-load.tcl
+++ b/tests/integration/convert-ziplist-zset-on-load.tcl
@@ -25,4 +25,15 @@ start_server [list overrides [list "dir" $server_path "dbfilename" "zset-ziplist
     }
 }
 
+exec cp -f tests/assets/zset-ziplist.rdb $server_path
+start_server [list overrides [list "dir" $server_path "dbfilename" "zset-ziplist.rdb" "zset-max-ziplist-value" 1]] {
+    test "RDB load ziplist zset: converts to skiplist when zset-max-ziplist-value is exceeded" {
+        r select 0
+
+        assert_encoding skiplist zset
+        assert_equal 2 [r zcard zset]
+        assert_match {one 1 two 2} [r zrange zset 0 -1 withscores]
+    }
+}
+
 }

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -938,4 +938,27 @@ start_server {tags {"hash"}} {
         assert_error "*value is NaN or Infinity*" {r hincrbyfloat hfoo field +inf}
         assert_equal 0 [r exists hfoo]
     } {} {valgrind:skip}
+
+    test {Hash listpack is converted to hashtable on RDB load when value exceeds hash-max-listpack-value} {
+        set orig_entries [lindex [r config get hash-max-listpack-entries] 1]
+        set orig_value [lindex [r config get hash-max-listpack-value] 1]
+
+        # Write under a permissive value threshold so the hash stays listpack,
+        # then tighten the threshold before reloading through RDB. The load path
+        # must convert the oversized listpack to a hashtable.
+        r config set hash-max-listpack-entries 512
+        r config set hash-max-listpack-value 256
+        r del myhash
+        r hset myhash f [string repeat a 200]
+
+        r config set hash-max-listpack-value 64
+        r debug reload
+
+        set err [catch {assert_encoding hashtable myhash} err_msg]
+
+        r config set hash-max-listpack-entries $orig_entries
+        r config set hash-max-listpack-value $orig_value
+
+        if {$err} {error $err_msg}
+    } {} {needs:debug}
 }

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -950,6 +950,7 @@ start_server {tags {"hash"}} {
         r config set hash-max-listpack-value 256
         r del myhash
         r hset myhash f [string repeat a 200]
+        assert_encoding listpack myhash
 
         r config set hash-max-listpack-value 64
         r debug reload

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -181,6 +181,7 @@ foreach type {single multiple single_multiple} {
         r config set set-max-listpack-value 256
         r del myset
         r sadd myset [string repeat a 200]
+        assert_encoding listpack myset
 
         r config set set-max-listpack-value 64
         r debug reload

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -168,7 +168,30 @@ foreach type {single multiple single_multiple} {
         assert_equal 1 [r sadd myset b]
         assert_encoding hashtable myset
     }
-}
+} ;# foreach type
+
+    test {Set listpack is converted to hashtable on RDB load when value exceeds set-max-listpack-value} {
+        set orig_entries [lindex [r config get set-max-listpack-entries] 1]
+        set orig_value [lindex [r config get set-max-listpack-value] 1]
+
+        # Write under a permissive value threshold so the set stays listpack,
+        # then tighten the threshold before reloading through RDB. The load path
+        # must convert the oversized listpack to a hashtable.
+        r config set set-max-listpack-entries 512
+        r config set set-max-listpack-value 256
+        r del myset
+        r sadd myset [string repeat a 200]
+
+        r config set set-max-listpack-value 64
+        r debug reload
+
+        set err [catch {assert_encoding hashtable myset} err_msg]
+
+        r config set set-max-listpack-entries $orig_entries
+        r config set set-max-listpack-value $orig_value
+
+        if {$err} {error $err_msg}
+    } {} {needs:debug}
 
     test {Variadic SADD} {
         r del myset

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2983,6 +2983,29 @@ start_server {tags {"zset"}} {
             r config set zset-max-listpack-entries $original_max
         }
     }
+
+    test {ZSet listpack is converted to skiplist on RDB load when value exceeds zset-max-listpack-value} {
+        set orig_entries [lindex [r config get zset-max-listpack-entries] 1]
+        set orig_value [lindex [r config get zset-max-listpack-value] 1]
+
+        # Write under a permissive value threshold so the zset stays listpack,
+        # then tighten the threshold before reloading through RDB. The load path
+        # must convert the oversized listpack to a skiplist.
+        r config set zset-max-listpack-entries 512
+        r config set zset-max-listpack-value 256
+        r del myzset
+        r zadd myzset 1 [string repeat a 200]
+
+        r config set zset-max-listpack-value 64
+        r debug reload
+
+        set err [catch {assert_encoding skiplist myzset} err_msg]
+
+        r config set zset-max-listpack-entries $orig_entries
+        r config set zset-max-listpack-value $orig_value
+
+        if {$err} {error $err_msg}
+    } {} {needs:debug}
 }
 
 start_server [list overrides [list save ""] tags {"zset needs:debug external:skip"}] {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2995,6 +2995,7 @@ start_server {tags {"zset"}} {
         r config set zset-max-listpack-value 256
         r del myzset
         r zadd myzset 1 [string repeat a 200]
+        assert_encoding listpack myzset
 
         r config set zset-max-listpack-value 64
         r debug reload


### PR DESCRIPTION
Closes #4203

## Problem

The listpack/ziplist-encoded hash/set/zset load paths in `rdb.c` only
checked the entries threshold (O(1) via `lpLength`) and skipped the
value-size threshold when deciding whether to convert to hashtable /
skiplist. The runtime insertion path applies both (`t_hash.c:375`,
`t_set.c:164`, `t_zset.c:1538`), so a key loaded from RDB could end up
listpack-encoded even though its current config says it should be
hashtable -- but only if the offending dimension was value size, not
count.

Concretely: lower `hash-max-listpack-value` (or the set/zset
equivalents) and reload a snapshot produced under a larger threshold,
and oversized listpacks stay in place. Issue #4203.

The same gap existed on the two legacy ziplist branches
(`RDB_TYPE_HASH_ZIPLIST`, `RDB_TYPE_ZSET_ZIPLIST`).

## Fix

Add `lpMaxElementLength(lp, step)` which scans a listpack once and
returns the maximum entry length, measured as the length of the string
form so integer-encoded entries count the same as at runtime (both go
through `ll2string`). `step=1` inspects every entry (sets; hashes,
where both field and value matter); `step=2` skips every second entry
(zsets, where only the element length is checked at runtime, scores are
numbers).

Wire it into all five hash/set/zset load branches:

- `RDB_TYPE_HASH_LISTPACK`, `RDB_TYPE_SET_LISTPACK`, `RDB_TYPE_ZSET_LISTPACK`
- `RDB_TYPE_HASH_ZIPLIST`, `RDB_TYPE_ZSET_ZIPLIST` (legacy)

The entries check short-circuits first via `||`, so the O(n) scan only
runs when entries alone wouldn't force a conversion -- same shape as
the existing `RDB_TYPE_HASH_ZIPLIST` zipmap path and the field-by-field
`RDB_TYPE_HASH` branch.

## Tests

- `tests/unit/type/{hash,set,zset}.tcl`: write an oversized value under
  a permissive threshold, pin the listpack encoding, tighten the
  threshold, reload via `DEBUG RELOAD`, assert the encoding flips.
  Covers the three listpack branches.
- `tests/integration/convert-ziplist-{hash,zset}-on-load.tcl`: add
  `*-max-ziplist-value 1` variants next to the existing entries
  variants. Loads the prebuilt `tests/assets/*-ziplist.rdb` fixtures,
  covering the two legacy ziplist branches.

All five tests fail before this change and pass after (verified by
disabling the `lpMaxElementLength` call in each branch).

## Scope intentionally excluded

HyperLogLog has a similar shape of asymmetry (`hll_sparse_max_bytes` is
only checked on the `PFADD` write path, not on RDB load), but it's a
different kind of problem: HLL is stored as `RDB_TYPE_STRING`, and
sparse vs dense is an internal representation, not an `OBJ_ENCODING_*`
choice. Worth a separate issue if we want to pursue it.