### PR TITLE
Preserve aclfile permissions when executing ACL SAVE

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -28,6 +28,7 @@
  */
 
 #include "server.h"
+#include <sys/stat.h>
 #include "sha256.h"
 #include "module.h"
 #include "intset.h"
@@ -2723,7 +2724,12 @@ static int ACLSaveToFile(const char *filename) {
     /* Create a temp file with the new content. */
     tmpfilename = sdsnew(filename);
     tmpfilename = sdscatfmt(tmpfilename, ".tmp-%i-%I", (int)getpid(), commandTimeSnapshot());
-    if ((fd = open(tmpfilename, O_WRONLY | O_CREAT, 0644)) == -1) {
+    struct stat sb;
+    mode_t acl_mode = 0600; /* Safe default: user read/write only */
+    if (stat(filename, &sb) == 0) {
+        acl_mode = sb.st_mode & 07777;
+    }
+    if ((fd = open(tmpfilename, O_WRONLY | O_CREAT, acl_mode)) == -1) {
         serverLog(LL_WARNING, "Opening temp ACL file for ACL SAVE: %s", strerror(errno));
         goto cleanup;
     }


### PR DESCRIPTION
Fixes #4014

## Problem
`ACL SAVE` creates the temp file with hardcoded `0644` permissions. When the temp file is renamed over the original, the original file's permission/ownership structure is lost. If the original file had restricted permissions (e.g., `0600`), the new file is now world-readable.

## Solution
Before creating the temp file, `stat()` the existing ACL file. If it exists, use its permission mode for the temp file. If it doesn't exist, default to `0600` (user read/write only) rather than `0644`.

## Testing
- Compiles cleanly with `make -j$(nproc)`