### PR TITLE
Rename default-bgsave-method to bgsave-default-method

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3361,7 +3361,7 @@ standardConfig static_configs[] = {
     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
     createBoolConfig("activerehashing", NULL, MODIFIABLE_CONFIG, server.activerehashing, 1, NULL, NULL),
     createBoolConfig("stop-writes-on-bgsave-error", NULL, MODIFIABLE_CONFIG, server.stop_writes_on_bgsave_err, 1, NULL, NULL),
-    createEnumConfig("default-bgsave-method", NULL, MODIFIABLE_CONFIG, bgsave_method_enum, server.default_bgsave_method, RDB_BGSAVE_TYPE_FORK, NULL, NULL),
+    createEnumConfig("bgsave-default-method", NULL, MODIFIABLE_CONFIG, bgsave_method_enum, server.bgsave_default_method, RDB_BGSAVE_TYPE_FORK, NULL, NULL),
     createBoolConfig("set-proc-title", NULL, IMMUTABLE_CONFIG, server.set_proc_title, 1, NULL, NULL), /* Should setproctitle be used? */
     createBoolConfig("lazyfree-lazy-eviction", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_eviction, 1, NULL, NULL),
     createBoolConfig("lazyfree-lazy-expire", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_expire, 1, NULL, NULL),

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1736,7 +1736,7 @@ int isSaveInProgress(void) {
  * module can handle a forkless save. Otherwise fall back to a fork-based save
  * and log why, so the fallback is not silent. */
 int resolveBgsaveType(void) {
-    if (server.default_bgsave_method != RDB_BGSAVE_TYPE_FORKLESS) return RDB_BGSAVE_TYPE_FORK;
+    if (server.bgsave_default_method != RDB_BGSAVE_TYPE_FORKLESS) return RDB_BGSAVE_TYPE_FORK;
 
     if (!server.forkless_infrastructure_enabled) {
         serverLog(LL_WARNING, "Falling back to fork-based save: forkless is configured but "

--- a/src/server.h
+++ b/src/server.h
@@ -2116,7 +2116,7 @@ struct valkeyServer {
     int rdb_key_save_delay;               /* Delay in microseconds between keys while
                                            * writing aof or rdb. (for testings). negative
                                            * value means fractions of microseconds (on average). */
-    int default_bgsave_method;            /* Default bgsave method: RDB_BGSAVE_TYPE_FORK or RDB_BGSAVE_TYPE_FORKLESS */
+    int bgsave_default_method;            /* Default bgsave method: RDB_BGSAVE_TYPE_FORK or RDB_BGSAVE_TYPE_FORKLESS */
     int key_load_delay;                   /* Delay in microseconds between keys while
                                            * loading aof or rdb. (for testings). negative
                                            * value means fractions of microseconds (on average). */

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -231,7 +231,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
             r config set rdb-key-save-delay 1000
             populate 5000
             assert_lessthan 999 [s rdb_changes_since_last_save]
-            r config set default-bgsave-method $bgsave_type
+            r config set bgsave-default-method $bgsave_type
             r bgsave
             assert_equal [s rdb_bgsave_in_progress] 1
             
@@ -256,7 +256,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
     foreach bgsave_type {"fork" "forkless"} {
         test "bgsave $bgsave_type resets the change counter" {
             r config set rdb-key-save-delay 0
-            r config set default-bgsave-method $bgsave_type
+            r config set bgsave-default-method $bgsave_type
             r bgsave
             wait_for_condition 50 100 {
                 [s rdb_bgsave_in_progress] == 0
@@ -275,7 +275,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         test "bgsave $bgsave_type metrics are correct after success" {
             set saves_before [s rdb_saves]
             populate 100 "" 16
-            r config set default-bgsave-method $bgsave_type
+            r config set bgsave-default-method $bgsave_type
             r bgsave
             waitForBgsave r
             assert {[s rdb_saves] == $saves_before + 1}
@@ -294,7 +294,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
             set saves_before [s rdb_saves]
             populate 1000 "" 16
             r config set rdb-key-save-delay 10000000
-            r config set default-bgsave-method $bgsave_type
+            r config set bgsave-default-method $bgsave_type
             r bgsave
             wait_for_condition 50 100 {
                 [s rdb_bgsave_in_progress] == 1
@@ -325,7 +325,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
             r config set rdb-key-save-delay 1000000
             populate 100 "" 16
 
-            r config set default-bgsave-method $bgsave_type
+            r config set bgsave-default-method $bgsave_type
             r bgsave
             wait_for_condition 50 100 {
                 [s rdb_bgsave_in_progress] == 1
@@ -376,7 +376,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start slow forkless save
         r config set rdb-key-save-delay 10000000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -416,7 +416,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start forkless save with very slow save (high delay per key)
         r config set rdb-key-save-delay 10000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -458,7 +458,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start slow forkless save
         r config set rdb-key-save-delay 10000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -500,7 +500,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start slow forkless save
         r config set rdb-key-save-delay 10000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -589,7 +589,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start forkless save with very slow save (high delay per key)
         r config set rdb-key-save-delay 10000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -677,7 +677,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start slow forkless save
         r config set rdb-key-save-delay 10000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -744,7 +744,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start slow forkless save
         r config set rdb-key-save-delay 10000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -801,7 +801,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start forkless save with very slow save (high delay per key)
         r config set rdb-key-save-delay 10000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -873,7 +873,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start save with slow speed
         r config set rdb-key-save-delay 100000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         
         wait_for_condition 50 100 {
@@ -1002,7 +1002,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         }
         
         # Start save and wait for completion
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         waitForBgsave r
         
@@ -1070,7 +1070,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start save with stopped speed
         r config set rdb-key-save-delay 10000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         
         wait_for_condition 50 100 {
@@ -1121,7 +1121,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start save with slow speed to keep it running during modifications
         r config set rdb-key-save-delay 1000000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave        
         wait_for_condition 50 100 {
             [s rdb_bgsave_in_progress] == 1
@@ -1188,7 +1188,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start save with stopped speed
         r config set rdb-key-save-delay 10000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         
         wait_for_condition 50 100 {
@@ -1252,7 +1252,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         
         # Start save with slow speed
         r config set rdb-key-save-delay 10000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         
         wait_for_condition 50 100 {
@@ -1356,7 +1356,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
                 r config set rdb-key-save-delay 1000000
                 populate 100 "" 16
 
-                r config set default-bgsave-method $first_type
+                r config set bgsave-default-method $first_type
                 r bgsave
                 wait_for_condition 50 100 {
                     [s rdb_bgsave_in_progress] == 1
@@ -1365,7 +1365,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
                 }
                 assert_equal [s rdb_current_bgsave_type] $first_type
 
-                r config set default-bgsave-method $second_type
+                r config set bgsave-default-method $second_type
                 assert_error "ERR Background save already in progress" {r bgsave}
                 
                 r bgsave cancel
@@ -1580,7 +1580,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
             r config set rdb-key-save-delay 10000000
             populate 1000
             r set x x
-            r config set default-bgsave-method $bgsave_type
+            r config set bgsave-default-method $bgsave_type
             r bgsave
             
             if {$bgsave_type ne "forkless"} {
@@ -1619,7 +1619,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
             ]
 
             r config set rdb-key-save-delay 0
-            r config set default-bgsave-method $bgsave_type
+            r config set bgsave-default-method $bgsave_type
             r bgsave
             waitForBgsave r
 
@@ -1659,14 +1659,14 @@ start_server {} {
 
 
 start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
-    test {default-bgsave-method can be set to forkless with forkless-infrastructure-enabled} {
-        r config set default-bgsave-method forkless
-        assert_equal [lindex [r config get default-bgsave-method] 1] "forkless"
+    test {bgsave-default-method can be set to forkless with forkless-infrastructure-enabled} {
+        r config set bgsave-default-method forkless
+        assert_equal [lindex [r config get bgsave-default-method] 1] "forkless"
     }
 }
 
-start_server {overrides {forkless-infrastructure-enabled yes default-bgsave-method forkless}} {
-    test {BGSAVE uses forkless when default-bgsave-method is forkless} {
+start_server {overrides {forkless-infrastructure-enabled yes bgsave-default-method forkless}} {
+    test {BGSAVE uses forkless when bgsave-default-method is forkless} {
         r set key value
         set result [r bgsave]
         assert_match "*Background saving started*" $result
@@ -1675,8 +1675,8 @@ start_server {overrides {forkless-infrastructure-enabled yes default-bgsave-meth
     }
 }
 
-start_server {overrides {default-bgsave-method fork}} {
-    test {BGSAVE uses fork when default-bgsave-method is fork} {
+start_server {overrides {bgsave-default-method fork}} {
+    test {BGSAVE uses fork when bgsave-default-method is fork} {
         r set key value
         set result [r bgsave]
         assert_match "*Background saving started*" $result

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -597,7 +597,7 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         # Start slow forkless save
         r config set rdb-key-save-delay 100000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         
         wait_for_condition 50 100 {
@@ -635,7 +635,7 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         # Start slow forkless save
         r config set rdb-key-save-delay 50000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         
         wait_for_condition 50 100 {
@@ -677,7 +677,7 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         # Start very slow forkless save - 2 seconds per key
         r config set rdb-key-save-delay 2000000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         
         wait_for_condition 50 100 {
@@ -711,7 +711,7 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         # Set 1 second delay per key
         r config set rdb-key-save-delay 1000000
         waitForBgsave r
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         
         wait_for_condition 50 100 {
@@ -746,7 +746,7 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         # Start and complete a fast forkless save
         r config set rdb-key-save-delay 0
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         waitForBgsave r
         
@@ -771,7 +771,7 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         # Start slow forkless save
         r config set rdb-key-save-delay 100000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
         
         wait_for_condition 50 100 {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -2092,7 +2092,7 @@ start_server {overrides {forkless-infrastructure-enabled yes} tags {"introspecti
             r flushall
             r set k v
             r config set rdb-key-save-delay 10000000
-            r config set default-bgsave-method $bgsave_type
+            r config set bgsave-default-method $bgsave_type
             r bgsave
             wait_for_condition 1000 10 {
                 [s rdb_bgsave_in_progress] eq 1

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -311,7 +311,7 @@ start_server {tags {"modules"} overrides {forkless-infrastructure-enabled yes sa
 
         # Start slow forkless save
         r config set rdb-key-save-delay 200000
-        r config set default-bgsave-method forkless
+        r config set bgsave-default-method forkless
         r bgsave
 
         wait_for_condition 50 100 {

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -759,7 +759,7 @@ start_server {overrides {forkless-infrastructure-enabled yes} tags {"other" "ext
             r flushall
             r save
             r set x 10
-            r config set default-bgsave-method $bgsave_type
+            r config set bgsave-default-method $bgsave_type
             r bgsave
             waitForBgsave r
 
@@ -774,7 +774,7 @@ start_server {overrides {forkless-infrastructure-enabled yes} tags {"other" "ext
             r flushdb
             r set x 10
             r expire x 1000
-            r config set default-bgsave-method $bgsave_type
+            r config set bgsave-default-method $bgsave_type
             r bgsave
             waitForBgsave r
             r debug reload

--- a/valkey.conf
+++ b/valkey.conf
@@ -563,7 +563,7 @@ locale-collate ""
 # When enabled, the server allocates 4 additional bytes per key.
 #
 # Note: This only enables the infrastructure support. The actual forkless save
-# behavior is controlled separately by 'default-bgsave-method forkless'.
+# behavior is controlled separately by 'bgsave-default-method forkless'.
 #
 # forkless-infrastructure-enabled no
 
@@ -610,7 +610,7 @@ stop-writes-on-bgsave-error yes
 # Setting this to 'forkless' requires 'forkless-infrastructure-enabled yes' to be
 # enabled at startup. If it is not enabled, the server will fall back to fork.
 #
-# default-bgsave-method fork
+# bgsave-default-method fork
 
 # Control compression when dumping .rdb databases.
 # Supported values:


### PR DESCRIPTION
Per the TSC decision, rename the config so it is grouped under the "bgsave-" prefix