### PR TITLE
Fix writeable typo in an expire test name

### DIFF
--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -610,7 +610,7 @@ start_server {tags {"expire"}} {
             }
         }
 
-        test {expired key which is created in writeable replicas should be deleted by active expiry} {
+        test {expired key which is created in writable replicas should be deleted by active expiry} {
             $primary flushall
             $replica config set replica-read-only no
             foreach {yes_or_no} {yes no} {


### PR DESCRIPTION
One test name spells it `writeable`. Outside `deps/` that is the only occurrence left in the tree, everywhere else is `writable`.

Current releases of `typos` flag it, and the Spellcheck job installs `typos` through `taiki-e/install-action` without pinning a version, so the job can turn red without anyone touching this repo. With this word changed, `typos --config=./.config/typos.toml` is clean across the tree.

It is a test name, so nothing changes behaviour, and nothing else refers to the old one.
