### PR TITLE
Bypass ACL checks for AOF client during EXEC transaction execution

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -250,7 +250,10 @@ void execCommand(client *c) {
         /* ACL permissions are also checked at the time of execution in case
          * they were changed after the commands were queued. */
         int acl_errpos;
-        int acl_retval = ACLCheckAllPerm(c, &acl_errpos);
+        int acl_retval = ACL_OK;
+        if (c->id != CLIENT_ID_AOF) {
+            acl_retval = ACLCheckAllPerm(c, &acl_errpos);
+        }
         if (acl_retval != ACL_OK) {
             char *reason;
             switch (acl_retval) {


### PR DESCRIPTION
Fixes #3983

## Problem
When `execCommand()` runs queued commands inside a MULTI/EXEC block, it re-checks ACL permissions at execution time. If the default user has been disabled, the AOF fake client (which runs as the default user) fails these checks, causing transaction commands loaded from AOF to be silently rejected. This results in data loss on server restart.

## Solution
Skip the ACL re-check inside `execCommand()` when the client is the AOF fake client (`c->id == CLIENT_ID_AOF`). AOF commands were already validated when they were originally executed and written to the AOF file.

## Testing
- Compiles cleanly with `make -j$(nproc)`