### PR TITLE
Add support for USE_SYSTEM_JEMALLOC flag

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -330,9 +330,14 @@ ifeq ($(MALLOC),tcmalloc_minimal)
 endif
 
 ifeq ($(MALLOC),jemalloc)
+ifeq ($(USE_SYSTEM_JEMALLOC),yes)
+	FINAL_CFLAGS+= -DUSE_JEMALLOC -DUSE_SYSTEM_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+	FINAL_LIBS := -ljemalloc $(FINAL_LIBS)
+else
 	DEPENDENCY_TARGETS+= jemalloc
 	FINAL_CFLAGS+= -DUSE_JEMALLOC -I../deps/jemalloc/include
 	FINAL_LIBS := ../deps/jemalloc/lib/libjemalloc.a $(FINAL_LIBS)
+endif
 endif
 
 ifeq ($(USE_LTTNG),yes)


### PR DESCRIPTION
Addresses #1882. This is the `0004-Add-support-for-USE_SYSTEM_JEMALLOC-flag.patch` idea from the Debian packaging, but reduced to a single Makefile hunk — no C source changes at all.

### Change

```make
ifeq ($(MALLOC),jemalloc)
ifeq ($(USE_SYSTEM_JEMALLOC),yes)
	FINAL_CFLAGS+= -DUSE_JEMALLOC -DUSE_SYSTEM_JEMALLOC -DJEMALLOC_NO_DEMANGLE
	FINAL_LIBS := -ljemalloc $(FINAL_LIBS)
else
	...unchanged vendored branch...
endif
endif
```

### Why no C changes are needed

The downstream patch carries per-file shims — `#define je_mallctl mallctl`, `#define je_nallocx(...) nallocx(...)` and friends in `debug.c`, `object.c`, `sds.c`, `zmalloc.c` and `zmalloc.h`. Those are hand-emulating something `jemalloc.h` already does.

When jemalloc is built without a prefix, the header maps `je_*` to the unprefixed names under `#ifndef JEMALLOC_NO_RENAME`, then `#undef`s them all at the end under `#ifndef JEMALLOC_NO_DEMANGLE` — the `je_*` names are documented as stable aliases available precisely when `JEMALLOC_NO_DEMANGLE` is defined. Defining it in `FINAL_CFLAGS` keeps every `je_*` call site in the tree valid.

Two things I confirmed while arriving at this: without the define the build fails to link `je_malloc_usable_size` and `je_sdallocx`, and putting the define in `zmalloc.h` is not enough, because `debug.c` reaches `jemalloc.h` through another include first and the header's include guard means only the first inclusion counts.

### Defrag is unchanged

`allocator_defrag.h` gates `HAVE_DEFRAG` on `VALKEY_VENDORED_JEMALLOC`, which only the vendored `jemalloc.sh`-generated header defines (9fb850dab, after #1585). This PR does not touch that gate: a system-jemalloc build refuses `activedefrag yes` exactly as it does today with the downstream patch. This is only about being able to link the system allocator.

### Default build untouched

Without `USE_SYSTEM_JEMALLOC=yes` the vendored branch is taken as before. Verified on this branch: default build links jemalloc statically and `CONFIG SET activedefrag yes` returns `OK`.

### Validation

#1882 asks for system jemalloc to be properly validated. Built 7.2.14, 8.0.10, 8.1.9, 9.0.5 and 9.1.1 with the equivalent change on Debian 12 (jemalloc 5.3.0) and Ubuntu 22.04 (jemalloc 5.2.1), amd64 — 10/10:

- all link `libjemalloc.so.2` and report `mem_allocator:jemalloc-<version>`
- `MEMORY DOCTOR` and `MEMORY MALLOC-STATS` work, exercising the `je_mallctl` and `je_malloc_stats_print` paths
- `PING`/`SET`/`SAVE` fine; repeated failed `SAVE`s (forced by a `dump.rdb` directory) leave `used_memory` rising normally

Same change built on `unstable` here, alone and combined with #4438, with `-D_FORTIFY_SOURCE=2` hardening flags set.

Refs #1882
