### PR TITLE
Avoid a year-2038 problem

### DIFF
--- a/src/latency.h
+++ b/src/latency.h
@@ -45,7 +45,8 @@
 /* Representation of a latency sample: the sampling time and the latency
  * observed in milliseconds. */
 struct latencySample {
-    int32_t time;     /* We don't use time_t to force 4 bytes usage everywhere. */
+    uint32_t time;    /* We don't use time_t to force 4 bytes usage everywhere.
+                         Unsigned, so the four bytes last until 2106. */
     uint32_t latency; /* Latency in milliseconds. */
 };
 


### PR DESCRIPTION
We make the sample timestamp unsigned
so it still occupies the same 4 bytes for compact representation but can now represent dates until year 2106.

This patch was done while reviewing potential year-2038 issues in openSUSE.