### PR TITLE
Use a unique temp file name for forkless save

### DIFF
--- a/src/forkless.c
+++ b/src/forkless.c
@@ -301,7 +301,7 @@ int forklessSaveToDisk(const char *filename) {
      * collide with a fork-based rdbSave() (same process) or another forkless
      * save. */
     char tmpfile[256];
-    snprintf(tmpfile, sizeof(tmpfile), "temp-forkless-%lld.rdb", (long long)server.stat_rdb_saves);
+    snprintf(tmpfile, sizeof(tmpfile), "temp-forkless-%d-%lld.rdb", (int)getpid(), (long long)server.stat_rdb_saves);
 
     FILE *file = fopen(tmpfile, "wb");
     if (file == NULL) {

--- a/src/forkless.c
+++ b/src/forkless.c
@@ -194,7 +194,7 @@ static void forklessSaveCloseSnapshotFile(void *args[]) {
     }
 
     if (saveInfo->terminated || saveInfo->err_code != C_OK) {
-        rdbRemoveTempFile(getpid(), 0);
+        bg_unlink(saveInfo->temp_file);
     }
     sdsfree(saveInfo->temp_file);
     sdsfree(saveInfo->final_file);
@@ -297,8 +297,11 @@ int forklessSaveToDisk(const char *filename) {
 
     server.stat_rdb_saves++;
 
+    /* Use a forkless-specific name with a unique counter so the temp file can't
+     * collide with a fork-based rdbSave() (same process) or another forkless
+     * save. */
     char tmpfile[256];
-    snprintf(tmpfile, sizeof(tmpfile), "temp-%d.rdb", (int)getpid());
+    snprintf(tmpfile, sizeof(tmpfile), "temp-forkless-%lld.rdb", (long long)server.stat_rdb_saves);
 
     FILE *file = fopen(tmpfile, "wb");
     if (file == NULL) {


### PR DESCRIPTION
The forkless save wrote to temp-<pid>.rdb, the same path fork-based rdbSave() uses. Both run in the same process, so an in-flight forkless save and a synchronous save collided on one file, truncating or renaming each other's temp file. 