### PR TITLE
Deflake qbuf fill waits in client-eviction tests

### DIFF
--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -19,6 +19,18 @@ proc client_exists {name} {
     return true
 }
 
+# Block-wait until the named client's query buffer reaches exactly
+# the given size. The fill is monotonic and settles at exactly this
+# value, so a generous budget cannot hide a stall or a wrong value;
+# it only tolerates slow CLIENT LIST polling on loaded CI runners.
+proc wait_for_qbuf_size {name size} {
+    wait_for_condition 500 100 {
+        [client_field $name qbuf] == $size
+    } else {
+        fail "Failed to fill qbuf for $name"
+    }
+}
+
 proc gen_client {} {
     set rr [valkey_client]
     set name "tst_[randstring 4 4 simplealpha]"
@@ -315,14 +327,7 @@ start_server {} {
             if {[catch {
                 $rr write [join [list "*1\r\n\$$qbsize\r\n" [string repeat v $qbsize]] ""]
                 $rr flush
-                # The qbuf must reach exactly qbsize, so a generous budget
-                # cannot hide a stall; it only tolerates slow fills on
-                # heavily loaded CI runners.
-                wait_for_condition 500 100 {
-                    [client_field $cname qbuf] == $qbsize
-                } else {
-                    fail "Failed to fill qbuf for test"
-                }
+                wait_for_qbuf_size $cname $qbsize
             } e] && $no_evict == off} {
                 assert {![client_exists $cname]}
             } elseif {$no_evict == on} {
@@ -361,14 +366,8 @@ start_server {} {
         set qbsize [expr {$maxmemory_clients - $obuf_size}]
         $rr1 write [join [list "*1\r\n\$$qbsize\r\n" [string repeat v $qbsize]] ""]
         $rr1 flush
-        # Wait for qbuff to be as expected. The qbuf must reach exactly
-        # qbsize, so a generous budget cannot hide a stall; it only
-        # tolerates slow fills on heavily loaded CI runners.
-        wait_for_condition 500 100 {
-            [client_field qbuf-client qbuf] == $qbsize
-        } else {
-            fail "Failed to fill qbuf for test"
-        }
+        # Wait for qbuf to be as expected.
+        wait_for_qbuf_size qbuf-client $qbsize
 
         # Make the other two obuf-clients pass obuf limit and also pass maxmemory-clients
         # We use two obuf-clients to make sure that even if client eviction is attempted

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -315,7 +315,10 @@ start_server {} {
             if {[catch {
                 $rr write [join [list "*1\r\n\$$qbsize\r\n" [string repeat v $qbsize]] ""]
                 $rr flush
-                wait_for_condition 200 10 {
+                # The qbuf must reach exactly qbsize, so a generous budget
+                # cannot hide a stall; it only tolerates slow fills on
+                # heavily loaded CI runners.
+                wait_for_condition 500 100 {
                     [client_field $cname qbuf] == $qbsize
                 } else {
                     fail "Failed to fill qbuf for test"
@@ -358,8 +361,10 @@ start_server {} {
         set qbsize [expr {$maxmemory_clients - $obuf_size}]
         $rr1 write [join [list "*1\r\n\$$qbsize\r\n" [string repeat v $qbsize]] ""]
         $rr1 flush
-        # Wait for qbuff to be as expected
-        wait_for_condition 200 10 {
+        # Wait for qbuff to be as expected. The qbuf must reach exactly
+        # qbsize, so a generous budget cannot hide a stall; it only
+        # tolerates slow fills on heavily loaded CI runners.
+        wait_for_condition 500 100 {
             [client_field qbuf-client qbuf] == $qbsize
         } else {
             fail "Failed to fill qbuf for test"


### PR DESCRIPTION
Closes #4324

## What changed

The two exact-fill qbuf waits in `tests/unit/client-eviction.tcl` now use `500 x 100 ms` instead of `200 x 10 ms`.

The failing `test-fedorarawhide-tls-module` run exhausted its nominal two-second budget even though the polls took about 28 seconds in wall time. Each `CLIENT LIST` call took roughly 120 ms on the loaded runner, and a neighboring test that normally finishes in under a second took 32 seconds.

These waits target an exact value that then stays on a plateau: the test parks an incomplete multibulk payload, so the command never completes and qbuf remains at the expected size. A larger budget therefore does not hide a wrong value or a stalled fill; those cases still time out. The coarser interval also reduces the polling load.

The identical 10 MiB wait in the no-evict test gets the same treatment. The smaller `>=` waits are unchanged because they have slack and were not involved in the failure.

## Testing

- The three affected test cases pass with `./runtest --single tests/unit/client-eviction.tcl`.
- I could not reproduce the exact `--tls-module` job on Fedora Rawhide because tcltls 2.0.1 with OpenSSL 4 rejects the test CA before the test starts. The changed Tcl is mode-independent, and the same wait path had 17 consecutive green TLS-module runs with the older local toolchain.

Precedent: 5074e5c and d64f207.

Best Regards, Tarik