### PR TITLE
Fix a/an article errors across comments, test names, and error strings

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1134,7 +1134,7 @@ cleanup:
 /* This is a wrapper to the write syscall in order to retry on short writes
  * or if the syscall gets interrupted. It could look strange that we retry
  * on short writes given that we are writing to a block device: normally if
- * the first call is short, there is a end-of-space condition, so the next
+ * the first call is short, there is an end-of-space condition, so the next
  * is likely to fail. However apparently in modern systems this is no longer
  * true, and in general it looks just more resilient to retry the write. If
  * there is an actual error condition we'll get it at the next try. */
@@ -1168,7 +1168,7 @@ ssize_t aofWrite(int fd, const char *buf, size_t len) {
  * About the 'force' argument:
  *
  * When the fsync policy is set to 'everysec' we may delay the flush if there
- * is still an fsync() going on in the background thread, since for instance
+ * is still a fsync() going on in the background thread, since for instance
  * on Linux write(2) will be blocked by the background fsync anyway.
  * When this happens we remember that there is some aof buffer to be
  * flushed ASAP, and will try to do that in the serverCron() function.

--- a/src/config.c
+++ b/src/config.c
@@ -1257,7 +1257,7 @@ struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
          * Append the line and populate the option -> line numbers map. */
         rewriteConfigAppendLine(state, line);
 
-        /* If this is a alias config, replace it with the original name. */
+        /* If this is an alias config, replace it with the original name. */
         standardConfig *s_conf = lookupConfig(argv[0]);
         if (s_conf && s_conf->flags & ALIAS_CONFIG) {
             sdsfree(argv[0]);

--- a/src/debug.c
+++ b/src/debug.c
@@ -1001,7 +1001,7 @@ void debugCommand(client *c) {
             addReplyVerbatim(c, buf, strlen(buf), "txt");
         } else {
             addReplyError(c, "The value stored at the specified key is not "
-                             "represented using an hash table");
+                             "represented using a hash table");
         }
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "change-repl-id") && c->argc == 2) {
         serverLog(LL_NOTICE, "Changing replication IDs after receiving DEBUG change-repl-id");

--- a/src/entry.c
+++ b/src/entry.c
@@ -57,7 +57,7 @@
  *     Identified by: Does not have embedded value, value is an sds, referenced by pointer.
  *
  *
- * Type 4: Value is an stringRef, referenced by pointer
+ * Type 4: Value is a stringRef, referenced by pointer
  *     With this type, the field is embedded, and the value is a stringRef, referenced by pointer.  Extra
  *     bits in the sdshdr8(+) are used to encode aux flags which indicate the presence of a value by
  *     pointer.  An aux bit may indicate the presence of an optional expiration.  Note that the

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1398,7 +1398,7 @@ void lpRandomPairs(unsigned char *lp, unsigned int count, listpackEntry *keys, l
     /* sort by indexes. */
     qsort(picks, count, sizeof(rand_pick), uintCompare);
 
-    /* fetch the elements form the listpack into a output array respecting the original order. */
+    /* fetch the elements from the listpack into an output array respecting the original order. */
     unsigned int lpindex = picks[0].index, pickindex = 0;
     p = lpSeek(lp, lpindex);
     while (p && pickindex < count) {

--- a/src/modules/lua/script_lua.c
+++ b/src/modules/lua/script_lua.c
@@ -564,7 +564,7 @@ static uint32_t digits10(uint64_t v) {
     return 12 + digits10(v / 1000000000000UL);
 }
 
-/* Convert a unsigned long long into a string. Returns the number of
+/* Convert an unsigned long long into a string. Returns the number of
  * characters needed to represent the number.
  * If the buffer is not big enough to store the string, 0 is returned.
  *

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -689,7 +689,7 @@ typedef struct {
 
 /* Trim the stream 's' according to args->trim_strategy, and return the
  * number of elements removed from the stream. The 'approx' option, if non-zero,
- * specifies that the trimming must be performed in a approximated way in
+ * specifies that the trimming must be performed in an approximated way in
  * order to maximize performances. This means that the stream may contain
  * entries with IDs < 'id' in case of MINID (or more elements than 'maxlen'
  * in case of MAXLEN), and elements are only removed if we can remove
@@ -1553,7 +1553,7 @@ long long streamEstimateDistanceFromFirstEverEntry(stream *s, streamID *id) {
  * are created in the pending list of the stream and consumers. We need
  * to propagate this changes in the form of XCLAIM commands. */
 void streamPropagateXCLAIM(client *c, robj *key, streamCG *group, robj *groupname, robj *id, streamNACK *nack) {
-    /* We need to generate an XCLAIM that will work in a idempotent fashion:
+    /* We need to generate an XCLAIM that will work in an idempotent fashion:
      *
      * XCLAIM <key> <group> <consumer> 0 <id> TIME <milliseconds-unix-time>
      *        RETRYCOUNT <count> FORCE JUSTID LASTID <id>.

--- a/src/util.c
+++ b/src/util.c
@@ -385,7 +385,7 @@ err:
     return 0;
 }
 
-/* Convert a unsigned long long into a string. Returns the number of
+/* Convert an unsigned long long into a string. Returns the number of
  * characters needed to represent the number.
  * If the buffer is not big enough to store the string, 0 is returned.
  *

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1582,7 +1582,7 @@ void ziplistRandomPairs(unsigned char *zl, unsigned int count, ziplistEntry *key
     /* sort by indexes. */
     qsort(picks, count, sizeof(rand_pick), uintCompare);
 
-    /* fetch the elements form the ziplist into a output array respecting the original order. */
+    /* fetch the elements from the ziplist into an output array respecting the original order. */
     unsigned int zipindex = picks[0].index, pickindex = 0;
     p = ziplistIndex(zl, zipindex);
     while (ziplistGet(p, &key, &klen, &klval) && pickindex < count) {

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -280,7 +280,7 @@ tags {"aof external:skip logreqres:skip"} {
         }
     }
 
-    ## Test that the server exits when the AOF contains a unknown command
+    ## Test that the server exits when the AOF contains an unknown command
     create_aof $aof_dirpath $aof_file {
         append_to_aof [formatCommand set foo hello]
         append_to_aof [formatCommand bla foo hello]

--- a/tests/modules/datatype2.c
+++ b/tests/modules/datatype2.c
@@ -411,7 +411,7 @@ int MemUsage_RedisCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int a
 
     long long dbid;
     if ((ValkeyModule_StringToLongLong(argv[1], (long long *)&dbid) != VALKEYMODULE_OK)) {
-        return ValkeyModule_ReplyWithError(ctx, "ERR invalid value: must be a integer");
+        return ValkeyModule_ReplyWithError(ctx, "ERR invalid value: must be an integer");
     }
 
     if (dbid < 0 || dbid >= MAX_DB) {

--- a/tests/modules/reply.c
+++ b/tests/modules/reply.c
@@ -72,7 +72,7 @@ int rw_array(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
 
     long long integer;
     if (ValkeyModule_StringToLongLong(argv[1], &integer) != VALKEYMODULE_OK)
-        return ValkeyModule_ReplyWithError(ctx, "Arg cannot be parsed as a integer");
+        return ValkeyModule_ReplyWithError(ctx, "Arg cannot be parsed as an integer");
 
     ValkeyModule_ReplyWithArray(ctx, integer);
     for (int i = 0; i < integer; ++i) {
@@ -87,7 +87,7 @@ int rw_map(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
 
     long long integer;
     if (ValkeyModule_StringToLongLong(argv[1], &integer) != VALKEYMODULE_OK)
-        return ValkeyModule_ReplyWithError(ctx, "Arg cannot be parsed as a integer");
+        return ValkeyModule_ReplyWithError(ctx, "Arg cannot be parsed as an integer");
 
     ValkeyModule_ReplyWithMap(ctx, integer);
     for (int i = 0; i < integer; ++i) {
@@ -103,7 +103,7 @@ int rw_set(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
 
     long long integer;
     if (ValkeyModule_StringToLongLong(argv[1], &integer) != VALKEYMODULE_OK)
-        return ValkeyModule_ReplyWithError(ctx, "Arg cannot be parsed as a integer");
+        return ValkeyModule_ReplyWithError(ctx, "Arg cannot be parsed as an integer");
 
     ValkeyModule_ReplyWithSet(ctx, integer);
     for (int i = 0; i < integer; ++i) {
@@ -118,7 +118,7 @@ int rw_attribute(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
 
     long long integer;
     if (ValkeyModule_StringToLongLong(argv[1], &integer) != VALKEYMODULE_OK)
-        return ValkeyModule_ReplyWithError(ctx, "Arg cannot be parsed as a integer");
+        return ValkeyModule_ReplyWithError(ctx, "Arg cannot be parsed as an integer");
 
     if (ValkeyModule_ReplyWithAttribute(ctx, integer) != VALKEYMODULE_OK) {
         return ValkeyModule_ReplyWithError(ctx, "Attributes aren't supported by RESP 2");

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -12,7 +12,7 @@ start_server {tags {"modules"}} {
         }
         r hello $proto
 
-        test "RESP$proto: RM_ReplyWithString: an string reply" {
+        test "RESP$proto: RM_ReplyWithString: a string reply" {
             # RedisString
             set string [r rw.string "Redis"]
             assert_equal "Redis" $string
@@ -21,7 +21,7 @@ start_server {tags {"modules"}} {
             assert_equal "A simple string" $string
         }
 
-        test "RESP$proto: RM_ReplyWithBigNumber: an string reply" {
+        test "RESP$proto: RM_ReplyWithBigNumber: a string reply" {
             assert_equal "123456778901234567890" [r rw.bignumber "123456778901234567890"]
         }
 
@@ -82,7 +82,7 @@ start_server {tags {"modules"}} {
             assert_equal {0 1 2 3 4} [r rw.array 5]
         }
 
-        test "RESP$proto: RM_ReplyWithMap: an map reply" {
+        test "RESP$proto: RM_ReplyWithMap: a map reply" {
             set res [r rw.map 3]
             if {$proto == 2} {
                 assert_equal {0 0 1 1.5 2 3} $res
@@ -91,11 +91,11 @@ start_server {tags {"modules"}} {
             }
         }
 
-        test "RESP$proto: RM_ReplyWithSet: an set reply" {
+        test "RESP$proto: RM_ReplyWithSet: a set reply" {
             assert_equal {0 1 2} [r rw.set 3]
         }
 
-        test "RESP$proto: RM_ReplyWithAttribute: an set reply" {
+        test "RESP$proto: RM_ReplyWithAttribute: a set reply" {
             if {$proto == 2} {
                 catch {[r rw.attribute 3]} e
                 assert_match "Attributes aren't supported by RESP 2" $e

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -301,7 +301,7 @@ start_server {tags {"pause network"}} {
         assert_match $evicted_keys [s 0 evicted_keys]
 
         # The previous config set triggers a time event, but due to the pause,
-        # no eviction has been made. After the unpause, a eviction will happen.
+        # no eviction has been made. After the unpause, an eviction will happen.
         r client unpause
         wait_for_condition 1000 10 {
             [expr $evicted_keys + 1] eq [s 0 evicted_keys]

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -243,7 +243,7 @@ start_server {tags {"hash"}} {
         list [r hlen bighash]
     } {1024}
 
-    test {Is the big hash encoded with an hash table?} {
+    test {Is the big hash encoded with a hash table?} {
         assert_encoding hashtable bighash
     }
 

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -93,7 +93,7 @@ start_server {
         r ping
     }
 
-    test {LINSERT correctly recompress full quicklistNode after inserting a element before it} {
+    test {LINSERT correctly recompress full quicklistNode after inserting an element before it} {
         r del key
         config_set list-compress-depth 1
         r rpush key b
@@ -106,7 +106,7 @@ start_server {
         r ping
     }
 
-    test {LINSERT correctly recompress full quicklistNode after inserting a element after it} {
+    test {LINSERT correctly recompress full quicklistNode after inserting an element after it} {
         r del key
         config_set list-compress-depth 1
         r rpush key b

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -354,7 +354,7 @@ start_server {
     test {Blocking XREADGROUP for stream that ran dry (issue #5299)} {
         set rd [valkey_deferring_client]
 
-        # Add a entry then delete it, now stream's last_id is 666.
+        # Add an entry then delete it, now stream's last_id is 666.
         r DEL mystream
         r XGROUP CREATE mystream mygroup $ MKSTREAM
         r XADD mystream 666 key value
@@ -380,7 +380,7 @@ start_server {
     test "Blocking XREADGROUP will ignore BLOCK if ID is not >" {
         set rd [valkey_deferring_client]
 
-        # Add a entry then delete it, now stream's last_id is 666.
+        # Add an entry then delete it, now stream's last_id is 666.
         r DEL mystream
         r XGROUP CREATE mystream mygroup $ MKSTREAM
         r XADD mystream 666 key value

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -372,7 +372,7 @@ start_server {
     test "Blocking XREAD for stream that ran dry (issue #5299)" {
         set rd [valkey_deferring_client]
 
-        # Add a entry then delete it, now stream's last_id is 666.
+        # Add an entry then delete it, now stream's last_id is 666.
         r DEL mystream
         r XADD mystream 666 key value
         r XDEL mystream 666

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -3207,7 +3207,7 @@ start_server [list overrides [list save ""] tags {"zset needs:debug external:ski
 
             # There are several possibilities here:
             # 1: One is that we finish the rehash during the add.
-            # 2. The second is that we finish the rehash after the last add and then trigger a expand.
+            # 2. The second is that we finish the rehash after the last add and then trigger an expand.
             # 3. The last one is the situation we want to test, ht1 reached MAX_FILL_PERCENT_HARD after
             #    adding 34 new elements.
             set htstats [r debug htstats-key myzset full]


### PR DESCRIPTION
Fixes several "a"/"an" article mistakes in code comments, test names, and error-reply strings (e.g. "a integer" -> "an integer", "an hash table" -> "a hash table").

Comment/string-literal only, no functional changes. Build passes; affected unit tests pass locally.