### PR TITLE
In rdb tests, cancel bgsave before resetting the key-save delay

### DIFF
--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -622,8 +622,8 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         set target [getInfoProperty $dbg forkless_queue_length_target]
         assert {$target > 0}
         
-        r config set rdb-key-save-delay 0
         r bgsave cancel
+        r config set rdb-key-save-delay 0
         waitForBgsave r
     }
 
@@ -663,8 +663,8 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         # At least one should have increased
         assert {$queued2 > $queued1 || $processed2 > $processed1}
         
-        r config set rdb-key-save-delay 0
         r bgsave cancel
+        r config set rdb-key-save-delay 0
         waitForBgsave r
     }
 
@@ -695,8 +695,8 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         # Should be processing an item for ~1 second (1000+ ms)
         assert {$item_time > 1000}
         
-        r config set rdb-key-save-delay 0
         r bgsave cancel
+        r config set rdb-key-save-delay 0
         waitForBgsave r
     }
 
@@ -730,8 +730,8 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         # in the tens of seconds range. Use a wide band to avoid timing flakes.
         assert {$estimated > 0 && $estimated < 300}
         
-        r config set rdb-key-save-delay 0
         r bgsave cancel
+        r config set rdb-key-save-delay 0
         waitForBgsave r
     }
 
@@ -782,8 +782,8 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
             fail "rdb_current_bgsave_time_sec did not advance during forkless save"
         }
 
-        r config set rdb-key-save-delay 0
         r bgsave cancel
+        r config set rdb-key-save-delay 0
         waitForBgsave r
     }
 }

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -323,8 +323,8 @@ start_server {tags {"modules"} overrides {forkless-infrastructure-enabled yes sa
         catch {r module load $testmodule} err
         assert_match "*Error*" $err
 
-        r config set rdb-key-save-delay 0
         r bgsave cancel
+        r config set rdb-key-save-delay 0
         waitForBgsave r
 
         # After forkless save completes, module load should succeed


### PR DESCRIPTION
To address AI comment.

Six forkless cleanup blocks reset rdb-key-save-delay to 0 and then run BGSAVE CANCEL. Removing the per-key delay lets the running forkless save finish almost immediately, so the cancel can arrive after the save has already completed. BGSAVE CANCEL then returns "Background saving is currently not in progress or scheduled" and the test fails due to the tcl harness aborting.

Cancel first, while the save is still throttled and in progress, then reset the delay.