### PR TITLE
Exclude async blocked time from slowlog command duration

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -127,7 +127,8 @@ void blockClient(client *c, int btype) {
  * In case the command failed internally, ERROR_COMMAND_FAILED should be passed.
  * A value of zero indicate no error was reported after the command was unblocked  */
 void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int failed_or_rejected) {
-    c->duration += blocked_us + reply_us;
+    (void)blocked_us;
+    c->duration += reply_us;
     c->lastcmd->microseconds += c->duration;
     clusterSlotStatsAddCpuDuration(c, c->duration);
     c->lastcmd->calls++;


### PR DESCRIPTION
Addresses #4274

## Problem
When a client is blocked (e.g., by a module or BLPOP), the total blocked time `blocked_us` is added to `c->duration` in `updateStatsOnUnblock()`. This inflates the command's slowlog entry, making it appear that the command itself was slow when in reality it was just waiting.

## Solution
Exclude `blocked_us` from the duration calculation in `updateStatsOnUnblock()`, only counting `reply_us` (the actual reply-processing time). The blocked time is still tracked via the `command-unblocking` latency event.

## Testing
- Compiles cleanly with `make -j$(nproc)`