### PR TITLE
Tests: stabilize EXEC commandlog timing checks

### DIFF
--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -308,17 +308,17 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
     } {} {needs:debug}
 
     test {COMMANDLOG slow - EXEC records total transaction time when inner commands are individually fast} {
-        r config set commandlog-execution-slower-than 100000
+        r config set commandlog-execution-slower-than 1000000
         r commandlog reset slow
         r multi
-        for {set i 0} {$i < 10} {incr i} {
+        for {set i 0} {$i < 40} {incr i} {
             r debug sleep 0.03
         }
         r exec
         assert_equal [r commandlog len slow] 1
         set e [lindex [r commandlog get -1 slow] 0]
         assert_equal [lindex $e 3] {exec}
-        assert {[lindex $e 2] >= 100000}
+        assert {[lindex $e 2] >= 1000000}
     } {} {needs:debug}
 
     test {COMMANDLOG slow - EXEC is not logged when transaction is below threshold} {

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -186,17 +186,17 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
     } {} {needs:debug}
 
     test {SLOWLOG - EXEC records total transaction time when inner commands are individually fast} {
-        r config set slowlog-log-slower-than 100000
+        r config set slowlog-log-slower-than 1000000
         r slowlog reset
         r multi
-        for {set i 0} {$i < 10} {incr i} {
+        for {set i 0} {$i < 40} {incr i} {
             r debug sleep 0.03
         }
         r exec
         assert_equal [r slowlog len] 1
         set e [lindex [r slowlog get] 0]
         assert_equal [lindex $e 3] {exec}
-        assert {[lindex $e 2] >= 100000}
+        assert {[lindex $e 2] >= 1000000}
     } {} {needs:debug}
 
     test {SLOWLOG - EXEC is not logged when transaction is below threshold} {


### PR DESCRIPTION
The EXEC timing tests left too little margin between each 30 ms inner command and the 100 ms logging threshold. On a busy runner, individual commands could cross the threshold.

Increase the threshold to one second and use forty 30 ms commands. This preserves the original assertion that only EXEC is logged while its cumulative execution time exceeds the threshold.

Failed in [Daily CI](https://github.com/valkey-io/valkey/actions/runs/31808798687/job/94794098977).

Verified with 100 runs of both test files on macOS: [5300 passed, 0 failed](https://github.com/sarthakaggarwal97/valkey/actions/runs/31832827797/job/94872323940).

It started failing after #4267 