### PR TITLE
fix: deduplicate sentinel known-replica lines during CONFIG REWRITE

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2107,9 +2107,19 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
         /* rewriteConfigMarkAsProcessed is handled after the loop */
 
         /* sentinel known-replica */
+        /* Track the addresses we have already emitted, so we never write two
+         * identical "sentinel known-replica" lines for the same address. A
+         * primary can legitimately know several replicas whose addresses
+         * collapse onto the same host:port (e.g. multiple DNS names that
+         * resolve to the same instance, or unresolved hostnames whose ip is
+         * left as an empty string). Emitting the address twice would produce
+         * a config file that is rejected on the next startup with
+         * "Duplicate hostname and port for replica." */
+        dict *written_replicas = dictCreate(&stringSetDictType);
         di2 = dictGetIterator(primary->replicas);
         while ((de = dictNext(di2)) != NULL) {
             sentinelAddr *replica_addr;
+            sds replica_key;
 
             ri = dictGetVal(de);
             replica_addr = ri->addr;
@@ -2120,6 +2130,15 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
              * already successfully promoted. So as the address of this replica
              * we use the old primary address instead. */
             if (sentinelAddrOrHostnameEqual(replica_addr, primary_addr)) replica_addr = primary->addr;
+
+            /* Skip addresses already written for this primary. */
+            replica_key = announceSentinelAddrAndPort(replica_addr);
+            if (dictFind(written_replicas, replica_key) != NULL) {
+                sdsfree(replica_key);
+                continue;
+            }
+            dictAdd(written_replicas, replica_key, NULL);
+
             line = sdscatprintf(sdsempty(), "sentinel known-replica %s %s %d", primary->name,
                                 announceSentinelAddr(replica_addr), replica_addr->port);
             /* try to replace any known-replica option first if found */
@@ -2131,6 +2150,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             /* rewriteConfigMarkAsProcessed is handled after the loop */
         }
         dictReleaseIterator(di2);
+        dictRelease(written_replicas);
 
         /* sentinel known-sentinel */
         di2 = dictGetIterator(primary->sentinels);


### PR DESCRIPTION
## Description

Fixes #4530.

Sentinel 8.0.2 can rewrite a **valid** Sentinel configuration into an **invalid** one containing duplicate `sentinel known-replica` entries. After that, the same Sentinel cannot restart because the load path rejects the file it wrote itself:

```
*** FATAL CONFIG FILE ERROR (Version 8.0.2) ***
>>> 'sentinel known-replica mymaster master 6379'
Duplicate hostname and port for replica.
```

## Root cause

In `rewriteConfigSentinelOption()` (`src/sentinel.c`), the `sentinel known-replica` rewrite loop iterates `primary->replicas` and emits one line per replica. When several in-memory replica entries resolve to the **same address as the monitored primary** — e.g. multiple DNS names pointing at the same instance (`master-a`/`master-b`), or distinct unresolved hostnames whose `ip` is left as an empty string — the loop's address-equality check:

```c
if (sentinelAddrOrHostnameEqual(replica_addr, primary_addr)) replica_addr = primary->addr;
```

collapses each such replica onto the primary address and emits one **identical** `sentinel known-replica` line per entry. The result is a config with duplicate lines that the load path (`createSentinelValkeyInstance`, keyed by `announceSentinelAddrAndPort`) rejects on restart.

The issue is severe in Kubernetes StatefulSet/headless-Service deployments: once the invalid file is persisted to a PVC, the affected Sentinel enters a permanent CrashLoop until the file is manually repaired.

## Fix

During `CONFIG REWRITE`, track the addresses already emitted for each primary (using the same `announceSentinelAddrAndPort` key the load path uses) and skip duplicates. This guarantees the invariant:

> A Sentinel configuration accepted and written by Sentinel should be accepted by Sentinel on the next startup.

No behavior change for normal configurations — distinct replica addresses are still all emitted.

## Reproduction

The issue provides three Docker Compose reproductions (same-IP aliases, failover promotion, and unresolved-hostname cases); all three produce duplicate `known-replica` lines before this fix and none after.

Signed-off-by: waterWang <waterWang@users.noreply.github.com>