### PR TITLE
Report expiration lag in INFO latencystats

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2168,6 +2168,13 @@ static keyStatus expireIfNeededWithDictIndex(serverDb *db, robj *key, robj *val,
     else if (policy == POLICY_KEEP_EXPIRED) /* Treat expired keys as invalid, but do not delete them. */
         return KEY_EXPIRED;
 
+    /* Read the deadline before the key goes away, so we can record how long it
+     * outlived it. Only the caller that finds the key is in a position to know
+     * this, and only on this branch, where a deletion is about to happen. */
+    mstime_t expire_at = -1;
+    if (server.latency_tracking_enabled)
+        expire_at = val != NULL ? objectGetExpire(val) : getExpireWithDictIndex(db, key, dict_index);
+
     /* The key needs to be converted from static to heap before deleted */
     int static_key = key->refcount == OBJ_STATIC_REFCOUNT;
     if (static_key) {
@@ -2178,6 +2185,8 @@ static keyStatus expireIfNeededWithDictIndex(serverDb *db, robj *key, robj *val,
     if (static_key) {
         decrRefCount(key);
     }
+    if (expire_at > 0)
+        updateExpireLagHistogram(&server.expire_lag_lazy_histogram, expire_at, commandTimeSnapshot());
     return KEY_DELETED;
 }
 

--- a/src/db.c
+++ b/src/db.c
@@ -2185,8 +2185,11 @@ static keyStatus expireIfNeededWithDictIndex(serverDb *db, robj *key, robj *val,
     if (static_key) {
         decrRefCount(key);
     }
-    if (expire_at > 0)
-        updateExpireLagHistogram(&server.expire_lag_lazy_histogram, expire_at, commandTimeSnapshot());
+    /* Read the clock here rather than taking commandTimeSnapshot(). The snapshot
+     * is frozen for the whole execution unit, so anything that waits inside a
+     * MULTI, a script or a nested RM_Call would be subtracted from the lag we
+     * report. The active cycle already passes its own current timestamp. */
+    if (expire_at > 0) updateExpireLagHistogram(&server.expire_lag_lazy_histogram, expire_at, mstime());
     return KEY_DELETED;
 }
 

--- a/src/db.c
+++ b/src/db.c
@@ -2168,12 +2168,24 @@ static keyStatus expireIfNeededWithDictIndex(serverDb *db, robj *key, robj *val,
     else if (policy == POLICY_KEEP_EXPIRED) /* Treat expired keys as invalid, but do not delete them. */
         return KEY_EXPIRED;
 
-    /* Read the deadline before the key goes away, so we can record how long it
-     * outlived it. Only the caller that finds the key is in a position to know
-     * this, and only on this branch, where a deletion is about to happen. */
+    /* Read the deadline and the clock before the key goes away, so we can record
+     * how long it outlived it. Only the caller that finds the key is in a
+     * position to know this, and only on this branch, where a deletion is about
+     * to happen.
+     *
+     * mstime() rather than commandTimeSnapshot(), because the snapshot is frozen
+     * for the whole execution unit and anything that waits inside a MULTI, a
+     * script or a nested RM_Call would be subtracted from the lag. And read here
+     * rather than after the deletion, so that freeing the value does not land in
+     * this histogram: deleteExpiredKeyAndPropagateWithDictIndex() already reports
+     * that separately as the expire-del latency event, and the active cycle
+     * likewise passes a timestamp taken before it deletes. */
     mstime_t expire_at = -1;
-    if (server.latency_tracking_enabled)
+    mstime_t caught_at = 0;
+    if (server.latency_tracking_enabled) {
         expire_at = val != NULL ? objectGetExpire(val) : getExpireWithDictIndex(db, key, dict_index);
+        caught_at = mstime();
+    }
 
     /* The key needs to be converted from static to heap before deleted */
     int static_key = key->refcount == OBJ_STATIC_REFCOUNT;
@@ -2185,11 +2197,7 @@ static keyStatus expireIfNeededWithDictIndex(serverDb *db, robj *key, robj *val,
     if (static_key) {
         decrRefCount(key);
     }
-    /* Read the clock here rather than taking commandTimeSnapshot(). The snapshot
-     * is frozen for the whole execution unit, so anything that waits inside a
-     * MULTI, a script or a nested RM_Call would be subtracted from the lag we
-     * report. The active cycle already passes its own current timestamp. */
-    if (expire_at > 0) updateExpireLagHistogram(&server.expire_lag_lazy_histogram, expire_at, mstime());
+    if (expire_at > 0) updateExpireLagHistogram(&server.expire_lag_lazy_histogram, expire_at, caught_at);
     return KEY_DELETED;
 }
 

--- a/src/expire.c
+++ b/src/expire.c
@@ -73,6 +73,7 @@ int activeExpireCycleTryExpire(serverDb *db, robj *val, mstime_t now, int didx) 
         deleteExpiredKeyAndPropagateWithDictIndex(db, keyobj, didx);
         decrRefCount(keyobj);
         exitExecutionUnit();
+        if (server.latency_tracking_enabled) updateExpireLagHistogram(&server.expire_lag_active_histogram, t, now);
         return 1;
     } else {
         return 0;

--- a/src/server.c
+++ b/src/server.c
@@ -2802,6 +2802,14 @@ void resetServerStats(void) {
     server.stat_expired_keys_with_vola_stale_perc = 0;
     server.stat_expired_time_cap_reached_count = 0;
     server.stat_expire_cycle_time_used = 0;
+    if (server.expire_lag_active_histogram) {
+        hdr_close(server.expire_lag_active_histogram);
+        server.expire_lag_active_histogram = NULL;
+    }
+    if (server.expire_lag_lazy_histogram) {
+        hdr_close(server.expire_lag_lazy_histogram);
+        server.expire_lag_lazy_histogram = NULL;
+    }
     server.stat_evictedkeys = 0;
     server.stat_evictedclients = 0;
     server.stat_evictedscripts = 0;
@@ -3731,6 +3739,22 @@ void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int
         hdr_init(LATENCY_HISTOGRAM_MIN_VALUE, LATENCY_HISTOGRAM_MAX_VALUE, LATENCY_HISTOGRAM_PRECISION,
                  latency_histogram);
     hdr_record_value(*latency_histogram, duration_hist);
+}
+
+/* Record how late a key was deleted relative to its own expiration deadline.
+ * A key stops being readable the instant its deadline passes, but it is only
+ * deleted, and its `expired` notification only published, once some client
+ * touches it or the active expire cycle happens to sample it. This histogram
+ * measures that gap so operators can see it instead of inferring it. */
+void updateExpireLagHistogram(struct hdr_histogram **lag_histogram, mstime_t expire_at, mstime_t deleted_at) {
+    if (expire_at <= 0) return; /* Unknown deadline, nothing meaningful to record. */
+    int64_t lag_ns = (int64_t)(deleted_at - expire_at) * 1000000;
+    if (lag_ns < EXPIRE_LAG_HISTOGRAM_MIN_VALUE) lag_ns = EXPIRE_LAG_HISTOGRAM_MIN_VALUE;
+    if (lag_ns > EXPIRE_LAG_HISTOGRAM_MAX_VALUE) lag_ns = EXPIRE_LAG_HISTOGRAM_MAX_VALUE;
+    if (*lag_histogram == NULL)
+        hdr_init(EXPIRE_LAG_HISTOGRAM_MIN_VALUE, EXPIRE_LAG_HISTOGRAM_MAX_VALUE, EXPIRE_LAG_HISTOGRAM_PRECISION,
+                 lag_histogram);
+    hdr_record_value(*lag_histogram, lag_ns);
 }
 
 /* Handle the alsoPropagate() API to handle commands that want to propagate
@@ -6762,6 +6786,12 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         info = sdscatprintf(info, "# Latencystats\r\n");
         if (server.latency_tracking_enabled) {
             info = genValkeyInfoStringLatencyStats(info, server.commands);
+            if (server.expire_lag_active_histogram)
+                info = fillPercentileDistributionLatencies(info, "expire_lag_active",
+                                                           server.expire_lag_active_histogram);
+            if (server.expire_lag_lazy_histogram)
+                info = fillPercentileDistributionLatencies(info, "expire_lag_lazy",
+                                                           server.expire_lag_lazy_histogram);
         }
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -3748,9 +3748,12 @@ void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int
  * measures that gap so operators can see it instead of inferring it. */
 void updateExpireLagHistogram(struct hdr_histogram **lag_histogram, mstime_t expire_at, mstime_t deleted_at) {
     if (expire_at <= 0) return; /* Unknown deadline, nothing meaningful to record. */
-    int64_t lag_ns = (int64_t)(deleted_at - expire_at) * 1000000;
+    /* Clamp while still in milliseconds. Converting first would depend on the
+     * two timestamps being close enough for the product to fit. */
+    mstime_t lag_ms = deleted_at - expire_at;
+    if (lag_ms > EXPIRE_LAG_HISTOGRAM_MAX_VALUE / 1000000) lag_ms = EXPIRE_LAG_HISTOGRAM_MAX_VALUE / 1000000;
+    int64_t lag_ns = lag_ms > 0 ? (int64_t)lag_ms * 1000000 : 0;
     if (lag_ns < EXPIRE_LAG_HISTOGRAM_MIN_VALUE) lag_ns = EXPIRE_LAG_HISTOGRAM_MIN_VALUE;
-    if (lag_ns > EXPIRE_LAG_HISTOGRAM_MAX_VALUE) lag_ns = EXPIRE_LAG_HISTOGRAM_MAX_VALUE;
     if (*lag_histogram == NULL)
         hdr_init(EXPIRE_LAG_HISTOGRAM_MIN_VALUE, EXPIRE_LAG_HISTOGRAM_MAX_VALUE, EXPIRE_LAG_HISTOGRAM_PRECISION,
                  lag_histogram);

--- a/src/server.c
+++ b/src/server.c
@@ -3745,12 +3745,17 @@ void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int
  * A key stops being readable the instant its deadline passes, but it is only
  * deleted, and its `expired` notification only published, once some client
  * touches it or the active expire cycle happens to sample it. This histogram
- * measures that gap so operators can see it instead of inferring it. */
-void updateExpireLagHistogram(struct hdr_histogram **lag_histogram, mstime_t expire_at, mstime_t deleted_at) {
+ * measures that gap so operators can see it instead of inferring it.
+ *
+ * Both callers pass the clock as of the moment they caught the key, not as of
+ * the moment the deletion returned, so that freeing a large value stays out of
+ * this histogram. That cost is already reported on its own as the expire-del
+ * latency event. */
+void updateExpireLagHistogram(struct hdr_histogram **lag_histogram, mstime_t expire_at, mstime_t caught_at) {
     if (expire_at <= 0) return; /* Unknown deadline, nothing meaningful to record. */
     /* Clamp while still in milliseconds. Converting first would depend on the
      * two timestamps being close enough for the product to fit. */
-    mstime_t lag_ms = deleted_at - expire_at;
+    mstime_t lag_ms = caught_at - expire_at;
     if (lag_ms > EXPIRE_LAG_HISTOGRAM_MAX_VALUE / 1000000) lag_ms = EXPIRE_LAG_HISTOGRAM_MAX_VALUE / 1000000;
     int64_t lag_ns = lag_ms > 0 ? (int64_t)lag_ms * 1000000 : 0;
     if (lag_ns < EXPIRE_LAG_HISTOGRAM_MIN_VALUE) lag_ns = EXPIRE_LAG_HISTOGRAM_MIN_VALUE;

--- a/src/server.c
+++ b/src/server.c
@@ -5907,9 +5907,15 @@ void bytesToHuman(char *s, size_t size, unsigned long long n) {
     }
 }
 
-/* Fill percentile distribution of latencies. */
-sds fillPercentileDistributionLatencies(sds info, const char *histogram_name, struct hdr_histogram *histogram) {
-    info = sdscatfmt(info, "latency_percentiles_usec_%s:", histogram_name);
+/* Fill percentile distribution of latencies. The field prefix is a parameter
+ * because `latency_percentiles_usec_` is a command keyed namespace: everything
+ * under it is expected to be a command name. Anything that is not one needs a
+ * prefix of its own. */
+sds fillPercentileDistributionLatencies(sds info,
+                                        const char *prefix,
+                                        const char *histogram_name,
+                                        struct hdr_histogram *histogram) {
+    info = sdscatfmt(info, "%s_%s:", prefix, histogram_name);
     for (int j = 0; j < server.latency_tracking_info_percentiles_len; j++) {
         char fbuf[128];
         size_t len = snprintf(fbuf, sizeof(fbuf), "%f", server.latency_tracking_info_percentiles[j]);
@@ -6001,7 +6007,8 @@ sds genValkeyInfoStringLatencyStats(sds info, hashtable *commands) {
         char *tmpsafe;
         if (c->latency_histogram) {
             info = fillPercentileDistributionLatencies(
-                info, getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->latency_histogram);
+                info, "latency_percentiles_usec", getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe),
+                c->latency_histogram);
             if (tmpsafe != NULL) zfree(tmpsafe);
         }
         if (c->subcommands_ht) {
@@ -6790,10 +6797,10 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         if (server.latency_tracking_enabled) {
             info = genValkeyInfoStringLatencyStats(info, server.commands);
             if (server.expire_lag_active_histogram)
-                info = fillPercentileDistributionLatencies(info, "expire_lag_active",
+                info = fillPercentileDistributionLatencies(info, "expire_lag_percentiles_usec", "active",
                                                            server.expire_lag_active_histogram);
             if (server.expire_lag_lazy_histogram)
-                info = fillPercentileDistributionLatencies(info, "expire_lag_lazy",
+                info = fillPercentileDistributionLatencies(info, "expire_lag_percentiles_usec", "lazy",
                                                            server.expire_lag_lazy_histogram);
         }
     }

--- a/src/server.h
+++ b/src/server.h
@@ -704,9 +704,9 @@ typedef enum {
  * deadline and its actual deletion is bounded by how often the sampler happens
  * to draw that key, not by command execution time, so it needs a much wider
  * range than the per command histograms above. */
-#define EXPIRE_LAG_HISTOGRAM_MIN_VALUE 1000L          /* >= 1 microsec */
-#define EXPIRE_LAG_HISTOGRAM_MAX_VALUE 3600000000000L /* <= 1 hour */
-#define EXPIRE_LAG_HISTOGRAM_PRECISION 2              /* 2 significant digits, as above. */
+#define EXPIRE_LAG_HISTOGRAM_MIN_VALUE 1000LL          /* >= 1 microsec */
+#define EXPIRE_LAG_HISTOGRAM_MAX_VALUE 3600000000000LL /* <= 1 hour */
+#define EXPIRE_LAG_HISTOGRAM_PRECISION 2               /* 2 significant digits, as above. */
 
 /* Busy module flags, see busy_module_yield_flags */
 #define BUSY_MODULE_YIELD_NONE (0)

--- a/src/server.h
+++ b/src/server.h
@@ -700,6 +700,14 @@ typedef enum {
                                                  * LATENCY_HISTOGRAM_MAX_VALUE range. Value quantization within the range will thus be no larger than 1/100th \
                                                  * (or 1%) of any value. The total size per histogram should sit around 40 KiB Bytes. */
 
+/* Expiration lag histogram init settings. The lag between a key's expiration
+ * deadline and its actual deletion is bounded by how often the sampler happens
+ * to draw that key, not by command execution time, so it needs a much wider
+ * range than the per command histograms above. */
+#define EXPIRE_LAG_HISTOGRAM_MIN_VALUE 1000L          /* >= 1 microsec */
+#define EXPIRE_LAG_HISTOGRAM_MAX_VALUE 3600000000000L /* <= 1 hour */
+#define EXPIRE_LAG_HISTOGRAM_PRECISION 2              /* 2 significant digits, as above. */
+
 /* Busy module flags, see busy_module_yield_flags */
 #define BUSY_MODULE_YIELD_NONE (0)
 #define BUSY_MODULE_YIELD_EVENTS (1 << 0)
@@ -1951,6 +1959,10 @@ struct valkeyServer {
     long long stat_client_outbuf_limit_disconnections; /* Total number of clients reached output buf length limit */
     long long stat_total_prefetch_entries;             /* Total number of prefetched dict entries */
     long long stat_total_prefetch_batches;             /* Total number of prefetched batches */
+    /* Nanoseconds a key spent between its expiration deadline and its actual
+     * deletion, split by whichever path did the deleting. */
+    struct hdr_histogram *expire_lag_active_histogram;
+    struct hdr_histogram *expire_lag_lazy_histogram;
     /* The following two are used to track instantaneous metrics, like
      * number of operations per second, network traffic. */
     struct {
@@ -3522,6 +3534,7 @@ void preventCommandAOF(client *c);
 void preventCommandReplication(client *c);
 void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd);
 void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int64_t duration_hist);
+void updateExpireLagHistogram(struct hdr_histogram **lag_histogram, mstime_t expire_at, mstime_t deleted_at);
 int prepareForShutdown(client *c, int flags);
 void replyToClientsBlockedOnShutdown(void);
 int abortShutdown(void);

--- a/src/server.h
+++ b/src/server.h
@@ -3534,7 +3534,7 @@ void preventCommandAOF(client *c);
 void preventCommandReplication(client *c);
 void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd);
 void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int64_t duration_hist);
-void updateExpireLagHistogram(struct hdr_histogram **lag_histogram, mstime_t expire_at, mstime_t deleted_at);
+void updateExpireLagHistogram(struct hdr_histogram **lag_histogram, mstime_t expire_at, mstime_t caught_at);
 int prepareForShutdown(client *c, int flags);
 void replyToClientsBlockedOnShutdown(void);
 int abortShutdown(void);

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -743,8 +743,8 @@ proc errorrstat {cmd r} {
     }
 }
 
-proc latencyrstat_percentiles {cmd r} {
-    if {[regexp "\r\nlatency_percentiles_usec_$cmd:(.*?)\r\n" [$r info latencystats] _ value]} {
+proc latencyrstat_percentiles {cmd r {prefix latency_percentiles_usec}} {
+    if {[regexp "\r\n${prefix}_$cmd:(.*?)\r\n" [$r info latencystats] _ value]} {
         set _ $value
     }
 }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -342,6 +342,49 @@ start_server {tags {"expire"}} {
         r ttl foo
     } {-2}
 
+    test {Expiration lag: lazy deletion reports how long the key outlived its deadline} {
+        r flushall
+        r config resetstat
+        r config set latency-tracking yes
+        r debug set-active-expire 0
+        r psetex lagkey 100 v
+        after 600
+        # The read is what deletes the key here, so the reported lag is the
+        # time the key spent past its deadline before anyone asked for it.
+        assert_equal {} [r get lagkey]
+        set line [latencyrstat_percentiles expire_lag_lazy r]
+        assert_match {*p50=*} $line
+        assert_match {} [latencyrstat_percentiles expire_lag_active r]
+        regexp {p50=([0-9.]+)} $line -> p50
+        assert {$p50 >= 400000}
+        r debug set-active-expire 1
+    } {OK} {needs:debug}
+
+    test {Expiration lag: the active cycle reports its own samples} {
+        r flushall
+        r config resetstat
+        r config set latency-tracking yes
+        r psetex activelagkey 100 v
+        wait_for_condition 50 100 {
+            [latencyrstat_percentiles expire_lag_active r] ne {}
+        } else {
+            fail "active expire cycle recorded no lag sample"
+        }
+        assert_match {*p50=*} [latencyrstat_percentiles expire_lag_active r]
+    }
+
+    test {Expiration lag: nothing is recorded while latency tracking is off} {
+        r flushall
+        r config resetstat
+        r config set latency-tracking no
+        r psetex offlagkey 100 v
+        after 600
+        assert_equal {} [r get offlagkey]
+        assert_match {} [latencyrstat_percentiles expire_lag_lazy r]
+        assert_match {} [latencyrstat_percentiles expire_lag_active r]
+        r config set latency-tracking yes
+    } {OK}
+
     # Start a new server with empty data and AOF file.
     start_server {overrides {appendonly {yes} appendfsync always} tags {external:skip}} {
         test {All time-to-live(TTL) in commands are propagated as absolute timestamp in milliseconds in AOF} {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -360,6 +360,27 @@ start_server {tags {"expire"}} {
         r debug set-active-expire 1
     } {OK} {needs:debug}
 
+    test {Expiration lag: lazy deletion measures elapsed time, not the execution unit clock} {
+        r flushall
+        r config resetstat
+        r config set latency-tracking yes
+        r debug set-active-expire 0
+        r psetex unitlagkey 100 v
+        after 200
+        # The deletion happens inside the transaction, after the sleep. The clock
+        # the execution unit carries is frozen at EXEC, so reading that instead of
+        # the current time would drop the whole second the key spent waiting.
+        r multi
+        r debug sleep 1
+        r get unitlagkey
+        assert_equal {} [lindex [r exec] 1]
+        set line [latencyrstat_percentiles lazy r expire_lag_percentiles_usec]
+        assert_match {*p50=*} $line
+        regexp {p50=([0-9.]+)} $line -> p50
+        assert {$p50 >= 900000}
+        r debug set-active-expire 1
+    } {OK} {needs:debug}
+
     test {Expiration lag: the active cycle reports its own samples} {
         r flushall
         r config resetstat

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -364,6 +364,7 @@ start_server {tags {"expire"}} {
         r flushall
         r config resetstat
         r config set latency-tracking yes
+        r debug set-active-expire 1
         r psetex activelagkey 100 v
         wait_for_condition 50 100 {
             [latencyrstat_percentiles active r expire_lag_percentiles_usec] ne {}
@@ -371,19 +372,26 @@ start_server {tags {"expire"}} {
             fail "active expire cycle recorded no lag sample"
         }
         assert_match {*p50=*} [latencyrstat_percentiles active r expire_lag_percentiles_usec]
-    }
+    } {} {needs:debug}
 
     test {Expiration lag: nothing is recorded while latency tracking is off} {
         r flushall
         r config resetstat
         r config set latency-tracking no
+        r debug set-active-expire 0
         r psetex offlagkey 100 v
         after 600
+        # Take the lazy path on purpose: with the active cycle running the key
+        # would usually be reaped before anyone reads it.
         assert_equal {} [r get offlagkey]
+        # Read INFO with tracking back on. The whole latencystats body is emitted
+        # only while tracking is on, so asserting on it with tracking off would
+        # match nothing whether or not a sample had been recorded.
+        r config set latency-tracking yes
         assert_match {} [latencyrstat_percentiles lazy r expire_lag_percentiles_usec]
         assert_match {} [latencyrstat_percentiles active r expire_lag_percentiles_usec]
-        r config set latency-tracking yes
-    } {OK}
+        r debug set-active-expire 1
+    } {OK} {needs:debug}
 
     # Start a new server with empty data and AOF file.
     start_server {overrides {appendonly {yes} appendfsync always} tags {external:skip}} {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -352,9 +352,9 @@ start_server {tags {"expire"}} {
         # The read is what deletes the key here, so the reported lag is the
         # time the key spent past its deadline before anyone asked for it.
         assert_equal {} [r get lagkey]
-        set line [latencyrstat_percentiles expire_lag_lazy r]
+        set line [latencyrstat_percentiles lazy r expire_lag_percentiles_usec]
         assert_match {*p50=*} $line
-        assert_match {} [latencyrstat_percentiles expire_lag_active r]
+        assert_match {} [latencyrstat_percentiles active r expire_lag_percentiles_usec]
         regexp {p50=([0-9.]+)} $line -> p50
         assert {$p50 >= 400000}
         r debug set-active-expire 1
@@ -366,11 +366,11 @@ start_server {tags {"expire"}} {
         r config set latency-tracking yes
         r psetex activelagkey 100 v
         wait_for_condition 50 100 {
-            [latencyrstat_percentiles expire_lag_active r] ne {}
+            [latencyrstat_percentiles active r expire_lag_percentiles_usec] ne {}
         } else {
             fail "active expire cycle recorded no lag sample"
         }
-        assert_match {*p50=*} [latencyrstat_percentiles expire_lag_active r]
+        assert_match {*p50=*} [latencyrstat_percentiles active r expire_lag_percentiles_usec]
     }
 
     test {Expiration lag: nothing is recorded while latency tracking is off} {
@@ -380,8 +380,8 @@ start_server {tags {"expire"}} {
         r psetex offlagkey 100 v
         after 600
         assert_equal {} [r get offlagkey]
-        assert_match {} [latencyrstat_percentiles expire_lag_lazy r]
-        assert_match {} [latencyrstat_percentiles expire_lag_active r]
+        assert_match {} [latencyrstat_percentiles lazy r expire_lag_percentiles_usec]
+        assert_match {} [latencyrstat_percentiles active r expire_lag_percentiles_usec]
         r config set latency-tracking yes
     } {OK}
 


### PR DESCRIPTION
Part of #4384, which has the measurements.

A volatile key stops being readable at its deadline but is deleted only once the active cycle samples it or a client touches it. `expired_keys` and `expired_stale_perc` do not report that gap.

Both paths hold the deadline when they act, so the lag costs one subtraction. Both feed hdr histograms in `INFO latencystats`, gated on `latency-tracking`, allocated on first expiration, freed by `CONFIG RESETSTAT`:

    expire_lag_percentiles_usec_active:p50=19193135.103
    expire_lag_percentiles_usec_lazy:p50=2818572.287

The last four commits answer the review notes: own field prefix, a tracking-off test that can fail, elapsed time rather than the unit clock, and the delete's own cost left out, since `expire-del` reports it.

Four cases in `tests/unit/expire.tcl`; expire, info, latency-monitor, introspection, other pass (346). clang-format-18 clean.
