### PR TITLE
Add per-slot repl-stream-bytes metric to CLUSTER SLOT-STATS

### DIFF
--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -434,6 +434,7 @@ typedef struct slotStat {
     uint64_t cpu_usec;
     uint64_t network_bytes_in;
     uint64_t network_bytes_out;
+    uint64_t repl_stream_bytes;
 } slotStat;
 
 typedef struct slotRange {

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -12,6 +12,7 @@ typedef enum {
     CPU_USEC,
     NETWORK_BYTES_IN,
     NETWORK_BYTES_OUT,
+    REPL_STREAM_BYTES,
     SLOT_STAT_COUNT,
     INVALID
 } slotStatType;
@@ -51,6 +52,7 @@ static uint64_t getSlotStat(int slot, slotStatType stat_type) {
     case CPU_USEC: slot_stat = server.cluster->slot_stats[slot].cpu_usec; break;
     case NETWORK_BYTES_IN: slot_stat = server.cluster->slot_stats[slot].network_bytes_in; break;
     case NETWORK_BYTES_OUT: slot_stat = server.cluster->slot_stats[slot].network_bytes_out; break;
+    case REPL_STREAM_BYTES: slot_stat = server.cluster->slot_stats[slot].repl_stream_bytes; break;
     case SLOT_STAT_COUNT:
     case INVALID: serverPanic("Invalid slot stat type %d was found.", stat_type);
     }
@@ -108,6 +110,8 @@ static void addReplySlotStat(client *c, int slot) {
         addReplyLongLong(c, server.cluster->slot_stats[slot].network_bytes_in);
         addReplyBulkCString(c, "network-bytes-out");
         addReplyLongLong(c, server.cluster->slot_stats[slot].network_bytes_out);
+        addReplyBulkCString(c, "repl-stream-bytes");
+        addReplyLongLong(c, server.cluster->slot_stats[slot].repl_stream_bytes);
     }
 }
 
@@ -170,6 +174,31 @@ void clusterSlotStatsIncrNetworkBytesOutForReplication(long long len) {
  * This will decrement `len` value times the active replica count. */
 void clusterSlotStatsDecrNetworkBytesOutForReplication(long long len) {
     clusterSlotStatsUpdateNetworkBytesOutForReplication(-len);
+}
+
+/* Accumulates replication bytes per slot. Records the byte count fed into the
+ * replication buffer once per write, regardless of replica count. This complements network-bytes-out
+ * which multiplies by replica count, allowing recovery of the single-stream replication volume. */
+static void clusterSlotStatsUpdateReplStreamBytes(long long len) {
+    client *c = server.current_client;
+    if (c == NULL || !clusterSlotStatsEnabled(c->slot)) return;
+
+    serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
+    serverAssert(nodeIsPrimary(server.cluster->myself));
+    /* Ensure we don't underflow the counter when adjusting downwards. */
+    serverAssert(len >= 0 || server.cluster->slot_stats[c->slot].repl_stream_bytes >= (uint64_t)-len);
+    server.cluster->slot_stats[c->slot].repl_stream_bytes += len;
+}
+
+/* Increment replication bytes counter. */
+void clusterSlotStatsIncrReplStreamBytes(long long len) {
+    clusterSlotStatsUpdateReplStreamBytes(len);
+}
+
+/* Decrement replication bytes counter.
+ * This is used to remove accounting of data which doesn't belong to any particular slot, e.g. SELECT command. */
+void clusterSlotStatsDecrReplStreamBytes(long long len) {
+    clusterSlotStatsUpdateReplStreamBytes(-len);
 }
 
 /* Upon SPUBLISH, two egress events are triggered.
@@ -287,6 +316,8 @@ void clusterSlotStatsCommand(client *c) {
             order_by = NETWORK_BYTES_IN;
         } else if (!strcasecmp(objectGetVal(c->argv[3]), "network-bytes-out") && server.cluster_slot_stats_enabled) {
             order_by = NETWORK_BYTES_OUT;
+        } else if (!strcasecmp(objectGetVal(c->argv[3]), "repl-stream-bytes") && server.cluster_slot_stats_enabled) {
+            order_by = REPL_STREAM_BYTES;
         } else {
             addReplyError(c, "Unrecognized sort metric for ORDERBY.");
             return;

--- a/src/cluster_slot_stats.h
+++ b/src/cluster_slot_stats.h
@@ -19,3 +19,7 @@ void clusterSlotStatsAddNetworkBytesOutForUserClient(client *c);
 void clusterSlotStatsIncrNetworkBytesOutForReplication(long long len);
 void clusterSlotStatsDecrNetworkBytesOutForReplication(long long len);
 void clusterSlotStatsAddNetworkBytesOutForShardedPubSubInternalPropagation(client *c, int slot);
+
+/* repl-stream-bytes metric. */
+void clusterSlotStatsIncrReplStreamBytes(long long len);
+void clusterSlotStatsDecrReplStreamBytes(long long len);

--- a/src/commands/cluster-slot-stats.json
+++ b/src/commands/cluster-slot-stats.json
@@ -44,6 +44,9 @@
                             },
                             "network-bytes-out": {
                                 "type": "integer"
+                            },
+                            "repl-stream-bytes": {
+                                "type": "integer"
                             }
                         }
                     }

--- a/src/replication.c
+++ b/src/replication.c
@@ -452,6 +452,7 @@ void feedReplicationBuffer(char *s, size_t len) {
     if (server.repl_backlog == NULL) return;
 
     clusterSlotStatsIncrNetworkBytesOutForReplication(len);
+    clusterSlotStatsIncrReplStreamBytes(len);
 
     while (len > 0) {
         size_t start_pos = 0;        /* The position of referenced block to start sending. */
@@ -614,6 +615,7 @@ void replicationFeedReplicas(int dictid, robj **argv, int argc) {
          * its per-slot network-bytes-out accumulation is made by the above function call.
          * To cancel-out this accumulation, below adjustment is made. */
         clusterSlotStatsDecrNetworkBytesOutForReplication(sdslen(objectGetVal(selectcmd)));
+        clusterSlotStatsDecrReplStreamBytes(sdslen(objectGetVal(selectcmd)));
 
         decrRefCount(selectcmd);
 

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -798,7 +798,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
 
 start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
 
-    set metrics [list "key-count" "cpu-usec" "network-bytes-in" "network-bytes-out"]
+    set metrics [list "key-count" "cpu-usec" "network-bytes-in" "network-bytes-out" "repl-stream-bytes"]
 
     # SET keys for target hashslots, to encourage ordering.
     set hash_tags [list 0 1 2 3 4]
@@ -888,6 +888,8 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY $orderby}
         set orderby "network-bytes-out"
         assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY $orderby}
+        set orderby "repl-stream-bytes"
+        assert_error "ERR*" {R 0 CLUSTER SLOT-STATS ORDERBY $orderby}
     }
 
 }
@@ -915,7 +917,7 @@ start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-en
     # * network-bytes-out will remain empty in the replica, since primary client do not receive replies, unless for replicationSendAck().
     set deterministic_metrics [list key-count network-bytes-in]
     set non_deterministic_metrics [list cpu-usec]
-    set empty_metrics [list network-bytes-out]
+    set empty_metrics [list network-bytes-out repl-stream-bytes]
 
     # Setup replication.
     assert {[s -1 role] eq {slave}}
@@ -1048,5 +1050,222 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         # Cleanup
         R 0 del $key
         R 0 config set min-string-size-avoid-copy-reply $copy_avoid
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Test cases for CLUSTER SLOT-STATS repl-stream-bytes metric correctness.
+# -----------------------------------------------------------------------------
+
+start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+
+    # Define shared variables.
+    set key "FOO"
+    set key_slot [R 0 CLUSTER KEYSLOT $key]
+    set metrics_to_assert [list repl-stream-bytes]
+
+    # Setup replication.
+    assert {[s -1 role] eq {slave}}
+    wait_for_condition 1000 50 {
+        [s -1 master_link_status] eq {up}
+    } else {
+        fail "Instance #1 master link status is not up"
+    }
+    R 1 readonly
+
+    test "CLUSTER SLOT-STATS repl-stream-bytes, counts write bytes and excludes the SELECT preamble." {
+        # This is the first write on the fresh replica link, so the replication
+        # stream contains a SELECT preamble followed by the SET command:
+        #   SELECT: *2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n          --> 23 bytes
+        #   SET:    *3\r\n$3\r\nSET\r\n$3\r\nFOO\r\n$5\r\nVALUE\r\n --> 33 bytes
+        #   Total on the wire: 56 bytes.
+        # The slot counter must report only the SET (33), proving the SELECT
+        # preamble is deducted. The repl offset delta must be 56, proving the
+        # preamble genuinely reached the stream.
+        set offset_before [s 0 master_repl_offset]
+        assert_equal [R 0 SET $key VALUE] {OK}
+        set offset_after [s 0 master_repl_offset]
+
+        # Slot counter: only SET bytes attributed.
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        set expected_slot_stats [
+            dict create $key_slot [
+                dict create repl-stream-bytes 33
+            ]
+        ]
+        assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+
+        # Offset delta: SELECT (23) + SET (33) = 56.
+        assert_equal [expr {$offset_after - $offset_before}] 56
+    }
+    R 0 CONFIG RESETSTAT
+
+    test "CLUSTER SLOT-STATS repl-stream-bytes, value is 0 on replica." {
+        R 0 SET $key VALUE2
+        wait_for_condition 500 10 {
+            [R 1 EXISTS $key] == 1
+        } else {
+            fail "Key was not replicated"
+        }
+        # Slot stats already enabled on replica via overrides — this genuinely proves
+        # replicas do not increment the counter (not vacuously passing due to disabled stats).
+        set slot_stats [R 1 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        assert_empty_slot_stats $slot_stats $metrics_to_assert
+    }
+    R 0 CONFIG RESETSTAT
+
+    test "CLUSTER SLOT-STATS repl-stream-bytes, reset on slot ownership change." {
+        R 0 SET $key VALUE
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        set slot_stats_dict [convert_array_into_dict $slot_stats]
+        assert {[dict get $slot_stats_dict $key_slot repl-stream-bytes] > 0}
+
+        R 0 CLUSTER DELSLOTS $key_slot
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        assert_empty_slot_stats $slot_stats $metrics_to_assert
+
+        R 0 CLUSTER ADDSLOTS $key_slot
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        assert_empty_slot_stats $slot_stats $metrics_to_assert
+    }
+    R 0 CONFIG RESETSTAT
+
+    test "CLUSTER SLOT-STATS repl-stream-bytes, CONFIG RESETSTAT clears counter." {
+        R 0 SET $key VALUE
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        set slot_stats_dict [convert_array_into_dict $slot_stats]
+        assert {[dict get $slot_stats_dict $key_slot repl-stream-bytes] > 0}
+
+        R 0 CONFIG RESETSTAT
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        assert_empty_slot_stats $slot_stats $metrics_to_assert
+    }
+    R 0 CONFIG RESETSTAT
+
+    test "CLUSTER SLOT-STATS repl-stream-bytes, non-slot commands produce no bytes." {
+        R 0 INFO
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        assert_empty_slot_stats $slot_stats $metrics_to_assert
+    }
+    R 0 CONFIG RESETSTAT
+
+    test "CLUSTER SLOT-STATS repl-stream-bytes, MULTI/EXEC wrappers counted for multi-op transactions." {
+        # A MULTI transaction with >1 write command propagates the wrappers to
+        # the replication stream. Measured ground truth:
+        # MULTI:  *1\r\n$5\r\nMULTI\r\n                          --> 15 bytes
+        # SET a:  *3\r\n$3\r\nSET\r\n$6\r\na{FOO}\r\n$1\r\nx\r\n --> 32 bytes
+        # SET b:  *3\r\n$3\r\nSET\r\n$6\r\nb{FOO}\r\n$1\r\nx\r\n --> 32 bytes
+        # EXEC:   *1\r\n$4\r\nEXEC\r\n                           --> 14 bytes
+        # Total: 15 + 32 + 32 + 14 = 93 bytes.
+        set r1 [valkey_client]
+        $r1 MULTI
+        $r1 SET "a{FOO}" x
+        $r1 SET "b{FOO}" x
+        $r1 EXEC
+
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        set expected_slot_stats [
+            dict create $key_slot [
+                dict create repl-stream-bytes 93
+            ]
+        ]
+        assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+    }
+    R 0 CONFIG RESETSTAT
+
+    test "CLUSTER SLOT-STATS repl-stream-bytes, single-op transaction elides MULTI/EXEC wrappers." {
+        # When a transaction has exactly 1 write command (numops <= 1), the server
+        # optimises away the MULTI/EXEC wrappers and propagates only the inner command.
+        # SET:  *3\r\n$3\r\nSET\r\n$6\r\na{FOO}\r\n$1\r\nx\r\n --> 32 bytes (no wrappers).
+        set r1 [valkey_client]
+        $r1 MULTI
+        $r1 SET "a{FOO}" x
+        $r1 EXEC
+
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        set expected_slot_stats [
+            dict create $key_slot [
+                dict create repl-stream-bytes 32
+            ]
+        ]
+        assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+    }
+    R 0 CONFIG RESETSTAT
+
+    test "CLUSTER SLOT-STATS ORDERBY repl-stream-bytes, correct sorting." {
+        # Write different amounts to different slots to produce ordering.
+        set key_a "a{0}"
+        set key_b "b{1}"
+        set slot_a [R 0 CLUSTER KEYSLOT $key_a]
+        set slot_b [R 0 CLUSTER KEYSLOT $key_b]
+        R 0 SET $key_a [string repeat x 100]
+        R 0 SET $key_b [string repeat x 10]
+        set slot_stats [R 0 CLUSTER SLOT-STATS ORDERBY repl-stream-bytes DESC]
+        assert_slot_stats_monotonic_descent $slot_stats repl-stream-bytes
+        set slot_stats [R 0 CLUSTER SLOT-STATS ORDERBY repl-stream-bytes ASC]
+        assert_slot_stats_monotonic_ascent $slot_stats repl-stream-bytes
+    }
+}
+
+# Verify repl-stream-bytes does not multiply by replica count (unlike network-bytes-out).
+
+start_cluster 1 2 {tags {external:skip cluster} overrides {cluster-slot-stats-enabled yes}} {
+
+    set key "FOO"
+    set key_slot [R 0 CLUSTER KEYSLOT $key]
+
+    # Setup replication — wait for both replicas.
+    assert {[s -1 role] eq {slave}}
+    assert {[s -2 role] eq {slave}}
+    wait_for_condition 1000 50 {
+        [s -1 master_link_status] eq {up}
+    } else {
+        fail "Replica #1 master link status is not up"
+    }
+    wait_for_condition 1000 50 {
+        [s -2 master_link_status] eq {up}
+    } else {
+        fail "Replica #2 master link status is not up"
+    }
+    R 1 readonly
+    R 2 readonly
+
+    # Confirm exactly 2 replicas are connected.
+    wait_for_condition 500 10 {
+        [s 0 connected_slaves] == 2
+    } else {
+        fail "Primary does not have 2 connected replicas"
+    }
+
+    # Warmup write to consume the SELECT preamble, then reset stats.
+    R 0 SET $key WARMUP
+    wait_for_condition 500 10 {
+        [R 1 EXISTS $key] == 1
+    } else {
+        fail "Warmup key not replicated to replica 1"
+    }
+    wait_for_condition 500 10 {
+        [R 2 EXISTS $key] == 1
+    } else {
+        fail "Warmup key not replicated to replica 2"
+    }
+    R 0 CONFIG RESETSTAT
+
+    test "CLUSTER SLOT-STATS repl-stream-bytes is invariant to replica count (2 replicas)." {
+        R 0 SET $key VALUE
+        # Replication stream: *3\r\n$3\r\nSET\r\n$3\r\nFOO\r\n$5\r\nVALUE\r\n --> 33 bytes.
+        # Client reply:       +OK\r\n --> 5 bytes.
+        #
+        # network-bytes-out = replication (33 * 2 replicas) + client reply (5) = 71.
+        # repl-stream-bytes = replication counted once = 33.
+        #
+        # This divergence is the reason this field exists: it recovers the
+        # single-stream volume that network-bytes-out obscures with its
+        # replica-count multiplication.
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
+        set slot_stats_dict [convert_array_into_dict $slot_stats]
+        set stats [dict get $slot_stats_dict $key_slot]
+        assert_equal [dict get $stats repl-stream-bytes] 33
+        assert_equal [dict get $stats network-bytes-out] 71
     }
 }


### PR DESCRIPTION
Fixes #4447

### Description

Add `repl-stream-bytes` to `CLUSTER SLOT-STATS` — a cumulative per-slot counter of bytes generated into the replication stream, counted once per write regardless of replica count. This complements `network-bytes-out` (which multiplies by replica count and mixes in client-response bytes) by exposing the single-stream replication volume per slot.

The counter stays at 0 when no replication backlog exists — i.e. no replica has ever connected, or `repl-backlog-ttl` has elapsed since the last one disconnected.

The implementation mirrors `network-bytes-out`'s replication accounting:
- Increments at the same site in `feedReplicationBuffer` with the same `len`.
- Deducts the SELECT preamble at the same site (SELECT carries no slot semantics).
- Uses the same slot resolution (`server.current_client->slot`) and the same guard chain.
- Gated by `cluster-slot-stats-enabled`, ORDERBY-sortable, always 0 on replicas, zeroed by the existing `memset`-based reset paths (ADDSLOTS/DELSLOTS, CONFIG RESETSTAT).

The only deliberate difference: no `len *= listLength(server.replicas)` multiplication.

### Testing

- `SET FOO VALUE` on a freshly connected replica: the slot counter reads exactly 33 while `master_repl_offset` advances 56 — proving the 23-byte SELECT preamble reached the replication stream but was not attributed to any slot.
- Value is 0 on the replica (via `empty_metrics` list).
- Reset to 0 on slot ownership change (DELSLOTS → ADDSLOTS).
- CONFIG RESETSTAT clears counter.
- ORDERBY `repl-stream-bytes` sorts correctly (DESC and ASC).
- MULTI/EXEC transaction wrappers are counted (93 bytes for 2 SETs); single-op transactions elide wrappers (32 bytes).
- Replica-count invariance: on a 1-primary-2-replica cluster, counter reads 33 while `network-bytes-out` reads 71.
- Non-slot commands produce 0.
