### PR TITLE
Fix RDMA UAF: connection freed inside callHandler

### DIFF
--- a/src/rdma.c
+++ b/src/rdma.c
@@ -1775,22 +1775,20 @@ static int rdmaHasPendingData(void) {
 }
 
 static int rdmaProcessPendingData(void) {
-    listIter li;
     listNode *ln;
     rdma_connection *rdma_conn;
     connection *conn;
     int processed = 0;
 
-    listRewind(pending_list, &li);
-    while ((ln = listNext(&li))) {
+    /* handle one head node at a time, nodes may be freed by handlers */
+    unsigned long remaining = listLength(pending_list);
+    while (remaining-- > 0 && (ln = listFirst(pending_list)) != NULL) {
         rdma_conn = listNodeValue(ln);
         conn = &rdma_conn->c;
 
         /* a connection can be disconnected by remote peer, CM event mark state as CONN_STATE_CLOSED, kick connection
          * read/write handler to close connection */
         if (conn->state == CONN_STATE_ERROR || conn->state == CONN_STATE_CLOSED) {
-            /* Unlink before callHandler: read_handler may schedule close and
-             * free the connection when refs drop to 0 */
             listDelNode(pending_list, ln);
             rdma_conn->pending_list_node = NULL;
 
@@ -1804,6 +1802,10 @@ static int rdmaProcessPendingData(void) {
             ++processed;
             continue;
         }
+
+        /* rotate to tail, the node can be deleted by the handler below */
+        listUnlinkNode(pending_list, ln);
+        listLinkNodeTail(pending_list, ln);
 
         connRdmaEventHandler(NULL, -1, rdma_conn, 0);
         ++processed;

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -1789,6 +1789,8 @@ static int rdmaProcessPendingData(void) {
         /* a connection can be disconnected by remote peer, CM event mark state as CONN_STATE_CLOSED, kick connection
          * read/write handler to close connection */
         if (conn->state == CONN_STATE_ERROR || conn->state == CONN_STATE_CLOSED) {
+            /* Unlink before callHandler: read_handler may schedule close and
+             * free the connection when refs drop to 0 */
             listDelNode(pending_list, ln);
             rdma_conn->pending_list_node = NULL;
 

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -740,7 +740,8 @@ static void connRdmaEventHandler(struct aeEventLoop *el, int fd, void *clientDat
         client *c = connGetPrivateData(conn);
         if (c && c->io_read_state == CLIENT_COMPLETED_IO) break;
 
-        if (conn->read_handler && (callHandler(conn, conn->read_handler) == C_ERR)) {
+        /* the connection may be freed inside the handler */
+        if (conn->read_handler && !callHandler(conn, conn->read_handler)) {
             return;
         }
     }
@@ -1250,6 +1251,12 @@ static void connRdmaClose(connection *conn) {
     rdma_connection *rdma_conn = (rdma_connection *)conn;
     struct rdma_cm_id *cm_id = rdma_conn->cm_id;
     RdmaContext *ctx;
+
+    /* unlink from pending_list before the connection gets freed */
+    if (rdma_conn->pending_list_node) {
+        listDelNode(pending_list, rdma_conn->pending_list_node);
+        rdma_conn->pending_list_node = NULL;
+    }
 
     if (conn->fd != -1) {
         aeDeleteFileEvent(server.el, conn->fd, AE_READABLE);


### PR DESCRIPTION
## Summary
When I was doing some performance tests, I found this problem.
Fix heap-use-after-free bugs in the RDMA transport when several clients disconnect concurrently. Three related fixes in src/rdma.c; no hot-path impact for live connections.

## Symptom

Multiple RDMA clients disconnecting at once (e.g. valkey-benchmark -c 4 -P 16) can crash the server at teardown:
```
=== ASSERTION FAILED ===
==> networking.c:2174 'ln != NULL' is not true
```
Crash rate on RXE: ~7% overall, up to ~37% for -c 4 -P 16. Plain TCP is unaffected.

## Root Cause

- connRdmaEventHandler() — callHandler() may free the connection and return 0, but the loop checked for C_ERR (never returned). The loop then reads freed rdma_conn / ctx memory.

- connRdmaClose() — connection was freed while still linked in pending_list (TLS already unlinks in connTLSClose()).

- rdmaProcessPendingData() — fix (2) allows mid-loop node deletion, but the loop used listIter, whose cached next pointer goes stale when another pending connection is closed synchronously (same class as TLS #4234).

## Fix
Return from connRdmaEventHandler() when callHandler() returns 0.
Unlink from pending_list in connRdmaClose() before freeing.
Walk pending_list head-by-head (like tlsProcessPendingData()); rotate normal nodes to tail via listUnlinkNode() + listLinkNodeTail() (no alloc/free per iteration).

## Verification
Reproducer: ~37% crash before, 40/40 clean after.
ASAN: deterministic UAF within 21 runs before, 15 runs clean after.
Full RDMA benchmark matrix (240 runs) and smoke suite pass; throughput unchanged.