### PR TITLE
Skip IO-thread read-done followup unless update_state sync-invokes handlers

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -147,6 +147,10 @@ typedef struct ConnectionType {
     void (*postpone_update_state)(struct connection *conn, int postpone_mask);
     /* Called by the main-thread */
     void (*update_state)(struct connection *conn);
+    /* 1 if update_state may synchronously invoke read/write handlers.
+     * When set, processClientIOReadsDone defers clearing postpone until after
+     * command batching; leave 0 for transports that do not need that. */
+    int sync_handlers_in_update_state;
 
     /* TLS specified methods */
     sds (*get_peer_cert)(struct connection *conn);

--- a/src/connection.h
+++ b/src/connection.h
@@ -530,6 +530,10 @@ static inline void connSetPostponeUpdateState(connection *conn, int postpone_mas
     }
 }
 
+static inline int connUpdateStateMayInvokeHandlers(connection *conn) {
+    return conn && conn->type && conn->type->sync_handlers_in_update_state;
+}
+
 static inline int connIsIntegrityChecked(connection *conn) {
     return conn->type->connIntegrityChecked && conn->type->connIntegrityChecked();
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -6572,7 +6572,7 @@ int processClientIOReadsDone(client *c) {
      * handlers. Always call update_state, including ACCEPTING. */
     if (c->conn) {
         int mask = 0;
-        if (!in_accept_state && c->conn->type->sync_handlers_in_update_state) {
+        if (!in_accept_state && connUpdateStateMayInvokeHandlers(c->conn)) {
             mask = CONN_POSTPONE_READ;
             if (c->io_write_state != CLIENT_IDLE) mask |= CONN_POSTPONE_WRITE;
             needs_post_read_update = 1;

--- a/src/networking.c
+++ b/src/networking.c
@@ -6568,10 +6568,12 @@ int processClientIOReadsDone(client *c) {
     int in_accept_state = (connGetState(c->conn) == CONN_STATE_ACCEPTING);
     int needs_post_read_update = 0;
 
+    /* Defer the post-batch update only when update_state may sync-invoke
+     * handlers. Always call update_state, including ACCEPTING. */
     if (c->conn) {
         int mask = 0;
-        if (!in_accept_state) {
-            mask |= CONN_POSTPONE_READ;
+        if (!in_accept_state && c->conn->type->sync_handlers_in_update_state) {
+            mask = CONN_POSTPONE_READ;
             if (c->io_write_state != CLIENT_IDLE) mask |= CONN_POSTPONE_WRITE;
             needs_post_read_update = 1;
         }

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -1860,6 +1860,8 @@ static ConnectionType CT_RDMA = {
     .process_pending_data = rdmaProcessPendingData,
     .postpone_update_state = postPoneUpdateRdmaState,
     .update_state = updateRdmaState,
+    /* updateRdmaState → connRdmaEventHandler may sync-call read/write handlers. */
+    .sync_handlers_in_update_state = 1,
 
     /* Miscellaneous */
     .connIntegrityChecked = NULL,


### PR DESCRIPTION
## Summary
Follow-up of #3611.

The May 27 On-Demand run on this PR (SET/GET, 96B, io-threads 2/10, pipeline 1/10) showed no significant RPS change. After `17ec23f` removed `post_read_done_postpone_mask`, `processClientIOReadsDone()` started postponing READ and returning `needs_post_read_update = 1` for every non-ACCEPTING completed read.

That second phase (`lookupClientByID` + `processPendingCommandAndInputBuffer` + `connUpdateState`) is only required when `update_state` may synchronously invoke handlers. For other transports it is per-completion overhead. This matches the post-merge dashboard drop: small payloads, io-threads, **P1 worse than P10**.

This PR restores the original gate without bringing `struct client` into the connection driver (the review concern that led to `17ec23f`):

- `ConnectionType.sync_handlers_in_update_state` (0 by default)
- Set only where `update_state` can sync-call handlers
- Mask is still computed in `networking.c` from IO state
- `connUpdateState()` still runs immediately, including ACCEPTING

## Test plan
- [x] On-Demand benchmark vs `unstable`: SET/GET, data 16/128, io-threads 2/10, pipelines 1/10 (expect P1 small-object recovery; 2048B ~flat)
- [x] RDMA + io-threads pipeline still does not re-enter `parseInputBuffer` with a non-empty `cmd_queue`
- [x] Existing io-threads / pause / TLS CI

Local ABBA on a laptop (same HEAD, same `valkey-benchmark`, warmup+duration, physical-core split) was **inconclusive**: a few percent in both directions, and the io-threads=1 / 2048B controls also drifted. I am not claiming the laptop run proves the dashboard regression is gone. Please use the official On-Demand / perf farm for that.