### PR TITLE
fix: add release_header dependency to valkey-cli and valkey-benchmark [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,7 @@ list(APPEND CLI_LIBS "ffc")
 valkey_build_and_install_bin(valkey-cli "${VALKEY_CLI_SRCS}" "${VALKEY_SERVER_LDFLAGS}" "${CLI_LIBS}" "redis-cli")
 add_dependencies(valkey-cli generate_commands_def)
 add_dependencies(valkey-cli generate_fmtargs_h)
+add_dependencies(valkey-cli release_header)
 
 # Target: valkey-benchmark
 list(APPEND BENCH_LIBS "fpconv")
@@ -83,6 +84,7 @@ valkey_build_and_install_bin(valkey-benchmark "${VALKEY_BENCHMARK_SRCS}" "${VALK
                              "redis-benchmark")
 add_dependencies(valkey-benchmark generate_commands_def)
 add_dependencies(valkey-benchmark generate_fmtargs_h)
+add_dependencies(valkey-benchmark release_header)
 
 # Targets: valkey-sentinel, valkey-check-aof and valkey-check-rdb are just symbolic links
 valkey_create_symlink("valkey-server" "valkey-sentinel")


### PR DESCRIPTION
Fixes #4538.

The valkey-cli and valkey-benchmark targets both compile release.c, which #includes the generated release.h, but neither declares a dependency on the `release_header` custom target that generates it. Only valkey-server declares that dependency in src/CMakeLists.txt.

Under parallel make (`make -jN`, N > 1), compilation of release.c for the cli and benchmark targets can start before mkreleasehdr.sh produces release.h, causing intermittent `fatal error: 'release.h' file not found`.

This adds `add_dependencies(valkey-cli release_header)` and `add_dependencies(valkey-benchmark release_header)`, matching the dependency pattern already applied on the `unstable` branch.