### PR TITLE
Deflake CLUSTER SYNCSLOTS ESTABLISH command interface test

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -47,10 +47,14 @@ proc get_migration_by_name {node_idx name} {
 }
 
 proc wait_for_migration_registered {node_idx jobname} {
+    # A job in a terminal state stops guarding its slots against a competing
+    # migration, so require the job to be registered and still live.
     wait_for_condition 100 100 {
-        [get_migration_by_name $node_idx $jobname] ne ""
+        [get_migration_by_name $node_idx $jobname] ne "" &&
+        [dict get [get_migration_by_name $node_idx $jobname] state] ni {failed cancelled success}
     } else {
-        fail "Migration $jobname was not registered on node $node_idx within 10000 ms"
+        set curr_state [get_migration_by_name $node_idx $jobname]
+        fail "Migration $jobname was not registered and live on node $node_idx within 10000 ms (currently $curr_state)"
     }
 }
 
@@ -72,13 +76,13 @@ proc wait_for_countkeysinslot {node_idx slot value} {
     }
 }
 
-proc wait_for_migration {node_idx slot} {
+proc wait_for_migration {node_idx slot {maxtries 100}} {
     set target_id [R $node_idx CLUSTER MYID]
-    wait_for_condition 100 100 {
+    wait_for_condition $maxtries 100 {
         [is_slot_migrated $node_idx $slot]
     } else {
         set nodes [get_cluster_nodes $node_idx]
-        fail "Cluster node $target_id did not get slot $slot within 10000 ms (current $nodes)"
+        fail "Cluster node $target_id did not get slot $slot within [expr {$maxtries * 100}] ms (current $nodes)"
     }
     wait_for_cluster_propagation
 }
@@ -1955,36 +1959,54 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
 
     test "Migration not cancelled when snapshot takes more time than repl-timeout" {
         assert_does_not_resync {
+            # The target must not kill the import link while the source's
+            # snapshot is quiet for longer than repl-timeout (the source
+            # cannot send ACKs while its child is snapshotting).
             R 2 CONFIG SET repl-timeout 2
 
-            # Load keys before the snapshot to target a snapshot time > 2sec
-            # 50 * 100ms = 5 sec
-            R 2 CONFIG SET rdb-key-save-delay 100000
+            # Load keys before the snapshot to target a snapshot time > 2sec.
+            # 50 * 100ms = 5 sec. The delay must be on node 0: it is the
+            # source of this migration and runs the snapshot.
+            R 0 CONFIG SET rdb-key-save-delay 100000
             populate 50 "$0_slot_tag:1:" 1000 -0
 
-            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node2_id]
-            set jobname [get_job_name 0 0]
+            set errcode [catch {
+                assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node2_id]
+                set jobname [get_job_name 0 0]
 
-            wait_for_migration 2 0
+                # The snapshot is designed to take at least 5 seconds, and
+                # instrumented (gcov) builds add tens of seconds on top, so
+                # the default 10 second budget has no headroom. Give the
+                # migration two minutes to complete.
+                wait_for_migration 2 0 1200
 
-            # Keys successfully migrated
-            assert_match "50" [R 2 CLUSTER COUNTKEYSINSLOT 0]
-            assert_match "0" [R 0 CLUSTER COUNTKEYSINSLOT 0]
+                # Keys successfully migrated
+                assert_match "50" [R 2 CLUSTER COUNTKEYSINSLOT 0]
+                assert_match "0" [R 0 CLUSTER COUNTKEYSINSLOT 0]
 
-            # Also eventually reflected in replicas
-            wait_for_countkeysinslot 5 0 50
-            wait_for_countkeysinslot 3 0 0
+                # Also eventually reflected in replicas
+                wait_for_countkeysinslot 5 0 50
+                wait_for_countkeysinslot 3 0 0
 
-            # Migration log shows success on both ends
-            assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
-            assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+                # Migration log shows success on both ends
+                assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
+                assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+            } errmsg options]
+
+            # These must be restored even if the block above failed. Leaking
+            # the key save delay makes later tests' snapshots take minutes,
+            # which cascades into aborting the whole file. Also cancel the
+            # migration in case it is still running (in the happy path it
+            # already finished, so ignore the error).
+            R 2 CONFIG SET repl-timeout 60
+            R 0 CONFIG SET rdb-key-save-delay 0
+            catch {R 0 CLUSTER CANCELSLOTMIGRATIONS}
+            if {$errcode} { return -options $options $errmsg }
 
             # Cleanup for next test
             assert_match "OK" [R 2 FLUSHDB SYNC]
             assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node0_id]
             wait_for_migration 0 0
-            R 2 CONFIG SET repl-timeout 60
-            R 2 CONFIG SET rdb-key-save-delay 0
         }
     }
 

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -46,6 +46,14 @@ proc get_migration_by_name {node_idx name} {
     return ""
 }
 
+proc wait_for_migration_registered {node_idx jobname} {
+    wait_for_condition 100 100 {
+        [get_migration_by_name $node_idx $jobname] ne ""
+    } else {
+        fail "Migration $jobname was not registered on node $node_idx within 10000 ms"
+    }
+}
+
 proc wait_for_migration_field {node_idx jobname field value} {
     wait_for_condition 100 100 {
         [get_migration_by_name $node_idx $jobname] ne "" && [dict get [get_migration_by_name $node_idx $jobname] $field] eq $value
@@ -1533,11 +1541,15 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
             # Unknown field
             assert_error "*syntax error*" {R 0 CLUSTER SYNCSLOTS ESTABLISH SOURCE $node2_id NAME $fake_jobname SLOTSRANGE 16383 16383 BAD_FIELD bad_value}
 
-            # Already importing
+            # Already importing. The slot is rejected as soon as the import job
+            # is registered on the target, so only wait for that. Waiting for a
+            # later state such as waiting-for-paused would make this test depend
+            # on the source finishing its snapshot, which can take much longer
+            # than the wait budget on instrumented builds.
             set_debug_prevent_pause 1
             assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
             set jobname [get_job_name 2 16383]
-            wait_for_migration_field 0 $jobname state waiting-for-paused
+            wait_for_migration_registered 0 $jobname
             assert_error "*Slot is already being imported on the target by a different migration*" {R 0 CLUSTER SYNCSLOTS ESTABLISH SOURCE $node2_id NAME $fake_jobname SLOTSRANGE 16383 16383}
             assert_match "OK" [R 2 CLUSTER CANCELSLOTMIGRATIONS]
             wait_for_migration_field 0 $jobname state failed


### PR DESCRIPTION
## Problem

This file aborts the whole test client on the Codecov job. [Run 31730148235](https://github.com/valkey-io/valkey/actions/runs/31730148235):

```
[err]: CLUSTER SYNCSLOTS ESTABLISH command interface in tests/unit/cluster/cluster-migrateslots.tcl
Migration effc0eb7d1f42f09d1a28384798c2c9795be1784 on node 0 did not have state == waiting-for-paused
(currently ... create_time 1786645569 last_update_time 1786645569 last_ack_time 1786645593
 state receiving-snapshot ...)
[exception]: Executing test client: ERR I am already migrating slot 16383..
```

`cluster-migrateslots.tcl:1540` waited for the import to reach `waiting-for-paused`, which requires the source to finish its snapshot. Under gcov that took 24s, past the wait budget.

The `fail` then aborted the test before its `CLUSTER CANCELSLOTMIGRATIONS` on line 1542, leaving node 2 exporting 16383. The next test's `MIGRATESLOTS` is rejected by `clusterIsSlotExporting()` (`cluster_migrateslots.c:1183`), and a server error is a Tcl exception rather than an assertion, so it kills the test client and every test after it. Same cascade @murphyjacob4 described in #2692.

## Fix

The assertion being guarded only needs the import job to exist: `clusterIsSlotImporting()` (`cluster_migrateslots.c:494-505`) skips only finished jobs, so `receiving-snapshot` already rejects a duplicate `ESTABLISH`. Wait for registration instead of a state.

Raising the wait budget is the tempting alternative. It loses: @rainsupreme measured a blanket 3x budget in #4153 with no change in failure rate, and the same stall has been seen past 60s.

## Testing

`./runtest --single unit/cluster/cluster-migrateslots`: 137 passed before and after.

To prove the weaker wait still guards the assertion, I temporarily pinned the import in `receiving-snapshot` (`rdb-key-save-delay 100000` plus 50 keys on the source), asserted that state, and confirmed the duplicate `ESTABLISH` still errors. Passed, then removed the scaffold.

This fixes one of at least five failing signatures in this file, so #4153 stays open. The most frequent one, `AOF maintains consistency through many migrations`, runs 120 migrations in 10.2s locally, ~85ms against a 10s per-wait budget, so its CI failures are not marginal slowness and this change does nothing for them.

This was generated by AI but verified, with love, by a human.
