### PR TITLE
Fix out-of-bounds access in cluster message receivers

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -9614,8 +9614,8 @@ typedef struct moduleClusterNodeInfo {
 /* We have an array of message types: each bucket is a linked list of
  * configured receivers. The array covers the full uint8_t range, so
  * every valid cluster message type (0..255) has a bucket. */
-#define MAX_CLUSTER_MESSAGE_TYPES (UINT8_MAX + 1)
-static moduleClusterReceiver *clusterReceivers[MAX_CLUSTER_MESSAGE_TYPES];
+#define NUM_CLUSTER_MESSAGE_TYPES (UINT8_MAX + 1)
+static moduleClusterReceiver *clusterReceivers[NUM_CLUSTER_MESSAGE_TYPES];
 
 /* Dispatch the message to the right module receiver. */
 void moduleCallClusterReceivers(const char *sender_id,
@@ -9646,7 +9646,10 @@ void moduleCallClusterReceivers(const char *sender_id,
  * will be invoked with details, including the 40-byte node ID of the sender.
  *
  * In Valkey 8.1 and later, the node ID is null-terminated. Prior to 8.1, it was
- * not null-terminated */
+ * not null-terminated.
+ *
+ * Note: Old versions of Valkey could not handle type 255. This was fixed in
+ * 9.1.2, 9.0.6, 8.1.10, 8.0.11 and 7.2.15. */
 void VM_RegisterClusterMessageReceiver(ValkeyModuleCtx *ctx,
                                        uint8_t type,
                                        ValkeyModuleClusterMessageReceiver callback) {
@@ -13336,7 +13339,7 @@ void moduleUnregisterCommands(struct ValkeyModule *module) {
 static void moduleUnregisterClusterReceivers(ValkeyModule *module) {
     if (!server.cluster_enabled) return;
 
-    for (int type = 0; type < MAX_CLUSTER_MESSAGE_TYPES; type++) {
+    for (int type = 0; type < NUM_CLUSTER_MESSAGE_TYPES; type++) {
         moduleClusterReceiver *r = clusterReceivers[type], *prev = NULL;
         while (r) {
             if (r->module == module) {

--- a/src/module.c
+++ b/src/module.c
@@ -9612,8 +9612,10 @@ typedef struct moduleClusterNodeInfo {
 } moduleClusterNodeInfo;
 
 /* We have an array of message types: each bucket is a linked list of
- * configured receivers. */
-static moduleClusterReceiver *clusterReceivers[UINT8_MAX];
+ * configured receivers. The array covers the full uint8_t range, so
+ * every valid cluster message type (0..255) has a bucket. */
+#define MAX_CLUSTER_MESSAGE_TYPES (UINT8_MAX + 1)
+static moduleClusterReceiver *clusterReceivers[MAX_CLUSTER_MESSAGE_TYPES];
 
 /* Dispatch the message to the right module receiver. */
 void moduleCallClusterReceivers(const char *sender_id,
@@ -13334,7 +13336,7 @@ void moduleUnregisterCommands(struct ValkeyModule *module) {
 static void moduleUnregisterClusterReceivers(ValkeyModule *module) {
     if (!server.cluster_enabled) return;
 
-    for (int type = 0; type < UINT8_MAX; type++) {
+    for (int type = 0; type < MAX_CLUSTER_MESSAGE_TYPES; type++) {
         moduleClusterReceiver *r = clusterReceivers[type], *prev = NULL;
         while (r) {
             if (r->module == module) {

--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -67,7 +67,7 @@ int test_cluster_shards(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
 #define MSGTYPE_DING 1
 #define MSGTYPE_DONG 2
 #define MSGTYPE_TEST_UAF 3
-#define MSGTYPE_TEST_MAX 254
+#define MSGTYPE_TEST_MAX 255
 
 /* test.pingall */
 int PingallCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -333,7 +333,7 @@ start_cluster 3 0 [list config_lines $modules] {
             fail "node1 didn't receive cluster module message after re-registration"
         }
         verify_log_message 0 "*DING (type 3) RECEIVED*TestUAF*" 0
-        verify_log_message 0 "*DING (type 254) RECEIVED*TestMAX*" 0
+        verify_log_message 0 "*DING (type 255) RECEIVED*TestMAX*" 0
     }
 
     test "VM_RegisterClusterMessageReceiver - dangling callback after MODULE UNLOAD" {
@@ -358,7 +358,7 @@ start_cluster 3 0 [list config_lines $modules] {
             fail "node1 didn't receive cluster module message"
         }
         verify_no_log_message 0 "*DING (type 3) RECEIVED*TestUAF*" $loglines
-        verify_no_log_message 0 "*DING (type 254) RECEIVED*TestMAX*" $loglines
+        verify_no_log_message 0 "*DING (type 255) RECEIVED*TestMAX*" $loglines
         assert_equal PONG [$node1 PING]
     }
 }


### PR DESCRIPTION
The cluster message receiver array was sized UINT8_MAX (255), so the
valid index range was 0..254. Two issues existed:

- VM_RegisterClusterMessageReceiver allowed type 255, an out-of-bounds
  WRITE past the end of the array.

- moduleCallClusterReceivers would perform an out-of-bounds READ when a
  cluster bus packet carried type 255 (UINT8_MAX), which can be sent by
  any cluster member.

Grow the array to MAX_CLUSTER_MESSAGE_TYPES (UINT8_MAX + 1) so the full
uint8_t type range (0..255) is covered, and use the explicit constant in
both dispatch and unregister paths. type 255 is now a valid, dispatchable
message type.