### PR TITLE
Fix deadlock when a blocking command is followed by a partial pipelined command

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4269,8 +4269,6 @@ int processInputBuffer(client *c) {
         c->read_flags = isReplicatedClient(c) ? READ_FLAGS_REPLICATED : 0;
         c->read_flags |= authRequired(c) ? READ_FLAGS_AUTH_REQUIRED : 0;
 
-        /* A popped NEEDMORE is a queued partial; its completion bytes may already
-         * be in querybuf (read while blocked), so re-parse instead of waiting for I/O. */
         bool popped_from_queue;
         /* If commands are queued up, pop from the queue first */
         if (!consumeCommandQueue(c)) {
@@ -4285,9 +4283,14 @@ int processInputBuffer(client *c) {
         prefetchCommandQueueKeys(c);
 
         parseResult res = handleParseResults(c);
-        if (res != PARSE_OK) {
-            if (res == PARSE_ERR || !popped_from_queue) break;
+        if (res == PARSE_NEEDMORE && popped_from_queue) {
+            /* A queued partial; its completion bytes may already be in querybuf
+             * (read while blocked), so re-parse instead of waiting for I/O. */
             continue;
+        } else if (res != PARSE_OK) {
+            /* Parse error or partial command. */
+            break;
+        }
         }
 
         if (c->argc == 0) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -4291,7 +4291,6 @@ int processInputBuffer(client *c) {
             /* Parse error or partial command. */
             break;
         }
-        }
 
         if (c->argc == 0) {
             /* No command to process - continue parsing the query buf. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -4269,17 +4269,25 @@ int processInputBuffer(client *c) {
         c->read_flags = isReplicatedClient(c) ? READ_FLAGS_REPLICATED : 0;
         c->read_flags |= authRequired(c) ? READ_FLAGS_AUTH_REQUIRED : 0;
 
+        /* A popped NEEDMORE is a queued partial; its completion bytes may already
+         * be in querybuf (read while blocked), so re-parse instead of waiting for I/O. */
+        bool popped_from_queue;
         /* If commands are queued up, pop from the queue first */
         if (!consumeCommandQueue(c)) {
             parseInputBuffer(c);
             prepareCommandQueue(c);
+            popped_from_queue = false;
+        } else {
+            popped_from_queue = true;
         }
 
         /* Prefetch keys for the next commands in queue, if not already done. */
         prefetchCommandQueueKeys(c);
 
-        if (handleParseResults(c) != PARSE_OK) {
-            break;
+        parseResult res = handleParseResults(c);
+        if (res != PARSE_OK) {
+            if (res == PARSE_ERR || !popped_from_queue) break;
+            continue;
         }
 
         if (c->argc == 0) {

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -314,6 +314,28 @@ start_server {tags {"protocol network"}} {
         assert_equal [r exec] 2
     }
 
+    test "Partial command after blocking command is completed on unblock" {
+        reconnect
+        set rd [valkey_deferring_client]
+        $rd client id
+        set cid [$rd read]
+        $rd write "*3\r\n\$5\r\nBLPOP\r\n\$6\r\nmylist\r\n\$1\r\n0\r\n*3\r\n\$3\r\nSET\r\n\$3\r\n"
+        $rd flush
+        wait_for_blocked_client
+        $rd write "key\r\n\$5\r\nvalue\r\n"
+        $rd flush
+        wait_for_condition 50 100 {
+            [regexp {qbuf=([1-9][0-9]*)} [r client list id $cid]]
+        } else {
+            fail "completion bytes never reached the query buffer"
+        }
+        r rpush mylist item
+        assert_equal {mylist item} [$rd read]
+        assert_equal "OK" [$rd read]
+        assert_equal "value" [r get key]
+        $rd close
+    }
+
 }
 
 start_server {tags {"protocol hello"}} {


### PR DESCRIPTION
 ## Root cause
When a blocking command (e.g. `BLPOP`) blocks with a partially parsed pipelined command stashed in `cmd_queue`, the remaining bytes of that command are read into `querybuf` while the client is blocked. On unblock, `processInputBuffer` pops the partial entry; `handleParseResults` returns `PARSE_NEEDMORE`, and the loop broke unconditionally — so the partial was never re-parsed even though its completion bytes were already in `querybuf`. The client deadlocked permanently.

Not specific to valkey-search: it reproduces with plain `BLPOP` (no modules), so it affects any workload that pipelines around a blocking command.

 ## Fix
Track whether the current command was popped from `cmd_queue` vs freshly parsed. On `PARSE_NEEDMORE` from a popped entry, `continue` the loop (re-parse resumes incrementally via the preserved `c->multibulklen`, parsing disjoint bytes — no duplicate work) instead of `break`. The direct-parse path still `break`s to wait for I/O; a parse error still `break`s. 

## Test
Added to `tests/unit/protocol.tcl`  -- the `BLPOP` + partial-`SET` reproducer, command split across a packet boundary, completed on unblock. 
Verified: hangs (`TIMEOUT`) without the fix, passes with it.