### PR TITLE
Remove the static compression buffer, over-allocate instead

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -62,8 +62,11 @@
 #include <sys/stat.h>
 #include <sys/param.h>
 
-/* Size of the static buffer used for rdbcompression */
-#define LZF_STATIC_BUFFER_SIZE (8 * 1024)
+/* Minimum size of the rdbcompression output buffer. Short-lived temporaries are
+ * over-allocated to a fixed size so they come from a single jemalloc bin; sizing
+ * them exactly spreads allocations across bins and inflates copy-on-write in
+ * fork children. */
+#define LZF_MIN_BUFFER_SIZE (8 * 1024)
 
 /* This macro is called when the internal RDB structure is corrupt */
 #define rdbReportCorruptRDB(...) rdbReportError(1, __LINE__, __VA_ARGS__)
@@ -444,20 +447,18 @@ writeerr:
 ssize_t rdbSaveLzfStringObject(rio *rdb, unsigned char *s, size_t len) {
     size_t comprlen, outlen;
     void *out;
-    static void *buffer = NULL;
 
     /* We require at least four bytes compression for this to be worth it */
     if (len <= 4) return 0;
     outlen = len - 4;
-    if (outlen < LZF_STATIC_BUFFER_SIZE) {
-        if (!buffer) buffer = zmalloc(LZF_STATIC_BUFFER_SIZE);
-        out = buffer;
-    } else {
-        if ((out = zmalloc(outlen + 1)) == NULL) return 0;
-    }
+    /* Over-allocate to a fixed minimum so every allocation is served from the
+     * same jemalloc bin. Exact-sized allocations spread across many bins, and in
+     * a fork child that reuses pages still shared with the parent, driving
+     * copy-on-write up to roughly the size of the dataset. */
+    out = zmalloc(outlen + 1 > LZF_MIN_BUFFER_SIZE ? outlen + 1 : LZF_MIN_BUFFER_SIZE);
     comprlen = lzf_compress(s, len, out, outlen);
     ssize_t nwritten = comprlen ? rdbSaveLzfBlob(rdb, out, comprlen, len) : 0;
-    if (out != buffer) zfree(out);
+    zfree(out);
     return nwritten;
 }
 


### PR DESCRIPTION
## Problem

`rdbSaveLzfStringObject()` compresses into a function-scoped `static` buffer, added
in #905 to reduce copy-on-write during `BGSAVE`/`BGAOFRW`:

```c
static void *buffer = NULL;
...
if (outlen < LZF_STATIC_BUFFER_SIZE) {
    if (!buffer) buffer = zmalloc(LZF_STATIC_BUFFER_SIZE);
    out = buffer;
}
```

Reusing one process-wide buffer makes the function non-reentrant. Two concurrent
callers compress into the same memory, and because `rdbSaveLzfBlob()` writes the
length header *before* copying the payload:

```c
rdbSaveLen(rdb, compress_len);
rdbSaveLen(rdb, original_len);
rdbWriteRaw(rdb, data, compress_len);   // payload copied last
```

an interleaving in that window emits one caller's `compress_len`/`original_len`
with another caller's bytes, producing an RDB that fails to load with
`Invalid LZF compressed string`. The lazy `if (!buffer)` init is a second,
smaller race on the pointer itself.

## The reuse is not what saves the copy-on-write

Sizing the buffer exactly spreads allocations across many jemalloc bins. Since
#905 also frees serialized strings with `zfree` in the child, those allocations
land in freed memory that is still shared with the parent, and writing compressed
data into it dirties those pages. So the cost tracks **dataset size**, not the
number of size classes.

Pinning every allocation to a fixed minimum size keeps them all in one bin, which
recovers the full benefit with no shared state.

Measured with `rdb_last_cow_size` (the child's own COW accounting), 3 runs per
arm, 15% fragmentation, values padded by `valkey-benchmark`:

| BGSAVE, no write load | static buffer | exact size | min size |
|---|---|---|---|
| 3M keys × 120 B (`used_memory` 446 MiB) | 14.504 MiB | 380.641 MiB | 14.457 MiB |
| 10M keys × 500 B (`used_memory` 4611 MiB) | 167.523 MiB | 4782.410 MiB | 167.473 MiB |

| BGSAVE, concurrent writes | static buffer | exact size | min size |
|---|---|---|---|
| 3M keys × 120 B | 499.828 MiB | 533.016 MiB | 506.289 MiB |

Exact sizing costs 26–28× more copy-on-write than the static buffer, up to roughly
the size of the dataset. Over-allocating to a fixed minimum tracks the static
buffer to within 0.3% with no write load and 1.3% under write load. The final
patch was re-measured separately and is COW-neutral: 14.441 vs 14.463 MiB and
167.475 vs 167.461 MiB against current `unstable`. `rdb_size` was byte-identical
across all arms, and BGSAVE wall time was unchanged in every run.

Under write load all three converge, because the parent is dirtying dataset pages
anyway and COW is already near total — consistent with #905's observation that the
effect appears "even without any write load".

## Testing

Full suite on the pushed commit: **5355 passed, 0 failed**. Builds clean with no
new warnings.
