### PR TITLE
Fix flaky replica-priority test by disabling replica validity factor

### DIFF
--- a/tests/unit/cluster/replica-priority.tcl
+++ b/tests/unit/cluster/replica-priority.tcl
@@ -1,4 +1,4 @@
-start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
+start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000 cluster-replica-validity-factor 0}} {
     test "Replica can do a better ranking in auto failover based on the priority" {
         # primary R 0, replica1 R 3, replica2 R 6
 


### PR DESCRIPTION
Some CI environments run slowly, so the paused old primary can stay
disconnected from its primary long enough to exceed the
cluster-replica-validity-factor limit. In that case the old primary is
disqualified from the second auto failover.

Fixes #4406