### PR TITLE
genericGetKeys return keys in order consistent with getKeysUsingKeySpecs

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2726,16 +2726,21 @@ int genericGetKeys(int storeKeyOfs,
     keys = getKeysPrepareResult(result, numkeys);
     result->numkeys = numkeys;
 
-    /* Add all key positions for argv[firstKeyOfs...n] to keys[] */
-    for (i = 0; i < num; i++) {
-        keys[i].pos = firstKeyOfs + (i * keyStep);
-        keys[i].flags = 0;
+    int keyIdx = 0;
+    /* If there's a destination key, put this first */
+    if (storeKeyOfs) {
+        keys[keyIdx].pos = storeKeyOfs;
+        keys[keyIdx].flags = 0;
+        keyIdx++;
     }
 
-    if (storeKeyOfs) {
-        keys[num].pos = storeKeyOfs;
-        keys[num].flags = 0;
+    /* Add all key positions for argv[firstKeyOfs...n] to keys[] */
+    for (i = 0; i < num; i++) {
+        keys[keyIdx].pos = firstKeyOfs + (i * keyStep);
+        keys[keyIdx].flags = 0;
+        keyIdx++;
     }
+
     return result->numkeys;
 }
 


### PR DESCRIPTION
Prior to this update, `genericGetKeys` returns a destination key last, even though it occurs first in the command order.  This is inconsistent with `getKeysUsingKeySpecs` which returns the destination key first.

And example is `ZUNIONSTORE dest 2 src1 src2`
Before this change, `genericGetKeys` returns these as `[src1, src2, dest]`
After the change, `genericGetKeys` returns these as `[dest, src1, src2]`

This is important for interaction with `CMD_WRITE_FIRSTKEY_ONLY`.