### PR TITLE
Match BGSAVE CANCEL command documentation in bgsave.json to code

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -7187,17 +7187,27 @@ commandHistory BGSAVE_History[] = {
 #define BGSAVE_Keyspecs NULL
 #endif
 
-/* BGSAVE save_type argument table */
-struct COMMAND_ARG BGSAVE_save_type_Subargs[] = {
+/* BGSAVE operation save save_type argument table */
+struct COMMAND_ARG BGSAVE_operation_save_save_type_Subargs[] = {
 {MAKE_ARG("fork",ARG_TYPE_PURE_TOKEN,-1,"FORK",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("forkless",ARG_TYPE_PURE_TOKEN,-1,"FORKLESS",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
+/* BGSAVE operation save argument table */
+struct COMMAND_ARG BGSAVE_operation_save_Subargs[] = {
+{MAKE_ARG("schedule",ARG_TYPE_PURE_TOKEN,-1,"SCHEDULE",NULL,"3.2.2",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("save-type",ARG_TYPE_ONEOF,-1,NULL,NULL,"9.2.0",CMD_ARG_OPTIONAL,2,NULL),.subargs=BGSAVE_operation_save_save_type_Subargs},
+};
+
+/* BGSAVE operation argument table */
+struct COMMAND_ARG BGSAVE_operation_Subargs[] = {
+{MAKE_ARG("save",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=BGSAVE_operation_save_Subargs},
+{MAKE_ARG("cancel",ARG_TYPE_PURE_TOKEN,-1,"CANCEL",NULL,"8.1.0",CMD_ARG_NONE,0,NULL)},
+};
+
 /* BGSAVE argument table */
 struct COMMAND_ARG BGSAVE_Args[] = {
-{MAKE_ARG("schedule",ARG_TYPE_PURE_TOKEN,-1,"SCHEDULE",NULL,"3.2.2",CMD_ARG_OPTIONAL,0,NULL)},
-{MAKE_ARG("save-type",ARG_TYPE_ONEOF,-1,NULL,NULL,"9.2.0",CMD_ARG_OPTIONAL,2,NULL),.subargs=BGSAVE_save_type_Subargs},
-{MAKE_ARG("cancel",ARG_TYPE_PURE_TOKEN,-1,"CANCEL",NULL,"8.1.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("operation",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=BGSAVE_operation_Subargs},
 };
 
 /********** COMMAND COUNT ********************/
@@ -12036,7 +12046,7 @@ struct COMMAND_STRUCT serverCommandTable[] = {
 /* server */
 {MAKE_CMD("acl","A container for Access List Control commands.","Depends on subcommand.","6.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,ACL_History,0,ACL_Tips,0,NULL,-2,CMD_SENTINEL,ACL_CATEGORY_SLOW,NULL,ACL_Keyspecs,0,NULL,0),.subcommands=ACL_Subcommands},
 {MAKE_CMD("bgrewriteaof","Asynchronously rewrites the append-only file to disk.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,BGREWRITEAOF_History,0,BGREWRITEAOF_Tips,0,bgrewriteaofCommand,1,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,BGREWRITEAOF_Keyspecs,0,NULL,0)},
-{MAKE_CMD("bgsave","Asynchronously saves the database(s) to disk.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,BGSAVE_History,3,BGSAVE_Tips,0,bgsaveCommand,-1,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,BGSAVE_Keyspecs,0,NULL,3),.args=BGSAVE_Args},
+{MAKE_CMD("bgsave","Asynchronously saves the database(s) to disk.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,BGSAVE_History,3,BGSAVE_Tips,0,bgsaveCommand,-1,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,BGSAVE_Keyspecs,0,NULL,1),.args=BGSAVE_Args},
 {MAKE_CMD("command","Returns detailed information about all commands.","O(N) where N is the total number of commands","2.8.13",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,COMMAND_History,0,COMMAND_Tips,1,commandCommand,-1,CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION|ACL_CATEGORY_SLOW,NULL,COMMAND_Keyspecs,0,NULL,0),.subcommands=COMMAND_Subcommands},
 {MAKE_CMD("commandlog","A container for command log commands.","Depends on subcommand.","8.1.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,COMMANDLOG_History,0,COMMANDLOG_Tips,0,NULL,-2,0,ACL_CATEGORY_SLOW,NULL,COMMANDLOG_Keyspecs,0,NULL,0),.subcommands=COMMANDLOG_Subcommands},
 {MAKE_CMD("config","A container for server configuration commands.","Depends on subcommand.","2.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,CONFIG_History,0,CONFIG_Tips,0,NULL,-2,0,ACL_CATEGORY_SLOW,NULL,CONFIG_Keyspecs,0,NULL,0),.subcommands=CONFIG_Subcommands},

--- a/src/commands/bgsave.json
+++ b/src/commands/bgsave.json
@@ -27,36 +27,48 @@
         ],
         "arguments": [
             {
-                "name": "schedule",
-                "token": "SCHEDULE",
-                "type": "pure-token",
-                "optional": true,
-                "since": "3.2.2"
-            },
-            {
-                "name": "save-type",
+                "name": "operation",
                 "type": "oneof",
                 "optional": true,
-                "since": "9.2.0",
                 "arguments": [
                     {
-                        "name": "fork",
-                        "token": "FORK",
-                        "type": "pure-token"
+                        "name": "save",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "schedule",
+                                "token": "SCHEDULE",
+                                "type": "pure-token",
+                                "optional": true,
+                                "since": "3.2.2"
+                            },
+                            {
+                                "name": "save-type",
+                                "type": "oneof",
+                                "optional": true,
+                                "since": "9.2.0",
+                                "arguments": [
+                                    {
+                                        "name": "fork",
+                                        "token": "FORK",
+                                        "type": "pure-token"
+                                    },
+                                    {
+                                        "name": "forkless",
+                                        "token": "FORKLESS",
+                                        "type": "pure-token"
+                                    }
+                                ]
+                            }
+                        ]
                     },
                     {
-                        "name": "forkless",
-                        "token": "FORKLESS",
-                        "type": "pure-token"
+                        "name": "cancel",
+                        "token": "CANCEL",
+                        "type": "pure-token",
+                        "since": "8.1.0"
                     }
                 ]
-            },
-            {
-                "name": "cancel",
-                "token": "CANCEL",
-                "type": "pure-token",
-                "optional": true,
-                "since": "8.1.0"
             }
         ],
         "reply_schema": {


### PR DESCRIPTION
The parser in rdb.c rejects `BGSAVE CANCEL` combined with any other option, while still allowing `SCHEDULE` with `FORK`/`FORKLESS`. The documentation in bgsave.json did not reflect that. Restructured the args for a resulting grammar of `BGSAVE  [ [SCHEDULE] [FORK|FORKLESS] | CANCEL ]`