### PR TITLE
Schedule AOF rewrite during a forkless save instead of failing

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -965,7 +965,7 @@ int startAppendOnly(void) {
     serverAssert(server.aof_state == AOF_OFF);
 
     server.aof_state = AOF_WAIT_REWRITE;
-    if (hasActiveChildProcess() && server.child_type != CHILD_TYPE_AOF) {
+    if (hasActiveSaveOrChild() && server.child_type != CHILD_TYPE_AOF) {
         server.aof_rewrite_scheduled = 1;
         serverLog(LL_NOTICE, "AOF was enabled but there is already another background operation. An AOF background was "
                              "scheduled to start when possible.");


### PR DESCRIPTION
`rewriteAppendOnlyFileBackground()` was updated to check `hasActiveSaveOrChild()` instead of just `hasActiveChildProcess`, in order to not allow an AOF rewrite during forkless save.

But to get to `rewriteAppendOnlyFileBackground`, we route through `startAppendOnly()` first. `startAppendOnly` still decided schedule-vs-run using `hasActiveChildProcess()`, which is false during a forkless save. So it would choose 'run', call `rewriteAppendOnlyFileBackground()`, which would then error out due to the updated check, instead of scheduling a rewrite.