### PR TITLE
Move forkless save time metrics to the debug section

### DIFF
--- a/src/forkless.c
+++ b/src/forkless.c
@@ -375,14 +375,12 @@ int isForklessSaveInProgress(void) {
 /* Appends forkless save INFO metrics to the provided sds string. */
 sds forkless_catInfo(sds info) {
     long long estimated_seconds_remaining = -1;
-    long long current_item_ms = -1;
 
     if (onValkeyMainThread()) {
         bgIterator *iter = bgIteratorFind(FORKLESS_SAVE_FILE_ITER_NAME);
         if (iter != NULL) {
             bgIteratorStatus status = {0};
             bgIteratorGetStatus(iter, &status);
-            current_item_ms = status.current_item_ms;
 
             if (status.dbentries_processed > 0) {
                 long long total_keys =
@@ -396,27 +394,29 @@ sds forkless_catInfo(sds info) {
         }
     }
 
-    return sdscatprintf(info,
-                        "forkless_current_item_ms:%lld\r\n"
-                        "forkless_estimated_seconds_remaining:%lld\r\n",
-                        current_item_ms,
-                        estimated_seconds_remaining);
+    return sdscatprintf(info, "forkless_estimated_seconds_remaining:%lld\r\n", estimated_seconds_remaining);
 }
 
 /* Appends forkless debug metrics to the provided sds string. */
 sds forkless_catDebugInfo(sds info) {
     bgIteratorStatus status = {0};
+    long long current_item_ms = -1;
 
     if (onValkeyMainThread()) {
         bgIterator *iter = bgIteratorFind(FORKLESS_SAVE_FILE_ITER_NAME);
-        if (iter != NULL) bgIteratorGetStatus(iter, &status);
+        if (iter != NULL) {
+            bgIteratorGetStatus(iter, &status);
+            current_item_ms = status.current_item_ms;
+        }
     }
 
     return sdscatprintf(info,
+                        "forkless_current_item_ms:%lld\r\n"
                         "forkless_current_queue_length:%lu\r\n"
                         "forkless_queue_length_target:%lu\r\n"
                         "forkless_dbentries_queued:%lu\r\n"
                         "forkless_dbentries_processed:%lu\r\n",
+                        current_item_ms,
                         status.queue_length,
                         status.queue_length_target,
                         status.dbentries_queued,

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -576,14 +576,12 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         r config set save ""
         r flushall
         
-        set info [r info persistence]
-        
         # When no forkless save is running, time metrics should be -1
-        assert_match "*forkless_current_item_ms:-1*" $info
-        assert_match "*forkless_estimated_seconds_remaining:-1*" $info
+        set dbg [r info debug]
+        assert_match "*forkless_current_item_ms:-1*" $dbg
+        assert_match "*forkless_estimated_seconds_remaining:-1*" [r info persistence]
         
         # Debug metrics should be 0
-        set dbg [r info debug]
         assert_match "*forkless_current_queue_length:0*" $dbg
         assert_match "*forkless_queue_length_target:0*" $dbg
         assert_match "*forkless_dbentries_queued:0*" $dbg
@@ -606,14 +604,13 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
             fail "forkless save didn't start"
         }
         
-        set info [r info persistence]
+        set dbg [r info debug]
         
-        # Verify time metrics are present in persistence section
-        assert_match "*forkless_current_item_ms:*" $info
-        assert_match "*forkless_estimated_seconds_remaining:*" $info
+        # Verify time metrics are present in debug section
+        assert_match "*forkless_current_item_ms:*" $dbg
+        assert_match "*forkless_estimated_seconds_remaining:*" [r info persistence]
         
         # Verify queue metrics are present in debug section
-        set dbg [r info debug]
         assert_match "*forkless_current_queue_length:*" $dbg
         assert_match "*forkless_queue_length_target:*" $dbg
         assert_match "*forkless_dbentries_queued:*" $dbg
@@ -688,12 +685,12 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         # Wait until the item has been processing for at least 1 second
         wait_for_condition 50 100 {
-            [s forkless_current_item_ms] > 1000
+            [getInfoProperty [r info debug] forkless_current_item_ms] > 1000
         } else {
             fail "forkless_current_item_ms never exceeded 1000"
         }
         
-        set item_time [s forkless_current_item_ms]
+        set item_time [getInfoProperty [r info debug] forkless_current_item_ms]
         
         # Should be processing an item for ~1 second (1000+ ms)
         assert {$item_time > 1000}
@@ -725,7 +722,7 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         
         set dbg [r info debug]
         set processed [getInfoProperty $dbg forkless_dbentries_processed]
-        set estimated [s forkless_estimated_seconds_remaining]
+        set estimated [getInfoProperty [r info persistence] forkless_estimated_seconds_remaining]
         
         # Should have processed at least 1 key
         assert {$processed >= 1}
@@ -750,14 +747,12 @@ start_server {tags {"info" "external:skip"} overrides {save "" forkless-infrastr
         r bgsave
         waitForBgsave r
         
-        set info [r info persistence]
-        
         # After save completes, time metrics should be -1
-        assert_match "*forkless_current_item_ms:-1*" $info
-        assert_match "*forkless_estimated_seconds_remaining:-1*" $info
+        set dbg [r info debug]
+        assert_match "*forkless_current_item_ms:-1*" $dbg
+        assert_match "*forkless_estimated_seconds_remaining:-1*" [r info persistence]
         
         # Debug metrics should be 0
-        set dbg [r info debug]
         assert_match "*forkless_current_queue_length:0*" $dbg
         assert_match "*forkless_queue_length_target:0*" $dbg
         assert_match "*forkless_dbentries_queued:0*" $dbg


### PR DESCRIPTION
Per the TSC decision, `forkless_current_item_ms` ~and `forkless_estimated_seconds_remaining`~ move out of the `INFO persistence` section and into the `debug` section, alongside the existing forkless queue metrics. 