### PR TITLE
Perf increase for HGETALL reads

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -289,7 +289,26 @@ static int shouldDeferPushMessage(client *c) {
  * Maybe called with NULL obj for evaluation with no regard to object size
  * Copy avoidance can be allowed only for regular Valkey clients
  * that use _writeToClient handler to write replies to client connection */
+
+/* True if the I/O thread count alone enables copy avoidance, regardless of the
+ * size of the object being replied. Depends only on server config. */
+static inline int copyAvoidEnabledByIOThreads(void) {
+    return server.min_io_threads_copy_avoid && server.io_threads_num >= server.min_io_threads_copy_avoid;
+}
+
 static int isCopyAvoidPreferred(client *c, robj *obj) {
+    /* Cheap config-only early-out before any per-client or per-object work.
+     * With no object to size-check, the I/O thread gate is the only thing that
+     * can enable copy avoidance; with an object, the applicable size limit must
+     * at least be configured. Callers on the hot reply path additionally test
+     * copyAvoidEnabledByIOThreads() inline so they can skip this call. */
+    if (!copyAvoidEnabledByIOThreads()) {
+        if (!obj) return 0;
+        size_t size_limit = (server.io_threads_num == 1) ? (size_t)server.min_string_size_copy_avoid
+                                                         : (size_t)server.min_string_size_copy_avoid_threaded;
+        if (!size_limit) return 0;
+    }
+
     if (c->flag.fake || isDeferredReplyEnabled(c)) return 0;
     /* Skip copy avoidance when push bytes would be deferred into pending_push_messages. */
     if (shouldDeferPushMessage(c)) return 0;
@@ -303,7 +322,7 @@ static int isCopyAvoidPreferred(client *c, robj *obj) {
     }
 
     /* Copy avoidance is preferred for any string size starting certain number of I/O threads  */
-    if (server.min_io_threads_copy_avoid && server.io_threads_num >= server.min_io_threads_copy_avoid) return 1;
+    if (copyAvoidEnabledByIOThreads()) return 1;
 
     if (!obj) return 0;
 
@@ -653,7 +672,7 @@ static size_t _addReplyPayloadToBuffer(client *c, const void *payload, size_t le
 static size_t _addReplyToBuffer(client *c, const char *s, size_t len) {
     if (!len) return 0;
     if (!c->bufpos) {
-        c->flag.buf_encoded = isCopyAvoidPreferred(c, NULL);
+        c->flag.buf_encoded = copyAvoidEnabledByIOThreads() && isCopyAvoidPreferred(c, NULL);
     }
     return _addReplyPayloadToBuffer(c, s, len, PLAIN_REPLY);
 }
@@ -675,7 +694,8 @@ static void _addReplyPayloadToList(client *c, list *reply_list, const char *payl
     listNode *ln = listLast(reply_list);
     clientReplyBlock *tail = ln ? listNodeValue(ln) : NULL;
     /* Determine if encoded buffer is required */
-    int encoded = payload_type == BULK_STR_REF || isCopyAvoidPreferred(c, NULL);
+    int encoded =
+        payload_type == BULK_STR_REF || (copyAvoidEnabledByIOThreads() && isCopyAvoidPreferred(c, NULL));
 
     /* Note that 'tail' may be NULL even if we have a tail node, because when
      * addReplyDeferredLen() is used, it sets a dummy node to NULL just
@@ -748,7 +768,9 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
      * replication link that caused a reply to be generated we'll simply disconnect it.
      * Note this is the simplest way to check a command added a response. Replication links are used to write data but
      * not for responses, so we should normally never get here on a replica client. */
-    if (getClientType(c) == CLIENT_TYPE_REPLICA) {
+    /* Equivalent to getClientType(c) == CLIENT_TYPE_REPLICA, but kept inline: this
+     * runs on every reply append, and getClientType() does not get inlined here. */
+    if (unlikely(!c->flag.primary && c->flag.replica && !c->flag.monitor)) {
         sds cmdname = c->lastcmd ? c->lastcmd->fullname : NULL;
         logInvalidUseAndFreeClientAsync(c, "Replica generated a reply to command '%s'",
                                         cmdname ? cmdname : "<unknown>");
@@ -1543,8 +1565,66 @@ void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     _addReplyToBufferOrList(c, "\r\n", 2);
 }
 
+/* Emit a complete bulk string ($<len>\r\n<data>\r\n) into the client's static
+ * reply buffer with a single append, or return 0 if it does not fit.
+ *
+ * The generic path splits every bulk string into three appends (header, data,
+ * trailing CRLF), and each one re-walks the buffer-or-list logic. For commands
+ * that emit many small bulk strings back to back - HGETALL over a hashtable
+ * encoded hash being the motivating case - that dominates the command cost.
+ * Doing the whole thing in one memcpy-style append keeps the common case to a
+ * single bounds check.
+ *
+ * Only handles the plain (non copy-avoiding) static buffer; callers fall back
+ * to the generic path for everything else. */
+static inline int tryAddBulkCBufferFast(client *c, const void *p, size_t len) {
+    /* The generic path drops replies for such clients; don't bypass that. */
+    if (unlikely(c->flag.close_after_reply)) return 0;
+    /* Deferred and push-message routing send the reply somewhere other than
+     * c->buf; leave those to the generic path. */
+    if (unlikely(isDeferredReplyEnabled(c) || c->flag.pushing)) return 0;
+    /* Encoded buffers carry per-chunk payload headers, so the fused write
+     * below (which assumes a flat buffer) does not apply. Note c->bufpos == 0
+     * means the encoding for this buffer has not been decided yet. */
+    if (c->flag.buf_encoded || c->bufpos == 0) return 0;
+    /* Once the reply list is in use the static buffer is closed for writes. */
+    if (listLength(c->reply) > 0) return 0;
+    if (unlikely(server.debug_client_enforce_reply_list)) return 0;
+
+    /* $ + up to 20 digits + \r\n + data + \r\n */
+    char hdr[LONG_STR_SIZE + 3];
+    size_t hdr_len;
+    if (len < OBJ_SHARED_BULKHDR_LEN) {
+        /* Reuse the shared "$<len>\r\n" strings for small lengths. */
+        hdr_len = OBJ_SHARED_HDR_STRLEN(len);
+        memcpy(hdr, objectGetVal(shared.bulkhdr[len]), hdr_len);
+    } else {
+        hdr[0] = '$';
+        int n = ll2string(hdr + 1, sizeof(hdr) - 1, (long long)len);
+        hdr[n + 1] = '\r';
+        hdr[n + 2] = '\n';
+        hdr_len = n + 3;
+    }
+
+    size_t total = hdr_len + len + 2;
+    if (total > c->buf_usable_size - c->bufpos) return 0;
+
+    char *dst = c->buf + c->bufpos;
+    memcpy(dst, hdr, hdr_len);
+    memcpy(dst + hdr_len, p, len);
+    dst[hdr_len + len] = '\r';
+    dst[hdr_len + len + 1] = '\n';
+    c->bufpos += total;
+    if (c->buf_peak < (size_t)c->bufpos) c->buf_peak = (size_t)c->bufpos;
+
+    c->net_output_bytes_curr_cmd += total;
+    reqresSaveClientReplyOffset(c);
+    return 1;
+}
+
 void addWritePreparedReplyBulkCBuffer(writePreparedClient *wpc, const void *p, size_t len) {
     client *c = (client *)wpc;
+    if (tryAddBulkCBufferFast(c, p, len)) return;
     _addReplyLongLongWithPrefix(c, len, '$');
     _addReplyToBufferOrList(c, p, len);
     _addReplyToBufferOrList(c, "\r\n", 2);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1775,6 +1775,9 @@ void hgetexCommand(client *c) {
     commitDeferredReplyBuffer(c, 1);
 }
 
+/* Number of hash entries prefetched at a time by the HGETALL fast path. */
+#define HGETALL_PREFETCH_BATCH 16
+
 void genericHgetallCommand(client *c, int flags) {
     robj *o;
     hashTypeIterator hi;
@@ -1785,8 +1788,87 @@ void genericHgetallCommand(client *c, int flags) {
 
     writePreparedClient *wpc = prepareClientForFutureWrites(c);
     if (!wpc) return;
-    /* We return a map if the user requested fields and values, like in the
-     * HGETALL case. Otherwise to use a flat array makes more sense. */
+
+    /* Fast path: hashtable-encoded hash with no volatile (TTL-bearing) fields.
+     *
+     * Two things matter here:
+     *
+     * 1. The element count is known up front and exact (no field can expire
+     *    mid-iteration), so we can emit a real aggregate header instead of a
+     *    deferred one. That matters for more than the header itself:
+     *    addReplyDeferredLen() parks a placeholder node on c->reply, and once
+     *    that list is non-empty every subsequent reply skips the client's
+     *    static buffer and goes through the heap-allocated reply blocks. On a
+     *    hash with dozens of fields that is the dominant cost of the command.
+     *
+     * 2. Walking the hash chases pointers into scattered heap allocations
+     *    (bucket -> entry -> field/value sds). Emitting each reply as we reach
+     *    the entry serializes those cache misses. Collecting a batch and
+     *    prefetching it first lets the misses overlap with useful work. */
+    if (o->encoding == OBJ_ENCODING_HASHTABLE && !hashTypeHasVolatileFields(o)) {
+        unsigned long length = hashTypeLength(o);
+        if (length == 0) {
+            addReply(c, emptyResp);
+            return;
+        }
+        if (flags & OBJ_HASH_FIELD && flags & OBJ_HASH_VALUE) {
+            addReplyMapLen(c, length);
+        } else {
+            addReplyArrayLen(c, length);
+        }
+
+        hashtableIterator iter;
+        hashtableInitIterator(&iter, objectGetVal(o), 0);
+        void *batch[HGETALL_PREFETCH_BATCH];
+
+        while (1) {
+            /* Phase 1: collect a batch of entry pointers and prefetch the
+             * entry structs themselves. We deliberately do not dereference
+             * them here, so the prefetches have time to land. */
+            int batch_count = 0;
+            while (batch_count < HGETALL_PREFETCH_BATCH) {
+                void *next;
+                if (!hashtableNext(&iter, &next)) break;
+                batch[batch_count++] = next;
+                valkey_prefetch(next);
+            }
+            if (batch_count == 0) break;
+
+            /* Phase 2: entries are warm now, so prefetch the field/value sds
+             * buffers they point at. */
+            for (int i = 0; i < batch_count; i++) {
+                if (flags & OBJ_HASH_FIELD) valkey_prefetch(entryGetField(batch[i]));
+                if (flags & OBJ_HASH_VALUE) {
+                    size_t vlen;
+                    valkey_prefetch(entryGetValue(batch[i], &vlen));
+                }
+            }
+
+            /* Phase 3: emit the replies against cache-warm data. */
+            for (int i = 0; i < batch_count; i++) {
+                if (flags & OBJ_HASH_FIELD) {
+                    sds field = entryGetField(batch[i]);
+                    addWritePreparedReplyBulkCBuffer(wpc, field, sdslen(field));
+                    count++;
+                }
+                if (flags & OBJ_HASH_VALUE) {
+                    size_t vlen;
+                    char *val = entryGetValue(batch[i], &vlen);
+                    addWritePreparedReplyBulkCBuffer(wpc, val, vlen);
+                    count++;
+                }
+            }
+        }
+        hashtableCleanupIterator(&iter);
+        /* The header was written up front, so the element count must match it
+         * exactly or we have emitted a malformed reply. */
+        serverAssert((unsigned long)count == ((flags & OBJ_HASH_FIELD && flags & OBJ_HASH_VALUE) ? length * 2 : length));
+        return;
+    }
+
+    /* Slow path: listpack encoding, or a hash with volatile fields whose count
+     * may shrink mid-iteration as fields expire. The length isn't known until
+     * we've walked it, so the aggregate header has to be deferred. */
     void *replylen = addReplyDeferredLen(c);
     hashTypeInitIterator(o, &hi);
     while (hashTypeNext(&hi) != C_ERR) {
@@ -1801,6 +1883,7 @@ void genericHgetallCommand(client *c, int flags) {
     }
 
     hashTypeResetIterator(&hi);
+
     /* Make sure we returned the right number of elements. */
     if (flags & OBJ_HASH_FIELD && flags & OBJ_HASH_VALUE) {
         setDeferredMapLen(c, replylen, count / 2);


### PR DESCRIPTION
_Note: this is AI Slop. The ideal case for this PR is a real contributor is inspired by this diff and puts up their own informed change._

This tries to address a performance difference I've been noticing between Redis and Valkey. My use of Valkey involves a dozen or so clients fetching moderately sized hashmaps all the time. While both projects are faster at this than the pre-fork version, Redis seems to be almost twice as fast as Valkey in this case, when comparing latest versions.

Claude: 

```
  The fix
  
  bench/valkey-hgetall-perf.patch (~170 lines, t_hash.c + networking.c). A fast path for
  hashtable-encoded hashes with no volatile (TTL) fields — where the count is known and 
  exact — emits a real header and batch-prefetches entries. Listpack hashes and TTL-bearing
  hashes

  keep the existing deferred path unchanged, since their length can shrink mid-iteration.
  
  ┌────────────────┬───────┬────────────────┐
  │     build      │ ops/s │ µs/op (server) │
  ├────────────────┼───────┼────────────────┤
  │ Valkey 9.1.1   │ 214k  │ 4.57           │
  ├────────────────┼───────┼────────────────┤
  │ Valkey + patch │ 260k  │ 3.24           │
  ├────────────────┼───────┼────────────────┤
  │ Redis 8.8      │ 261k  │ 3.09           │
  └────────────────┴───────┴────────────────┘

  Ablation: the t_hash change is the bigger lever, the networking change contributes 
  independently, and they compose. On the reporter's own scenario, server CPU went 
  3.50s → 3.11s vs Redis's 3.22s.
  
  Verification: 966 tests pass across hash/list/set/zset/string/protocol; HGETALL/HKEYS/HVALS
  output is byte-identical to Redis in both encodings and RESP3; TTL-field cases (partial
  expiry, full expiry, key deletion) all correct.
```

Fixes https://github.com/valkey-io/valkey/issues/3451 