### PR TITLE
Reject multiple save types in BGSAVE command

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4207,8 +4207,17 @@ void bgsaveCommand(client *c) {
             }
             return;
         } else if (!strcasecmp(arg, "fork")) {
+            /* The save type is a "oneof": at most one of FORK/FORKLESS. */
+            if (chosen_save_type != RDB_BGSAVE_TYPE_NONE) {
+                addReplyErrorObject(c, shared.syntaxerr);
+                return;
+            }
             chosen_save_type = RDB_BGSAVE_TYPE_FORK;
         } else if (!strcasecmp(arg, "forkless")) {
+            if (chosen_save_type != RDB_BGSAVE_TYPE_NONE) {
+                addReplyErrorObject(c, shared.syntaxerr);
+                return;
+            }
             if (!server.forkless_options_supported) {
                 addReplyError(c, "BGSAVE FORKLESS requires starting the server with forkless-options-supported enabled");
                 return;

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -358,6 +358,15 @@ start_server {overrides {forkless-options-supported yes save ""}} {
         }
     }
 }
+start_server {overrides {forkless-options-supported yes save ""}} {
+    test "BGSAVE rejects conflicting save types" {
+        # save-type is a oneof: at most one of FORK/FORKLESS may be given.
+        assert_error "*syntax*" {r bgsave fork forkless}
+        assert_error "*syntax*" {r bgsave forkless fork}
+        assert_error "*syntax*" {r bgsave fork fork}
+        assert_error "*syntax*" {r bgsave forkless forkless}
+    }
+}
 
 start_server {overrides {forkless-options-supported yes save ""}} {
     test "forkless bgsave contains expired keys from when save started" {


### PR DESCRIPTION
To resolve AI comment, reject BGSAVE commands such as `BGSAVE FORK FORK`, `BGSAVE FORK FORKLESS` etc.