### PR TITLE
Fix flaky EXEC command log tests

### DIFF
--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -315,8 +315,7 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
             r debug sleep 0.03
         }
         r exec
-        assert_equal [r commandlog len slow] 1
-        set e [lindex [r commandlog get -1 slow] 0]
+        set e [lindex [r commandlog get 1 slow] 0]
         assert_equal [lindex $e 3] {exec}
         assert {[lindex $e 2] >= 100000}
     } {} {needs:debug}

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -193,8 +193,7 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
             r debug sleep 0.03
         }
         r exec
-        assert_equal [r slowlog len] 1
-        set e [lindex [r slowlog get] 0]
+        set e [lindex [r slowlog get 1] 0]
         assert_equal [lindex $e 3] {exec}
         assert {[lindex $e 2] >= 100000}
     } {} {needs:debug}


### PR DESCRIPTION
## Summary

- query only the newest slow-log entry in the EXEC transaction-duration tests
- keep asserting that the newest entry is EXEC and exceeds the configured threshold
- allow correctly slow inner commands to appear when the test server is descheduled

Fixes #4420
Fixes #4421

## Root cause

`DEBUG SLEEP 0.03` uses `nanosleep()`, while command duration is measured as wall-clock elapsed time around each `call()`. On a contended runner, an inner command can therefore take more than the 100 ms threshold and be correctly added to SLOWLOG and COMMANDLOG.

The tests assumed that the entire log would contain exactly one entry. That assumption is timing-sensitive and is not required to verify the intended behavior: EXEC is recorded with the total transaction duration and is the newest entry.

## Testing

- `make -j`
- affected COMMANDLOG test repeated 50 times: 50 passed, 0 failed
- affected SLOWLOG test repeated 50 times: 50 passed, 0 failed
- `./runtest --single unit/commandlog --clients 1`: 27 passed, 0 failed
- `./runtest --single unit/slowlog --clients 1`: 22 passed, 0 failed
- controlled scheduler pause: both logs contained a slow inner command, while `GET 1` correctly returned EXEC
