### PR TITLE
Only touch currentForklessSave on the main thread

### DIFF
--- a/src/forkless.c
+++ b/src/forkless.c
@@ -220,6 +220,7 @@ void forklessSaveComplete(bool terminated, void *privdata) {
     saveInfo->terminated = terminated;
     /* The save iterator should be terminated and freed at this point in time. */
     saveInfo->iterator = NULL;
+    currentForklessSave = NULL;
     /* For file based forkless save, we need to generate the RDB end marker. and complete the save */
     if (!saveInfo->terminated && saveInfo->err_code == C_OK) {
         saveInfo->err_code = rdbWriteFooter(&saveInfo->save_rio, REPLICA_REQ_NONE) == C_ERR ? C_ERR : C_OK;

--- a/src/forkless.c
+++ b/src/forkless.c
@@ -129,7 +129,6 @@ static void *forklessSaveProcessor(void *arg) {
     serverLog(LL_NOTICE, "forkless-save: background processor finished. %ld items processed. %s",
               items, message);
 
-    currentForklessSave = NULL;
     saveInfo->err_code = err;
     bgIteratorClose(saveInfo->iterator);
     return NULL;


### PR DESCRIPTION
`currentForklessSave` was cleared in `forklessSaveProcessor`, which runs on the worker thread, while `forklessSaveCancel` reads it (and its iterator) on the main thread. Two threads writing/reading the same pointer with no lock is a data race that can crash the cancel path.

The contract is that we always pass an `ITEM_CLOSE` when we finish, which causes the cleanup function to get called which clears up `currentForklessSave` anyway, so this should be safe.

Update: that cleanup runs after the async file close, but `forklessSaveComplete` nulls the iterator earlier - so a `BGSAVE CANCEL` in that window would terminate a `NULL` iterator and crash. So I also clear `currentForklessSave` where we null the iterator in `forklessSaveComplete`