### PR TITLE
Check hash-max-listpack-value when loading RDB_TYPE_HASH_LISTPACK

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2596,7 +2596,24 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                 goto emptykey;
             }
 
-            if (hashTypeLength(o) > server.hash_max_listpack_entries) hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
+            {
+                unsigned char *lp = objectGetVal(o);
+                unsigned char *p = lpFirst(lp);
+                int convert = 0;
+                while (p) {
+                    unsigned int slen = 0;
+                    long long lval = 0;
+                    unsigned char *vstr = lpGetValue(p, &slen, &lval);
+                    if (vstr && slen > server.hash_max_listpack_value) {
+                        convert = 1;
+                        break;
+                    }
+                    p = lpNext(lp, p);
+                }
+                if (convert || hashTypeLength(o) > server.hash_max_listpack_entries) {
+                    hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
+                }
+            }
             break;
         default:
             /* totally unreachable */


### PR DESCRIPTION
Fixes #4203

## Problem
The `RDB_TYPE_HASH_LISTPACK` load path only checks `hash_max_listpack_entries` when deciding whether to convert a loaded hash to a hashtable. It does not check `hash_max_listpack_value`. This is asymmetric with the runtime path (`hashTypeSet`) and the per-element `RDB_TYPE_HASH` loading path, both of which also convert when a field or value exceeds `hash_max_listpack_value`.

## Solution
After loading a `RDB_TYPE_HASH_LISTPACK`, iterate through the listpack entries and check each field/value size against `server.hash_max_listpack_value`. If any exceeds the threshold, convert to hashtable encoding.

## Testing
- Compiles cleanly with `make -j$(nproc)`