### PR TITLE
Validate stream listpack live and deleted record counts on load

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -4038,12 +4038,24 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, uint64_t *va
     p = next;
     if (!lpValidateNext(lp, &next, size)) return 0;
 
+    /* Only the sum of the two header counts is validated by the traversal
+     * below, so count the live and deleted records actually present and
+     * reconcile both. streamIteratorRemoveEntry() frees the whole node once the
+     * declared live count reaches 1, so a header that understates it makes XDEL
+     * destroy the records it failed to account for. */
+    int64_t declared_live = entry_count, declared_deleted = deleted_count;
+    uint64_t live_records = 0, deleted_records = 0;
+
     entry_count += deleted_count;
     while (entry_count--) {
         if (!p) return 0;
         int64_t fields = primary_fields, extra_fields = 3;
         int64_t flags = lpGetIntegerIfValid(p, &valid_record);
         if (!valid_record) return 0;
+        if (flags & STREAM_ITEM_FLAG_DELETED)
+            deleted_records++;
+        else
+            live_records++;
         p = next;
         if (!lpValidateNext(lp, &next, size)) return 0;
 
@@ -4088,6 +4100,7 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, uint64_t *va
     }
 
     if (next) return 0;
+    if (live_records != (uint64_t)declared_live || deleted_records != (uint64_t)declared_deleted) return 0;
 
     return 1;
 }

--- a/src/unit/test_t_stream.cpp
+++ b/src/unit/test_t_stream.cpp
@@ -9,7 +9,97 @@
 #include <cstring>
 
 extern "C" {
+#include "listpack.h"
 #include "stream.h"
+}
+
+/* Mirrors of the record flags private to t_stream.c. */
+#define TEST_STREAM_ITEM_FLAG_DELETED (1 << 0)
+#define TEST_STREAM_ITEM_FLAG_SAMEFIELDS (1 << 1)
+
+/* Build a structurally valid stream listpack holding two same-fields records.
+ * The declared header counts and the per-record deleted flags are supplied
+ * separately so a caller can describe a header whose live/deleted split
+ * disagrees with the records that actually follow. */
+static unsigned char *buildTwoRecordStreamListpack(long long declared_live,
+                                                   long long declared_deleted,
+                                                   int first_deleted,
+                                                   int second_deleted) {
+    unsigned char *lp = lpNew(0);
+
+    /* Primary entry: count, deleted, num-primary-fields, field, terminator. */
+    lp = lpAppendInteger(lp, declared_live);
+    lp = lpAppendInteger(lp, declared_deleted);
+    lp = lpAppendInteger(lp, 1);
+    lp = lpAppend(lp, (unsigned char *)"f", 1);
+    lp = lpAppendInteger(lp, 0);
+
+    /* Two records, each reusing the primary field, so lp-count is 1 field
+     * plus the three fixed elements. */
+    for (int i = 0; i < 2; i++) {
+        int deleted = i == 0 ? first_deleted : second_deleted;
+        long long flags = TEST_STREAM_ITEM_FLAG_SAMEFIELDS;
+        if (deleted) flags |= TEST_STREAM_ITEM_FLAG_DELETED;
+
+        lp = lpAppendInteger(lp, flags);
+        lp = lpAppendInteger(lp, 0); /* ms diff */
+        lp = lpAppendInteger(lp, i); /* seq diff */
+        lp = lpAppend(lp, (unsigned char *)(i == 0 ? "v1" : "v2"), 2);
+        lp = lpAppendInteger(lp, 4);
+    }
+
+    return lp;
+}
+
+class StreamListpackIntegrityTest : public ::testing::Test {};
+
+/* Control: the header split matches the records, so the payload is accepted.
+ * This keeps the mismatch tests below honest by proving the hand-built
+ * fixture is otherwise structurally valid. */
+TEST_F(StreamListpackIntegrityTest, TestAcceptsMatchingLiveAndDeletedCounts) {
+    unsigned char *lp = buildTwoRecordStreamListpack(2, 0, 0, 0);
+    uint64_t valid_count = 0;
+    ASSERT_EQ(lpLength(lp), 15u);
+    ASSERT_EQ(streamValidateListpackIntegrity(lp, lpBytes(lp), &valid_count), 1);
+    ASSERT_EQ(valid_count, 2u);
+    lpFree(lp);
+}
+
+TEST_F(StreamListpackIntegrityTest, TestAcceptsMatchingDeletedRecord) {
+    unsigned char *lp = buildTwoRecordStreamListpack(1, 1, 0, 1);
+    uint64_t valid_count = 0;
+    ASSERT_EQ(streamValidateListpackIntegrity(lp, lpBytes(lp), &valid_count), 1);
+    ASSERT_EQ(valid_count, 1u);
+    lpFree(lp);
+}
+
+/* Both records are live, but the header claims one live and one deleted. The
+ * total still equals two, so a total-only check accepts this payload while the
+ * live count is understated. XDEL then sees a declared live count of 1, frees
+ * the whole node and destroys the record the header did not account for. */
+TEST_F(StreamListpackIntegrityTest, TestRejectsUnderstatedLiveCount) {
+    unsigned char *lp = buildTwoRecordStreamListpack(1, 1, 0, 0);
+    uint64_t valid_count = 0;
+    ASSERT_EQ(lpLength(lp), 15u);
+    ASSERT_EQ(streamValidateListpackIntegrity(lp, lpBytes(lp), &valid_count), 0);
+    lpFree(lp);
+}
+
+/* The mirrored case: one record is flagged deleted while the header claims
+ * two live records and no deleted ones. The total again matches. */
+TEST_F(StreamListpackIntegrityTest, TestRejectsOverstatedLiveCount) {
+    unsigned char *lp = buildTwoRecordStreamListpack(2, 0, 0, 1);
+    uint64_t valid_count = 0;
+    ASSERT_EQ(streamValidateListpackIntegrity(lp, lpBytes(lp), &valid_count), 0);
+    lpFree(lp);
+}
+
+/* Every record is flagged deleted while the header claims both are live. */
+TEST_F(StreamListpackIntegrityTest, TestRejectsAllRecordsDeletedWithLiveHeader) {
+    unsigned char *lp = buildTwoRecordStreamListpack(2, 0, 1, 1);
+    uint64_t valid_count = 0;
+    ASSERT_EQ(streamValidateListpackIntegrity(lp, lpBytes(lp), &valid_count), 0);
+    lpFree(lp);
 }
 
 class StreamIdTest : public ::testing::Test {};

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -794,6 +794,38 @@ test {corrupt payload: stream listpack with negative deleted count} {
     }
 }
 
+test {corrupt payload: stream listpack live and deleted counts do not match the records} {
+    # A master entry may declare a live/deleted split that disagrees with the
+    # records that follow. Only the sum is validated by the entry loop, and the
+    # stream length here matches the declared live count, so the payload passes
+    # both checks while understating the live records. XDEL then reads the
+    # declared live count of 1, treats the node as holding its last live record
+    # and frees the whole node, destroying the record the header did not account
+    # for. XLEN disagrees with XRANGE until that happens.
+    #
+    # Built from a valid two-live-record control by changing the master entry
+    # count from 2 to 1, its deleted count from 0 to 1 and the stream length
+    # from 2 to 1, then recomputing the DUMP CRC64. All three encode in the
+    # same byte width, so no other byte moves.
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        catch {r restore _split_mismatch 0 "\x15\x01\x10\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x2D\x2D\x00\x00\x00\x11\x00\x01\x01\x01\x01\x01\x01\x81\x66\x02\x00\x01\x02\x01\x00\x01\x00\x01\x81\x76\x02\x04\x01\x00\x01\x01\x01\x00\x01\x01\x01\x81\x67\x02\x81\x77\x02\x06\x01\xFF\x01\x02\x00\x01\x00\x00\x00\x02\x00\x50\x00\x90\x7A\xE8\x68\xB6\x55\xB2\x22"} err
+        assert_match "*Bad data format*" $err
+        assert_equal 0 [r exists _split_mismatch]
+        verify_log_message 0 "*Stream listpack integrity check failed*" 0
+
+        # The control differs only in those three bytes, so it must still load
+        # and delete one record without disturbing the other.
+        set stream_valid "\x15\x01\x10\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x2D\x2D\x00\x00\x00\x11\x00\x02\x01\x00\x01\x01\x01\x81\x66\x02\x00\x01\x02\x01\x00\x01\x00\x01\x81\x76\x02\x04\x01\x00\x01\x01\x01\x00\x01\x01\x01\x81\x67\x02\x81\x77\x02\x06\x01\xFF\x02\x02\x00\x01\x00\x00\x00\x02\x00\x50\x00\xA1\xDF\xE0\xE1\x48\xC5\xF8\x85"
+        assert_equal OK [r restore _control 0 $stream_valid]
+        assert_equal 2 [r xlen _control]
+        assert_equal {{1-0 {f v}} {2-0 {g w}}} [r xrange _control - +]
+        assert_equal 1 [r xdel _control 1-0]
+        assert_equal 1 [r xlen _control]
+        assert_equal {{2-0 {g w}}} [r xrange _control - +]
+        assert_equal [r ping] "PONG"
+    }
+}
+
 test {corrupt payload: fuzzer findings - streamLastValidID panic} {
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
         r debug set-skip-checksum-validation 1


### PR DESCRIPTION
Follow-up to #3922. That PR rejects a payload whose stream length disagrees with the sum of the
declared live counts, but the live/deleted split inside a master entry is still only validated as a
total. A payload can declare `live=1, deleted=1` over two live records and set the stream length to
1, satisfying both the sum check and the new length check while understating the live records.

`XDEL` then reads the declared live count, treats the node as holding its last live record and frees
the whole node, destroying the record the header did not account for. Until then `XLEN` disagrees
with what `XRANGE` returns:

```
RESTORE _s 0 <payload>   +OK
XLEN                     1
XRANGE _s - +            1-0 {f v}, 2-0 {g w}     two records, XLEN says one
XDEL _s 1-0              1                        delete one record
XLEN                     0
XRANGE _s - +            (empty)                  both are gone
```

`streamTrim()` is exposed from the other direction: `lpReplaceInteger(lp, &p, entries -
deleted_from_lp)` can write a negative live count when the header understates.

### This PR

Counts the `STREAM_ITEM_FLAG_DELETED` flag while walking the records and rejects the listpack if
either declared count disagrees with what is present. Ingestion only, no format or protocol change,
valid data unaffected.