### PR TITLE
Reject fork during a forkless save

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -7342,7 +7342,7 @@ void closeChildUnusedResourceAfterFork(void) {
 /* purpose is one of CHILD_TYPE_ types */
 int serverFork(int purpose) {
     if (isMutuallyExclusiveChildType(purpose)) {
-        if (hasActiveChildProcess()) {
+        if (hasActiveSaveOrChild()) {
             errno = EALREADY;
             return -1;
         }


### PR DESCRIPTION
A forkless save exists to avoid the CoW memory spike of a fork-based save. But the save still writes to the pages of the data it walks (object refcounts, the iterator epoch in object metadata, and rehash state in collections), and the main thread keeps serving writes. So if a fork child is alive during the save, all of those writes trigger CoW.
