### PR TITLE
Fix ORDERBY truncation in CLUSTER SLOT-STATS comparators

### DIFF
--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -57,14 +57,16 @@ static uint64_t getSlotStat(int slot, slotStatType stat_type) {
     return slot_stat;
 }
 
-/* Compare by stat in ascending order. If stat is the same, compare by slot in ascending order. */
+/* Compare by stat in ascending order. If stat is the same, compare by slot in ascending order.
+ * Note: subtraction of uint64_t values cast to int truncates when the difference exceeds
+ * INT_MAX, potentially inverting the sort order. Use three-way comparison instead. */
 static int slotStatForSortAscCmp(const void *a, const void *b) {
     slotStatForSort entry_a = *((slotStatForSort *)a);
     slotStatForSort entry_b = *((slotStatForSort *)b);
     if (entry_a.stat == entry_b.stat) {
         return entry_a.slot - entry_b.slot;
     }
-    return entry_a.stat - entry_b.stat;
+    return (entry_a.stat > entry_b.stat) - (entry_a.stat < entry_b.stat);
 }
 
 /* Compare by stat in descending order. If stat is the same, compare by slot in ascending order. */
@@ -74,7 +76,7 @@ static int slotStatForSortDescCmp(const void *a, const void *b) {
     if (entry_b.stat == entry_a.stat) {
         return entry_a.slot - entry_b.slot;
     }
-    return entry_b.stat - entry_a.stat;
+    return (entry_b.stat > entry_a.stat) - (entry_b.stat < entry_a.stat);
 }
 
 static void collectAndSortSlotStats(slotStatForSort slot_stats[], slotStatType order_by, int desc) {
@@ -329,4 +331,14 @@ void clusterSlotStatsCommand(client *c) {
 
 int clusterSlotStatsEnabled(int slot) {
     return server.cluster_slot_stats_enabled && server.cluster_enabled && slot != -1;
+}
+
+/* Test-only wrappers for static comparators, following the testOnly* pattern
+ * used elsewhere (e.g. quicklist.c, networking.c, intset.c). */
+int testOnlySlotStatForSortAscCmp(const void *a, const void *b) {
+    return slotStatForSortAscCmp(a, b);
+}
+
+int testOnlySlotStatForSortDescCmp(const void *a, const void *b) {
+    return slotStatForSortDescCmp(a, b);
 }

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -333,8 +333,6 @@ int clusterSlotStatsEnabled(int slot) {
     return server.cluster_slot_stats_enabled && server.cluster_enabled && slot != -1;
 }
 
-/* Test-only wrappers for static comparators, following the testOnly* pattern
- * used elsewhere (e.g. quicklist.c, networking.c, intset.c). */
 int testOnlySlotStatForSortAscCmp(const void *a, const void *b) {
     return slotStatForSortAscCmp(a, b);
 }

--- a/src/unit/test_cluster_slot_stats.cpp
+++ b/src/unit/test_cluster_slot_stats.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+
+#include <cstdint>
+
+extern "C" {
+#include "server.h"
+
+/* Struct mirroring the file-scope definition in cluster_slot_stats.c. */
+typedef struct {
+    int slot;
+    uint64_t stat;
+} slotStatForSort;
+
+/* Wrapper function declarations for accessing static comparators. */
+int testOnlySlotStatForSortAscCmp(const void *a, const void *b);
+int testOnlySlotStatForSortDescCmp(const void *a, const void *b);
+}
+
+class ClusterSlotStatsTest : public ::testing::Test {};
+
+/* Small-value sanity: ascending comparator orders by stat value. */
+TEST_F(ClusterSlotStatsTest, AscCmpSmallValues) {
+    slotStatForSort a = {0, 10};
+    slotStatForSort b = {1, 20};
+    EXPECT_LT(testOnlySlotStatForSortAscCmp(&a, &b), 0);
+    EXPECT_GT(testOnlySlotStatForSortAscCmp(&b, &a), 0);
+}
+
+/* Small-value sanity: descending comparator orders by stat value (reversed). */
+TEST_F(ClusterSlotStatsTest, DescCmpSmallValues) {
+    slotStatForSort a = {0, 10};
+    slotStatForSort b = {1, 20};
+    EXPECT_GT(testOnlySlotStatForSortDescCmp(&a, &b), 0);
+    EXPECT_LT(testOnlySlotStatForSortDescCmp(&b, &a), 0);
+}
+
+/* Ascending: a.stat < b.stat with difference exceeding INT_MAX must return negative. */
+TEST_F(ClusterSlotStatsTest, AscCmpDiffExceedsIntMax) {
+    slotStatForSort a = {0, 1};
+    slotStatForSort b = {1, 5000000000ULL};
+    EXPECT_LT(testOnlySlotStatForSortAscCmp(&a, &b), 0);
+}
+
+/* Ascending: a.stat > b.stat with difference exceeding INT_MAX must return positive. */
+TEST_F(ClusterSlotStatsTest, AscCmpLargeGreaterThanSmall) {
+    slotStatForSort a = {0, 5000000000ULL};
+    slotStatForSort b = {1, 1};
+    EXPECT_GT(testOnlySlotStatForSortAscCmp(&a, &b), 0);
+}
+
+/* Descending: a.stat < b.stat with difference exceeding INT_MAX must return positive. */
+TEST_F(ClusterSlotStatsTest, DescCmpDiffExceedsIntMax) {
+    slotStatForSort a = {0, 1};
+    slotStatForSort b = {1, 5000000000ULL};
+    EXPECT_GT(testOnlySlotStatForSortDescCmp(&a, &b), 0);
+}
+
+/* Descending: a.stat > b.stat with difference exceeding INT_MAX must return negative. */
+TEST_F(ClusterSlotStatsTest, DescCmpLargeGreaterThanSmall) {
+    slotStatForSort a = {0, 5000000000ULL};
+    slotStatForSort b = {1, 1};
+    EXPECT_LT(testOnlySlotStatForSortDescCmp(&a, &b), 0);
+}
+
+/* Exactly 2^32 difference: the buggy subtraction-cast truncates to zero.
+ * This must NOT return 0 (equal). */
+TEST_F(ClusterSlotStatsTest, AscCmpExactly2Pow32) {
+    slotStatForSort a = {0, 4294967296ULL};
+    slotStatForSort b = {1, 0};
+    EXPECT_GT(testOnlySlotStatForSortAscCmp(&a, &b), 0);
+    EXPECT_LT(testOnlySlotStatForSortAscCmp(&b, &a), 0);
+}
+
+TEST_F(ClusterSlotStatsTest, DescCmpExactly2Pow32) {
+    slotStatForSort a = {0, 4294967296ULL};
+    slotStatForSort b = {1, 0};
+    EXPECT_LT(testOnlySlotStatForSortDescCmp(&a, &b), 0);
+    EXPECT_GT(testOnlySlotStatForSortDescCmp(&b, &a), 0);
+}
+
+/* Tie-break: equal stat values order by ascending slot in both comparators. */
+TEST_F(ClusterSlotStatsTest, AscCmpTieBreakBySlot) {
+    slotStatForSort a = {5, 100};
+    slotStatForSort b = {10, 100};
+    EXPECT_LT(testOnlySlotStatForSortAscCmp(&a, &b), 0);
+    EXPECT_GT(testOnlySlotStatForSortAscCmp(&b, &a), 0);
+}
+
+TEST_F(ClusterSlotStatsTest, DescCmpTieBreakBySlot) {
+    slotStatForSort a = {5, 100};
+    slotStatForSort b = {10, 100};
+    EXPECT_LT(testOnlySlotStatForSortDescCmp(&a, &b), 0);
+    EXPECT_GT(testOnlySlotStatForSortDescCmp(&b, &a), 0);
+}
+
+/* Equal entries: same slot and same stat must return zero. */
+TEST_F(ClusterSlotStatsTest, AscCmpEqual) {
+    slotStatForSort a = {7, 42};
+    slotStatForSort b = {7, 42};
+    EXPECT_EQ(testOnlySlotStatForSortAscCmp(&a, &b), 0);
+}
+
+TEST_F(ClusterSlotStatsTest, DescCmpEqual) {
+    slotStatForSort a = {7, 42};
+    slotStatForSort b = {7, 42};
+    EXPECT_EQ(testOnlySlotStatForSortDescCmp(&a, &b), 0);
+}


### PR DESCRIPTION
Fixes #4458

### Description

Both slot-stat comparators return a `uint64_t` difference as `int`:

```c
return entry_a.stat - entry_b.stat;
```

The subtraction is done in `uint64_t` arithmetic and then truncated to `int`, so `ORDERBY` sorts incorrectly once two slots' counters differ by more than `INT_MAX` — and a difference of exactly 2³² truncates to zero, making two very different slots compare equal.

This affects the cumulative counters `cpu-usec`, `network-bytes-in` and `network-bytes-out`, which grow without bound until `CONFIG RESETSTAT` or a slot ownership change.

Replaced with an explicit three-way comparison, keeping the existing tie-break on slot number (safe, since slots are bounded at 16383):

```c
return (entry_a.stat > entry_b.stat) - (entry_a.stat < entry_b.stat);
```

The values are only compared, never subtracted, so nothing can overflow. This idiom is already used at `src/vset.c:869`.

Surfaced by the review of #4455, which adds a fourth cumulative byte counter that would inherit this.

### Testing

Added a test to `tests/unit/cluster/slot-stats.tcl` that drives one slot's `network-bytes-in` past `INT_MAX` (repeatedly overwriting one large key, so memory stays flat) and asserts the ordering in both directions. It fails without the fix — the heavy slot lands last in a `DESC` sort — and passes with it.

Tagged `slow`: the test moves ~2.2 GB and takes ~150s.
