### PR TITLE
Rename client flag `replica` to `replica_or_monitor`

### DIFF
--- a/src/logreqres.c
+++ b/src/logreqres.c
@@ -81,7 +81,7 @@ static int reqresShouldLog(client *c) {
     if (c->flag.fake || c->conn == NULL) return 0;
 
     /* Ignore client with streaming non-standard response */
-    if (c->flag.pubsub || c->flag.monitor || c->flag.replica) return 0;
+    if (c->flag.pubsub || c->flag.replica_or_monitor) return 0;
 
     /* We only log normal user clients.
      * Internal clients (slot migration etc.) may use shared buffers or emit commands that

--- a/src/module.c
+++ b/src/module.c
@@ -3890,7 +3890,7 @@ int modulePopulateClientInfoStructure(void *ci, client *client, int structver) {
     if (client->conn->type == connectionTypeTls()) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_SSL;
     if (client->flag.readonly) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_READONLY;
     if (client->flag.primary) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_PRIMARY;
-    if (client->flag.replica) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_REPLICA;
+    if (client->flag.replica_or_monitor) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_REPLICA;
     if (client->flag.monitor) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_MONITOR;
     if (client->flag.module) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_MODULE;
     if (client->flag.authenticated) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_AUTHENTICATED;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2032,7 +2032,7 @@ void unlinkClient(client *c) {
          * snapshot child may take some time to die, during which the migration will continue past
          * the snapshot state. */
         if (c->repl_data && server.rdb_pipe_conns &&
-            ((c->flag.replica && c->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END))) {
+            ((getClientType(c) == CLIENT_TYPE_REPLICA && c->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END))) {
             int i;
             int still_alive = 0;
             for (i = 0; i < server.rdb_pipe_numconns; i++) {
@@ -2090,8 +2090,8 @@ void unlinkClient(client *c) {
 void clearClientConnectionState(client *c) {
     listNode *ln;
 
-    /* MONITOR clients are also marked with CLIENT_REPLICA, we need to
-     * distinguish between the two.
+    /* MONITOR clients share the replica_or_monitor flag, so clear both of them
+     * here. The assert below then only fires for actual replicas and primaries.
      */
     if (c->flag.monitor) {
         ln = listSearchKey(server.monitors, c);
@@ -2099,10 +2099,10 @@ void clearClientConnectionState(client *c) {
         listDelNode(server.monitors, ln);
 
         c->flag.monitor = 0;
-        c->flag.replica = 0;
+        c->flag.replica_or_monitor = 0;
     }
 
-    serverAssert(!(c->flag.replica || c->flag.primary || c->slot_migration_job));
+    serverAssert(!(c->flag.replica_or_monitor || c->flag.primary || c->slot_migration_job));
 
     if (c->flag.tracking) disableTracking(c);
     selectDb(c, 0);
@@ -4473,12 +4473,10 @@ sds catClientInfoString(sds s, client *client, int hide_user_data) {
     char flags[17], events[3], capa[9], conninfo[CONN_INFO_LEN], *p;
 
     p = flags;
-    if (client->flag.replica) {
-        if (client->flag.monitor)
-            *p++ = 'O';
-        else
-            *p++ = 'S';
-    }
+    if (client->flag.monitor)
+        *p++ = 'O';
+    else if (client->flag.replica_or_monitor)
+        *p++ = 'S';
 
     if (client->flag.primary) *p++ = 'M';
     if (client->flag.pubsub) *p++ = 'P';
@@ -4712,16 +4710,16 @@ void clientSetinfoCommand(client *c) {
 /* Reset the client state to resemble a newly connected client.
  */
 void resetCommand(client *c) {
-    /* MONITOR clients are also marked with CLIENT_REPLICA, we need to
-     * distinguish between the two.
+    /* MONITOR clients share the replica_or_monitor flag, and RESET is allowed for
+     * them, so mask both flags off before deciding whether this is a real replica.
      */
     struct ClientFlags flags = c->flag;
     if (flags.monitor) {
         flags.monitor = 0;
-        flags.replica = 0;
+        flags.replica_or_monitor = 0;
     }
 
-    if (flags.replica || flags.primary || flags.module) {
+    if (flags.replica_or_monitor || flags.primary || flags.module) {
         addReplyError(c, "can only reset normal client connections");
         return;
     }
@@ -5125,10 +5123,10 @@ static int clientMatchesFlagFilter(client *c, sds flag_filter) {
         /* Check each flag */
         switch (flag) {
         case 'O': /* client in MONITOR mode */
-            if (!(c->flag.replica && c->flag.monitor)) return 0;
+            if (!c->flag.monitor) return 0;
             break;
         case 'S': /* client is a replica node connection to this instance */
-            if (!c->flag.replica) return 0;
+            if (getClientType(c) != CLIENT_TYPE_REPLICA) return 0;
             break;
         case 'M': /* client is a primary */
             if (!c->flag.primary) return 0;
@@ -5185,7 +5183,7 @@ static int clientMatchesFlagFilter(client *c, sds flag_filter) {
             if (!c->slot_migration_job || isImportSlotMigrationJob(c->slot_migration_job)) return 0;
             break;
         case 'N': /* Check for no flags */
-            if (c->flag.replica || c->flag.primary || c->flag.pubsub ||
+            if (c->flag.replica_or_monitor || c->flag.primary || c->flag.pubsub ||
                 c->flag.multi || c->flag.blocked || c->flag.tracking ||
                 c->flag.tracking_broken_redir || c->flag.tracking_bcast ||
                 c->flag.dirty_cas || c->flag.close_after_reply ||

--- a/src/replication.c
+++ b/src/replication.c
@@ -949,7 +949,7 @@ int primaryTryPartialResynchronization(client *c, long long psync_offset) {
      * 3) Inform the client we can continue with +CONTINUE
      * 4) Send the backlog data (from the offset to the end) to the replica. */
     waitForClientIO(c);
-    c->flag.replica = 1;
+    c->flag.replica_or_monitor = 1;
     if (c->repl_data->associated_rdb_client_id && lookupRdbClientByID(c->repl_data->associated_rdb_client_id)) {
         c->repl_data->repl_state = REPLICA_STATE_BG_RDB_LOAD;
         removeReplicaFromPsyncWait(c);
@@ -1076,7 +1076,7 @@ int startBgsaveForReplication(int mincapa, int req, int rdbver) {
 
             if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START) {
                 replica->repl_data->repl_state = REPL_STATE_NONE;
-                replica->flag.replica = 0;
+                replica->flag.replica_or_monitor = 0;
                 listDelNode(server.replicas, ln);
                 addReplyError(replica, "BGSAVE failed, replication can't continue");
                 replica->flag.close_after_reply = 1;
@@ -1107,7 +1107,7 @@ int startBgsaveForReplication(int mincapa, int req, int rdbver) {
 /* SYNC and PSYNC command implementation. */
 void syncCommand(client *c) {
     /* ignore SYNC if already replica or in monitor mode */
-    if (c->flag.replica) return;
+    if (c->flag.replica_or_monitor) return;
 
     initClientReplicationData(c);
 
@@ -1226,7 +1226,7 @@ void syncCommand(client *c) {
     c->repl_data->repl_state = REPLICA_STATE_WAIT_BGSAVE_START;
     if (server.repl_disable_tcp_nodelay) anetDisableTcpNoDelay(NULL, c->conn->fd); /* Non critical if it fails. */
     c->repl_data->repldbfd = -1;
-    c->flag.replica = 1;
+    c->flag.replica_or_monitor = 1;
     listAddNodeTail(server.replicas, c);
 
     /* Create the replication backlog if needed. */
@@ -1335,7 +1335,7 @@ void freeClientReplicationData(client *c) {
     freeReplicaReferencedReplBuffer(c);
     /* Primary/replica cleanup Case 1:
      * we lost the connection with a replica. */
-    if (c->flag.replica) {
+    if (c->flag.replica_or_monitor) {
         /* If there is no any other replica waiting dumping RDB finished, the
          * current child process need not continue to dump RDB, then we kill it.
          * So child process won't use more memory, and we also can fork a new
@@ -1483,7 +1483,7 @@ void replconfCommand(client *c) {
              * internal only command that normal clients should never use. */
             long long offset;
 
-            if (!c->flag.replica) return;
+            if (getClientType(c) != CLIENT_TYPE_REPLICA) return;
             if ((getLongLongFromObject(c->argv[j + 1], &offset) != C_OK)) return;
             if (offset > c->repl_data->repl_ack_off) c->repl_data->repl_ack_off = offset;
             if (c->argc > j + 3 && !strcasecmp(objectGetVal(c->argv[j + 2]), "fack")) {
@@ -4695,7 +4695,7 @@ void replicaofCommand(client *c) {
     } else {
         long port;
 
-        if (c->flag.replica) {
+        if (c->flag.replica_or_monitor) {
             /* If a client is already a replica they cannot run this command,
              * because it involves flushing all replicas (including this
              * client) */

--- a/src/server.c
+++ b/src/server.c
@@ -4712,7 +4712,7 @@ int processCommand(client *c) {
     /* Prevent a replica from sending commands that access the keyspace.
      * The main objective here is to prevent abuse of client pause check
      * from which replicas are exempt. */
-    if (c->flag.replica && (is_may_replicate_command || is_write_command || is_read_command)) {
+    if (c->flag.replica_or_monitor && (is_may_replicate_command || is_write_command || is_read_command)) {
         sds replica_err = sdsnew("Replica can't interact with the keyspace");
         rejectCommandSds(c, replica_err, 1);
         return C_OK;
@@ -4720,7 +4720,7 @@ int processCommand(client *c) {
 
     /* If the server is paused, block the client until the pause has ended. Replicas and slot
      * export clients are never paused to allow failover/slot migration to succeed. */
-    if (!c->flag.replica && (!c->slot_migration_job || isImportSlotMigrationJob(c->slot_migration_job)) &&
+    if (!c->flag.replica_or_monitor && (!c->slot_migration_job || isImportSlotMigrationJob(c->slot_migration_job)) &&
         ((isPausedActions(PAUSE_ACTION_CLIENT_ALL)) || ((isPausedActions(PAUSE_ACTION_CLIENT_WRITE)) && is_may_replicate_command))) {
         blockPostponeClient(c);
         return C_OK;
@@ -6896,11 +6896,11 @@ void monitorCommand(client *c) {
     }
 
     /* ignore MONITOR if already replica or in monitor mode */
-    if (c->flag.replica) return;
+    if (c->flag.replica_or_monitor) return;
 
     initClientReplicationData(c);
 
-    c->flag.replica = 1;
+    c->flag.replica_or_monitor = 1;
     c->flag.monitor = 1;
     listAddNodeTail(server.monitors, c);
     addReply(c, shared.ok);

--- a/src/server.h
+++ b/src/server.h
@@ -1117,8 +1117,8 @@ typedef enum {
 
 typedef struct ClientFlags {
     uint64_t primary : 1;                  /* This client is a primary */
-    uint64_t replica : 1;                  /* This client is a replica */
-    uint64_t monitor : 1;                  /* This client is a replica monitor, see MONITOR */
+    uint64_t replica_or_monitor : 1;       /* Replica *or* MONITOR, see getClientType() */
+    uint64_t monitor : 1;                  /* This client is in MONITOR mode, see MONITOR */
     uint64_t multi : 1;                    /* This client is in a MULTI context */
     uint64_t blocked : 1;                  /* The client is waiting in a blocking operation */
     uint64_t dirty_cas : 1;                /* Watched keys modified. EXEC will fail. */
@@ -1432,12 +1432,18 @@ static inline int clientConnPostponeMaskFromIOState(client *c) {
  * CLIENT_TYPE_REPLICA  -> replica
  * CLIENT_TYPE_PUBSUB -> Client subscribed to Pub/Sub channels
  * CLIENT_TYPE_PRIMARY -> The client representing our replication primary.
+ *
+ * This is the right way to ask "is this an actual replica". MONITOR clients reuse
+ * the replica plumbing (they set flag.replica_or_monitor, are exempt from the idle
+ * timeout and from client pause, and are torn down through
+ * freeClientReplicationData()), so reading flag.replica_or_monitor directly also
+ * matches monitors.
  */
 static inline int getClientType(client *c) {
     if (unlikely(c->flag.primary)) return CLIENT_TYPE_PRIMARY;
-    /* Even though MONITOR clients are marked as replicas, we
+    /* Even though MONITOR clients share the replica flag, we
      * want the expose them as normal clients. */
-    if (unlikely(c->flag.replica) && !c->flag.monitor) return CLIENT_TYPE_REPLICA;
+    if (unlikely(c->flag.replica_or_monitor) && !c->flag.monitor) return CLIENT_TYPE_REPLICA;
     if (c->flag.pubsub) return CLIENT_TYPE_PUBSUB;
     if (unlikely(c->slot_migration_job)) return isImportSlotMigrationJob(c->slot_migration_job) ? CLIENT_TYPE_SLOT_IMPORT : CLIENT_TYPE_SLOT_EXPORT;
     return CLIENT_TYPE_NORMAL;

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -55,10 +55,10 @@ int clientsCronHandleTimeout(client *c, mstime_t now_ms) {
 
     if (server.maxidletime &&
         /* This handles the idle clients connection timeout if set. */
-        !c->flag.replica &&   /* No timeout for replicas and monitors */
-        !mustObeyClient(c) && /* No timeout for primaries and AOF */
-        !c->flag.blocked &&   /* No timeout for BLPOP */
-        !c->flag.pubsub &&    /* No timeout for Pub/Sub clients */
+        !c->flag.replica_or_monitor && /* No timeout for replicas and monitors */
+        !mustObeyClient(c) &&          /* No timeout for primaries and AOF */
+        !c->flag.blocked &&            /* No timeout for BLPOP */
+        !c->flag.pubsub &&             /* No timeout for Pub/Sub clients */
         (now - c->last_interaction > server.maxidletime)) {
         serverLog(LL_VERBOSE, "Closing idle client");
         freeClient(c);

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -522,6 +522,27 @@ start_server {tags {"introspection"}} {
         catch {$c1 close}
     }
 
+    # MONITOR clients share the internal replica_or_monitor flag with real replicas,
+    # but they report flags=O, so the S filter must not match them.
+    test {CLIENT LIST with FLAGS filter distinguishes replicas from MONITOR clients} {
+        set rd [valkey_deferring_client]
+        $rd client setname monitorclient
+        assert_equal {OK} [$rd read]
+        $rd monitor
+        assert_equal {OK} [$rd read]
+
+        assert_match "*name=monitorclient*" [r client list flags O]
+        assert_no_match "*name=monitorclient*" [r client list flags S]
+
+        # An actual replica connection is the other way around.
+        set repl [attach_to_replication_stream]
+        assert_match "*flags=S*" [r client list flags S]
+        assert_no_match "*flags=S*" [r client list flags O]
+        close_replication_stream $repl
+
+        $rd close
+    }
+
     # Test CLIENT LIST with NOT-TYPE filter
     test {CLIENT LIST with NOT-TYPE filter} {
         r client setname mytestclient


### PR DESCRIPTION
Closes #4397, where the surface changes below were raised for agreement.

`monitorCommand()` sets both `flag.replica` and `flag.monitor`, because MONITOR clients reuse the replica plumbing: exempt from the idle timeout and from client pause, skipped by the request/response log, torn down through `freeClientReplicationData()`. So the bit named `replica` actually means "replica **or** monitor", and readers keep getting it wrong.

This renames it to `replica_or_monitor` and points the reader at `getClientType(c) == CLIENT_TYPE_REPLICA` for the "is this an actual replica" question. The name is deliberately clunky, so it reads as a question at each of the 24 use sites.

The rename earns its keep immediately: the compiler flagged `resetCommand()`, which copies the flags struct into a local and so does not match a `c->flag.replica` grep. That is the failure mode the alternative fix ("just stop setting the flag for monitors") has, since it is a compiler no-op.

## Behavior changes

Two sites were reading the flag as "replica" and are corrected. Both were called out in #4397.

1. **`CLIENT LIST` / `CLIENT KILL` with `FLAGS S` matched MONITOR clients.** `catClientInfoString()` reports monitors as `flags=O` and never `S`, so the filter could return a client whose own `flags=` field contradicted the filter it matched. Verified by reverting just this hunk, at which point the new test fails with a returned client whose info string reads `flags=O`.

2. **`REPLCONF ACK` from a MONITOR client** passed the guard (monitors get `repl_data` from `initClientReplicationData()`) and overwrote `repl_ack_off` / `repl_ack_time`. Not otherwise observable: the client is not in `server.replicas` and its `repl_state` is `REPL_STATE_NONE`, so the `replicaPutOnline()` and `replicaStartCommandStream()` paths cannot trigger. Requires admin ACL. No test, since there is nothing observable to assert.

Everything else keeps current behavior exactly, including the three items #4397 proposed to leave alone: the MONITOR exemption from client pause, the keyspace-command rejection for monitors, and `VALKEYMODULE_CLIENTINFO_FLAG_REPLICA` being set for monitors.

One note against the issue's table: `replicaofCommand()` is listed there under "real replica only", but I kept it as `replica_or_monitor` so a MONITOR client is still rejected. Narrowing it would let monitors run `REPLICAOF`, which is a behavior change nobody asked for and which was not among the items raised.

## Incidental readability cleanups

Visible once the name stopped lying, all behavior-preserving:

- `reqresShouldLog()` checked `flag.monitor || flag.replica`, which is redundant since monitor implies the shared flag.
- The `FLAGS O` filter checked `flag.replica && flag.monitor`, redundant the same way.
- `catClientInfoString()` now tests `monitor` first and `replica_or_monitor` second, mirroring the filter logic instead of nesting.

## Testing

- `make` clean at `-Werror`; `clang-format-18` clean on all touched files.
- New test in `unit/introspection` asserting `FLAGS S` matches an actual replica (via `attach_to_replication_stream`) and not a MONITOR client, and that `FLAGS O` is the other way around. Confirmed it fails without the fix.
- `unit/introspection`, `unit/introspection-2`, `unit/other`: 266 passed, 0 failed.
- `integration/replication`, `integration/replication-2`: 125 passed, 0 failed.

The `DEVELOPMENT_GUIDE` pitfall entry that documents this trap is in a separate in-flight PR. Once both land, that entry should point at the flag name rather than asking people to remember.

---

*This was generated by AI but verified, with love, by a human.*
