### PR TITLE
Fix re-entry into processPendingCommandAndInputBuffer on blocked clients

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3989,6 +3989,10 @@ int processCommandAndResetClient(client *c) {
  * the client. Returns C_ERR if the client is no longer valid after executing
  * the command, and C_OK for all other cases. */
 int processPendingCommandAndInputBuffer(client *c) {
+    /* Blocked clients are resumed via processUnblockedClients(); skip them here
+     * to avoid re-entering processCommand() while pending_command is intentionally left set. */
+    if (c->flag.blocked) return C_OK;
+
     /* Notice, this code is also called from 'processUnblockedClients'.
      * But in case of a module blocked client (see RM_Call 'K' flag) we do not reach this code path.
      * So whenever we change the code here we need to consider if we need this change on module


### PR DESCRIPTION
Follow up #3611
Under io-threads, a pipelined MULTI/CLIENT PAUSE ALL/EXEC followed by CLIENT UNPAUSE on the same connection lets handleReadJobs()'s read-done followup re-enter processPendingCommandAndInputBuffer() on a client that blockPostponeClient() just blocked. pending_command is intentionally left set for retry after unblock, so the re-entry drives processCommand() again, hits blockPostponeClient() a second time and asserts on postponed_list_node already being set.

Guard the entry of processPendingCommandAndInputBuffer() rather than each call site: the same re-entry exists via
processClientsCommandsBatch() and addCommandToBatchAndProcessIfFull(), and the blocked client is properly resumed via processUnblockedClients().

Fix 2 daily tests:
https://github.com/valkey-io/valkey/actions/runs/31343907142/job/93322161468
https://github.com/valkey-io/valkey/actions/runs/31343907142/job/93322161363#step:8:861

@zuiderkwast 
Actually I met this problem in developing in #3335 , the commit is https://github.com/valkey-io/valkey/pull/3335/changes/e91cd9926165352a8d2e2d5d96115a1a6704f5f8
And I think the CI of io and  tls-io may fail again at some point, if fails again, you can ping me.

Maybe add a  `run-extra-test` label, until this PR can fix all fails in daily test? I don't know how that works.