### PR TITLE
DCO remediation for 5779dc7 and use serverassert.h in fbtree.c

### DIFF
--- a/src/fbtree.c
+++ b/src/fbtree.c
@@ -5,13 +5,14 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <string.h>
-#include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
+/* serverassert.h replaces assert.h: assert() routes to _serverAssert for crash
+ * reports, and it defines static_assert used by fbtree_internal.h below. */
+#include "serverassert.h"
 #include "config.h"
 #include "fbtree.h"
 #include "fbtree_internal.h"
-#include "serverassert.h"
 #include "zmalloc.h"
 #include "sds.h"
 

--- a/src/fbtree.c
+++ b/src/fbtree.c
@@ -7,8 +7,6 @@
 #include <string.h>
 #include <inttypes.h>
 #include <stdio.h>
-/* serverassert.h replaces assert.h: assert() routes to _serverAssert for crash
- * reports, and it defines static_assert used by fbtree_internal.h below. */
 #include "serverassert.h"
 #include "config.h"
 #include "fbtree.h"


### PR DESCRIPTION
Two small items for the zset-btree branch.

    1. DCO remediation (empty commit)

    The squash-merge of #4363 rewrote the commit author to my GitHub email ([abhishranchi@gmail.com](mailto:abhishranchi@gmail.com)) while the commit message kept my amazon.com Signed-off-by, so the DCO check on #4359 now fails on 5779dc7 with an author/signoff mismatch. This adds the standard DCO remediation commit in which I retroactively sign off that commit under the matching identity. No history rewrite needed.

    2. Use serverassert.h instead of assert.h in fbtree.c

    serverassert.h is a drop-in replacement for assert.h. It redefines assert() to route through _serverAssert so a failed assertion produces a crash report in the server log instead of a bare SIGABRT. fbtree.c included both headers, and the 13 assert() calls only routed to _serverAssert because serverassert.h happened to come last in the include list.

    This drops the assert.h include and moves serverassert.h above fbtree_internal.h, since that header uses static_assert, which serverassert.h also provides. A comment documents the ordering requirement. Compile-checked with -Werror.

    Merge note

    Please merge with a regular merge commit rather than squash. A squash would collapse the remediation commit into the code change and the DCO bot would no longer see the remediation declaration on the branch.