### PR TITLE
Skip IO-thread write-done client re-lookup unless update_state sync-invokes handlers (9.0)

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3282,11 +3282,16 @@ int processClientIOWriteDone(client *c, int allow_async_writes) {
     if (postWriteToClient(c) == C_ERR) {
         return 1;
     }
+
+    /* connUpdateState may sync-invoke handlers for some transports (e.g. RDMA)
+     * and free the client; only then re-fetch it by id after the update. */
+    int may_invoke_handlers = connUpdateStateMayInvokeHandlers(c->conn);
     uint64_t id = c->id;
     connUpdateState(c->conn);
-
-    c = lookupClientByID(id);
-    if (!c || !c->conn) return 1;
+    if (may_invoke_handlers) {
+        c = lookupClientByID(id);
+        if (!c || !c->conn) return 1;
+    }
 
     /* Replica ACK may have arrived while an IO-thread write was in flight. */
     if (c->flag.replica) {


### PR DESCRIPTION
Follow-up of #3335 (9.0 port of #3611), mirroring upstream #4440 and building on the read-side gate already in #4414.

postWriteToClient() before connUpdateState(), and added a lookupClientByID() re-fetch after the update so the flow survives the client being freed. That re-fetch is only required when connUpdateState() may synchronously invoke handlers (e.g. RDMA); for socket/TLS it is per-write-completion overhead.

Gate the re-fetch with connUpdateStateMayInvokeHandlers(), reusing the helper introduced by #4414, so TCP/TLS skip the extra radix-tree lookup while RDMA keeps the safety path.

Unlike upstream #4440, the 9.0 write-done path also re-reads the connection for replicas to collect ACKs that arrived during the in-flight write; that re-fetch is kept because the read handler may close the client, independently of update_state.