### PR TITLE
Bypass cached slot optimization for module and arbitrary-key commands

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -257,7 +257,8 @@ int getCachedKeySlot(sds key) {
      * so we must always recompute the slot for commands coming from the primary or AOF.
      */
     if (server.current_client && server.current_client->slot >= 0 && server.current_client->flag.executing_command &&
-        !mustObeyClient(server.current_client)) {
+        !mustObeyClient(server.current_client) &&
+        !(server.current_client->cmd->flags & (CMD_MODULE | CMD_TOUCHES_ARBITRARY_KEYS))) {
         debugServerAssertWithInfo(server.current_client, NULL,
                                   (int)keyHashSlot(key, (int)sdslen(key)) == server.current_client->slot);
         return server.current_client->slot;


### PR DESCRIPTION
Fixes #4398

## Problem
`getCachedKeySlot()` reuses the slot cached on `server.current_client` during command execution. However, module commands (`CMD_MODULE`) and arbitrary key-touching commands (`CMD_TOUCHES_ARBITRARY_KEYS`) can access undeclared keys across any slot via `VM_OpenKey()`. This causes `debugServerAssertWithInfo` to abort in debug builds when the key's actual slot doesn't match the cached slot.

## Solution
Skip the cached slot optimization when the executing command has `CMD_MODULE` or `CMD_TOUCHES_ARBITRARY_KEYS` flags set, falling through to compute the correct slot via `keyHashSlot()`.

## Testing
- Compiles cleanly with `make -j$(nproc)`