### PR TITLE
Skip IO-thread read-done followup unless update_state sync-invokes handlers (9.0)

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -146,6 +146,10 @@ typedef struct ConnectionType {
     void (*postpone_update_state)(struct connection *conn, int postpone_mask);
     /* Called by the main-thread */
     void (*update_state)(struct connection *conn);
+    /* 1 if update_state may synchronously invoke read/write handlers.
+     * When set, processIOThreadsReadDone defers clearing postpone until after
+     * command batching; leave 0 for transports that do not need that. */
+    int sync_handlers_in_update_state;
 
     /* TLS specified methods */
     sds (*get_peer_cert)(struct connection *conn);
@@ -521,6 +525,10 @@ static inline void connSetPostponeUpdateState(connection *conn, int postpone_mas
     if (conn && conn->type && conn->type->postpone_update_state) {
         conn->type->postpone_update_state(conn, postpone_mask);
     }
+}
+
+static inline int connUpdateStateMayInvokeHandlers(connection *conn) {
+    return conn && conn->type && conn->type->sync_handlers_in_update_state;
 }
 
 static inline int connIsIntegrityChecked(connection *conn) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -6598,11 +6598,12 @@ int processIOThreadsReadDone(void) {
         int in_accept_state = (connGetState(c->conn) == CONN_STATE_ACCEPTING);
         int needs_post_read_update = 0;
 
-        /* Keep READ postponed through command batching. */
+        /* Defer the post-batch update only when update_state may sync-invoke
+         * handlers. Always call update_state, including ACCEPTING. */
         if (c->conn) {
             int mask = 0;
-            if (!in_accept_state) {
-                mask |= CONN_POSTPONE_READ;
+            if (!in_accept_state && connUpdateStateMayInvokeHandlers(c->conn)) {
+                mask = CONN_POSTPONE_READ;
                 if (c->io_write_state != CLIENT_IDLE) mask |= CONN_POSTPONE_WRITE;
                 needs_post_read_update = 1;
             }

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -1859,6 +1859,8 @@ static ConnectionType CT_RDMA = {
     .process_pending_data = rdmaProcessPendingData,
     .postpone_update_state = postPoneUpdateRdmaState,
     .update_state = updateRdmaState,
+    /* updateRdmaState → connRdmaEventHandler may sync-call read/write handlers. */
+    .sync_handlers_in_update_state = 1,
 
     /* Miscellaneous */
     .connIntegrityChecked = NULL,


### PR DESCRIPTION

Follow-up of #3335 (9.0 port of #3611). Fixes a regression introduced by that PR, mirroring upstream #4401.

After the postpone-mask method landed, processIOThreadsReadDone() started postponing READ and returning needs_post_read_update = 1 for every non-ACCEPTING completed read. That second phase (lookupClientByID + processPendingCommandAndInputBuffer + connUpdateState) is only required when update_state may synchronously invoke handlers. For other transports it is per-completion overhead, hitting small payloads with io-threads and shallow pipelines the hardest.

This restores the original gate without bringing struct client into the connection driver:

- ConnectionType.sync_handlers_in_update_state (0 by default)
- Set only where update_state can sync-call handlers (RDMA)
- Mask is still computed in networking.c from IO state
- connUpdateState() still runs immediately, including ACCEPTING