### PR TITLE
Flush and fsync the snapshot before publishing it

### DIFF
--- a/src/forkless.c
+++ b/src/forkless.c
@@ -162,7 +162,15 @@ static void forklessSaveCloseSnapshotFile(void *args[]) {
     serverAssert(!onValkeyMainThread());
     forklessSaveInfo *saveInfo = (forklessSaveInfo *)args[0];
     /* Error or not, close the file... */
-    if (fsync(fileno(saveInfo->save_rio.io.file.fp)) != 0) {
+    /* Flush the RIO buffer to the OS before fsync, otherwise any bytes still
+     * buffered (including the tail written after the last autosync boundary and
+     * the RDB footer) are not covered by the fsync below. */
+    if (rioFlush(&saveInfo->save_rio) == 0) {
+        serverLog(LL_WARNING, "forkless-save: error flushing temp file [%s]: %s",
+                  saveInfo->temp_file, strerror(errno));
+        saveInfo->err_code = C_ERR;
+    }
+    if (valkey_fsync(fileno(saveInfo->save_rio.io.file.fp)) != 0) {
         serverLog(LL_WARNING, "forkless-save: error fsyncing temp file [%s]: %s",
                   saveInfo->temp_file, strerror(errno));
         saveInfo->err_code = C_ERR;
@@ -177,6 +185,11 @@ static void forklessSaveCloseSnapshotFile(void *args[]) {
         if (rename(saveInfo->temp_file, saveInfo->final_file) != 0) {
             serverLog(LL_WARNING, "forkless-save: error moving temp file [%s] to destination [%s]: %s",
                       saveInfo->temp_file, saveInfo->final_file, strerror(errno));
+            saveInfo->err_code = C_ERR;
+        } else if (fsyncFileDir(saveInfo->final_file) != 0) {
+            /* fsync the directory so the rename itself survives a crash. */
+            serverLog(LL_WARNING, "forkless-save: error syncing directory for [%s]: %s",
+                      saveInfo->final_file, strerror(errno));
             saveInfo->err_code = C_ERR;
         }
     }


### PR DESCRIPTION
When we write a piece of data to the RDB with rioWrite, it's not written straight to disk - it first goes into an in-memory buffer. Getting it durable is two steps: first flush the buffer to the OS cache (app level), then fsync the OS cache to the physical disk (OS level).

There are two ways this flush+fsync happens during a forkless save:

1. With rdb-save-incremental-fsync enabled, the rio code flushes+fsyncs automatically every X bytes as it writes.
2. Otherwise, we're responsible for doing it ourselves.

The problem: in forklessSaveCloseSnapshotFile we call fsync before the buffer is flushed, so the last piece of data isn't covered.

- If the config is disabled, we never flush/fsync during the save at all - so effectively the whole save is never fsynced.
- Even if it's enabled, it only fsyncs on X-byte boundaries, so the last piece isn't guaranteed to be synced. Example: a 10 MB file with 4 MB increments gets synced at 4 MB and 8 MB - the final 2 MB (plus the footer) never crosses a boundary and stays in the buffer.

So the tail needs to be flushed before the fsync, not after. Today the order is fsync → fclose, and fclose is what flushes the tail - but that happens after the fsync, and nothing fsyncs again afterward.

We didn't catch this in tests because reads are served from the OS cache, so the data was always reachable in normal runs. It would only surface on a crash/power loss that happens after the rename but before the tail is physically written - in that case the on-disk RDB is missing its last piece and is corrupt.

Fix: flush before fsync (flush → fsync → close), and also fsyncFileDir after the rename so the rename itself is durable - matching what the fork-based rdbSave already does.
