### PR TITLE
Tests: EXEC is now entry 0 of the MULTI redaction commandlog test

### DIFF
--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -208,8 +208,11 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
         r config set commandlog-execution-slower-than -1
         set slowlog_resp [r commandlog get -1 slow]
 
-        # The ACL SETUSER redaction must not carry over to the following SET
-        assert_equal {set foo bar} [lindex [lindex $slowlog_resp 0] 3]
+        # Entry 0 is the EXEC itself, entry 1 is the SET and entry 2 is the ACL SETUSER.
+        # The ACL SETUSER redaction must not carry over to the following SET.
+        assert_equal {exec} [lindex [lindex $slowlog_resp 0] 3]
+        assert_equal {set foo bar} [lindex [lindex $slowlog_resp 1] 3]
+        assert_equal {acl setuser (redacted) (redacted)} [lindex [lindex $slowlog_resp 2] 3]
         r acl deluser commandlog-test-user
     }
 


### PR DESCRIPTION
`unit/commandlog` fails on unstable at 917de6ac1:

```
*** [err]: COMMANDLOG slow - Redaction does not leak to later commands in a MULTI in tests/unit/commandlog.tcl
Expected 'set foo bar' to be equal to 'exec' (context: type eval line 12 cmd {assert_equal {set foo bar} [lindex [lindex $slowlog_resp 0] 3]} proc ::test)
```

#4267 dropped `SKIP_COMMANDLOG` from EXEC (`src/commands/exec.json:12`), so EXEC is now logged after the commands it ran, which puts it at entry 0 of the newest-first `COMMANDLOG GET`. The redaction test at `tests/unit/commandlog.tcl:212`, added by #4323, still reads entry 0 and gets the EXEC instead of the SET. Neither PR was rebased on the other, so this only broke on merge and not in either PR's CI.

The log after `MULTI; ACL SETUSER commandlog-test-user +get; SET foo bar; EXEC`:

| Entry | Command |
|---|---|
| 0 | `exec` |
| 1 | `set foo bar` |
| 2 | `acl setuser (redacted) (redacted)` |

Read the SET from entry 1 instead. The other tests #4267 touched already assert entry 0 is `exec` and entry 1 is the inner command, so this matches.

Also assert entries 0 and 2 rather than only the SET. The point of the test is that the ACL SETUSER redaction stops at the ACL SETUSER, and asserting entry 2 is redacted is what keeps it from passing if redaction breaks entirely. Asserting entry 0 is `exec` makes the index arithmetic fail loudly next time the entry order changes, instead of silently comparing against the wrong entry the way it just did.

## Testing

`unit/commandlog` goes from 29 passed, 1 failed to 30 passed. `unit/slowlog` and `unit/multi` are unchanged at 100 passed.

Reverting the `src/` hunks of 917de6ac1 confirms that commit is the trigger. The new entry-0 assert fails, along with the two EXEC tests 917de6ac1 added:

```
*** [err]: COMMANDLOG slow - Redaction does not leak to later commands in a MULTI in tests/unit/commandlog.tcl
Expected 'exec' to be equal to 'set foo bar' (context: type eval line 13 cmd {assert_equal {exec} [lindex [lindex $slowlog_resp 0] 3]} proc ::test)
*** [err]: COMMANDLOG slow - EXEC is logged alongside slow inner commands in tests/unit/commandlog.tcl
Expected '1' to be equal to '2' (context: type eval line 8 cmd {assert_equal [r commandlog len slow] 2} proc ::test)
*** [err]: COMMANDLOG slow - EXEC records total transaction time when inner commands are individually fast in tests/unit/commandlog.tcl
Expected '0' to be equal to '1' (context: type eval line 9 cmd {assert_equal [r commandlog len slow] 1} proc ::test)
```

*This was generated by AI but verified, with love, by a human.*