### PR TITLE
Dispatch weekly tests using branch definition of daily.yml

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -51,6 +51,7 @@ jobs:
     needs: determine-release-branches
     if: needs.determine-release-branches.outputs.has-branches == 'true' && github.repository == 'valkey-io/valkey'
     runs-on: ubuntu-latest
+    timeout-minutes: 1440
     permissions:
       actions: write
       contents: read
@@ -74,5 +75,9 @@ jobs:
           echo "$out"
 
           run_id=$(grep -oiE 'actions/runs/[0-9]+' <<<"$out" | grep -oE '[0-9]+' | head -1 || true)
+          if [ -z "$run_id" ]; then
+            echo "gh workflow run returned no run URL (rare 204 dispatch response) for $BRANCH" >&2
+            exit 1
+          fi
 
           gh run watch "$run_id" --repo "$REPO" --exit-status --compact --interval 300

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -50,6 +50,7 @@ jobs:
   run-daily-for-release-branches:
     needs: determine-release-branches
     if: needs.determine-release-branches.outputs.has-branches == 'true' && github.repository == 'valkey-io/valkey'
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: read
@@ -59,10 +60,19 @@ jobs:
       matrix:
         release-branch: ${{ fromJson(needs.determine-release-branches.outputs.branches) }}
       max-parallel: 2
-    uses: ./.github/workflows/daily.yml
-    with:
-      use_repo: valkey-io/valkey
-      use_git_ref: ${{ matrix.release-branch }}
-      skipjobs: ""
-      skiptests: ""
-    secrets: inherit
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BRANCH: ${{ matrix.release-branch }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Dispatch daily.yml on ${{ matrix.release-branch }} and wait
+        run: |
+          set -euo pipefail
+
+          out=$(gh workflow run daily.yml --repo "$REPO" --ref "$BRANCH" \
+            -f use_repo="$REPO" -f use_git_ref="$BRANCH" -f skipjobs=none -f skiptests=none 2>&1)
+          echo "$out"
+
+          run_id=$(grep -oiE 'actions/runs/[0-9]+' <<<"$out" | grep -oE '[0-9]+' | head -1 || true)
+
+          gh run watch "$run_id" --repo "$REPO" --exit-status --compact --interval 300


### PR DESCRIPTION
When inspecting weekly test invocations https://github.com/valkey-io/valkey/actions/runs/31298449996, it can be observed that the tests for all branches (7.2, 8.0, 8.1, 9.0, 9.1) are run using the `daily.yml` defined in the `unstable` branch.

The `unstable` definition of `daily.yml` is using the latest expectations in terms of file structure & test run methodologies, which are not applicable to older versions of **valkey**, this in turn results in various types of failures, for example:
- Tests not running due to missing files -> `couldn't read file "tests/tests/unit.tcl": no such file or directory`
- Tests being skipped -> Cluster tests not running for 7.2 causing `reply-schemas-validator` to fail

In this change each branch gets tested using it's own definition of `daily.yml`, this is done via standard `gh` CLI commands