### PR TITLE
Preserve config file permissions on rewrite

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1126,6 +1126,7 @@ struct rewriteConfigState {
     int force_write;      /* True if we want all keywords to be force
                              written. Currently only used for testing
                              and debug information. */
+    mode_t file_mode;     /* Config file mode to use on rewrite. */
 };
 
 /* Free the configuration rewrite state. */
@@ -1145,6 +1146,7 @@ struct rewriteConfigState *rewriteConfigCreateState(void) {
     state->lines = NULL;
     state->needs_signature = 1;
     state->force_write = 0;
+    state->file_mode = 0644 & ~server.umask;
     return state;
 }
 
@@ -1196,6 +1198,7 @@ struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
     if (fp == NULL) {
         return state;
     }
+    state->file_mode = sb.st_mode & 0777;
 
     if (sb.st_size == 0) {
         fclose(fp);
@@ -1770,7 +1773,7 @@ sds getConfigDebugInfo(void) {
  *
  * The function returns 0 on success, otherwise -1 is returned and errno
  * is set accordingly. */
-int rewriteConfigOverwriteFile(char *configfile, sds content) {
+int rewriteConfigOverwriteFile(char *configfile, sds content, mode_t file_mode) {
     int fd = -1;
     int retval = -1;
     char tmp_conffile[PATH_MAX];
@@ -1810,7 +1813,7 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
 
     if (fsync(fd))
         serverLog(LL_WARNING, "Could not sync tmp config file to disk (%s)", strerror(errno));
-    else if (fchmod(fd, 0644 & ~server.umask) == -1)
+    else if (fchmod(fd, file_mode) == -1)
         serverLog(LL_WARNING, "Could not chmod config file (%s)", strerror(errno));
     else if (rename(tmp_conffile, configfile) == -1)
         serverLog(LL_WARNING, "Could not rename tmp config file (%s)", strerror(errno));
@@ -1876,7 +1879,7 @@ int rewriteConfig(char *path, int force_write) {
     /* Step 4: generate a new configuration file from the modified state
      * and write it into the original file. */
     newcontent = rewriteConfigGetContentFromState(state);
-    retval = rewriteConfigOverwriteFile(server.configfile, newcontent);
+    retval = rewriteConfigOverwriteFile(server.configfile, newcontent, state->file_mode);
 
     sdsfree(newcontent);
     rewriteConfigReleaseState(state);

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1463,6 +1463,15 @@ start_server {tags {"introspection"}} {
         }
     } {} {external:skip}
 
+    test {CONFIG REWRITE preserves existing config file permissions} {
+        set config_file [srv 0 config_file]
+        file attributes $config_file -permissions 00600
+        assert_equal 00600 [file attributes $config_file -permissions]
+
+        r config rewrite
+        assert_equal 00600 [file attributes $config_file -permissions]
+    } {} {external:skip}
+
     test {CONFIG REWRITE handles save and shutdown properly} {
         r config set save "3600 1 300 100 60 10000"
         r config set shutdown-on-sigterm "nosave now"


### PR DESCRIPTION
currently, config rewrite override file mode. so this patch preserve original file permissions.