### PR TITLE
Renamed forkless-options-supported and updated ObjectTest

### DIFF
--- a/src/bgiteration.c
+++ b/src/bgiteration.c
@@ -1999,7 +1999,7 @@ static bgIterator *bgIteratorCreate(const char *name,
                                     void *privdata,
                                     bgIterationType iter_type,
                                     genericIterator *keyset_iter) {
-    serverAssert(server.forkless_options_supported);
+    serverAssert(server.forkless_infrastructure_enabled);
     serverAssert(hasMainThreadExclusivity());
     serverAssert(server.cluster_enabled || iter_type == BGITERATION_TYPE_FULLSCAN);
 

--- a/src/config.c
+++ b/src/config.c
@@ -3386,7 +3386,7 @@ standardConfig static_configs[] = {
     createBoolConfig("replica-ignore-maxmemory", "slave-ignore-maxmemory", MODIFIABLE_CONFIG, server.repl_replica_ignore_maxmemory, 1, NULL, NULL),
     createBoolConfig("jemalloc-bg-thread", NULL, MODIFIABLE_CONFIG, server.jemalloc_bg_thread, 1, NULL, updateJemallocBgThread),
     createBoolConfig("activedefrag", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.active_defrag_enabled, CONFIG_ACTIVE_DEFRAG_DEFAULT, isValidActiveDefrag, NULL),
-    createBoolConfig("forkless-options-supported", NULL, IMMUTABLE_CONFIG, server.forkless_options_supported, 0, NULL, NULL),
+    createBoolConfig("forkless-infrastructure-enabled", NULL, IMMUTABLE_CONFIG, server.forkless_infrastructure_enabled, 0, NULL, NULL),
     createBoolConfig("syslog-enabled", NULL, IMMUTABLE_CONFIG, server.syslog_enabled, 0, NULL, NULL),
     createBoolConfig("cluster-enabled", NULL, IMMUTABLE_CONFIG, server.cluster_enabled, 0, NULL, NULL),
     createBoolConfig("appendonly", NULL, MODIFIABLE_CONFIG | DENY_LOADING_CONFIG, server.aof_enabled, 0, NULL, updateAppendOnly),

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4209,8 +4209,8 @@ void bgsaveCommand(client *c) {
         } else if (!strcasecmp(arg, "fork")) {
             chosen_save_type = RDB_BGSAVE_TYPE_FORK;
         } else if (!strcasecmp(arg, "forkless")) {
-            if (!server.forkless_options_supported) {
-                addReplyError(c, "BGSAVE FORKLESS requires starting the server with forkless-options-supported enabled");
+            if (!server.forkless_infrastructure_enabled) {
+                addReplyError(c, "BGSAVE FORKLESS requires starting the server with forkless-infrastructure-enabled enabled");
                 return;
             }
             chosen_save_type = RDB_BGSAVE_TYPE_FORKLESS;
@@ -4222,7 +4222,7 @@ void bgsaveCommand(client *c) {
 
     /* If user didn't explicitly specify save type, let the system choose */
     if (chosen_save_type == RDB_BGSAVE_TYPE_NONE) {
-        chosen_save_type = (server.default_bgsave_method == RDB_BGSAVE_TYPE_FORKLESS && server.forkless_options_supported && moduleAllDatatypesHandleForklessSave())
+        chosen_save_type = (server.default_bgsave_method == RDB_BGSAVE_TYPE_FORKLESS && server.forkless_infrastructure_enabled && moduleAllDatatypesHandleForklessSave())
                                ? RDB_BGSAVE_TYPE_FORKLESS
                                : RDB_BGSAVE_TYPE_FORK;
     } else if (chosen_save_type == RDB_BGSAVE_TYPE_FORKLESS && !moduleAllDatatypesHandleForklessSave()) {

--- a/src/server.c
+++ b/src/server.c
@@ -1706,7 +1706,7 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
                  server.lastbgsave_status == C_OK)) {
                 serverLog(LL_NOTICE, "%d changes in %d seconds. Saving...", sp->changes, (int)sp->seconds);
                 int type = (server.default_bgsave_method == RDB_BGSAVE_TYPE_FORKLESS &&
-                            server.forkless_options_supported &&
+                            server.forkless_infrastructure_enabled &&
                             moduleAllDatatypesHandleForklessSave())
                                ? RDB_BGSAVE_TYPE_FORKLESS
                                : RDB_BGSAVE_TYPE_FORK;
@@ -2390,7 +2390,7 @@ void initServerConfig(void) {
     for (j = 0; j < CONFIG_DEFAULT_BINDADDR_COUNT; j++) server.bindaddr[j] = zstrdup(default_bindaddr[j]);
     memset(server.listeners, 0x00, sizeof(server.listeners));
     server.active_expire_enabled = 1;
-    server.forkless_options_supported = 0;
+    server.forkless_infrastructure_enabled = 0;
     server.lazy_expire_disabled = 0;
     server.skip_checksum_validation = 0;
     server.loading = 0;
@@ -3086,7 +3086,7 @@ void initServer(void) {
     server.db = zcalloc(sizeof(serverDb *) * server.dbnum);
 
     /* Set object metadata size before creating any database key objects */
-    if (server.forkless_options_supported) {
+    if (server.forkless_infrastructure_enabled) {
         /* NOTE: At this time, there is only one reason for dbEntry metadata: bgIteration.  However,
          * if/when new metadata options are added, we will need to compute the size of a variable
          * size metadata, and provide appropriate accessors to access the specific portion of the

--- a/src/server.h
+++ b/src/server.h
@@ -2094,7 +2094,7 @@ struct valkeyServer {
     int rdb_checksum;                     /* Use RDB checksum? */
     int rdb_del_sync_files;               /* Remove RDB files used only for SYNC if
                                              the instance does not use persistence. */
-    int forkless_options_supported;       /* Enable forkless options support. */
+    int forkless_infrastructure_enabled;  /* Enable forkless options support. */
     time_t lastsave;                      /* Unix time of last successful save */
     time_t lastbgsave_try;                /* Unix time of last attempted bgsave */
     time_t rdb_save_time_last;            /* Time used by last RDB save run. */

--- a/src/unit/test_bgiteration.cpp
+++ b/src/unit/test_bgiteration.cpp
@@ -281,7 +281,7 @@ class BgIterationTest : public ::testing::Test {
 
     void SetUp() override {
         server.main_thread_id = pthread_self();
-        server.forkless_options_supported = 1;
+        server.forkless_infrastructure_enabled = 1;
         objectSetMetadataSize(BGITERATION_ENTRY_METADATA_SIZE);
 
         bgIteration_unitTestDisableCloning();

--- a/src/unit/test_object.cpp
+++ b/src/unit/test_object.cpp
@@ -52,6 +52,7 @@ class ObjectTest : public ::testing::Test {
             decrRefCount(obj);
             if (!isEmbedded) break;
         }
+        EXPECT_LE(len, 256) << "no embedding limit found within the search range";
 
         sdsfree(k);
         return len - 1;

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -224,7 +224,7 @@ start_server_and_kill_it [list "dir" $server_path] {
     }
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     foreach bgsave_type {"" "fork" "forkless"} {
         test "Test FLUSHALL aborts bgsave $bgsave_type" {
             # 5000 keys with 1ms sleep per key should take 5 second
@@ -359,7 +359,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     }
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "forkless bgsave contains expired keys from when save started" {
         
         # Set two keys that expire together
@@ -398,7 +398,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "FLUSHDB during single-db forkless bgsave causes save to fail" {
         
         # Populate database with complex dataset
@@ -436,7 +436,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "FLUSHDB during multi-db forkless bgsave causes save to fail" {
         
         # Populate multiple databases
@@ -480,7 +480,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "multiple databases modifications during forkless bgsave" {
         
         # Populate 5 databases with all data types
@@ -571,7 +571,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "modify new keys during forkless bgsave" {
         
         # Populate database with all data types
@@ -655,7 +655,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "SWAPDB during forkless bgsave" {
         
         # Populate 5 databases with all data types
@@ -721,7 +721,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "delete all keys after SWAPDB during forkless bgsave" {
         
         # Populate 5 databases with all data types
@@ -781,7 +781,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "deleting keys during forkless bgsave" {
         
         # Populate database with all data types
@@ -826,7 +826,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "blocking commands during forkless bgsave" {
         
         # Create initial dataset with 100 keys
@@ -971,7 +971,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "TTL expiration during forkless bgsave" {
         
         # Create initial dataset with 100 keys
@@ -1047,7 +1047,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "evictions during forkless bgsave" {
         
         # Create initial dataset
@@ -1097,7 +1097,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "comprehensive modifications on all data types during forkless bgsave" {
         
         # Create initial dataset with 1000 keys
@@ -1159,7 +1159,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "store key deletion by georadius during forkless bgsave" {
         
         # Create initial dataset with geo data
@@ -1205,7 +1205,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test "transactions during forkless bgsave" {
         
         # Populate 5 databases
@@ -1330,7 +1330,7 @@ start_server {overrides {forkless-options-supported yes save ""}} {
     } {} {needs:debug}
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     foreach first_type {fork forkless} {
         foreach second_type {fork forkless} {
             test "$first_type bgsave blocks $second_type bgsave" {
@@ -1550,7 +1550,7 @@ start_server [list overrides [list "dir" $server_path "dbfilename" "scriptbackup
     }
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     foreach bgsave_type {"" "fork" "forkless"} {
         test "failed bgsave $bgsave_type prevents writes" {
             # Make sure the server saves an RDB on shutdown
@@ -1635,29 +1635,29 @@ start_server {} {
 }
 
 
-start_server {overrides {forkless-options-supported yes save ""}} {
-    test {default-bgsave-method can be set to forkless with forkless-options-supported} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
+    test {default-bgsave-method can be set to forkless with forkless-infrastructure-enabled} {
         r config set default-bgsave-method forkless
         assert_equal [lindex [r config get default-bgsave-method] 1] "forkless"
     }
 }
 
 start_server {} {
-    test {BGSAVE FORKLESS requires forkless-options-supported} {
+    test {BGSAVE FORKLESS requires forkless-infrastructure-enabled} {
         catch {r bgsave forkless} err
-        assert_match "*forkless-options-supported*" $err
+        assert_match "*forkless-infrastructure-enabled*" $err
     }
 }
 
-start_server {overrides {forkless-options-supported yes save ""}} {
-    test {BGSAVE FORKLESS works with forkless-options-supported} {
+start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
+    test {BGSAVE FORKLESS works with forkless-infrastructure-enabled} {
         r bgsave forkless
         waitForBgsave r
         assert_equal [s rdb_last_bgsave_type] "forkless"
     }
 }
 
-start_server {overrides {forkless-options-supported yes default-bgsave-method forkless}} {
+start_server {overrides {forkless-infrastructure-enabled yes default-bgsave-method forkless}} {
     test {BGSAVE uses forkless when default-bgsave-method is forkless} {
         r set key value
         set result [r bgsave]

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -571,7 +571,7 @@ start_server {tags {"info" "external:skip"}} {
     }
 }
 
-start_server {tags {"info" "external:skip"} overrides {save "" forkless-options-supported yes}} {
+start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastructure-enabled yes}} {
     test {INFO forkless save metrics show default values when no save is running} {
         r config set save ""
         r flushall

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1362,7 +1362,7 @@ start_server {tags {"introspection"}} {
             rdma-rx-size
             rdma-bind
             rdma-port
-            forkless-options-supported
+            forkless-infrastructure-enabled
         }
 
         if {!$::tls} {
@@ -2086,7 +2086,7 @@ test {CONFIG hash-seed is immutable and settable at startup} {
     }
 } {} {external:skip}
 
-start_server {overrides {forkless-options-supported yes} tags {"introspection" "external:skip"}} {
+start_server {overrides {forkless-infrastructure-enabled yes} tags {"introspection" "external:skip"}} {
     foreach bgsave_type {"" "fork" "forkless"} {
         test "CLIENT KILL close the client connection during bgsave - $bgsave_type" {
             r flushall

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -305,7 +305,7 @@ tags "modules" {
     }
 }
 
-start_server {tags {"modules"} overrides {forkless-options-supported yes save "" enable-debug-command yes enable-module-command yes}} {
+start_server {tags {"modules"} overrides {forkless-infrastructure-enabled yes save "" enable-debug-command yes enable-module-command yes}} {
     test {MODULE LOAD is blocked during forkless save} {
         r debug populate 100
 

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -753,7 +753,7 @@ if {$::verbose} {
 close $tempFileId
 file delete $tempFileName
 
-start_server {overrides {forkless-options-supported yes} tags {"other" "external:skip"}} {
+start_server {overrides {forkless-infrastructure-enabled yes} tags {"other" "external:skip"}} {
     foreach bgsave_type {"" "fork" "forkless"} {
         test "BGSAVE $bgsave_type" {
             r flushall

--- a/valkey.conf
+++ b/valkey.conf
@@ -566,7 +566,7 @@ locale-collate ""
 # behavior is controlled separately by 'default-bgsave-method forkless' or by
 # explicitly using 'BGSAVE FORKLESS'.
 #
-# forkless-options-supported no
+# forkless-infrastructure-enabled no
 
 ################################ SNAPSHOTTING  ################################
 
@@ -608,7 +608,7 @@ stop-writes-on-bgsave-error yes
 
 # Default method for background saves (BGSAVE and automatic periodic saves).
 #
-# Setting this to 'forkless' requires 'forkless-options-supported yes' to be
+# Setting this to 'forkless' requires 'forkless-infrastructure-enabled yes' to be
 # enabled at startup. If it is not enabled, the server will fall back to fork.
 #
 # Regardless of this setting, you can always override the method explicitly


### PR DESCRIPTION
Addressed metadata-related changes for #4460 

* Renamed `forkless-options-supported` to `forkless-infrastructure-enabled` as https://github.com/valkey-io/valkey/pull/4460#issuecomment-5397991264
* Added an explicit check in `findMaxEmbeddableValueLen` in test_object.cpp as https://github.com/valkey-io/valkey/pull/4460#discussion_r3805546811