### PR TITLE
Reject overflowing save config values

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2942,36 +2942,44 @@ static sds getConfigDirOption(standardConfig *config) {
     return sdsnew(buf);
 }
 
-/* Parse a single "<seconds> <changes>" save point. On success 1 is returned and
- * the parsed values are stored in seconds_out and changes_out, otherwise 0 is
- * returned and *err is set.
+/* Parse a single "<seconds> <changes>" save point. On success true is returned
+ * and the parsed values are stored in seconds_out and changes_out, otherwise
+ * false is returned and *err is set.
  *
  * Both values are capped at INT_MAX (about 68 years for the seconds, which is
  * way more than any sane save point): changes is stored in an int, and seconds,
  * while stored in a time_t, is emitted as a long by rewriteConfigSaveOption().
  * Without the check the values silently wrap, and a negative changes count
  * makes serverCron() fire a background save on every single change. */
-static int parseSaveParamPair(sds seconds_str, sds changes_str, time_t *seconds_out, int *changes_out, const char **err) {
+static bool parseSaveSecondsChangesPair(sds seconds_str, sds changes_str, time_t *seconds_out, int *changes_out, const char **err) {
     char *eptr;
     long long seconds, changes;
 
     errno = 0;
     seconds = strtoll(seconds_str, &eptr, 10);
-    if (eptr == seconds_str || eptr[0] != '\0' || errno == ERANGE || seconds < 1 || seconds > INT_MAX) {
-        *err = "Invalid save parameters";
-        return 0;
+    if (eptr == seconds_str || eptr[0] != '\0') {
+        *err = "Invalid save parameters: seconds must be an integer";
+        return false;
+    }
+    if (errno == ERANGE || seconds < 1 || seconds > INT_MAX) {
+        *err = "Invalid save parameters: seconds must be between 1 and INT_MAX";
+        return false;
     }
 
     errno = 0;
     changes = strtoll(changes_str, &eptr, 10);
-    if (eptr == changes_str || eptr[0] != '\0' || errno == ERANGE || changes < 0 || changes > INT_MAX) {
-        *err = "Invalid save parameters";
-        return 0;
+    if (eptr == changes_str || eptr[0] != '\0') {
+        *err = "Invalid save parameters: changes must be an integer";
+        return false;
+    }
+    if (errno == ERANGE || changes < 0 || changes > INT_MAX) {
+        *err = "Invalid save parameters: changes must be between 0 and INT_MAX";
+        return false;
     }
 
     *seconds_out = seconds;
     *changes_out = changes;
-    return 1;
+    return true;
 }
 
 static int setConfigSaveOption(standardConfig *config, sds *argv, int argc, const char **err) {
@@ -2994,7 +3002,7 @@ static int setConfigSaveOption(standardConfig *config, sds *argv, int argc, cons
         return 0;
     }
     for (j = 0; j < argc; j += 2) {
-        if (!parseSaveParamPair(argv[j], argv[j + 1], &seconds, &changes, err)) return 0;
+        if (!parseSaveSecondsChangesPair(argv[j], argv[j + 1], &seconds, &changes, err)) return 0;
     }
 
     /* Finally set the new config */
@@ -3013,7 +3021,7 @@ static int setConfigSaveOption(standardConfig *config, sds *argv, int argc, cons
 
     for (j = 0; j < argc; j += 2) {
         /* Already validated above, so this can't fail. */
-        serverAssert(parseSaveParamPair(argv[j], argv[j + 1], &seconds, &changes, err));
+        serverAssert(parseSaveSecondsChangesPair(argv[j], argv[j + 1], &seconds, &changes, err));
         appendServerSaveParams(seconds, changes);
     }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2942,9 +2942,43 @@ static sds getConfigDirOption(standardConfig *config) {
     return sdsnew(buf);
 }
 
+/* Parse a single "<seconds> <changes>" save point. On success 1 is returned and
+ * the parsed values are stored in seconds_out and changes_out, otherwise 0 is
+ * returned and *err is set.
+ *
+ * Both values are capped at INT_MAX (about 68 years for the seconds, which is
+ * way more than any sane save point): changes is stored in an int, and seconds,
+ * while stored in a time_t, is emitted as a long by rewriteConfigSaveOption().
+ * Without the check the values silently wrap, and a negative changes count
+ * makes serverCron() fire a background save on every single change. */
+static int parseSaveParamPair(sds seconds_str, sds changes_str, time_t *seconds_out, int *changes_out, const char **err) {
+    char *eptr;
+    long long seconds, changes;
+
+    errno = 0;
+    seconds = strtoll(seconds_str, &eptr, 10);
+    if (eptr == seconds_str || eptr[0] != '\0' || errno == ERANGE || seconds < 1 || seconds > INT_MAX) {
+        *err = "Invalid save parameters";
+        return 0;
+    }
+
+    errno = 0;
+    changes = strtoll(changes_str, &eptr, 10);
+    if (eptr == changes_str || eptr[0] != '\0' || errno == ERANGE || changes < 0 || changes > INT_MAX) {
+        *err = "Invalid save parameters";
+        return 0;
+    }
+
+    *seconds_out = seconds;
+    *changes_out = changes;
+    return 1;
+}
+
 static int setConfigSaveOption(standardConfig *config, sds *argv, int argc, const char **err) {
     UNUSED(config);
     int j;
+    time_t seconds;
+    int changes;
 
     /* Special case: treat single arg "" as zero args indicating empty save configuration */
     if (argc == 1 && !strcasecmp(argv[0], "")) {
@@ -2954,21 +2988,15 @@ static int setConfigSaveOption(standardConfig *config, sds *argv, int argc, cons
 
     /* Perform sanity check before setting the new config:
      * - Even number of args
-     * - Seconds >= 1, changes >= 0 */
+     * - Seconds >= 1, changes >= 0, and both fitting struct saveparam */
     if (argc & 1) {
         *err = "Invalid save parameters";
         return 0;
     }
-    for (j = 0; j < argc; j++) {
-        char *eptr;
-        long val;
-
-        val = strtoll(argv[j], &eptr, 10);
-        if (eptr[0] != '\0' || ((j & 1) == 0 && val < 1) || ((j & 1) == 1 && val < 0)) {
-            *err = "Invalid save parameters";
-            return 0;
-        }
+    for (j = 0; j < argc; j += 2) {
+        if (!parseSaveParamPair(argv[j], argv[j + 1], &seconds, &changes, err)) return 0;
     }
+
     /* Finally set the new config */
     if (!reading_config_file) {
         resetServerSaveParams();
@@ -2984,11 +3012,8 @@ static int setConfigSaveOption(standardConfig *config, sds *argv, int argc, cons
     }
 
     for (j = 0; j < argc; j += 2) {
-        time_t seconds;
-        int changes;
-
-        seconds = strtoll(argv[j], NULL, 10);
-        changes = strtoll(argv[j + 1], NULL, 10);
+        /* Already validated above, so this can't fail. */
+        serverAssert(parseSaveParamPair(argv[j], argv[j + 1], &seconds, &changes, err));
         appendServerSaveParams(seconds, changes);
     }
 

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1340,16 +1340,16 @@ start_server {tags {"introspection"}} {
 
         # Values that don't fit struct saveparam, both just above the limit and
         # way beyond what strtoll() can represent.
-        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "1 2147483648"}
-        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "2147483648 1"}
-        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "1 999999999999999999999999"}
-        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "999999999999999999999999 1"}
-        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "1 21474836499999999999999999999999"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters*} {r config set save "1 2147483648"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters*} {r config set save "2147483648 1"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters*} {r config set save "1 999999999999999999999999"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters*} {r config set save "999999999999999999999999 1"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters*} {r config set save "1 21474836499999999999999999999999"}
 
         # Non numeric, empty and out of range values, also when a valid pair comes first
-        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "900 foo"}
-        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "900 "}
-        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "900 1 1 2147483648"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters*} {r config set save "900 foo"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters*} {r config set save "900 "}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters*} {r config set save "900 1 1 2147483648"}
 
         # A rejected CONFIG SET must leave the previous save params untouched
         assert_equal $original [lindex [r config get save] 1]

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1335,6 +1335,60 @@ start_server {tags {"introspection"}} {
         }
     } {} {external:skip}
 
+    test {CONFIG SET save rejects out of range params} {
+        set original [lindex [r config get save] 1]
+
+        # Values that don't fit struct saveparam, both just above the limit and
+        # way beyond what strtoll() can represent.
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "1 2147483648"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "2147483648 1"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "1 999999999999999999999999"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "999999999999999999999999 1"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "1 21474836499999999999999999999999"}
+
+        # Non numeric, empty and out of range values, also when a valid pair comes first
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "900 foo"}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "900 "}
+        assert_error {ERR CONFIG SET failed*Invalid save parameters} {r config set save "900 1 1 2147483648"}
+
+        # A rejected CONFIG SET must leave the previous save params untouched
+        assert_equal $original [lindex [r config get save] 1]
+
+        # Valid values are still accepted, leading zeros and '+' included
+        r config set save "3600 1 300 100"
+        assert_equal {3600 1 300 100} [lindex [r config get save] 1]
+        r config set save "0300 +010"
+        assert_equal {300 10} [lindex [r config get save] 1]
+        r config set save "2147483647 2147483647"
+        assert_equal {2147483647 2147483647} [lindex [r config get save] 1]
+
+        # The same limits apply when the value comes from the command line
+        set pidfile [tmpfile invalid-save.pid]
+        set code [catch {
+            exec $::VALKEY_SERVER_BIN --port 0 --daemonize yes --pidfile $pidfile --save "1 2147483648"
+        } err]
+        if {$code == 0 && [file exists $pidfile]} {
+            catch {exec kill [string trim [read_file $pidfile]]}
+        }
+        file delete $pidfile
+        assert {$code != 0}
+        assert_match {*Invalid save parameters*} $err
+
+        # The same limits apply when loading a config file
+        set config [tmpfile invalid-save.conf]
+        set pidfile [tmpfile invalid-save.pid]
+        write_file $config "port 0\ndaemonize yes\npidfile $pidfile\nsave 1 2147483648"
+        set code [catch {exec $::VALKEY_SERVER_BIN $config} err]
+        if {$code == 0 && [file exists $pidfile]} {
+            catch {exec kill [string trim [read_file $pidfile]]}
+        }
+        file delete $config $pidfile
+        assert {$code != 0}
+        assert_match {*Invalid save parameters*} $err
+
+        r config set save $original
+    } {OK} {external:skip}
+
     test {CONFIG sanity} {
         # Do CONFIG GET, CONFIG SET and then CONFIG GET again
         # Skip immutable configs, one with no get, and other complicated configs


### PR DESCRIPTION
The save config was parsed twice: once for validation, with the value stored in a long, and once for the actual assignment, where seconds and changes are stored in the time_t and int fields of struct saveparam. Neither pass checked for overflow, so out of range values were silently truncated. "save 1 2147483648" turned into a changes count of -2147483648, making serverCron() start a background save on every single change, and values beyond long long were accepted as LLONG_MAX because strtoll() reports overflow through errno only.

Route both passes through a single parseSaveParamPair() helper so that they can no longer disagree, reject anything that does not fit struct saveparam, and keep the validation of all pairs ahead of resetServerSaveParams() so that a rejected value leaves the current save points untouched.