### PR TITLE
Tests: Restore tag state when a server fails to start

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -710,6 +710,8 @@ proc start_server {options {code undefined}} {
             set err {}
             append err [exec cat $stdout] "\n" [exec cat $stderr]
             start_server_error $executable $config_file $err
+            set ::singledb $old_singledb
+            set ::tags [lrange $::tags 0 end-[llength $tags]]
             return
         }
         set server_started 1


### PR DESCRIPTION
The early return in `start_server` for when the server doesn't come up doesn't pop `$::tags`, unlike the other two returns in that proc. The tags stay on the stack for the rest of the file, so every following `start_server` looks nested.

This mostly doesn't matter, except that `check_subtags` then rejects the top-level-only tags added in #3171. In https://github.com/valkey-io/valkey/actions/runs/31343907142 a TLS problem on Fedora Rawhide meant no server would start, and unit/scripting died with:

```
[exception]: Executing test client: Test design error: Tag is only allowed on toplevel: large-memory.
 in check_subtags at tests/support/server.tcl:205
 in start_server at tests/support/server.tcl:527
 in execute_test_file at tests/unit/scripting.tcl:1289
```

That kills the whole test client, so we lose the ~35 real "Can't start valkey-server" failures and just see a confusing design error instead. The underlying Rawhide TLS failure is separate and still needs a fix.

Verified with a test that forces a bad config in a tagged block and then opens a top-level `large-memory` block. Before, that aborts the client; after, `$::tags` is empty and the real failures get reported.

This was generated by AI but verified, with love, by a human.
