### PR TITLE
fix(forkless): Give the background save thread a large stack

### DIFF
--- a/src/forkless.c
+++ b/src/forkless.c
@@ -286,8 +286,7 @@ static void startBackgroundThread(forklessSaveInfo *saveInfo) {
     pthread_t thread_id;
     pthread_attr_t attr;
     int pthread_rc;
-    pthread_rc = pthread_attr_init(&attr);
-    serverAssert(pthread_rc == 0);
+    serverInitThreadAttribute(&attr);
     pthread_rc = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
     serverAssert(pthread_rc == 0);
     pthread_rc = pthread_create(&thread_id, &attr, &forklessSaveProcessor, saveInfo);


### PR DESCRIPTION
The forkless background save thread was created with `pthread_attr_init()`, leaving it with the platform default thread stack size. On musl (Alpine) that default is small (~128 KB), which is not enough for the RDB
serialization path: `rdbSaveObject()` -> `rdbSaveLzfStringObject()` ->
`lzf_compress()` places a large hash table on the stack (~256 KB on 32-bit), overflowing the thread stack and crashing.

Use `serverInitThreadAttribute()` like the bio threads do, so the background save thread gets a large guarded stack (`VALKEY_THREAD_STACK_SIZE`). The fork-based save is unaffected because the child inherits the main thread's stack.