### PR TITLE
Optimize pvector shrink on removal

### DIFF
--- a/src/unit/test_vset.cpp
+++ b/src/unit/test_vset.cpp
@@ -818,6 +818,47 @@ TEST_F(VsetTest, TestVsetMemUsage) {
     vsetRelease(&set);
 }
 
+TEST_F(VsetTest, TestVsetRemoveKeepsVectorAllocationBounded) {
+    vset set;
+    vset tight_set;
+    vsetInit(&set);
+    vsetInit(&tight_set);
+
+    const int total_entries = 126;
+    const int remaining_entries = 3;
+    mock_entry *entries[total_entries];
+    mock_entry *tight_entries[remaining_entries];
+
+    for (int i = 0; i < total_entries; i++) {
+        char key[32];
+        snprintf(key, sizeof(key), "key_%d", i);
+        entries[i] = mockCreateEntry(key, 1000);
+        ASSERT_TRUE(vsetAddEntry(&set, mockGetExpiry, entries[i]));
+    }
+
+    for (int i = 0; i < remaining_entries; i++) {
+        char key[32];
+        snprintf(key, sizeof(key), "tight_%d", i);
+        tight_entries[i] = mockCreateEntry(key, 1000);
+        ASSERT_TRUE(vsetAddEntry(&tight_set, mockGetExpiry, tight_entries[i]));
+    }
+
+    for (int i = 0; i < total_entries - remaining_entries; i++) {
+        ASSERT_TRUE(vsetRemoveEntry(&set, mockGetExpiry, entries[i]));
+    }
+
+    size_t tight_mem = vsetMemUsage(&tight_set);
+    size_t shrunk_mem = vsetMemUsage(&set);
+    ASSERT_GT(tight_mem, 0u);
+    ASSERT_GT(shrunk_mem, 0u);
+    ASSERT_LE(shrunk_mem, tight_mem * 2);
+
+    vsetRelease(&set);
+    vsetRelease(&tight_set);
+    for (int i = 0; i < total_entries; i++) mockFreeEntry(entries[i]);
+    for (int i = 0; i < remaining_entries; i++) mockFreeEntry(tight_entries[i]);
+}
+
 TEST_F(VsetTest, TestVsetClear) {
     vset set;
     vsetInit(&set);

--- a/src/vset.c
+++ b/src/vset.c
@@ -254,6 +254,10 @@ static inline uint32_t pvAlloc(pVector *vec) {
     return (vec ? vec->alloc : 0);
 }
 
+static inline size_t pvRequiredSize(size_t len) {
+    return len == 0 ? 0 : PV_HEADER_SIZE + len * sizeof(void *);
+}
+
 /* Ensures that a pVector has enough capacity to hold additional elements.
  *
  * This function guarantees that the given pVector `pv` has at least enough
@@ -279,7 +283,7 @@ static pVector *pvMakeRoomFor(pVector *pv, size_t additional) {
     /* Make sure we will have the capacity to store the extra number of elements */
     assert(pvLen(pv) + additional <= (1UL << PV_CARD_BITS) - 1);
 
-    size_t required = PV_HEADER_SIZE + (pvLen(pv) + additional) * sizeof(void *);
+    size_t required = pvRequiredSize(pvLen(pv) + additional);
 
     if (pvAlloc(pv) >= required) return pv;
 
@@ -324,7 +328,7 @@ static pVector *pvShrinkToFit(pVector *pv) {
     if (!pv) return NULL;
 
     size_t used = pvAlloc(pv);
-    size_t required = pvLen(pv) == 0 ? 0 : PV_HEADER_SIZE + pvLen(pv) * sizeof(void *);
+    size_t required = pvRequiredSize(pvLen(pv));
 
     if (used > required) {
         if (!required) {
@@ -334,6 +338,14 @@ static pVector *pvShrinkToFit(pVector *pv) {
         pv = zrealloc_usable(pv, required, &required);
         pv->alloc = required;
     }
+    return pv;
+}
+
+static pVector *pvShrinkIfWasteful(pVector *pv) {
+    size_t required = pvRequiredSize(pvLen(pv));
+    /* Avoid delete/reinsert thrashing: shrink only after more than
+     * half of the allocation is unused. */
+    if (pvAlloc(pv) > required * 2) return pvShrinkToFit(pv);
     return pv;
 }
 
@@ -539,7 +551,7 @@ uint32_t pvFind(const pVector *pv, const void *elem) {
 
 /* Removes the element at the specified index from the pVector.
  *
- * Shifts elements as necessary and optionally shrinks the vector if memory can be saved.
+ * Shifts elements as necessary and shrinks the vector if more than half of the allocation can be saved.
  * If this is the last element in the vector, the vector is freed and NULL is returned.
  *
  * Arguments:
@@ -559,7 +571,7 @@ pVector *pvRemoveAt(pVector *pv, uint32_t idx) {
     } else if (idx < pv->len - 1UL)
         memmove(&pv->data[idx], &pv->data[idx + 1], (pv->len - idx - 1) * sizeof(void *));
     pv->len--;
-    return pvShrinkToFit(pv);
+    return pvShrinkIfWasteful(pv);
 }
 
 /* Removes the first matching element from the pVector.


### PR DESCRIPTION
The patch changes `pvRemoveAt()` to shrink the vector only when more than half of the allocation can be reclaimed.

  Previously, every removal called `pvShrinkToFit()`, causing repeated reallocations during HDEL-heavy workloads. The new hysteresis keeps most of the speedup while bounding retained memory. The earlier RAX bulk-drain optimization was dropped  because it rarely triggers and adds untested complexity. 

This intentionally allows a small amount of slack after a delete-heavy sequence. The vector is only shrunk when its
  allocation grows beyond 2x the required size, avoiding repeated reallocations on every removal while keeping memory
  overhead bounded. If the vector drops to a single entry, the existing downgrade/free path still releases the vector
  allocation entirely.

  **Speed**

  | initial fields/bucket | baseline us/remove | patch us/remove | change |
  |---:|---:|---:|---:|
  | 4 | 0.03102 | 0.02680 | -13.6% |
  | 8 | 0.02095 | 0.01383 | -34.0% |
  | 16 | 0.02228 | 0.01188 | -46.7% |
  | 32 | 0.02475 | 0.01313 | -47.0% |
  | 64 | 0.02783 | 0.01653 | -40.6% |
  | 96 | 0.03069 | 0.01963 | -36.1% |
  | 126 | 0.03358 | 0.02311 | -31.2% |

  **Memory**

  Measured after deleting down to 3 entries per bucket.

  | initial fields/bucket | buckets | remaining entries | baseline bytes | patch bytes | change |
  |---:|---:|---:|---:|---:|---:|
  | 4 | 1 | 3 | 40 | 40 | +0.0% |
  | 4 | 10 | 30 | 264 | 328 | +24.2% |
  | 4 | 50 | 150 | 5232 | 5360 | +2.4% |
  | 4 | 100 | 300 | 10288 | 10384 | +0.9% |
  | 8 | 1 | 3 | 40 | 40 | +0.0% |
  | 8 | 10 | 30 | 264 | 328 | +24.2% |
  | 8 | 50 | 150 | 5232 | 5328 | +1.8% |
  | 8 | 100 | 300 | 10208 | 10320 | +1.1% |
  | 16 | 100 | 300 | 10144 | 10208 | +0.6% |
  | 32 | 100 | 300 | 10224 | 10128 | -0.9% |
  | 64 | 100 | 300 | 11248 | 11152 | -0.9% |
  | 96 | 100 | 300 | 10112 | 11696 | +15.7% |
  | 126 | 100 | 300 | 11744 | 11712 | -0.3% |