### PR TITLE
Hold no descriptor on nodes.conf when rename() publishes it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ redis.code-workspace
 .cscope*
 .swp
 nodes*.conf
+nodes*.conf.lock
 tests/cluster/tmp/*
 tests/rdma/rdma-test
 tags

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1106,10 +1106,11 @@ static sds clusterGenNodesConfContent(void) {
  * Note: we need to write the file in an atomic way from the point of view
  * of the POSIX filesystem semantics, so that if the server is stopped
  * or crashes during the write, we'll end with either the old file or the
- * new one. Since we have the full payload to write available we can use
- * a single write to write the whole file. If the preexisting file was
- * bigger we pad our payload with newlines that are anyway ignored and truncate
- * the file afterward.
+ * new one. We get that by writing the whole payload to a temp file and
+ * publishing it with rename(), so every save installs a new inode under the
+ * configured name. Nothing here may hold a descriptor on either file across
+ * the rename: the lock guarding the config lives on a separate file for that
+ * reason, see clusterLockConfig().
  *
  * This function will be called by either the main thread or a bio thread.
  * When called from a bio thread, latency is not recorded because it is not
@@ -1266,9 +1267,16 @@ static void clusterSaveConfigBackground(bool do_fsync) {
 /* Lock the cluster config using flock(), and retain the file descriptor used to
  * acquire the lock so that the file will be locked as long as the process is up.
  *
- * This works because we always update nodes.conf with a new version
- * in-place, reopening the file, and writing to it in place (later adjusting
- * the length with ftruncate()).
+ * The lock is taken on a sibling file, nodes.conf.lock, rather than on nodes.conf
+ * itself. flock() applies to the inode and not to the name, and
+ * clusterSaveConfig() publishes every new version with rename(), so a lock held
+ * on nodes.conf stops protecting it the moment the first save installs a
+ * different inode under the name. The lock file is only ever created, never
+ * replaced, so its inode is stable for as long as the directory lives.
+ *
+ * Keeping the lock off nodes.conf also leaves no descriptor open on the rename
+ * destination, which filesystems with Windows semantics, such as SMB, refuse to
+ * replace.
  *
  * On success C_OK is returned, otherwise an error is logged and
  * the function returns C_ERR to signal a lock was not acquired. */
@@ -1281,9 +1289,11 @@ int clusterLockConfig(char *filename) {
     /* To lock it, we need to open the file in a way it is created if
      * it does not exist, otherwise there is a race condition with other
      * processes. */
-    int fd = open(filename, O_WRONLY | O_CREAT | O_CLOEXEC, 0644);
+    sds lockfile = sdscatfmt(sdsempty(), "%s.lock", filename);
+    int fd = open(lockfile, O_WRONLY | O_CREAT | O_CLOEXEC, 0644);
     if (fd == -1) {
-        serverLog(LL_WARNING, "Can't open %s in order to acquire a lock: %s", filename, strerror(errno));
+        serverLog(LL_WARNING, "Can't open %s in order to acquire a lock: %s", lockfile, strerror(errno));
+        sdsfree(lockfile);
         return C_ERR;
     }
 
@@ -1296,11 +1306,14 @@ int clusterLockConfig(char *filename) {
                       "files.",
                       filename);
         } else {
-            serverLog(LL_WARNING, "Impossible to lock %s: %s", filename, strerror(errno));
+            serverLog(LL_WARNING, "Impossible to lock %s: %s", lockfile, strerror(errno));
         }
         close(fd);
+        sdsfree(lockfile);
         return C_ERR;
     }
+    sdsfree(lockfile);
+
     /* Lock acquired: leak the 'fd' by not closing it until shutdown time, so that
      * we'll retain the lock to the file as long as the process exists.
      *

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1121,6 +1121,7 @@ static int clusterSaveConfigImpl(sds content, bool from_bio, bool do_fsync) {
     size_t content_size, offset = 0;
     ssize_t written_bytes;
     int fd = -1;
+    int close_errno = 0;
     int retval = C_ERR;
     mstime_t latency;
     content_size = sdslen(content);
@@ -1158,6 +1159,22 @@ static int clusterSaveConfigImpl(sds content, bool from_bio, bool do_fsync) {
         latencyEndMonitor(latency);
         if (!from_bio) latencyAddSampleIfNeeded("cluster-config-fsync", latency);
         if (!from_bio) latencyTraceIfNeeded(cluster, cluster_config_fsync, latency);
+    }
+
+    /* Close the temp file before publishing it with rename(). A write error the
+     * kernel deferred is reported by close() and by nothing before it, so a
+     * truncated temp file would otherwise be renamed over a good nodes.conf,
+     * and clusterLoadConfig() panics on a corrupt file at the next start.
+     * ACLSaveToFile() closes before renaming for the same reason. */
+    latencyStartMonitor(latency);
+    close_errno = close(fd) == -1 ? errno : 0;
+    fd = -1;
+    latencyEndMonitor(latency);
+    if (!from_bio) latencyAddSampleIfNeeded("cluster-config-close", latency);
+    if (!from_bio) latencyTraceIfNeeded(cluster, cluster_config_close, latency);
+    if (close_errno) {
+        serverLog(LL_WARNING, "Could not close tmp cluster config file %s: %s", tmpfilename, strerror(close_errno));
+        goto cleanup;
     }
 
     latencyStartMonitor(latency);

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -125,6 +125,11 @@ proc remove_nodes_conf_folder {srv_idx} {
     exec rm -rf $cluster_conf_path
 }
 
+proc file_inode {path} {
+    file stat $path st
+    return $st(ino)
+}
+
 # The temp files a save leaves behind, if any. A save writes one and renames it
 # over the cluster config file, so none should survive a completed save.
 proc leftover_nodes_conf_tmp_files {srv_idx} {
@@ -261,6 +266,45 @@ start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-config-save-b
         # cluster_config_last_save_time must have advanced after a successful save.
         assert_morethan_equal [getInfoProperty [R 0 cluster info] cluster_config_last_save_time] $last_save_time_0
         assert_morethan_equal [getInfoProperty [R 1 cluster info] cluster_config_last_save_time] $last_save_time_1
+    }
+}
+
+start_server {tags {external:skip cluster singledb} overrides {cluster-enabled yes}} {
+    test {nodes.conf stays locked after the config is saved} {
+        set dir [lindex [r config get dir] 1]
+        set cluster_conf [lindex [r config get cluster-config-file] 1]
+        set conf_path [file join $dir $cluster_conf]
+
+        # Every save publishes nodes.conf with rename(), which puts a new inode
+        # under the name. Force one, then confirm the running node still holds
+        # the lock that stops a second node from using the same file.
+        set inode_before [file_inode $conf_path]
+        assert_equal {OK} [r cluster saveconfig]
+        wait_for_condition 50 100 {
+            [file_inode $conf_path] != $inode_before
+        } else {
+            fail "the save did not replace $cluster_conf"
+        }
+
+        # flock() does not exist on Solaris, so clusterLockConfig() does not lock
+        # at all there and a second node is expected to start.
+        if {$::tcl_platform(os) ne "SunOS"} {
+            set logfile [file join $dir second-node.log]
+            set pid [exec $::VALKEY_SERVER_BIN --port 0 \
+                         --unixsocket [file join $dir second-node.sock] \
+                         --cluster-enabled yes \
+                         --dir $dir \
+                         --cluster-config-file $cluster_conf \
+                         --logfile $logfile &]
+
+            wait_for_condition 100 100 {
+                ![process_is_alive $pid]
+            } else {
+                catch {exec kill -9 $pid}
+                fail "a second node started while $cluster_conf was already in use"
+            }
+            assert_match "*already used by a different Cluster node*" [exec cat $logfile]
+        }
     }
 }
 

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -125,6 +125,12 @@ proc remove_nodes_conf_folder {srv_idx} {
     exec rm -rf $cluster_conf_path
 }
 
+# The temp files a save leaves behind, if any. A save writes one and renames it
+# over the cluster config file, so none should survive a completed save.
+proc leftover_nodes_conf_tmp_files {srv_idx} {
+    return [glob -nocomplain "[get_nodes_conf_path $srv_idx].tmp-*"]
+}
+
 start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-config-save-behavior sync}} {
     test {cluster-config-save-behavior sync mode - node exits when config save fails} {
         # Create folder that can cause the rename fail.
@@ -199,6 +205,13 @@ start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-config-save-b
         assert_equal [count_log_message 0 "Cluster config updated even though writing the cluster config file to disk failed"] 1
         assert_morethan_equal [count_log_message -1 "Could not rename tmp cluster config file"] 2
         assert_equal [count_log_message -1 "Cluster config updated even though writing the cluster config file to disk failed"] 1
+
+        # A node whose renames keep failing must not accumulate temp files. This
+        # holds before this commit too; it is here to keep the invariant from
+        # regressing as the save path is reordered. The bio jobs were drained
+        # above, so no save is still in flight.
+        assert_equal {} [leftover_nodes_conf_tmp_files 0]
+        assert_equal {} [leftover_nodes_conf_tmp_files 1]
 
         # Check the info field is err.
         assert_equal "err" [getInfoProperty [R 0 cluster info] cluster_config_save_status]

--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -120,6 +120,8 @@ then
     rm -rf dump-*.rdb
     echo "Cleaning nodes-*.conf"
     rm -rf nodes-*.conf
+    echo "Cleaning nodes-*.conf.lock"
+    rm -rf nodes-*.conf.lock
     exit 0
 fi
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -1830,6 +1830,21 @@ aof-timestamp-enabled no
 # Make sure that instances running in the same system do not have
 # overlapping cluster configuration file names.
 #
+# A sibling lock file named <cluster-config-file>.lock (for example
+# nodes-6379.conf.lock) is also created in the same directory. It is empty,
+# never rewritten, and held exclusively for the life of the process so two
+# nodes cannot share one cluster config file. Deleting that lock file while
+# the node is running silently drops the guard. The lock file must remain
+# creatable: bind-mounts of only the config path (for example a Kubernetes
+# subPath), backup file lists, and directory-cleaning sidecars all need to
+# account for it.
+#
+# Give each node a real, distinct path. A symlink or hard link pointing two
+# nodes at one cluster config file is not supported: each node saves by writing
+# a temporary file and renaming it over the destination, which replaces the
+# symlink or breaks the hard link on the very first save, so the two nodes
+# silently diverge onto separate files.
+#
 # cluster-config-file nodes-6379.conf
 
 # This option controls how the cluster handles the saving behavior of the


### PR DESCRIPTION
Fixes #2884.

`clusterSaveConfig()` calls `rename()` while the process holds descriptors on **both** files involved:

1. the temp file it just wrote — the rename **source**
2. the startup lock on `nodes.conf` — the rename **destination**, held open for the life of the process by design

## Three problems follow

| # | Problem | Scope |
|---|---|---|
| 1 | Temp file is closed *after* the rename and the result discarded. A deferred write error is reported only by `close()`, so a truncated file gets published. `clusterLoadConfig()` then panics and the node won't start. | every filesystem |
| 2 | `flock()` applies to the inode, not the name. `rename()` puts a new inode under `nodes.conf` each save, so after the first save the lock guards an unnamed orphan and `nodes.conf` is unlocked. A second node can start on a config already in use. | every filesystem |
| 3 | SMB refuses to replace a file that has an open handle, so every save fails and `clusterSaveConfigOrDie()` exits the process — pod crash loop on Azure Files. | SMB / Azure Files |

```mermaid
flowchart TB
    LOCK["lock fd<br/>(held for process lifetime)"] -->|locked at startup| A["inode A<br/>= nodes.conf"]
    TMP["temp file fd<br/>(still open)"] --> R["rename(temp → nodes.conf)"]
    A -->|unlinked by the rename| ORPH["inode A<br/>orphan, no name"]
    R --> B["inode B<br/>= nodes.conf now"]
    LOCK -.->|"problem 2: guard on the orphan;<br/>nodes.conf UNLOCKED"| ORPH
    LOCK -.->|"problem 3: open handle on the<br/>destination → SMB refuses"| B
    style ORPH fill:#ffe0e0
    style B fill:#ffe0e0
```

Problem 3 needs **both** handles gone, which is why neither part fixes it alone.

- MS-FSCC 2.4.42 returns `STATUS_ACCESS_DENIED` when "the target file was open and ReplaceIfExists is nonzero"
- the Linux cifs client always sets `ReplaceIfExists = 1` (`fs/smb/client/smb2inode.c:411`)
- reported error, from bitnami/charts#20355:

```
rename(".../nodes.conf.tmp-372-1700481060091", ".../nodes.conf") = -1 EACCES
```

## Why the lock broke

- The lock's comment stated its precondition: it works "because we always update nodes.conf with a new version in-place".
- antirez said the same when he wrote it (redis/redis#1594): "we never unlink(2) the nodes.conf file but we just rewrite it in place".
- cc2848132 (#10924, 2022) made saving atomic via temp file + rename, removing that precondition.
- The lock was never revisited, and the #10924 review never mentions it.

## Fix

Hold no descriptor on `nodes.conf` when the rename happens.

1. Close the temp file and **check the result** before renaming, so a failed write aborts the save instead of publishing it. `ACLSaveToFile()` and `rdbSave()` already do this.
2. Take the startup lock on a sibling `nodes.conf.lock` instead of on `nodes.conf`. It is only ever created, never replaced, so its inode is stable and the guard survives any number of saves.

```mermaid
flowchart TB
    LOCK["lock fd"] -->|locked at startup| L["nodes.conf.lock<br/>created once, never renamed<br/>→ inode never changes"]
    W["write temp file, fsync"] --> C["close temp fd + check result<br/>→ abort save if the write failed"]
    C --> R["rename(temp → nodes.conf)<br/>no open handle on either side"]
    R --> B["new inode = nodes.conf"]
    style L fill:#e0ffe0
    style B fill:#e0ffe0
```

- The save path no longer touches the lock at all, so there is **no window** where `nodes.conf` is unguarded.
- A separate lock file is what mattsta originally proposed in redis/redis#1594. antirez chose the leaked descriptor because it was "just a handful lines of code" *and* because nodes.conf was rewritten in place. The second reason no longer holds.

## Evidence

Against a running server, 30 saves:

| | Value |
|---|---|
| `nodes.conf.lock` inode | `210362899` → `210362899` (unchanged) |
| `nodes.conf` inode | `210362901` → `210362913` (replaced) |
| descriptors held in that dir | exactly one: `8w .../nodes.conf.lock`, none on `nodes.conf` |
| second node on same config | exits 1, "already used by a different Cluster node" |

## Tests

1. New test in `tests/unit/cluster/misc.tcl`: forces a save, asserts the inode under `nodes.conf` changed, starts a second server on the same config file, asserts it exits with that message. **Fails without this change.**
2. Locking half skipped on Solaris, where `flock()` does not exist and a second node is expected to start.
3. Existing `cluster-config-save-behavior` test extended to assert no temp files are left behind.
4. Not covered: a failing `close()` cannot be forced from Tcl.
5. 554 passed, 0 failed across misc, base, shutdown, failover, manual-failover, manual-takeover, slot-migration, cluster-nodes-slots, info, cli, multi-slot-operations, auto-failover-on-shutdown.

## Notes

- **Solaris**: `clusterLockConfig()` still does not lock, unchanged.
- **Fork children**: `closeChildUnusedResourceAfterFork()` unaffected, so redis/redis#7674 still holds.
- **Shutdown unlock** (redis/redis#10912, so a large process restarting fast can retake the lock): previously ran on the orphaned inode because `clusterHandleServerShutdown()` saves first, so it did nothing. Now operates on a stable inode.
- **#2555** moves this function to a BIO thread and splits it into `clusterGenNodesConfContent()` / `clusterSaveConfigImpl()`. Conflicts textually but **not** semantically — the save path here never reads or writes `server.cluster_config_file_lock_fd`. Happy to rebase onto it or land after, whichever @enjoy-binbin prefers.
- **On-disk format**: unchanged.

## Cost

- `nodes.conf.lock` is a new, empty, never-removed file in the data directory.
- During a rolling upgrade an old node locks `nodes.conf` and a new node locks `nodes.conf.lock`, so the two do not exclude each other. Little is lost: the old node's lock is already orphaned after its first save, so it is not protecting `nodes.conf` either.

Both failures are severe — a node that cannot save `nodes.conf` exits, and a lock that stops locking lets two nodes share one config file — so 9.0 and 9.1 look worth backporting.

I have no Azure Files mount and cannot verify the SMB path myself. @bladedancer, if you can still reproduce #2884, this is the branch to try.
