### PR TITLE
Fix make test-unit link failure when libsystemd is auto-detected

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -680,6 +680,8 @@ persist-settings: distclean
 	echo BUILD_TLS=$(BUILD_TLS) >> .make-settings
 	echo BUILD_RDMA=$(BUILD_RDMA) >> .make-settings
 	echo USE_SYSTEMD=$(USE_SYSTEMD) >> .make-settings
+	echo BUILD_WITH_SYSTEMD=$(BUILD_WITH_SYSTEMD) >> .make-settings
+	echo LIBSYSTEMD_LIBS=$(LIBSYSTEMD_LIBS) >> .make-settings
 	echo BUILD_LUA=$(BUILD_LUA) >> .make-settings
 	echo USE_LIBBACKTRACE=$(USE_LIBBACKTRACE) >> .make-settings
 	echo LIBBACKTRACE_PREFIX=$(LIBBACKTRACE_PREFIX) >> .make-settings

--- a/src/unit/Makefile
+++ b/src/unit/Makefile
@@ -191,6 +191,11 @@ ifeq ($(BUILD_TLS),yes)
 	LD_LIBS += $(TLS_LIBS)
 endif
 
+# Add systemd libraries if enabled
+ifeq ($(BUILD_WITH_SYSTEMD),yes)
+	LD_LIBS += $(LIBSYSTEMD_LIBS)
+endif
+
 # Compile C++ test files, recompile if generated_wrappers or compiler flags change
 %.o: %.cpp generated_wrappers.cpp .flags
 	$(CXX) -MD -MP -std=c++17 -faligned-new -Wno-write-strings -fpermissive $(GCC_FLAGS) $(OPT) $(DEBUG) $(TEST_CFLAGS) -Wall -Wno-deprecated-declarations -c \


### PR DESCRIPTION
Closes #4338

## Problem

When libsystemd is installed, `src/Makefile` detects it through pkg-config, compiles `server.o` with `HAVE_LIBSYSTEMD`, and links the server with `-lsystemd`. Only the raw `USE_SYSTEMD` value was persisted to `.make-settings`, though, so `src/unit/Makefile` missed the auto-detected result and `valkey-unit-gtests` failed to link against `libvalkey.a`:

```text
undefined reference to `sd_notify'
```

## Fix

Persist `BUILD_WITH_SYSTEMD` and `LIBSYSTEMD_LIBS` to `.make-settings`, then append the library to the unit-test `LD_LIBS` when systemd support is enabled. This follows the existing `BUILD_TLS` pattern and keeps the library after the objects and `libvalkey.a` in link order.

## Testing

- `make distclean && make -j && make test-unit` with auto-detected libsystemd: 299 unit tests pass.
- `make distclean && make test-unit USE_SYSTEMD=no`: all unit tests pass.
- I did not run the Tcl integration suite because this only changes unit-test link wiring.

Best Regards, Tarik