### PR TITLE
Fix forkless save remaining time estimate

### DIFF
--- a/src/forkless.c
+++ b/src/forkless.c
@@ -372,12 +372,13 @@ sds forkless_catInfo(sds info) {
             current_item_millis = status.current_item_ms;
 
             if (status.dbentries_processed > 0) {
-                long long total_keys = 0;
-                for (int i = 0; i < server.dbnum; i++) {
-                    total_keys += server.db[i] ? dbSize(server.db[i]) : 0;
-                }
-                estimated_seconds_remaining = (total_keys - status.dbentries_processed) *
-                                              status.runtime_ms / status.dbentries_processed / 1000;
+                long long total_keys =
+                    (long long)atomic_load_explicit(&server.stat_current_save_keys_total, memory_order_relaxed);
+                /* The ETA is best effort. Clamp at 0 since dbentries_processed
+                 * can exceed total_keys (e.g. a full sync may process more than
+                 * the start-time key count). */
+                long long remaining = max(total_keys - (long long)status.dbentries_processed, 0);
+                estimated_seconds_remaining = remaining * status.runtime_ms / status.dbentries_processed / 1000;
             }
         }
     }


### PR DESCRIPTION

`forkless_estimated_seconds_remaining` sampled the live key count **now**, but compared it against `dbentries_processed`, which counts progress through the point-in-time snapshot taken **when the save started**. If keys were deleted during the save, the live count could drop below dbentries_processed and the estimate went negative.

Use server.stat_current_save_keys_total, the key count captured when the save started, so both sides of the subtraction share the same baseline and the estimate stays non-negative.