### PR TITLE
fix: prevent NULL dereference in usUntilEarliestTimer when all time events are pending deletion

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -312,6 +312,11 @@ static int64_t usUntilEarliestTimer(aeEventLoop *eventLoop) {
         te = te->next;
     }
 
+    /* The list may hold only events marked AE_DELETED_EVENT_ID, leaving no
+     * earliest timer. Mirror the empty-list case above and report "no timer"
+     * instead of dereferencing a NULL earliest. */
+    if (earliest == NULL) return -1;
+
     monotime now = getMonotonicUs();
     return (now >= earliest->when) ? 0 : earliest->when - now;
 }


### PR DESCRIPTION
## Description

In `usUntilEarliestTimer()` (src/ae.c), when every time event is a lazy-deleted zombie (`AE_DELETED_EVENT_ID`), the scan loop finds nothing, `earliest` stays `NULL`, and the function dereferences it at the return statement.

The empty-list case is guarded (`if (te == NULL) return -1;`), but the all-zombies case is not.

## Fix

Add a NULL check after the scan loop, mirroring the empty-list guard. This is a backport of the fix in redis/redis#15391.

## Related

Closes #4349