### PR TITLE
Handle write-blocked keys in VM_OpenKey

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -70,6 +70,7 @@
 #include "io_threads.h"
 #include "scripting_engine.h"
 #include "cluster_migrateslots.h"
+#include "bgiteration.h"
 #include "forkless.h"
 #include <dlfcn.h>
 #include <sys/stat.h>
@@ -4300,6 +4301,14 @@ static void moduleInitKeyTypeSpecific(ValkeyModuleKey *key) {
  * call ValkeyModule_CloseKey() and ValkeyModule_KeyType() on a NULL
  * value.
  *
+ * Valkey 9.2+: When opening a key with VALKEYMODULE_WRITE, NULL will be returned
+ * if the key is currently write-locked (i.e. if forkless operations are operating
+ * on the key).  This change is non-breaking as:
+ * * Modules have to opt-in using VALKEYMODULE_OPTIONS_HANDLE_FORKLESS_SAVE
+ * * Module write commands are blocked (before execution), if a declared key is write-locked
+ * The risk is only for a module that performs VM_OpenKey() on a key which was NOT
+ * declared in the current command OR arbitrarily opens keys during a timer event.
+ *
  * Extra flags that can be pass to the API under the mode argument:
  * * VALKEYMODULE_OPEN_KEY_NOTOUCH - Avoid touching the LRU/LFU of the key when opened.
  * * VALKEYMODULE_OPEN_KEY_NONOTIFY - Don't trigger keyspace event on key misses.
@@ -4318,6 +4327,7 @@ ValkeyModuleKey *VM_OpenKey(ValkeyModuleCtx *ctx, robj *keyname, int mode) {
 
     if (mode & VALKEYMODULE_WRITE) {
         value = lookupKeyWriteWithFlags(ctx->client->db, keyname, flags);
+        if (value && bgIteration_isEntryInuse(value)) return NULL;
     } else {
         value = lookupKeyReadWithFlags(ctx->client->db, keyname, flags);
         if (value == NULL) {


### PR DESCRIPTION
When bgIteration is using a key for background processing, we can't allow a module to open the key for write.

This change alters `VM_OpenKey` so that when opening a key for WRITE, a null will be returned if the key is currently in use.

This is not a breaking change as modules need to opt-in for forkless save using the `VALKEYMODULE_OPTIONS_HANDLE_FORKLESS_SAVE` flag.

Even after opting in, a NULL return is unlikely as most modules only modify a key as the direct result of a module command.  If the key is identified in the command, bgIteration will block the command before it ever reaches the module.

This is only a concern for modules which arbitrarily access keys (for write) which aren't declared in a command.