### PR TITLE
Add tls-groups to control TLS named groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,21 @@ Use `valkey-cli` to connect to the Valkey server:
     --cacert ./tests/tls/ca.crt
 ```
 
+TLS named group preferences can be restricted with `--tls-groups` on the server
+and clients, using the OpenSSL `SSL_CTX_set1_groups_list()` syntax:
+```
+./src/valkey-server --tls-port 6379 --port 0 \
+    --tls-cert-file ./tests/tls/valkey.crt \
+    --tls-key-file ./tests/tls/valkey.key \
+    --tls-ca-cert-file ./tests/tls/ca.crt \
+    --tls-groups X25519:prime256v1
+./src/valkey-cli --tls \
+    --cert ./tests/tls/valkey.crt \
+    --key ./tests/tls/valkey.key \
+    --cacert ./tests/tls/ca.crt \
+    --tls-groups X25519:prime256v1
+```
+
 Specifying `--tls-replication yes` makes a replica connect to the primary.
 
 Using `--tls-cluster yes` makes Valkey Cluster use TLS across nodes.

--- a/README.md
+++ b/README.md
@@ -222,18 +222,22 @@ Use `valkey-cli` to connect to the Valkey server:
 
 TLS named group preferences can be restricted with `--tls-groups` on the server
 and clients, using the OpenSSL `SSL_CTX_set1_groups_list()` syntax:
-```
-./src/valkey-server --tls-port 6379 --port 0 \
-    --tls-cert-file ./tests/tls/valkey.crt \
-    --tls-key-file ./tests/tls/valkey.key \
-    --tls-ca-cert-file ./tests/tls/ca.crt \
-    --tls-groups X25519:prime256v1
-./src/valkey-cli --tls \
-    --cert ./tests/tls/valkey.crt \
-    --key ./tests/tls/valkey.key \
-    --cacert ./tests/tls/ca.crt \
-    --tls-groups X25519:prime256v1
-```
+
+Run the server in one shell:
+
+    ./src/valkey-server --tls-port 6379 --port 0 \
+        --tls-cert-file ./tests/tls/valkey.crt \
+        --tls-key-file ./tests/tls/valkey.key \
+        --tls-ca-cert-file ./tests/tls/ca.crt \
+        --tls-groups X25519:prime256v1
+
+Then run `valkey-cli` from another shell:
+
+    ./src/valkey-cli --tls \
+        --cert ./tests/tls/valkey.crt \
+        --key ./tests/tls/valkey.key \
+        --cacert ./tests/tls/ca.crt \
+        --tls-groups X25519:prime256v1
 
 Specifying `--tls-replication yes` makes a replica connect to the primary.
 

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -102,6 +102,12 @@ int cliSecureConnection(valkeyContext *c, cliSSLconfig config, const char **err)
             goto error;
         }
 #endif
+#if CLI_TLS_SUPPORTS_GROUPS
+        if (config.groups && !cliSslCtxSetGroupsList(ssl_ctx, config.groups)) {
+            *err = "Error while configuring TLS groups";
+            goto error;
+        }
+#endif
     }
 
     SSL *ssl = SSL_new(ssl_ctx);

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -5,6 +5,22 @@
 #include "sds.h"
 #include <stdint.h>
 
+#ifdef USE_OPENSSL
+#include <openssl/ssl.h>
+#endif
+
+#if defined(TLS_NO_GROUPS)
+#define CLI_TLS_SUPPORTS_GROUPS 0
+#elif defined(SSL_CTX_set1_groups_list)
+#define CLI_TLS_SUPPORTS_GROUPS 1
+#define cliSslCtxSetGroupsList(ctx, list) SSL_CTX_set1_groups_list((ctx), (list))
+#elif defined(SSL_CTX_set1_curves_list)
+#define CLI_TLS_SUPPORTS_GROUPS 1
+#define cliSslCtxSetGroupsList(ctx, list) SSL_CTX_set1_curves_list((ctx), (list))
+#else
+#define CLI_TLS_SUPPORTS_GROUPS 0
+#endif
+
 typedef struct cliSSLconfig {
     /* Requested SNI, or NULL */
     char *sni;
@@ -22,6 +38,8 @@ typedef struct cliSSLconfig {
     char *ciphers;
     /* Preferred ciphersuites list, or NULL (applies only to TLSv1.3) */
     char *ciphersuites;
+    /* Preferred TLS named groups list, or NULL */
+    char *groups;
 } cliSSLconfig;
 
 

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -3,20 +3,12 @@
 
 #include <valkey/valkey.h>
 #include "sds.h"
+#include "tls.h"
 #include <stdint.h>
 
-#ifdef USE_OPENSSL
-#include <openssl/ssl.h>
-#endif
-
-#if defined(TLS_NO_GROUPS)
-#define CLI_TLS_SUPPORTS_GROUPS 0
-#elif defined(SSL_CTX_set1_groups_list)
+#if VALKEY_TLS_SUPPORTS_GROUPS
 #define CLI_TLS_SUPPORTS_GROUPS 1
-#define cliSslCtxSetGroupsList(ctx, list) SSL_CTX_set1_groups_list((ctx), (list))
-#elif defined(SSL_CTX_set1_curves_list)
-#define CLI_TLS_SUPPORTS_GROUPS 1
-#define cliSslCtxSetGroupsList(ctx, list) SSL_CTX_set1_curves_list((ctx), (list))
+#define cliSslCtxSetGroupsList(ctx, list) valkeyTlsCtxSetGroupsList((ctx), (list))
 #else
 #define CLI_TLS_SUPPORTS_GROUPS 0
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -3596,6 +3596,7 @@ standardConfig static_configs[] = {
     createStringConfig("tls-protocols", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.protocols, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ciphers", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ciphers, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ciphersuites", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ciphersuites, NULL, NULL, applyTlsCfg),
+    createStringConfig("tls-groups", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.groups, NULL, NULL, applyTlsCfg),
 
     /* Special configs */
     createSpecialConfig("dir", NULL, MODIFIABLE_CONFIG | PROTECTED_CONFIG | DENY_LOADING_CONFIG, setConfigDirOption, getConfigDirOption, rewriteConfigDirOption, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -33,6 +33,7 @@
 #include "server.h"
 #include "cluster.h"
 #include "connection.h"
+#include "tls.h"
 #include "bio.h"
 #include "module.h"
 #include "cluster_migrateslots.h"
@@ -3596,7 +3597,9 @@ standardConfig static_configs[] = {
     createStringConfig("tls-protocols", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.protocols, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ciphers", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ciphers, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ciphersuites", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ciphersuites, NULL, NULL, applyTlsCfg),
+#if VALKEY_TLS_SUPPORTS_GROUPS
     createStringConfig("tls-groups", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.groups, NULL, NULL, applyTlsCfg),
+#endif
 
     /* Special configs */
     createSpecialConfig("dir", NULL, MODIFIABLE_CONFIG | PROTECTED_CONFIG | DENY_LOADING_CONFIG, setConfigDirOption, getConfigDirOption, rewriteConfigDirOption, NULL),

--- a/src/server.h
+++ b/src/server.h
@@ -1677,6 +1677,7 @@ typedef struct serverTLSContextConfig {
     char *protocols;
     char *ciphers;
     char *ciphersuites;
+    char *groups;
     int prefer_server_ciphers;
     int session_caching;
     int session_cache_size;

--- a/src/tls.c
+++ b/src/tls.c
@@ -30,6 +30,7 @@
 #define VALKEYMODULE_CORE_MODULE /* A module that's part of the server core, uses server.h too. */
 
 #include "server.h"
+#include "tls.h"
 #include "connhelpers.h"
 #include "adlist.h"
 #include "io_threads.h"
@@ -70,18 +71,6 @@
 #define REDIS_TLS_PROTO_DEFAULT (REDIS_TLS_PROTO_TLSv1_2 | REDIS_TLS_PROTO_TLSv1_3)
 #else
 #define REDIS_TLS_PROTO_DEFAULT (REDIS_TLS_PROTO_TLSv1_2)
-#endif
-
-#if defined(TLS_NO_GROUPS)
-#define CONN_TLS_SUPPORTS_GROUPS 0
-#elif defined(SSL_CTX_set1_groups_list)
-#define CONN_TLS_SUPPORTS_GROUPS 1
-#define valkeyTlsCtxSetGroupsList(ctx, list) SSL_CTX_set1_groups_list((ctx), (list))
-#elif defined(SSL_CTX_set1_curves_list)
-#define CONN_TLS_SUPPORTS_GROUPS 1
-#define valkeyTlsCtxSetGroupsList(ctx, list) SSL_CTX_set1_curves_list((ctx), (list))
-#else
-#error "tls-groups requires OpenSSL with SSL_CTX_set1_groups_list or SSL_CTX_set1_curves_list. Define TLS_NO_GROUPS to build without TLS groups."
 #endif
 
 SSL_CTX *valkey_tls_ctx = NULL;
@@ -655,7 +644,7 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
 #endif
 
     if (ctx_config->groups) {
-#if CONN_TLS_SUPPORTS_GROUPS
+#if VALKEY_TLS_SUPPORTS_GROUPS
         if (!valkeyTlsCtxSetGroupsList(ctx, ctx_config->groups)) {
             serverLog(LL_WARNING, "Failed to configure TLS groups: %s", ctx_config->groups);
             goto error;

--- a/src/tls.c
+++ b/src/tls.c
@@ -72,6 +72,18 @@
 #define REDIS_TLS_PROTO_DEFAULT (REDIS_TLS_PROTO_TLSv1_2)
 #endif
 
+#if defined(TLS_NO_GROUPS)
+#define CONN_TLS_SUPPORTS_GROUPS 0
+#elif defined(SSL_CTX_set1_groups_list)
+#define CONN_TLS_SUPPORTS_GROUPS 1
+#define valkeyTlsCtxSetGroupsList(ctx, list) SSL_CTX_set1_groups_list((ctx), (list))
+#elif defined(SSL_CTX_set1_curves_list)
+#define CONN_TLS_SUPPORTS_GROUPS 1
+#define valkeyTlsCtxSetGroupsList(ctx, list) SSL_CTX_set1_curves_list((ctx), (list))
+#else
+#error "tls-groups requires OpenSSL with SSL_CTX_set1_groups_list or SSL_CTX_set1_curves_list. Define TLS_NO_GROUPS to build without TLS groups."
+#endif
+
 SSL_CTX *valkey_tls_ctx = NULL;
 SSL_CTX *valkey_tls_client_ctx = NULL;
 
@@ -641,6 +653,18 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
         goto error;
     }
 #endif
+
+    if (ctx_config->groups) {
+#if CONN_TLS_SUPPORTS_GROUPS
+        if (!valkeyTlsCtxSetGroupsList(ctx, ctx_config->groups)) {
+            serverLog(LL_WARNING, "Failed to configure TLS groups: %s", ctx_config->groups);
+            goto error;
+        }
+#else
+        serverLog(LL_WARNING, "Failed to configure TLS groups: not supported by this build");
+        goto error;
+#endif
+    }
 
     return ctx;
 

--- a/src/tls.h
+++ b/src/tls.h
@@ -7,6 +7,24 @@
 #ifndef __VALKEY_TLS_H
 #define __VALKEY_TLS_H
 
+#if defined(USE_OPENSSL)
+#include <openssl/ssl.h>
+
+#if defined(TLS_NO_GROUPS)
+#define VALKEY_TLS_SUPPORTS_GROUPS 0
+#elif defined(SSL_CTX_set1_groups_list)
+#define VALKEY_TLS_SUPPORTS_GROUPS 1
+#define valkeyTlsCtxSetGroupsList(ctx, list) SSL_CTX_set1_groups_list((ctx), (list))
+#elif defined(SSL_CTX_set1_curves_list)
+#define VALKEY_TLS_SUPPORTS_GROUPS 1
+#define valkeyTlsCtxSetGroupsList(ctx, list) SSL_CTX_set1_curves_list((ctx), (list))
+#else
+#define VALKEY_TLS_SUPPORTS_GROUPS 0
+#endif
+#else
+#define VALKEY_TLS_SUPPORTS_GROUPS 0
+#endif
+
 /* TLS reload functions - only available when TLS is built-in, not as a module */
 #if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
 void tlsReconfigureIfNeeded(void);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1915,6 +1915,11 @@ int parseOptions(int argc, char **argv) {
             if (lastarg) goto invalid;
             config.sslconfig.ciphersuites = strdup(argv[++i]);
 #endif
+#if CLI_TLS_SUPPORTS_GROUPS
+        } else if (!strcmp(argv[i], "--tls-groups")) {
+            if (lastarg) goto invalid;
+            config.sslconfig.groups = strdup(argv[++i]);
+#endif
 #endif
 #ifdef USE_RDMA
         } else if (!strcmp(argv[i], "--rdma")) {
@@ -1987,6 +1992,10 @@ usage:
         "                    colon (\":\"). See the ciphers(1ssl) manpage for more\n"
         "                    information about the syntax of this string, and\n"
         "                    specifically for TLSv1.3 ciphersuites.\n"
+#endif
+#if CLI_TLS_SUPPORTS_GROUPS
+        " --tls-groups <list> Sets the list of preferred TLS groups\n"
+        "                    in order of preference from highest to lowest separated by colon (\":\").\n"
 #endif
 #endif
         "";

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2834,6 +2834,10 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i], "--tls-ciphersuites") && !lastarg) {
             config.sslconfig.ciphersuites = argv[++i];
 #endif
+#if CLI_TLS_SUPPORTS_GROUPS
+        } else if (!strcmp(argv[i], "--tls-groups") && !lastarg) {
+            config.sslconfig.groups = argv[++i];
+#endif
 #endif
 #ifdef USE_RDMA
         } else if (!strcmp(argv[i], "--rdma")) {
@@ -2986,6 +2990,10 @@ static void usage(int err) {
         "                     in order of preference from highest to lowest separated by colon (\":\").\n"
         "                     See the ciphers(1ssl) manpage for more information about the syntax of this string,\n"
         "                     and specifically for TLSv1.3 ciphersuites.\n"
+#endif
+#if CLI_TLS_SUPPORTS_GROUPS
+        "  --tls-groups <list> Sets the list of preferred TLS groups\n"
+        "                     in order of preference from highest to lowest separated by colon (\":\").\n"
 #endif
 #endif
         "";

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -598,6 +598,16 @@ tags {"benchmark network external:skip logreqres:skip"} {
                 assert_match  {} [cmdstat get]
             }
 
+            test {benchmark: specific tls-groups} {
+                r flushall
+                r config resetstat
+                set cmd [valkeybenchmark $master_host $master_port "-r 50 -t set -n 1000 --tls-groups prime256v1"]
+                common_bench_setup $cmd
+                assert_match  {*calls=1000,*} [cmdstat set]
+                # assert one of the non benchmarked commands is not present
+                assert_match  {} [cmdstat get]
+            }
+
             test {benchmark: tls connecting using URI with authentication set,get} {
                 r config set primaryauth pass
                 set cmd [valkeybenchmarkuriuserpass $master_host $master_port "default" pass "-c 5 -n 10 -t set,get"]

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -590,6 +590,11 @@ tags {"benchmark network external:skip logreqres:skip"} {
 
         # tls specific tests
         if {$::tls} {
+            set tls_groups_supported 0
+            if {![catch {exec $::VALKEY_BENCHMARK_BIN --help} help]} {
+                set tls_groups_supported [string match "*--tls-groups*" $help]
+            }
+
             test {benchmark: specific tls-ciphers} {
                 set cmd [valkeybenchmark $master_host $master_port "-r 50 -t set -n 1000 --tls-ciphers \"DEFAULT:-AES128-SHA256\""]
                 common_bench_setup $cmd
@@ -599,6 +604,9 @@ tags {"benchmark network external:skip logreqres:skip"} {
             }
 
             test {benchmark: specific tls-groups} {
+                if {!$tls_groups_supported} {
+                    skip "TLS named groups are not supported by this build"
+                }
                 r flushall
                 r config resetstat
                 set cmd [valkeybenchmark $master_host $master_port "-r 50 -t set -n 1000 --tls-groups prime256v1"]

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1411,6 +1411,7 @@ start_server {tags {"introspection"}} {
                 tls-protocols
                 tls-ciphers
                 tls-ciphersuites
+                tls-groups
                 tls-port
             }
         }

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -14,6 +14,14 @@ start_server {tags {"tls"}} {
             return 0
         }
 
+        proc tls_valkey_cli {host port groups} {
+            set cmd [valkeycli $host $port [list \
+                --tls-ciphers ECDHE-RSA-AES128-GCM-SHA256 \
+                --tls-groups $groups \
+                PING]]
+            string trim [exec {*}$cmd 2>@1]
+        }
+
         test {TLS: Not accepting non-TLS connections on a TLS port} {
             set s [valkey [srv 0 host] [srv 0 port]]
             catch {$s PING} e
@@ -104,6 +112,42 @@ start_server {tags {"tls"}} {
 
             r CONFIG SET tls-protocols ""
             r CONFIG SET tls-ciphers "DEFAULT"
+        }
+
+        test {TLS: Verify tls-groups validates group names} {
+            assert_equal {OK} [r CONFIG SET tls-groups "prime256v1"]
+
+            catch {r CONFIG SET tls-groups "invalid-group"} e
+            assert_match {*Unable to update TLS configuration*} $e
+
+            r CONFIG SET tls-groups ""
+        }
+
+        test {TLS: Verify tls-groups with a common group} {
+            set ecdhe_ciphers ECDHE-RSA-AES128-GCM-SHA256
+            r CONFIG SET tls-protocols TLSv1.2
+            r CONFIG SET tls-ciphers $ecdhe_ciphers
+            r CONFIG SET tls-groups prime256v1
+
+            assert_equal {PONG} [tls_valkey_cli [srv 0 host] [srv 0 port] prime256v1]
+
+            r CONFIG SET tls-groups ""
+            r CONFIG SET tls-protocols ""
+            r CONFIG SET tls-ciphers DEFAULT
+        }
+
+        test {TLS: Verify tls-groups with disjoint groups} {
+            set ecdhe_ciphers ECDHE-RSA-AES128-GCM-SHA256
+            r CONFIG SET tls-protocols TLSv1.2
+            r CONFIG SET tls-ciphers $ecdhe_ciphers
+            r CONFIG SET tls-groups prime256v1
+
+            assert_equal 1 [catch {tls_valkey_cli [srv 0 host] [srv 0 port] secp384r1} e]
+            assert_no_match {*PONG*} $e
+
+            r CONFIG SET tls-groups ""
+            r CONFIG SET tls-protocols ""
+            r CONFIG SET tls-ciphers DEFAULT
         }
 
         test {TLS: Verify tls-cert-file is also used as a client cert if none specified} {

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -2,6 +2,11 @@ start_server {tags {"tls"}} {
     if {$::tls} {
         package require tls
 
+        set ::tls_groups 0
+        if {![catch {exec $::VALKEY_CLI_BIN --help} help]} {
+            set ::tls_groups [string match "*--tls-groups*" $help]
+        }
+
         proc check_client_stuck {control_client client_port {min_omem 1}} {
             set clients [$control_client CLIENT LIST]
             foreach client [split $clients "\n"] {
@@ -14,12 +19,14 @@ start_server {tags {"tls"}} {
             return 0
         }
 
-        proc tls_valkey_cli {host port groups} {
-            set cmd [valkeycli $host $port [list \
-                --tls-ciphers ECDHE-RSA-AES128-GCM-SHA256 \
-                --tls-groups $groups \
-                PING]]
-            string trim [exec {*}$cmd 2>@1]
+        if {$::tls_groups} {
+            proc tls_valkey_cli {host port groups} {
+                set cmd [valkeycli $host $port [list \
+                    --tls-ciphers ECDHE-RSA-AES128-GCM-SHA256 \
+                    --tls-groups $groups \
+                    PING]]
+                string trim [exec {*}$cmd 2>@1]
+            }
         }
 
         test {TLS: Not accepting non-TLS connections on a TLS port} {
@@ -115,6 +122,9 @@ start_server {tags {"tls"}} {
         }
 
         test {TLS: Verify tls-groups validates group names} {
+            if {!$::tls_groups} {
+                skip "TLS named groups are not supported by this build"
+            }
             assert_equal {OK} [r CONFIG SET tls-groups "prime256v1"]
 
             catch {r CONFIG SET tls-groups "invalid-group"} e
@@ -124,6 +134,9 @@ start_server {tags {"tls"}} {
         }
 
         test {TLS: Verify tls-groups with a common group} {
+            if {!$::tls_groups} {
+                skip "TLS named groups are not supported by this build"
+            }
             set ecdhe_ciphers ECDHE-RSA-AES128-GCM-SHA256
             r CONFIG SET tls-protocols TLSv1.2
             r CONFIG SET tls-ciphers $ecdhe_ciphers
@@ -137,6 +150,9 @@ start_server {tags {"tls"}} {
         }
 
         test {TLS: Verify tls-groups with disjoint groups} {
+            if {!$::tls_groups} {
+                skip "TLS named groups are not supported by this build"
+            }
             set ecdhe_ciphers ECDHE-RSA-AES128-GCM-SHA256
             r CONFIG SET tls-protocols TLSv1.2
             r CONFIG SET tls-ciphers $ecdhe_ciphers

--- a/valkey.conf
+++ b/valkey.conf
@@ -314,6 +314,11 @@ tcp-keepalive 300
 #
 # tls-ciphersuites TLS_CHACHA20_POLY1305_SHA256
 
+# Configure TLS group preferences. See the SSL_CTX_set1_groups_list(3ssl)
+# manpage for more information about the syntax of this string.
+#
+# tls-groups prime256v1
+
 # When choosing a cipher, use the server's preference instead of the client
 # preference. By default, the server follows the client's preference.
 #


### PR DESCRIPTION
## Summary

Fixes #4501 

Add support for configuring TLS named groups through the new tls-groups option.

This allows operators to control the TLS key-exchange groups used by Valkey, with the same option also available in valkey-cli and valkey-benchmark.

## Changes

- Add the modifiable tls-groups server configuration.
- Apply the configured groups to server and client TLS contexts.
- Add --tls-groups to valkey-cli and valkey-benchmark.
- Add configuration documentation and tests covering TLS group negotiation.

## Testing

- make BUILD_TLS=yes
- TLS unit tests
- CMake TLS build
- Manual tests with matching and disjoint TLS groups