### PR TITLE
Persist non-zero cluster-replica-priority to nodes.conf as an aux field

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -129,7 +129,9 @@ int auxAnnounceClientTcpPortPresent(clusterNode *n);
 int auxAnnounceClientTlsPortSetter(clusterNode *n, void *value, size_t length);
 sds auxAnnounceClientTlsPortGetter(clusterNode *n, sds s);
 int auxAnnounceClientTlsPortPresent(clusterNode *n);
-int auxAnnounceClientTlsPortPresent(clusterNode *n);
+int auxReplicaPrioritySetter(clusterNode *n, void *value, size_t length);
+sds auxReplicaPriorityGetter(clusterNode *n, sds s);
+int auxReplicaPriorityPresent(clusterNode *n);
 static void clusterBuildMessageHdrLight(clusterMsgLight *hdr, int type, size_t msglen);
 static void clusterBuildMessageHdr(clusterMsg *hdr, int type, size_t msglen);
 void freeClusterLink(clusterLink *link);
@@ -429,6 +431,7 @@ typedef enum {
     af_announce_client_tcp_port,
     af_announce_client_tls_port,
     af_availability_zone,
+    af_replica_priority,
     af_count, /* must be the last field */
 } auxFieldIndex;
 
@@ -446,6 +449,7 @@ auxFieldHandler auxFieldHandlers[] = {
     {"client-tcp-port", auxAnnounceClientTcpPortSetter, auxAnnounceClientTcpPortGetter, auxAnnounceClientTcpPortPresent},
     {"client-tls-port", auxAnnounceClientTlsPortSetter, auxAnnounceClientTlsPortGetter, auxAnnounceClientTlsPortPresent},
     {"availability-zone", auxAvailabilityZoneSetter, auxAvailabilityZoneGetter, auxAvailabilityZonePresent},
+    {"replica-priority", auxReplicaPrioritySetter, auxReplicaPriorityGetter, auxReplicaPriorityPresent},
 };
 
 int auxShardIdSetter(clusterNode *n, void *value, size_t length) {
@@ -637,6 +641,29 @@ sds auxAnnounceClientTlsPortGetter(clusterNode *n, sds s) {
 
 int auxAnnounceClientTlsPortPresent(clusterNode *n) {
     return n->announce_client_tls_port > 0 && n->announce_client_tls_port < 65536;
+}
+
+int auxReplicaPrioritySetter(clusterNode *n, void *value, size_t length) {
+    if (length < 1) return C_ERR;
+
+    unsigned long long replica_priority;
+    if (!string2ull((char *)value, length, &replica_priority)) return C_ERR;
+    if (replica_priority > UINT_MAX) return C_ERR;
+
+    n->replica_priority = (unsigned int)replica_priority;
+    return C_OK;
+}
+
+sds auxReplicaPriorityGetter(clusterNode *n, sds s) {
+    return sdscatfmt(s, "%u", n->replica_priority);
+}
+
+int auxReplicaPriorityPresent(clusterNode *n) {
+    /* Only persist a non-zero priority. A node that doesn't advertise a
+     * priority (old version or unset) is consistently treated as priority 0,
+     * which is the default and the highest failover rank, so there's no need
+     * to store the absent default. */
+    return n->replica_priority != 0;
 }
 
 /* clusterLink send queue blocks */
@@ -1425,7 +1452,10 @@ static void updateShardId(clusterNode *node, const char *shard_id) {
 }
 
 static void updateReplicaPriority(clusterNode *node, unsigned int replica_priority) {
+    if (node->replica_priority == replica_priority) return;
+
     node->replica_priority = replica_priority;
+    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
 }
 
 static inline int areInSameShard(clusterNode *node1, clusterNode *node2) {
@@ -1465,7 +1495,7 @@ void clusterUpdateMyselfClientIpV6(void) {
 void clusterUpdateMyselfReplicaPriority(void) {
     if (!myself) return;
     myself->replica_priority = server.cluster_replica_priority;
-    clusterDoBeforeSleep(CLUSTER_TODO_BROADCAST_ALL);
+    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
 }
 
 void clusterInit(void) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1456,6 +1456,10 @@ static void updateReplicaPriority(clusterNode *node, unsigned int replica_priori
 
     node->replica_priority = replica_priority;
     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
+    /* Only broadcast our own change. When this function is called from the
+     * gossip path (e.g. with `sender`), the value was learned from a peer and
+     * must not be re-broadcast. */
+    if (node == myself) clusterDoBeforeSleep(CLUSTER_TODO_BROADCAST_ALL);
 }
 
 static inline int areInSameShard(clusterNode *node1, clusterNode *node2) {
@@ -1494,8 +1498,7 @@ void clusterUpdateMyselfClientIpV6(void) {
 
 void clusterUpdateMyselfReplicaPriority(void) {
     if (!myself) return;
-    myself->replica_priority = server.cluster_replica_priority;
-    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
+    updateReplicaPriority(myself, server.cluster_replica_priority);
 }
 
 void clusterInit(void) {

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1393,3 +1393,29 @@ proc json_escape_string {s} {
     }
     return $out
 }
+
+proc read_file {path} {
+    set fd [open $path r]
+    set data [read $fd]
+    close $fd
+    return $data
+}
+
+proc write_file {path content} {
+    set fd [open $path w]
+    puts $fd $content
+    close $fd
+}
+
+proc file_has_pattern {path pattern} {
+    if {![file exists $path]} {
+        return 0
+    }
+    return [regexp $pattern [read_file $path]]
+}
+
+proc cluster_nodes_conf_path {id} {
+    set dir [lindex [R $id config get dir] 1]
+    set conf [lindex [R $id config get cluster-config-file] 1]
+    return [file join $dir $conf]
+}

--- a/tests/unit/cluster/availability-zone.tcl
+++ b/tests/unit/cluster/availability-zone.tcl
@@ -1,23 +1,3 @@
-proc read_file {path} {
-    set fd [open $path r]
-    set data [read $fd]
-    close $fd
-    return $data
-}
-
-proc file_has_pattern {path pattern} {
-    if {![file exists $path]} {
-        return 0
-    }
-    return [regexp $pattern [read_file $path]]
-}
-
-proc cluster_nodes_conf_path {id} {
-    set dir [lindex [R $id config get dir] 1]
-    set conf [lindex [R $id config get cluster-config-file] 1]
-    return [file join $dir $conf]
-}
-
 start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval 100}} {
     test "Availability zone appears in SLOTS/SHARDS" {
         set slots_resp [R 0 CLUSTER SLOTS]

--- a/tests/unit/cluster/bumpepoch-dead-node.tcl
+++ b/tests/unit/cluster/bumpepoch-dead-node.tcl
@@ -1,22 +1,3 @@
-proc cluster_nodes_conf_path {id} {
-    set dir [lindex [R $id config get dir] 1]
-    set conf [lindex [R $id config get cluster-config-file] 1]
-    return [file join $dir $conf]
-}
-
-proc read_file {path} {
-    set fd [open $path r]
-    set data [read $fd]
-    close $fd
-    return $data
-}
-
-proc write_file {path content} {
-    set fd [open $path w]
-    puts $fd $content
-    close $fd
-}
-
 test "CLUSTER BUMPEPOCH is not stuck on a tie with a dead node" {
     start_cluster 1 0 {tags {external:skip cluster}} {
         set R0_nodeid [R 0 CLUSTER MYID]

--- a/tests/unit/cluster/noflags-role-recovery.tcl
+++ b/tests/unit/cluster/noflags-role-recovery.tcl
@@ -1,22 +1,3 @@
-proc cluster_nodes_conf_path {id} {
-    set dir [lindex [R $id config get dir] 1]
-    set conf [lindex [R $id config get cluster-config-file] 1]
-    return [file join $dir $conf]
-}
-
-proc read_file {path} {
-    set fd [open $path r]
-    set data [read $fd]
-    close $fd
-    return $data
-}
-
-proc write_file {path content} {
-    set fd [open $path w]
-    puts $fd $content
-    close $fd
-}
-
 test "Recover primary role from noflags created via replica ref after nodes.conf edit" {
     start_cluster 3 3 {tags {external:skip cluster}} {
         # R0 is a primary.

--- a/tests/unit/cluster/replica-priority.tcl
+++ b/tests/unit/cluster/replica-priority.tcl
@@ -1,23 +1,3 @@
-proc read_file {path} {
-    set fd [open $path r]
-    set data [read $fd]
-    close $fd
-    return $data
-}
-
-proc file_has_pattern {path pattern} {
-    if {![file exists $path]} {
-        return 0
-    }
-    return [regexp $pattern [read_file $path]]
-}
-
-proc cluster_nodes_conf_path {id} {
-    set dir [lindex [R $id config get dir] 1]
-    set conf [lindex [R $id config get cluster-config-file] 1]
-    return [file join $dir $conf]
-}
-
 start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
     test "Replica can do a better ranking in auto failover based on the priority" {
         # primary R 0, replica1 R 3, replica2 R 6

--- a/tests/unit/cluster/replica-priority.tcl
+++ b/tests/unit/cluster/replica-priority.tcl
@@ -104,6 +104,12 @@ start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval
     }
 
     test "Non-zero replica priority is persisted in nodes.conf" {
+        set CLUSTER_PACKET_TYPE_NONE -1
+        set CLUSTER_PACKET_TYPE_ALL -2
+
+        set R0_nodeid [R 0 cluster myid]
+        set R6_nodeid [R 6 cluster myid]
+
         R 0 config set cluster-replica-priority 10
         R 3 config set cluster-replica-priority 20
         R 6 config set cluster-replica-priority 30
@@ -133,21 +139,35 @@ start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval
         R 0 config set cluster-replica-priority 0
         wait_for_condition 1000 50 {
             ![file_has_pattern $nodes_conf0 {replica-priority=0}] &&
+            ![file_has_pattern $nodes_conf0 {replica-priority=10}] &&
             ![file_has_pattern $nodes_conf3 {replica-priority=0}] &&
-            ![file_has_pattern $nodes_conf6 {replica-priority=0}]
+            ![file_has_pattern $nodes_conf3 {replica-priority=10}] &&
+            ![file_has_pattern $nodes_conf6 {replica-priority=0}] &&
+            ![file_has_pattern $nodes_conf6 {replica-priority=10}]
         } else {
             fail "Zero replica priority was unexpectedly persisted to nodes.conf"
         }
 
         # Restart node 3 and make sure it restores the learned peer priorities
-        # from nodes.conf instead of dropping them until the next gossip.
+        # from nodes.conf.
+        R 3 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_ALL
+        R 0 config set cluster-replica-priority 100
+        R 6 config set cluster-replica-priority 300
+        pause_process [srv 0 pid]
+        pause_process [srv -6 pid]
         restart_server -3 true false
-        wait_for_cluster_propagation
+        assert_equal [R 3 debug cluster-replica-priority $R0_nodeid] 0
+        assert_equal [R 3 debug cluster-replica-priority $R6_nodeid] 30
+
+        # Everything will be alright.
+        R 3 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_NONE
+        resume_process [srv 0 pid]
+        resume_process [srv -6 pid]
         wait_for_condition 1000 50 {
-            [R 3 debug cluster-replica-priority [R 0 cluster myid]] == 0 &&
-            [R 3 debug cluster-replica-priority [R 6 cluster myid]] == 30
+            [R 3 debug cluster-replica-priority $R0_nodeid] == 100 &&
+            [R 3 debug cluster-replica-priority $R6_nodeid] == 300
         } else {
-            fail "Persisted replica priority was not restored after restart"
+            fail "Replica priority did not propagate"
         }
     }
 } ;# start_cluster

--- a/tests/unit/cluster/replica-priority.tcl
+++ b/tests/unit/cluster/replica-priority.tcl
@@ -1,3 +1,23 @@
+proc read_file {path} {
+    set fd [open $path r]
+    set data [read $fd]
+    close $fd
+    return $data
+}
+
+proc file_has_pattern {path pattern} {
+    if {![file exists $path]} {
+        return 0
+    }
+    return [regexp $pattern [read_file $path]]
+}
+
+proc cluster_nodes_conf_path {id} {
+    set dir [lindex [R $id config get dir] 1]
+    set conf [lindex [R $id config get cluster-config-file] 1]
+    return [file join $dir $conf]
+}
+
 start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
     test "Replica can do a better ranking in auto failover based on the priority" {
         # primary R 0, replica1 R 3, replica2 R 6
@@ -80,6 +100,54 @@ start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval
             [R 6 debug cluster-replica-priority [R 0 cluster myid]] == 0
         } else {
             fail "Replica priority did not propagate"
+        }
+    }
+
+    test "Non-zero replica priority is persisted in nodes.conf" {
+        R 0 config set cluster-replica-priority 10
+        R 3 config set cluster-replica-priority 20
+        R 6 config set cluster-replica-priority 30
+
+        set nodes_conf0 [cluster_nodes_conf_path 0]
+        set nodes_conf3 [cluster_nodes_conf_path 3]
+        set nodes_conf6 [cluster_nodes_conf_path 6]
+
+        # Each node should learn its peers' non-zero priorities and write
+        # them to its own nodes.conf via the replica-priority aux field.
+        wait_for_condition 1000 50 {
+            [file_has_pattern $nodes_conf0 {replica-priority=10}] &&
+            [file_has_pattern $nodes_conf0 {replica-priority=20}] &&
+            [file_has_pattern $nodes_conf0 {replica-priority=30}] &&
+            [file_has_pattern $nodes_conf3 {replica-priority=10}] &&
+            [file_has_pattern $nodes_conf3 {replica-priority=20}] &&
+            [file_has_pattern $nodes_conf3 {replica-priority=30}] &&
+            [file_has_pattern $nodes_conf6 {replica-priority=10}] &&
+            [file_has_pattern $nodes_conf6 {replica-priority=20}] &&
+            [file_has_pattern $nodes_conf6 {replica-priority=30}]
+        } else {
+            fail "Non-zero replica priority was not persisted to nodes.conf"
+        }
+
+        # A node whose priority is 0 (the default, highest failover rank) must not
+        # be written to nodes.conf.
+        R 0 config set cluster-replica-priority 0
+        wait_for_condition 1000 50 {
+            ![file_has_pattern $nodes_conf0 {replica-priority=0}] &&
+            ![file_has_pattern $nodes_conf3 {replica-priority=0}] &&
+            ![file_has_pattern $nodes_conf6 {replica-priority=0}]
+        } else {
+            fail "Zero replica priority was unexpectedly persisted to nodes.conf"
+        }
+
+        # Restart node 3 and make sure it restores the learned peer priorities
+        # from nodes.conf instead of dropping them until the next gossip.
+        restart_server -3 true false
+        wait_for_cluster_propagation
+        wait_for_condition 1000 50 {
+            [R 3 debug cluster-replica-priority [R 0 cluster myid]] == 0 &&
+            [R 3 debug cluster-replica-priority [R 6 cluster myid]] == 30
+        } else {
+            fail "Persisted replica priority was not restored after restart"
         }
     }
 } ;# start_cluster


### PR DESCRIPTION
Add a "replica-priority" aux field so a node's non-default
cluster-replica-priority survives restarts and is restored from
nodes.conf instead of waiting for the next gossip round.

Trigger CLUSTER_TODO_SAVE_CONFIG when a node learns a new replica
priority via gossip (updateReplicaPriority) and when the local node's
priority is updated via CONFIG SET (clusterUpdateMyselfReplicaPriority),
so nodes.conf is rewritten.

It was introduced in #2204, but was omitted.