### PR TITLE
Minor cleanup to update cluster-node-timeout config name references

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -8143,7 +8143,7 @@ static int clusterManagerCommandSetTimeout(int argc, char **argv) {
             err = "";
         else
             need_free = 1;
-        clusterManagerLogErr("ERR setting node-timeout for %s:%d: %s\n", n->ip, n->port, err);
+        clusterManagerLogErr("ERR setting cluster-node-timeout for %s:%d: %s\n", n->ip, n->port, err);
         if (need_free) zfree(err);
         err_count++;
     }

--- a/valkey.conf
+++ b/valkey.conf
@@ -1885,12 +1885,12 @@ aof-timestamp-enabled no
 # the failover if, since the last interaction with the primary, the time
 # elapsed is greater than:
 #
-#   (node-timeout * cluster-replica-validity-factor) + repl-ping-replica-period
+#   (cluster-node-timeout * cluster-replica-validity-factor) + repl-ping-replica-period
 #
-# So for example if node-timeout is 30 seconds, and the cluster-replica-validity-factor
+# So for example if cluster-node-timeout is 15 seconds, and the cluster-replica-validity-factor
 # is 10, and assuming a default repl-ping-replica-period of 10 seconds, the
 # replica will not try to failover if it was not able to talk with the primary
-# for longer than 310 seconds.
+# for longer than 160 seconds.
 #
 # A large cluster-replica-validity-factor may allow replicas with too old data to failover
 # a primary, while a too small value may prevent the cluster from being able to


### PR DESCRIPTION
Update valkey.conf to use the real config name cluster-node-timeout
(instead of node-timeout) in the failover formula and use its default
value (15s) in the example, matching default behavior. Also fix the
error log in valkey-cli.c to print the correct config name.