### PR TITLE
Make the bgsave time-advance check non-flaky

### DIFF
--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -775,16 +775,13 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-options-
         }
         
         set time1 [s rdb_current_bgsave_time_sec]
-        
-        # Wait 2 seconds
-        after 2000
-        
-        set time2 [s rdb_current_bgsave_time_sec]
-        
-        # Time should have increased by approximately 2 seconds
-        assert {$time2 >= $time1 + 1}
-        assert {$time2 <= $time1 + 3}
-        
+
+        wait_for_condition 50 100 {
+            [s rdb_current_bgsave_time_sec] >= $time1 + 2
+        } else {
+            fail "rdb_current_bgsave_time_sec did not advance during forkless save"
+        }
+
         r config set rdb-key-save-delay 0
         r bgsave cancel
         waitForBgsave r


### PR DESCRIPTION
To fix AI comment, wait for at least 2 seconds passing rather than capping at 2s.