### PR TITLE
Remove save-type arguments from BGSAVE

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -7173,7 +7173,6 @@ struct COMMAND_STRUCT ACL_Subcommands[] = {
 commandHistory BGSAVE_History[] = {
 {"3.2.2","Added the `SCHEDULE` option."},
 {"8.1.0","Added the `CANCEL` option."},
-{"9.2.0","Added the `FORK` and `FORKLESS` options. `SCHEDULE` can be combined with `FORK` or `FORKLESS`."},
 };
 #endif
 
@@ -7187,21 +7186,9 @@ commandHistory BGSAVE_History[] = {
 #define BGSAVE_Keyspecs NULL
 #endif
 
-/* BGSAVE operation save save_type argument table */
-struct COMMAND_ARG BGSAVE_operation_save_save_type_Subargs[] = {
-{MAKE_ARG("fork",ARG_TYPE_PURE_TOKEN,-1,"FORK",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("forkless",ARG_TYPE_PURE_TOKEN,-1,"FORKLESS",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-};
-
-/* BGSAVE operation save argument table */
-struct COMMAND_ARG BGSAVE_operation_save_Subargs[] = {
-{MAKE_ARG("schedule",ARG_TYPE_PURE_TOKEN,-1,"SCHEDULE",NULL,"3.2.2",CMD_ARG_OPTIONAL,0,NULL)},
-{MAKE_ARG("save-type",ARG_TYPE_ONEOF,-1,NULL,NULL,"9.2.0",CMD_ARG_OPTIONAL,2,NULL),.subargs=BGSAVE_operation_save_save_type_Subargs},
-};
-
 /* BGSAVE operation argument table */
 struct COMMAND_ARG BGSAVE_operation_Subargs[] = {
-{MAKE_ARG("save",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=BGSAVE_operation_save_Subargs},
+{MAKE_ARG("schedule",ARG_TYPE_PURE_TOKEN,-1,"SCHEDULE",NULL,"3.2.2",CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("cancel",ARG_TYPE_PURE_TOKEN,-1,"CANCEL",NULL,"8.1.0",CMD_ARG_NONE,0,NULL)},
 };
 
@@ -12046,7 +12033,7 @@ struct COMMAND_STRUCT serverCommandTable[] = {
 /* server */
 {MAKE_CMD("acl","A container for Access List Control commands.","Depends on subcommand.","6.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,ACL_History,0,ACL_Tips,0,NULL,-2,CMD_SENTINEL,ACL_CATEGORY_SLOW,NULL,ACL_Keyspecs,0,NULL,0),.subcommands=ACL_Subcommands},
 {MAKE_CMD("bgrewriteaof","Asynchronously rewrites the append-only file to disk.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,BGREWRITEAOF_History,0,BGREWRITEAOF_Tips,0,bgrewriteaofCommand,1,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,BGREWRITEAOF_Keyspecs,0,NULL,0)},
-{MAKE_CMD("bgsave","Asynchronously saves the database(s) to disk.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,BGSAVE_History,3,BGSAVE_Tips,0,bgsaveCommand,-1,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,BGSAVE_Keyspecs,0,NULL,1),.args=BGSAVE_Args},
+{MAKE_CMD("bgsave","Asynchronously saves the database(s) to disk.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,BGSAVE_History,2,BGSAVE_Tips,0,bgsaveCommand,-1,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,BGSAVE_Keyspecs,0,NULL,1),.args=BGSAVE_Args},
 {MAKE_CMD("command","Returns detailed information about all commands.","O(N) where N is the total number of commands","2.8.13",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,COMMAND_History,0,COMMAND_Tips,1,commandCommand,-1,CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION|ACL_CATEGORY_SLOW,NULL,COMMAND_Keyspecs,0,NULL,0),.subcommands=COMMAND_Subcommands},
 {MAKE_CMD("commandlog","A container for command log commands.","Depends on subcommand.","8.1.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,COMMANDLOG_History,0,COMMANDLOG_Tips,0,NULL,-2,0,ACL_CATEGORY_SLOW,NULL,COMMANDLOG_Keyspecs,0,NULL,0),.subcommands=COMMANDLOG_Subcommands},
 {MAKE_CMD("config","A container for server configuration commands.","Depends on subcommand.","2.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,CONFIG_History,0,CONFIG_Tips,0,NULL,-2,0,ACL_CATEGORY_SLOW,NULL,CONFIG_Keyspecs,0,NULL,0),.subcommands=CONFIG_Subcommands},

--- a/src/commands/bgsave.json
+++ b/src/commands/bgsave.json
@@ -14,10 +14,6 @@
             [
                 "8.1.0",
                 "Added the `CANCEL` option."
-            ],
-            [
-                "9.2.0",
-                "Added the `FORK` and `FORKLESS` options. `SCHEDULE` can be combined with `FORK` or `FORKLESS`."
             ]
         ],
         "command_flags": [
@@ -32,35 +28,10 @@
                 "optional": true,
                 "arguments": [
                     {
-                        "name": "save",
-                        "type": "block",
-                        "arguments": [
-                            {
-                                "name": "schedule",
-                                "token": "SCHEDULE",
-                                "type": "pure-token",
-                                "optional": true,
-                                "since": "3.2.2"
-                            },
-                            {
-                                "name": "save-type",
-                                "type": "oneof",
-                                "optional": true,
-                                "since": "9.2.0",
-                                "arguments": [
-                                    {
-                                        "name": "fork",
-                                        "token": "FORK",
-                                        "type": "pure-token"
-                                    },
-                                    {
-                                        "name": "forkless",
-                                        "token": "FORKLESS",
-                                        "type": "pure-token"
-                                    }
-                                ]
-                            }
-                        ]
+                        "name": "schedule",
+                        "token": "SCHEDULE",
+                        "type": "pure-token",
+                        "since": "3.2.2"
                     },
                     {
                         "name": "cancel",

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1731,6 +1731,26 @@ int isSaveInProgress(void) {
     return isForkBgsaveInProgress() || isForklessSaveInProgress();
 }
 
+/* Choose the background save method based on configuration. Returns forkless
+ * only when it is configured, the infrastructure is enabled, and every loaded
+ * module can handle a forkless save. Otherwise fall back to a fork-based save
+ * and log why, so the fallback is not silent. */
+int resolveBgsaveType(void) {
+    if (server.default_bgsave_method != RDB_BGSAVE_TYPE_FORKLESS) return RDB_BGSAVE_TYPE_FORK;
+
+    if (!server.forkless_infrastructure_enabled) {
+        serverLog(LL_WARNING, "Falling back to fork-based save: forkless is configured but "
+                              "forkless-infrastructure-enabled is off");
+        return RDB_BGSAVE_TYPE_FORK;
+    }
+    if (!moduleAllModulesHandleForkless()) {
+        serverLog(LL_WARNING, "Falling back to fork-based save: forkless is configured but a loaded "
+                              "module has not declared VALKEYMODULE_OPTIONS_HANDLE_FORKLESS");
+        return RDB_BGSAVE_TYPE_FORK;
+    }
+    return RDB_BGSAVE_TYPE_FORKLESS;
+}
+
 /* Start a background save, choosing fork or forkless based on bgsave_type. */
 int rdbStartBgsave(int bgsave_type) {
     if (bgsave_type == RDB_BGSAVE_TYPE_FORKLESS) {
@@ -4166,19 +4186,15 @@ void saveCommand(client *c) {
     }
 }
 
-/* BGSAVE [SCHEDULE [FORK|FORKLESS]] | BGSAVE [FORK|FORKLESS] | BGSAVE CANCEL */
+/* BGSAVE [SCHEDULE] | BGSAVE CANCEL */
 void bgsaveCommand(client *c) {
     int schedule = 0;
-    int chosen_save_type = RDB_BGSAVE_TYPE_NONE;
 
     /* BGSAVE can be invoked with the following options:
      * - CANCEL: terminates an in-progress or scheduled BGSAVE
      * - SCHEDULE: schedules a BGSAVE when an AOF rewrite is in progress.
      *             Instead of returning an error, the BGSAVE is scheduled to run
-     *             when the AOF rewrite completes.
-     * - FORK: uses fork-based save (default)
-     * - FORKLESS: uses forkless save
-     * SCHEDULE can be combined with FORK or FORKLESS to specify the save method. */
+     *             when the AOF rewrite completes. */
     for (int i = 1; i < c->argc; i++) {
         char *arg = objectGetVal(c->argv[i]);
         if (!strcasecmp(arg, "schedule")) {
@@ -4207,30 +4223,13 @@ void bgsaveCommand(client *c) {
                 addReplyError(c, "Background saving is currently not in progress or scheduled");
             }
             return;
-        } else if (!strcasecmp(arg, "fork")) {
-            chosen_save_type = RDB_BGSAVE_TYPE_FORK;
-        } else if (!strcasecmp(arg, "forkless")) {
-            if (!server.forkless_infrastructure_enabled) {
-                addReplyError(c, "BGSAVE FORKLESS requires starting the server with forkless-infrastructure-enabled enabled");
-                return;
-            }
-            chosen_save_type = RDB_BGSAVE_TYPE_FORKLESS;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);
             return;
         }
     }
 
-    /* If user didn't explicitly specify save type, let the system choose */
-    if (chosen_save_type == RDB_BGSAVE_TYPE_NONE) {
-        chosen_save_type = (server.default_bgsave_method == RDB_BGSAVE_TYPE_FORKLESS && server.forkless_infrastructure_enabled && moduleAllModulesHandleForkless())
-                               ? RDB_BGSAVE_TYPE_FORKLESS
-                               : RDB_BGSAVE_TYPE_FORK;
-    } else if (chosen_save_type == RDB_BGSAVE_TYPE_FORKLESS && !moduleAllModulesHandleForkless()) {
-        addReplyError(c, "Can't use forkless save: one or more loaded modules have not declared "
-                         "VALKEYMODULE_OPTIONS_HANDLE_FORKLESS");
-        return;
-    }
+    int chosen_save_type = resolveBgsaveType();
 
     rdbSaveInfo rsi, *rsiptr;
     rsiptr = rdbPopulateSaveInfo(&rsi);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -203,6 +203,7 @@ int rdbLoadObjectType(rio *rdb);
 int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags);
 int rdbSaveBackground(int req, char *filename, rdbSaveInfo *rsi, int rdbflags);
 int rdbStartBgsave(int bgsave_type);
+int resolveBgsaveType(void);
 int rdbSaveToReplicasSockets(int req, int rdbver, rdbSaveInfo *rsi);
 void rdbRemoveTempFile(pid_t childpid, int from_signal);
 int rdbSaveToFile(const char *filename);

--- a/src/server.c
+++ b/src/server.c
@@ -1705,12 +1705,7 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
                 (server.unixtime - server.lastbgsave_try > CONFIG_BGSAVE_RETRY_DELAY ||
                  server.lastbgsave_status == C_OK)) {
                 serverLog(LL_NOTICE, "%d changes in %d seconds. Saving...", sp->changes, (int)sp->seconds);
-                int type = (server.default_bgsave_method == RDB_BGSAVE_TYPE_FORKLESS &&
-                            server.forkless_infrastructure_enabled &&
-                            moduleAllModulesHandleForkless())
-                               ? RDB_BGSAVE_TYPE_FORKLESS
-                               : RDB_BGSAVE_TYPE_FORK;
-                rdbStartBgsave(type);
+                rdbStartBgsave(resolveBgsaveType());
                 break;
             }
         }

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -225,13 +225,14 @@ start_server_and_kill_it [list "dir" $server_path] {
 }
 
 start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
-    foreach bgsave_type {"" "fork" "forkless"} {
+    foreach bgsave_type {"fork" "forkless"} {
         test "Test FLUSHALL aborts bgsave $bgsave_type" {
             # 5000 keys with 1ms sleep per key should take 5 second
             r config set rdb-key-save-delay 1000
             populate 5000
             assert_lessthan 999 [s rdb_changes_since_last_save]
-            r bgsave {*}$bgsave_type
+            r config set default-bgsave-method $bgsave_type
+            r bgsave
             assert_equal [s rdb_bgsave_in_progress] 1
             
             # Verify we're testing the right save type while it's running
@@ -252,10 +253,11 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         }
     }
 
-    foreach bgsave_type {"" "fork" "forkless"} {
+    foreach bgsave_type {"fork" "forkless"} {
         test "bgsave $bgsave_type resets the change counter" {
             r config set rdb-key-save-delay 0
-            r bgsave {*}$bgsave_type
+            r config set default-bgsave-method $bgsave_type
+            r bgsave
             wait_for_condition 50 100 {
                 [s rdb_bgsave_in_progress] == 0
             } else {
@@ -273,7 +275,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         test "bgsave $bgsave_type metrics are correct after success" {
             set saves_before [s rdb_saves]
             populate 100 "" 16
-            r bgsave $bgsave_type
+            r config set default-bgsave-method $bgsave_type
+            r bgsave
             waitForBgsave r
             assert {[s rdb_saves] == $saves_before + 1}
             assert {[s rdb_last_bgsave_time_sec] >= 0 && [s rdb_last_bgsave_time_sec] < 3600}
@@ -291,7 +294,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
             set saves_before [s rdb_saves]
             populate 1000 "" 16
             r config set rdb-key-save-delay 10000000
-            r bgsave $bgsave_type
+            r config set default-bgsave-method $bgsave_type
+            r bgsave
             wait_for_condition 50 100 {
                 [s rdb_bgsave_in_progress] == 1
             } else {
@@ -315,13 +319,14 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         }
     }
 
-    foreach bgsave_type {"" "fork" "forkless"} {
+    foreach bgsave_type {"fork" "forkless"} {
         test "bgsave cancel aborts $bgsave_type save" {
             # Generating RDB will take some 100 seconds
             r config set rdb-key-save-delay 1000000
             populate 100 "" 16
 
-            r bgsave {*}$bgsave_type
+            r config set default-bgsave-method $bgsave_type
+            r bgsave
             wait_for_condition 50 100 {
                 [s rdb_bgsave_in_progress] == 1
             } else {
@@ -371,7 +376,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start slow forkless save
         r config set rdb-key-save-delay 10000000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
         } else {
@@ -410,7 +416,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start forkless save with very slow save (high delay per key)
         r config set rdb-key-save-delay 10000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
         } else {
@@ -451,7 +458,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start slow forkless save
         r config set rdb-key-save-delay 10000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
         } else {
@@ -492,7 +500,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start slow forkless save
         r config set rdb-key-save-delay 10000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
         } else {
@@ -580,7 +589,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start forkless save with very slow save (high delay per key)
         r config set rdb-key-save-delay 10000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
         } else {
@@ -667,7 +677,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start slow forkless save
         r config set rdb-key-save-delay 10000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
         } else {
@@ -733,7 +744,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start slow forkless save
         r config set rdb-key-save-delay 10000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
         } else {
@@ -789,7 +801,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start forkless save with very slow save (high delay per key)
         r config set rdb-key-save-delay 10000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
         } else {
@@ -860,7 +873,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start save with slow speed
         r config set rdb-key-save-delay 100000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -988,7 +1002,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         }
         
         # Start save and wait for completion
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         waitForBgsave r
         
         # Reload from RDB
@@ -1055,7 +1070,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start save with stopped speed
         r config set rdb-key-save-delay 10000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -1105,7 +1121,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start save with slow speed to keep it running during modifications
         r config set rdb-key-save-delay 1000000
-        r bgsave forkless        
+        r config set default-bgsave-method forkless
+        r bgsave        
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
         } else {
@@ -1171,7 +1188,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start save with stopped speed
         r config set rdb-key-save-delay 10000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -1234,7 +1252,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start save with slow speed
         r config set rdb-key-save-delay 10000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -1337,7 +1356,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
                 r config set rdb-key-save-delay 1000000
                 populate 100 "" 16
 
-                r bgsave $first_type
+                r config set default-bgsave-method $first_type
+                r bgsave
                 wait_for_condition 50 100 {
                     [s rdb_bgsave_in_progress] == 1
                 } else {
@@ -1345,7 +1365,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
                 }
                 assert_equal [s rdb_current_bgsave_type] $first_type
 
-                assert_error "ERR Background save already in progress" {r bgsave $second_type}
+                r config set default-bgsave-method $second_type
+                assert_error "ERR Background save already in progress" {r bgsave}
                 
                 r bgsave cancel
                 waitForBgsave r
@@ -1551,7 +1572,7 @@ start_server [list overrides [list "dir" $server_path "dbfilename" "scriptbackup
 }
 
 start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
-    foreach bgsave_type {"" "fork" "forkless"} {
+    foreach bgsave_type {"fork" "forkless"} {
         test "failed bgsave $bgsave_type prevents writes" {
             # Make sure the server saves an RDB on shutdown
             r config set save "900 1"
@@ -1559,7 +1580,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
             r config set rdb-key-save-delay 10000000
             populate 1000
             r set x x
-            r bgsave {*}$bgsave_type
+            r config set default-bgsave-method $bgsave_type
+            r bgsave
             
             if {$bgsave_type ne "forkless"} {
                 set pid1 [get_child_pid 0]
@@ -1597,7 +1619,8 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
             ]
 
             r config set rdb-key-save-delay 0
-            r bgsave {*}$bgsave_type
+            r config set default-bgsave-method $bgsave_type
+            r bgsave
             waitForBgsave r
 
             # server is writable again
@@ -1639,21 +1662,6 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     test {default-bgsave-method can be set to forkless with forkless-infrastructure-enabled} {
         r config set default-bgsave-method forkless
         assert_equal [lindex [r config get default-bgsave-method] 1] "forkless"
-    }
-}
-
-start_server {} {
-    test {BGSAVE FORKLESS requires forkless-infrastructure-enabled} {
-        catch {r bgsave forkless} err
-        assert_match "*forkless-infrastructure-enabled*" $err
-    }
-}
-
-start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
-    test {BGSAVE FORKLESS works with forkless-infrastructure-enabled} {
-        r bgsave forkless
-        waitForBgsave r
-        assert_equal [s rdb_last_bgsave_type] "forkless"
     }
 }
 

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -597,7 +597,8 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         # Start slow forkless save
         r config set rdb-key-save-delay 100000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -634,7 +635,8 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         # Start slow forkless save
         r config set rdb-key-save-delay 50000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -675,7 +677,8 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         # Start very slow forkless save - 2 seconds per key
         r config set rdb-key-save-delay 2000000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -708,7 +711,8 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         # Set 1 second delay per key
         r config set rdb-key-save-delay 1000000
         waitForBgsave r
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -742,7 +746,8 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         # Start and complete a fast forkless save
         r config set rdb-key-save-delay 0
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         waitForBgsave r
         
         set info [r info persistence]
@@ -766,7 +771,8 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         # Start slow forkless save
         r config set rdb-key-save-delay 100000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
         
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -2087,12 +2087,13 @@ test {CONFIG hash-seed is immutable and settable at startup} {
 } {} {external:skip}
 
 start_server {overrides {forkless-infrastructure-enabled yes} tags {"introspection" "external:skip"}} {
-    foreach bgsave_type {"" "fork" "forkless"} {
+    foreach bgsave_type {"fork" "forkless"} {
         test "CLIENT KILL close the client connection during bgsave - $bgsave_type" {
             r flushall
             r set k v
             r config set rdb-key-save-delay 10000000
-            r bgsave {*}$bgsave_type
+            r config set default-bgsave-method $bgsave_type
+            r bgsave
             wait_for_condition 1000 10 {
                 [s rdb_bgsave_in_progress] eq 1
             } else {

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -311,7 +311,8 @@ start_server {tags {"modules"} overrides {forkless-infrastructure-enabled yes sa
 
         # Start slow forkless save
         r config set rdb-key-save-delay 200000
-        r bgsave forkless
+        r config set default-bgsave-method forkless
+        r bgsave
 
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -754,12 +754,13 @@ close $tempFileId
 file delete $tempFileName
 
 start_server {overrides {forkless-infrastructure-enabled yes} tags {"other" "external:skip"}} {
-    foreach bgsave_type {"" "fork" "forkless"} {
+    foreach bgsave_type {"fork" "forkless"} {
         test "BGSAVE $bgsave_type" {
             r flushall
             r save
             r set x 10
-            r bgsave {*}$bgsave_type
+            r config set default-bgsave-method $bgsave_type
+            r bgsave
             waitForBgsave r
 
             set expected_type [expr {$bgsave_type eq "forkless" ? "forkless" : "fork"}]
@@ -773,7 +774,8 @@ start_server {overrides {forkless-infrastructure-enabled yes} tags {"other" "ext
             r flushdb
             r set x 10
             r expire x 1000
-            r bgsave {*}$bgsave_type
+            r config set default-bgsave-method $bgsave_type
+            r bgsave
             waitForBgsave r
             r debug reload
             set ttl [r ttl x]

--- a/valkey.conf
+++ b/valkey.conf
@@ -563,8 +563,7 @@ locale-collate ""
 # When enabled, the server allocates 4 additional bytes per key.
 #
 # Note: This only enables the infrastructure support. The actual forkless save
-# behavior is controlled separately by 'default-bgsave-method forkless' or by
-# explicitly using 'BGSAVE FORKLESS'.
+# behavior is controlled separately by 'default-bgsave-method forkless'.
 #
 # forkless-infrastructure-enabled no
 
@@ -610,9 +609,6 @@ stop-writes-on-bgsave-error yes
 #
 # Setting this to 'forkless' requires 'forkless-infrastructure-enabled yes' to be
 # enabled at startup. If it is not enabled, the server will fall back to fork.
-#
-# Regardless of this setting, you can always override the method explicitly
-# with 'BGSAVE FORKLESS' or 'BGSAVE FORK'.
 #
 # default-bgsave-method fork
 


### PR DESCRIPTION
Per TSC decision, the `BGSAVE` command no longer takes `FORK` or `FORKLESS` arguments. The save method is chosen by the `default-bgsave-method` config instead. 
