### PR TITLE
Reject module cross-slot BlockClientOnKeys in cluster mode

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -8395,8 +8395,10 @@ ValkeyModuleBlockedClient *moduleBlockClient(ValkeyModuleCtx *ctx,
     /* We need to handle the invalid operation of calling modules blocking
      * commands from Lua or MULTI. We actually create an already aborted
      * (client set to NULL) blocked client handle, and actually reply with
-     * an error. */
-    bc->client = (islua || ismulti) ? NULL : c;
+     * an error. The same applies to the other error paths below: they must
+     * reset bc->client to NULL, otherwise a later VM_UnblockClient() would
+     * call unblockClient() on a client that was never blocked. */
+    bc->client = c;
     bc->module = ctx->module;
     bc->reply_callback = reply_callback;
     bc->auth_reply_cb = auth_reply_callback;
@@ -8417,6 +8419,7 @@ ValkeyModuleBlockedClient *moduleBlockClient(ValkeyModuleCtx *ctx,
     if (timeout_ms) {
         mstime_t now = mstime();
         if (timeout_ms > LLONG_MAX - now) {
+            bc->client = NULL;
             c->bstate->module_blocked_handle = NULL;
             addReplyError(c, "timeout is out of range"); /* 'timeout_ms+now' would overflow */
             return bc;
@@ -8425,17 +8428,36 @@ ValkeyModuleBlockedClient *moduleBlockClient(ValkeyModuleCtx *ctx,
     }
 
     if (islua || ismulti) {
+        bc->client = NULL;
         c->bstate->module_blocked_handle = NULL;
         addReplyError(c, islua ? "Blocking module command called from Lua script"
                                : "Blocking module command called from transaction");
     } else if (ctx->flags & VALKEYMODULE_CTX_BLOCKED_REPLY) {
+        bc->client = NULL;
         c->bstate->module_blocked_handle = NULL;
         addReplyError(c, "Blocking module command called from a Reply callback context");
     } else if (!auth_reply_callback && clientHasModuleAuthInProgress(c)) {
+        bc->client = NULL;
         c->bstate->module_blocked_handle = NULL;
         addReplyError(c, "Clients undergoing module based authentication can only be blocked on auth");
     } else {
         if (keys) {
+            /* In cluster mode, reject blocking on keys from different slots. */
+            if (server.cluster_enabled) {
+                int slot = -1;
+                for (int i = 0; i < numkeys; i++) {
+                    sds key = objectGetVal(keys[i]);
+                    int keyslot = keyHashSlot(key, sdslen(key));
+                    if (slot == -1) {
+                        slot = keyslot;
+                    } else if (keyslot != slot) {
+                        bc->client = NULL;
+                        c->bstate->module_blocked_handle = NULL;
+                        addReplyError(c, "Blocking on keys that belong to different slots is not allowed in cluster mode");
+                        return bc;
+                    }
+                }
+            }
             blockForKeys(c, BLOCKED_MODULE, keys, numkeys, timeout, flags & VALKEYMODULE_BLOCK_UNBLOCK_DELETED);
         } else {
             c->bstate->timeout = timeout;

--- a/tests/modules/blockonkeys.c
+++ b/tests/modules/blockonkeys.c
@@ -663,6 +663,57 @@ static int blockonkeys_signal_ready(ValkeyModuleCtx *ctx, ValkeyModuleString **a
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
 }
 
+static int blockonkeys_reply(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+    return ValkeyModule_ReplyWithSimpleString(ctx, "UNBLOCKED");
+}
+
+static int blockonkeys_timeout(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+    return ValkeyModule_ReplyWithSimpleString(ctx, "TIMEOUT");
+}
+
+/* BLOCKONKEYS.BLOCK_AND_UNBLOCK key timeout
+ *
+ * Blocks the client on a single key, then immediately unblocks it through the
+ * handle returned by BlockClientOnKeys. This is used to exercise the error
+ * paths of moduleBlockClient() that give up *after* the blocked handle has
+ * already been allocated (e.g. called from Lua/MULTI, or a timeout value that
+ * would overflow). In those cases BlockClientOnKeys returns an already-aborted
+ * handle (bc->client == NULL) and replies to the client with an error, and the
+ * module is still expected to call UnblockClient on the handle so that it is
+ * released cleanly instead of being leaked. */
+static int blockonkeys_block_and_unblock(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    if (argc != 3) return ValkeyModule_WrongArity(ctx);
+
+    long long timeout;
+    if (ValkeyModule_StringToLongLong(argv[2], &timeout) != VALKEYMODULE_OK)
+        return ValkeyModule_ReplyWithError(ctx, "ERR invalid timeout");
+
+    ValkeyModuleBlockedClient *bc = ValkeyModule_BlockClientOnKeys(ctx, blockonkeys_reply, blockonkeys_timeout,
+                                                                   NULL, timeout, &argv[1], 1, NULL);
+    ValkeyModule_UnblockClient(bc, NULL);
+    return VALKEYMODULE_OK;
+}
+
+/* BLOCKONKEYS.BLOCK_MULTI_SLOT declared_key blocked_key [blocked_key ...]
+ *
+ * The command's key spec declares only `declared_key` (firstkey=1), so the
+ * server computes c->slot from it. The module then blocks on the supplied
+ * `blocked_key`s, which the caller provides in a DIFFERENT slot. */
+static int blockonkeys_block_multi_slot(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    if (argc < 3) return ValkeyModule_WrongArity(ctx);
+
+    /* Block on every key from argv[2] onward. The command key spec only
+     * advertised argv[1], so c->slot is unrelated to these blocked keys. */
+    ValkeyModuleBlockedClient *bc = ValkeyModule_BlockClientOnKeys(ctx, blockonkeys_reply, blockonkeys_timeout,
+                                                                   NULL, 10000, &argv[2], argc - 2, NULL);
+    ValkeyModule_UnblockClient(bc, NULL);
+    return VALKEYMODULE_OK;
+}
+
 int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     VALKEYMODULE_NOT_USED(argv);
     VALKEYMODULE_NOT_USED(argc);
@@ -731,6 +782,14 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
 
     if (ValkeyModule_CreateCommand(ctx, "blockonkeys.signal_ready",
                                   blockonkeys_signal_ready, "write", 1, 1, 1) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "blockonkeys.block_and_unblock",
+                                   blockonkeys_block_and_unblock, "write", 1, 1, 1) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "blockonkeys.block_multi_slot",
+                                  blockonkeys_block_multi_slot, "write", 1, 1, 1) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
     return VALKEYMODULE_OK;

--- a/tests/unit/moduleapi/blockonkeys.tcl
+++ b/tests/unit/moduleapi/blockonkeys.tcl
@@ -349,6 +349,31 @@ start_server {tags {"modules"}} {
         $rd close
     }
 
+    test {Module block aborted: timeout out of range} {
+        r del k
+        assert_error "*timeout is out of range*" {r blockonkeys.block_and_unblock k 9223372036854775807}
+        assert_equal [r ping] {PONG}
+        assert_equal [s blocked_clients] 0
+    }
+
+    test {Module block aborted: called from MULTI} {
+        r del k
+        r multi
+        r blockonkeys.block_and_unblock k 0
+        assert_error "*Blocking module command called from transaction*" {r exec}
+        assert_equal [r ping] {PONG}
+        assert_equal [s blocked_clients] 0
+    }
+
+    test {Module block aborted: called from Lua script} {
+        r del k
+        assert_error "*Blocking module command called from Lua script*" {
+            r eval {return redis.call('blockonkeys.block_and_unblock', KEYS[1], '0')} 1 k
+        }
+        assert_equal [r ping] {PONG}
+        assert_equal [s blocked_clients] 0
+    }
+
     set master [srv 0 client]
     set master_host [srv 0 host]
     set master_port [srv 0 port]

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -416,4 +416,17 @@ start_cluster 2 0 {overrides {cluster-node-timeout 1000}} {
     }
 }
 
+set testmodule [file normalize tests/modules/blockonkeys.so]
+set modules [list loadmodule $testmodule]
+start_cluster 1 0 [list config_lines $modules] {
+    test "Module blocking on keys from different slots is rejected" {
+        set k1 "{a}declared"
+        set k2 "{b}blocked1"
+        set k3 "{c}blocked2"
+        assert_error "ERR *different slots*" {r blockonkeys.block_multi_slot $k1 $k2 $k3}
+        assert_equal [r ping] "PONG"
+        assert_equal [s blocked_clients] 0
+    }
+}
+
 } ;# end tag


### PR DESCRIPTION
If a module blocks a client on keys from different slots, the blocked
client is later checked by clientsCronHandleTimeout(), which calls
clusterRedirectBlockedClientIfNeeded(). There it hits the slot == c->slot
assertion (added in #2165), since we do not allow cross-slot commands,
and the server aborts.

A module can reach this through incorrect use of the API. Even though
it is a misuse, it should not be able to crash the server, so reject it
in moduleBlockClient() and reply with an error instead of blocking.

This adds one more error path that aborts after the blocked handle has
been allocated. Such paths must reset bc->client to NULL, otherwise a
later VM_UnblockClient() dereferences will crash the server. Only the
Lua/MULTI path did this; apply the same to the other paths as well.