### PR TITLE
Track and report key expiration lag metric in INFO stats

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2181,6 +2181,14 @@ static keyStatus expireIfNeededWithDictIndex(serverDb *db, robj *key, robj *val,
         key = createStringObject(objectGetVal(key), sdslen(objectGetVal(key)));
     }
     /* Delete the key */
+    mstime_t expire_time = val ? objectGetExpire(val) : getExpireWithDictIndex(db, key, dict_index);
+    if (expire_time >= 0) {
+        mstime_t lag = mstime() - expire_time;
+        if (lag > 0) {
+            server.stat_expire_lag_sum += lag;
+            server.stat_expire_lag_count++;
+        }
+    }
     deleteExpiredKeyAndPropagateWithDictIndex(db, key, dict_index);
     if (static_key) {
         decrRefCount(key);

--- a/src/expire.c
+++ b/src/expire.c
@@ -70,6 +70,11 @@ int activeExpireCycleTryExpire(serverDb *db, robj *val, mstime_t now, int didx) 
         enterExecutionUnit(1, 0);
         sds key = objectGetKey(val);
         robj *keyobj = createStringObject(key, sdslen(key));
+        mstime_t lag = now - t;
+        if (lag > 0) {
+            server.stat_expire_lag_sum += lag;
+            server.stat_expire_lag_count++;
+        }
         deleteExpiredKeyAndPropagateWithDictIndex(db, keyobj, didx);
         decrRefCount(keyobj);
         exitExecutionUnit();

--- a/src/server.c
+++ b/src/server.c
@@ -2834,6 +2834,8 @@ void resetServerStats(void) {
     server.stat_numcommands = 0;
     server.stat_numconnections = 0;
     server.stat_expiredkeys = 0;
+    server.stat_expire_lag_sum = 0;
+    server.stat_expire_lag_count = 0;
     server.stat_expiredfields = 0;
     server.stat_expired_keys_stale_perc = 0;
     server.stat_expired_keys_with_vola_stale_perc = 0;
@@ -6554,6 +6556,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "sync_partial_ok:%lld\r\n", server.stat_sync_partial_ok,
                 "sync_partial_err:%lld\r\n", server.stat_sync_partial_err,
                 "expired_keys:%lld\r\n", server.stat_expiredkeys,
+                "expired_time_cap_latency_avg_ms:%.2f\r\n", server.stat_expire_lag_count ? (double)server.stat_expire_lag_sum / server.stat_expire_lag_count : 0.0,
                 "expired_fields:%lld\r\n", server.stat_expiredfields,
                 "expired_stale_perc:%.2f\r\n", server.stat_expired_keys_stale_perc * 100,
                 "expired_keys_with_volatile_items_stale_perc:%.2f\r\n", server.stat_expired_keys_with_vola_stale_perc * 100,

--- a/src/server.h
+++ b/src/server.h
@@ -1875,6 +1875,8 @@ struct valkeyServer {
     long long stat_numcommands;                    /* Number of processed commands */
     long long stat_numconnections;                 /* Number of connections received */
     long long stat_expiredkeys;                    /* Number of expired keys */
+    long long stat_expire_lag_sum;                 /* Total expiration lag in ms */
+    long long stat_expire_lag_count;               /* Total expired keys tracked for lag */
     long long stat_expiredfields;                  /* Number of expired hash fields */
     double stat_expired_keys_stale_perc;           /* Percentage of keys probably expired */
     double stat_expired_keys_with_vola_stale_perc; /* Percentage of keys probably expired */


### PR DESCRIPTION
Partially addresses #4384

## Problem
There is no metric reporting how long a key outlives its own expiration deadline before being actually deleted. `expired_keys` counts deletions, `expired_stale_perc` tracks the sampler's hit rate, but nothing reports the gap between a key's TTL deadline and its actual deletion.

## Solution
Track expiration lag in both passive (`expireIfNeeded`) and active (`activeExpireCycleTryExpire`) expiration paths. Accumulate total lag and count, and report the average as `expired_time_cap_latency_avg_ms` in `INFO stats`.

## Testing
- Compiles cleanly with `make -j$(nproc)`