### PR TITLE
Client-side caching: Notify redirect client when tracking source disconnects

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2083,7 +2083,7 @@ void unlinkClient(client *c) {
     }
 
     /* Clear the tracking status. */
-    if (c->flag.tracking) disableTracking(c);
+    if (c->flag.tracking) disableTracking(c, 0);
 }
 
 /* Clear the client state to resemble a newly connected client. */
@@ -2104,7 +2104,7 @@ void clearClientConnectionState(client *c) {
 
     serverAssert(!(c->flag.replica || c->flag.primary || c->slot_migration_job));
 
-    if (c->flag.tracking) disableTracking(c);
+    if (c->flag.tracking) disableTracking(c, 0);
     selectDb(c, 0);
 #ifdef LOG_REQ_RES
     c->resp = server.client_default_resp;
@@ -5688,7 +5688,7 @@ void clientTrackingCommand(client *c) {
 
         enableTracking(c, redir, options, prefix, numprefix);
     } else if (!strcasecmp(objectGetVal(c->argv[2]), "off")) {
-        disableTracking(c);
+        disableTracking(c, 1);
     } else {
         zfree(prefix);
         addReplyErrorObject(c, shared.syntaxerr);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -279,8 +279,10 @@ void freeClientPubSubData(client *c) {
     c->pubsub_data->pubsub_patterns = NULL;
     hashtableRelease(c->pubsub_data->pubsubshard_channels);
     c->pubsub_data->pubsubshard_channels = NULL;
-    if (c->pubsub_data->client_tracking_prefixes) {
-        disableTracking(c);
+    /* Tracking state (redirection target and BCAST prefixes) is stored inside
+     * pubsub_data, so disable it while the structure is still alive. */
+    if (c->flag.tracking) {
+        disableTracking(c, 0);
     }
     zfree(c->pubsub_data);
     c->pubsub_data = NULL;

--- a/src/server.h
+++ b/src/server.h
@@ -3083,7 +3083,7 @@ void addReplyStatusFormat(client *c, const char *fmt, ...);
 
 /* Client side caching (tracking mode) */
 void enableTracking(client *c, uint64_t redirect_to, struct ClientFlags options, robj **prefix, size_t numprefix);
-void disableTracking(client *c);
+void disableTracking(client *c, int voluntary);
 void trackingRememberKeys(client *tracking, client *executing);
 void trackingInvalidateKey(client *c, robj *keyobj, int bcast);
 void trackingScheduleKeyInvalidation(uint64_t client_id, robj *keyobj);

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -49,6 +49,9 @@ uint64_t TrackingTableTotalItems = 0; /* Total number of IDs stored across
                                          are using server side for CSC. */
 robj *TrackingChannelName;
 
+/* Forward declaration. */
+void sendTrackingMessage(client *c, char *keyname, size_t keylen, int proto);
+
 /* This is the structure that we have as value of the PrefixTable, and
  * represents the list of keys modified, and the list of clients that need
  * to be notified, for a given prefix. */
@@ -63,8 +66,14 @@ typedef struct bcastState {
  * tracking mode, because we just store the ID of the client in the tracking
  * table, so we'll remove the ID reference in a lazy way. Otherwise, when a
  * client with many entries in the table is removed, it would cost a lot of
- * time to do the cleanup. */
-void disableTracking(client *c) {
+ * time to do the cleanup.
+ *
+ * The 'voluntary' parameter indicates whether tracking was disabled by an
+ * explicit CLIENT TRACKING OFF command from the client (1), or because the
+ * data connection was terminated (0). When the tracking source disconnects
+ * involuntarily and has a valid redirection target, we send a NULL message
+ * to the redirect client to signal that all keys should be invalidated. */
+void disableTracking(client *c, int voluntary) {
     /* If this client is in broadcasting mode, we need to unsubscribe it
      * from all the prefixes it is registered to. */
     if (c->flag.tracking_bcast) {
@@ -91,8 +100,19 @@ void disableTracking(client *c) {
         c->pubsub_data->client_tracking_prefixes = NULL;
     }
 
-    /* Clear flags and adjust the count. */
+    /* Clear flags and adjust the count. If tracking is disabled
+     * involuntarily (e.g. the connection was terminated) and the client
+     * redirects invalidation messages to another client, notify the
+     * redirection target that all keys should be invalidated. */
     if (c->flag.tracking) {
+        if (!voluntary &&
+            c->pubsub_data->client_tracking_redirection &&
+            !c->flag.tracking_broken_redir) {
+            /* Send a NULL invalidation to indicate that all keys
+             * should be invalidated. */
+            sendTrackingMessage(c, objectGetVal(shared.null[c->resp]),
+                                sdslen(objectGetVal(shared.null[c->resp])), 1);
+        }
         server.tracking_clients--;
         c->flag.tracking = 0;
         c->flag.tracking_broken_redir = 0;


### PR DESCRIPTION

## Problem

When using the [two-connection pattern](https://valkey.io/topics/client-side-caching/) for client-side caching with `CLIENT TRACKING on REDIRECT <client-id>`, if the **data connection** drops (e.g., timeout, network failure, `CLIENT KILL`), the **invalidation connection** stays alive and receives no notification. The application continues serving potentially stale cached data.

The data connection is only used when there is a cache miss. If all subsequent requests hit the local cache, the application may never make another request on the data connection and thus never discover that it has been disconnected — silently serving stale data indefinitely.

## Solution

Add a `voluntary` parameter to `disableTracking()`:

- `voluntary = 1` — called from `CLIENT TRACKING OFF`, no notification
- `voluntary = 0` — called from `unlinkClient()`, `clearClientConnectionState()`, and `freeClientPubSubData()`, sends an invalidation to the redirect target

When tracking is disabled involuntarily and the client has a valid redirect target, a NULL invalidation is sent via `sendTrackingMessage()`. NULL means "all keys invalidated", following the same pattern as `trackingInvalidateKeysOnFlush()`.