### PR TITLE
Tests: Add subject alternative names to the TLS test certificates

### DIFF
--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -22,28 +22,28 @@ start_server {tags {"tls"}} {
 
         test {TLS: Verify tls-auth-clients behaves as expected} {
             set s [valkey [srv 0 host] [srv 0 port]]
-            ::tls::import [$s channel]
+            ::tls::import [$s channel] -cafile $::tlsdir/ca.crt
             catch {$s PING} e
             assert_match {*error*} $e
 
             r CONFIG SET tls-auth-clients no
 
             set s [valkey [srv 0 host] [srv 0 port]]
-            ::tls::import [$s channel]
+            ::tls::import [$s channel] -cafile $::tlsdir/ca.crt
             catch {$s PING} e
             assert_match {PONG} $e
 
             r CONFIG SET tls-auth-clients optional
 
             set s [valkey [srv 0 host] [srv 0 port]]
-            ::tls::import [$s channel]
+            ::tls::import [$s channel] -cafile $::tlsdir/ca.crt
             catch {$s PING} e
             assert_match {PONG} $e
 
             r CONFIG SET tls-auth-clients yes
 
             set s [valkey [srv 0 host] [srv 0 port]]
-            ::tls::import [$s channel]
+            ::tls::import [$s channel] -cafile $::tlsdir/ca.crt
             catch {$s PING} e
             assert_match {*error*} $e
         }

--- a/utils/gen-test-certs.sh
+++ b/utils/gen-test-certs.sh
@@ -52,16 +52,20 @@ cat > tests/tls/openssl.cnf <<_END_
 [ server_cert ]
 keyUsage = digitalSignature, keyEncipherment
 nsCertType = server
+subjectAltName = IP:127.0.0.1, IP:::1, DNS:localhost
 
 [ client_cert ]
 keyUsage = digitalSignature, keyEncipherment
 nsCertType = client
 subjectAltName = URI:urn:valkey:user:first, URI:urn:valkey:user:second
+
+[ generic_cert ]
+subjectAltName = IP:127.0.0.1, IP:::1, DNS:localhost
 _END_
 
 generate_cert server "Server-only" "-extfile tests/tls/openssl.cnf -extensions server_cert"
 generate_cert client "Client-only" "-extfile tests/tls/openssl.cnf -extensions client_cert"
-generate_cert valkey "Generic-cert"
+generate_cert valkey "Generic-cert" "-extfile tests/tls/openssl.cnf -extensions generic_cert"
 
 # Create a CA bundle and hashed CA directory used by TLS tests.
 # (ca-multi.crt and ca-dir/)


### PR DESCRIPTION
`test-fedorarawhide-tls-module` has been failing every daily for the last few days, e.g. https://github.com/valkey-io/valkey/actions/runs/31343907142. The server comes up and loads the module fine, but every client connection gets rejected:

```
# Error accepting a client connection: error:0A000412:SSL routines::tls alert bad certificate
```

Rawhide is the only distro with tcltls 2.0, and that's the actual cause, not OpenSSL 4. `tls::socket` in 2.0 sets `-servername` itself when you don't pass `-autoservername` or `-servername`, which turns on hostname verification. Our server certs have no subjectAltName, so verification fails against 127.0.0.1. The server side only sees the resulting alert, which is why the error looks like the certs are bad. Verified by building tcltls 2.0 against OpenSSL 3.5.7 with the same certs, which fails the same way.

So add a SAN for 127.0.0.1, ::1 and localhost to the server cert. `valkey.crt` gets one too since a couple of the tls tests use it as a server cert.

tcltls 2.0 also stopped inheriting `tls::init` defaults in `tls::import`, so the bare imports in unit/tls.tcl need the CA passed explicitly. Only `-cafile` there, those tests are checking the behavior when the client has no cert.

Testing, since I can't easily run rawhide locally:
* On a rawhide container with tcltls 2.0.1, unit/tls goes from failing to 20 passed, and keyspace/auth/acl/introspection give 326 passed.
* On fedora latest with tcltls 1.7.22 there's no change, 89 passed.
* Locally, `s_client -verify_ip 127.0.0.1` against the server goes from `IP address mismatch` to `Verification: OK`.

Note the containers were arm64, so this needs the daily to confirm on x86. #4382 is also needed to make the failure legible when this happens again, otherwise the tag leak hides the real errors.

This was generated by AI but verified, with love, by a human.
