### PR TITLE
Fix signal mask parsing on 32-bit systems

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2652,9 +2652,10 @@ static int is_thread_ready_to_signal(const char *proc_pid_task_path, const char 
         /* iterate the file until we reach SigBlk or SigIgn field line */
         if (!strncmp(buff, "SigBlk:\t", field_name_len) || !strncmp(buff, "SigIgn:\t", field_name_len)) {
             line = buff + field_name_len;
-            unsigned long sig_mask;
-            if (-1 == string2ul_base16_async_signal_safe(line, sizeof(buff), &sig_mask)) {
-                serverLogRawFromHandler(LL_WARNING, "Can't convert signal mask to an unsigned long due to an overflow");
+            unsigned long long sig_mask;
+            if (-1 == string2ull_base16_async_signal_safe(line, sizeof(buff), &sig_mask)) {
+                serverLogRawFromHandler(LL_WARNING,
+                                        "Can't convert signal mask to an unsigned long long due to an overflow");
                 ret = 0;
                 break;
             }
@@ -2662,7 +2663,7 @@ static int is_thread_ready_to_signal(const char *proc_pid_task_path, const char 
             /* The bit position in a signal mask aligns with the signal number. Since signal numbers start from 1
             we need to adjust the signal number by subtracting 1 to align it correctly with the zero-based indexing used
           */
-            if (sig_mask & (1L << (sig_num - 1))) { /* if the signal is blocked/ignored return 0 */
+            if (sig_mask & (1ULL << (sig_num - 1))) { /* if the signal is blocked/ignored return 0 */
                 ret = 0;
                 break;
             }

--- a/src/unit/test_util.cpp
+++ b/src/unit/test_util.cpp
@@ -133,6 +133,22 @@ TEST_F(UtilTest, TestString2l) {
 #endif
 }
 
+TEST_F(UtilTest, TestString2ullBase16AsyncSignalSafe) {
+    char buf[32];
+    unsigned long long value;
+
+    valkey_strlcpy(buf, "0000010000000000", sizeof(buf));
+    ASSERT_EQ(string2ull_base16_async_signal_safe(buf, strlen(buf), &value), 1);
+    ASSERT_EQ(value, 1ULL << 40);
+
+    valkey_strlcpy(buf, "ffffffffffffffff", sizeof(buf));
+    ASSERT_EQ(string2ull_base16_async_signal_safe(buf, strlen(buf), &value), 1);
+    ASSERT_EQ(value, ULLONG_MAX);
+
+    valkey_strlcpy(buf, "10000000000000000", sizeof(buf));
+    ASSERT_EQ(string2ull_base16_async_signal_safe(buf, strlen(buf), &value), -1);
+}
+
 TEST_F(UtilTest, TestLl2string) {
     char buf[32];
     long long v;

--- a/src/util.c
+++ b/src/util.c
@@ -708,20 +708,20 @@ static int base_16_char_type(char c) {
     return -1;
 }
 
-/** This is an async-signal safe version of string2l to convert unsigned long to string.
+/** This is an async-signal-safe function to convert a hexadecimal string to an unsigned long long.
  * The function translates @param src until it reaches a value that is not 0-9, a-f or A-F, or @param we read slen
- * characters. On successes writes the result to @param result_output and returns 1. if the string represents an
- * overflow value, return -1. */
-int string2ul_base16_async_signal_safe(const char *src, size_t slen, unsigned long *result_output) {
+ * characters. On success, it writes the result to @param result_output and returns 1. If the string represents an
+ * overflow value, it returns -1. */
+int string2ull_base16_async_signal_safe(const char *src, size_t slen, unsigned long long *result_output) {
     static char ascii_to_dec[] = {'0', 'a' - 10, 'A' - 10};
 
     int char_type = 0;
     size_t curr_char_idx = 0;
-    unsigned long result = 0;
+    unsigned long long result = 0;
     int base = 16;
-    while ((-1 != (char_type = base_16_char_type(src[curr_char_idx]))) && curr_char_idx < slen) {
-        unsigned long curr_val = src[curr_char_idx] - ascii_to_dec[char_type];
-        if ((result > ULONG_MAX / base) || (result > (ULONG_MAX - curr_val) / base)) /* Overflow. */
+    while (curr_char_idx < slen && (-1 != (char_type = base_16_char_type(src[curr_char_idx])))) {
+        unsigned long long curr_val = src[curr_char_idx] - ascii_to_dec[char_type];
+        if ((result > ULLONG_MAX / base) || (result > (ULLONG_MAX - curr_val) / base)) /* Overflow. */
             return -1;
         result = result * base + curr_val;
         ++curr_char_idx;

--- a/src/util.h
+++ b/src/util.h
@@ -85,7 +85,7 @@ int ull2string(char *s, size_t len, unsigned long long value);
 int string2ll(const char *s, size_t slen, long long *value);
 int string2ull(const char *s, size_t slen, unsigned long long *value);
 int string2l(const char *s, size_t slen, long *value);
-int string2ul_base16_async_signal_safe(const char *src, size_t slen, unsigned long *result_output);
+int string2ull_base16_async_signal_safe(const char *src, size_t slen, unsigned long long *result_output);
 int string2ld(const char *s, size_t slen, long double *dp);
 int string2d(const char *s, size_t slen, double *dp);
 int trimDoubleString(char *buf, size_t len);


### PR DESCRIPTION
Linux exposes signal masks as 64-bit hexadecimal values, including to 32-bit processes. Parsing them as unsigned long overflowed on Alpine 32-bit, preventing the crash handler from collecting thread stack traces.

Parse signal masks as unsigned long long and add coverage for values above the 32-bit range and overflow handling.

Failed in [Daily CI](https://github.com/valkey-io/valkey/actions/runs/31798198043/job/94759856769).

Verified with 100 runs of the logging tests on Alpine 32-bit: [1200 passed, 0 failed](https://github.com/sarthakaggarwal97/valkey/actions/runs/31821271902/job/94834820008).