### PR TITLE
Skip IO-thread write-done client re-lookup unless update_state sync-invokes handlers

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3321,11 +3321,16 @@ void processClientIOWriteDone(client *c) {
 
     connSetPostponeUpdateState(c->conn, mask);
     if (postWriteToClient(c) == C_ERR) return;
+
+    /* connUpdateState may sync-invoke handlers for some transports (e.g. RDMA)
+     * and free the client; only then re-fetch it by id after the update. */
+    int may_invoke_handlers = connUpdateStateMayInvokeHandlers(c->conn);
     uint64_t id = c->id;
     connUpdateState(c->conn);
-
-    c = lookupClientByID(id);
-    if (!c || !c->conn) return;
+    if (may_invoke_handlers) {
+        c = lookupClientByID(id);
+        if (!c || !c->conn) return;
+    }
 
     if (!clientHasPendingReplies(c)) return;
 


### PR DESCRIPTION
## Summary
Follow-up of #3611 and #4401.

#3611 reordered `processClientIOWriteDone()` to call `postWriteToClient()` before `connUpdateState()`, and added a `lookupClientByID()` re-fetch after the update so the flow survives the client being freed. That re-fetch is only required when `connUpdateState()` may synchronously invoke handlers (e.g. RDMA) and free the client; for other transports it is per-write-completion overhead.

#4401 restored this gate on the read-done path (`processClientIOReadsDone`). This PR mirrors it on the write-done path with the same `connUpdateStateMayInvokeHandlers()` helper: record whether the transport may invoke handlers, always call `connUpdateState()`, and re-fetch the client by id only when it may have been freed.

Unlike the read path, `processClientIOWriteDone()` cannot run while the connection is `CONN_STATE_ACCEPTING` — accepts complete on the read path (`ioThreadAccept` → `JOB_RES_READ_CLIENT` → `processClientIOReadsDone`), and no reply is queued before the handshake finishes — so no accept-state guard is needed here.

## Performance
`valkey-benchmark`, 512B values, `--io-threads`, **pipeline 4** (moderate pipelining, where the per-write-completion cost is not amortized), ABBA vs the branch's base commit:

| | before | after | Δ |
|---|---|---|---|
| GET | 1,597,763 | 1,664,378 | **+4.2%** |
| SET | 1,389,232 | 1,401,345 | +0.9% (flat) |

This removes one `lookupClientByID()` (radix-tree lookup) per write completion for socket/TLS clients. SET is unaffected because its regression was read-side and already addressed by #4401.

<details><summary>benchmark command</summary>

```
# server: taskset -c 0-15 valkey-server --io-threads 16 --save '' --appendonly no
# client: taskset -c 16-31 valkey-benchmark -t set,get -n 20000000 -c 512 -P 4 --threads 16 -r 100000 -d 512 -q
```
</details>