### PR TITLE
For in-use blocking, check the client is in the list before removing it

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -1021,7 +1021,9 @@ static void unlinkBlockInUseClient(client *c) {
         robj *key = dictGetKey(de);
         list *clientList = keyToClients_getBlockedClientsList(key);
         serverAssert(clientList != NULL);
-        listDelNode(clientList, listSearchKey(clientList, c));
+        listNode *ln = listSearchKey(clientList, c);
+        serverAssert(ln != NULL);
+        listDelNode(clientList, ln);
         if (listLength(clientList) == 0) hashtableDelete(inuse_key_to_clients, key);
     }
     dictReleaseIterator(di);


### PR DESCRIPTION
blockInUse keeps two maps that must agree: each client stores the keys it waits on, and each key stores the list of clients waiting on it. `unlinkBlockInUseClient()` removed the client from a key's list without checking that the client was really there. If the two maps ever stop agreeing, `listSearchKey()` returns `NULL` and `listDelNode()` then reads that `NULL` pointer, so the server crashes on `NULL` dereference. Making this change because it's better to crash on a clear assertion.