### PR TITLE
Optimize HFE active expiry cleanup

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2046,8 +2046,6 @@ void propagateDeletion(serverDb *db, robj *key, int lazy, int slot) {
     server.replication_allowed = prev_replication_allowed;
 }
 
-#define EXPIRE_BULK_LIMIT ((size_t)1024) /* Maximum number of fields to active-expire (per replicated HDEL command */
-
 /* Propagate HDEL commands for deleted hash fields to AOF and replicas.
  *
  * This function builds and propagates a single HDEL command with multiple fields
@@ -2058,8 +2056,8 @@ int propagateFieldsDeletion(serverDb *db, robj *o, size_t n_fields, robj *fields
     int prev_replication_allowed = server.replication_allowed;
     server.replication_allowed = 1;
 
-    robj *argv[EXPIRE_BULK_LIMIT + 2]; /* HDEL + key + fields */
-    if (n_fields > EXPIRE_BULK_LIMIT) n_fields = EXPIRE_BULK_LIMIT;
+    robj *argv[HASH_FIELD_EXPIRE_BULK_LIMIT + 2]; /* HDEL + key + fields */
+    if (n_fields > HASH_FIELD_EXPIRE_BULK_LIMIT) n_fields = HASH_FIELD_EXPIRE_BULK_LIMIT;
 
     int argc = 0;
     robj *keyobj = createStringObjectFromSds(objectGetKey(o));
@@ -2094,8 +2092,8 @@ size_t dbReclaimExpiredFields(robj *o, serverDb *db, mstime_t now, unsigned long
 
     while (max_entries > 0) {
         /* Process in batches to avoid large stack allocations. */
-        unsigned long batch_size = max_entries > EXPIRE_BULK_LIMIT ? EXPIRE_BULK_LIMIT : max_entries;
-        robj *entries[EXPIRE_BULK_LIMIT];
+        unsigned long batch_size = max_entries > HASH_FIELD_EXPIRE_BULK_LIMIT ? HASH_FIELD_EXPIRE_BULK_LIMIT : max_entries;
+        robj *entries[HASH_FIELD_EXPIRE_BULK_LIMIT];
         size_t expired = hashTypeDeleteExpiredFields(o, now, batch_size, entries);
         if (expired == 0) break;
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -65,6 +65,8 @@
 #include <arm_neon.h>
 #endif
 
+#define HASHTABLE_POP_ENTRIES_STACK_MAX 128
+
 /* The default hashing function uses the SipHash implementation in siphash.c. */
 
 uint64_t siphash(const uint8_t *in, const size_t inlen, const uint8_t *k);
@@ -1747,19 +1749,13 @@ bool hashtablePop(hashtable *ht, const void *key, void **popped) {
     return 0;
 }
 
-/* Removes multiple distinct entries known to be in the table and returns the
- * number of entries removed. The entry destructor is not called. The caller
- * must pass distinct entries that are present in the table, and `count` must
- * not exceed HASHTABLE_POP_ENTRIES_STACK_MAX. `entries` is input-only. Batching
- * avoids per-delete hole filling and shrink checks. */
-size_t hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count) {
+static size_t hashtablePopKnownEntriesBatch(hashtable *ht, void **entries, size_t count) {
     assert(count <= HASHTABLE_POP_ENTRIES_STACK_MAX);
-    if (count == 0 || hashtableSize(ht) == 0) return 0;
+    if (count == 0) return 0;
 
     size_t bucket_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
     int table_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
     size_t affected_buckets = 0;
-    size_t removed = 0;
 
     hashtablePauseRehashing(ht);
     hashtablePauseAutoShrink(ht);
@@ -1791,7 +1787,6 @@ size_t hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count) {
                             table_index[affected_buckets] = table;
                             affected_buckets++;
                         }
-                        removed++;
                         deleted = true;
                         break;
                     }
@@ -1799,6 +1794,7 @@ size_t hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count) {
                 b = deleted ? NULL : getChildBucket(b);
             } while (b != NULL);
         }
+        assert(deleted);
     }
 
     hashtableResumeRehashing(ht);
@@ -1811,6 +1807,22 @@ size_t hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count) {
         }
     }
     hashtableResumeAutoShrink(ht);
+
+    return count;
+}
+
+/* Removes multiple distinct entries known to be in the table and returns the
+ * number of entries removed. The entry destructor is not called. The caller
+ * must pass distinct entries that are present in the table. `entries` is
+ * input-only. Batching avoids per-delete hole filling and shrink checks. */
+size_t hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count) {
+    size_t removed = 0;
+
+    for (size_t offset = 0; offset < count; offset += HASHTABLE_POP_ENTRIES_STACK_MAX) {
+        size_t remaining = count - offset;
+        size_t batch = remaining < HASHTABLE_POP_ENTRIES_STACK_MAX ? remaining : HASHTABLE_POP_ENTRIES_STACK_MAX;
+        removed += hashtablePopKnownEntriesBatch(ht, &entries[offset], batch);
+    }
 
     return removed;
 }

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1749,9 +1749,9 @@ bool hashtablePop(hashtable *ht, const void *key, void **popped) {
     return 0;
 }
 
-static size_t hashtablePopKnownEntriesBatch(hashtable *ht, void **entries, size_t count) {
+static void hashtablePopKnownEntriesBatch(hashtable *ht, void **entries, size_t count) {
     assert(count <= HASHTABLE_POP_ENTRIES_STACK_MAX);
-    if (count == 0) return 0;
+    if (count == 0) return;
 
     size_t bucket_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
     int table_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
@@ -1807,42 +1807,26 @@ static size_t hashtablePopKnownEntriesBatch(hashtable *ht, void **entries, size_
         }
     }
     hashtableResumeAutoShrink(ht);
-
-    return count;
 }
 
-/* Removes multiple distinct entries known to be in the table and returns the
- * number of entries removed. The entry destructor is not called. The caller
- * must pass distinct entries that are present in the table. `entries` is
- * input-only. Batching avoids per-delete hole filling and shrink checks. */
-size_t hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count) {
-    size_t removed = 0;
-
+/* Removes multiple distinct entries known to be in the table. The entry
+ * destructor is not called. The caller must pass distinct entries that are
+ * present in the table. `entries` is input-only. Batching avoids per-delete
+ * hole filling and shrink checks. */
+void hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count) {
     for (size_t offset = 0; offset < count; offset += HASHTABLE_POP_ENTRIES_STACK_MAX) {
         size_t remaining = count - offset;
         size_t batch = remaining < HASHTABLE_POP_ENTRIES_STACK_MAX ? remaining : HASHTABLE_POP_ENTRIES_STACK_MAX;
-        removed += hashtablePopKnownEntriesBatch(ht, &entries[offset], batch);
+        hashtablePopKnownEntriesBatch(ht, &entries[offset], batch);
     }
-
-    return removed;
 }
 
-/* Removes up to `count` arbitrary entries from the table, stores them in
- * `entries`, and returns the number of removed entries. The entry destructor is
- * not called. `entries` is output-only. If `cursor` is NULL, each call starts at
- * the first eligible bucket; otherwise, the per-table cursor avoids rescanning
- * the same empty bucket prefix when callers repeatedly drain a table in bounded
- * batches. The cursor is an approximate offset relative to the currently
- * eligible bucket range, so it remains safe across rehash progress and resizes
- * even though it may point to a different absolute bucket later. */
-size_t hashtablePopAnyEntries(hashtable *ht, void **entries, size_t count, size_t cursor[2]) {
+static size_t hashtablePopAnyEntriesBatch(hashtable *ht, void **entries, size_t count, size_t cursor[2]) {
+    assert(count <= HASHTABLE_POP_ENTRIES_STACK_MAX);
     if (count == 0 || hashtableSize(ht) == 0) return 0;
 
-    size_t stack_bucket_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
-    int stack_table_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
-    bool use_stack = count <= HASHTABLE_POP_ENTRIES_STACK_MAX;
-    size_t *bucket_index = use_stack ? stack_bucket_index : zmalloc(sizeof(*bucket_index) * count);
-    int *table_index = use_stack ? stack_table_index : zmalloc(sizeof(*table_index) * count);
+    size_t bucket_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
+    int table_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
     size_t affected_buckets = 0;
     size_t removed = 0;
 
@@ -1896,9 +1880,26 @@ size_t hashtablePopAnyEntries(hashtable *ht, void **entries, size_t count, size_
     }
     hashtableResumeAutoShrink(ht);
 
-    if (!use_stack) {
-        zfree(table_index);
-        zfree(bucket_index);
+    return removed;
+}
+
+/* Removes up to `count` arbitrary entries from the table, stores them in
+ * `entries`, and returns the number of removed entries. The entry destructor is
+ * not called. `entries` is output-only. If `cursor` is NULL, each call starts at
+ * the first eligible bucket; otherwise, the per-table cursor avoids rescanning
+ * the same empty bucket prefix when callers repeatedly drain a table in bounded
+ * batches. The cursor is an approximate offset relative to the currently
+ * eligible bucket range, so it remains safe across rehash progress and resizes
+ * even though it may point to a different absolute bucket later. */
+size_t hashtablePopAnyEntries(hashtable *ht, void **entries, size_t count, size_t cursor[2]) {
+    size_t removed = 0;
+
+    while (removed < count) {
+        size_t remaining = count - removed;
+        size_t batch = remaining < HASHTABLE_POP_ENTRIES_STACK_MAX ? remaining : HASHTABLE_POP_ENTRIES_STACK_MAX;
+        size_t got = hashtablePopAnyEntriesBatch(ht, &entries[removed], batch, cursor);
+        if (got == 0) break;
+        removed += got;
     }
 
     return removed;

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1806,6 +1806,9 @@ size_t hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count) {
         for (size_t i = 0; i < affected_buckets; i++) {
             compactBucketChain(ht, bucket_index[i], table_index[i]);
         }
+        for (size_t i = 0; i < count && hashtableIsRehashing(ht); i++) {
+            rehashStepOnReadIfNeeded(ht);
+        }
     }
     hashtableResumeAutoShrink(ht);
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1747,6 +1747,148 @@ bool hashtablePop(hashtable *ht, const void *key, void **popped) {
     return 0;
 }
 
+/* Removes multiple distinct entries known to be in the table and returns the
+ * number of entries removed. The entry destructor is not called. The caller
+ * must pass distinct entries that are present in the table, and `count` must
+ * not exceed HASHTABLE_POP_ENTRIES_STACK_MAX. `entries` is input-only. Batching
+ * avoids per-delete hole filling and shrink checks. */
+size_t hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count) {
+    assert(count <= HASHTABLE_POP_ENTRIES_STACK_MAX);
+    if (count == 0 || hashtableSize(ht) == 0) return 0;
+
+    size_t bucket_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
+    int table_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
+    size_t affected_buckets = 0;
+    size_t removed = 0;
+
+    hashtablePauseRehashing(ht);
+    hashtablePauseAutoShrink(ht);
+
+    for (size_t i = 0; i < count; i++) {
+        void *entry = entries[i];
+        const void *key = entryGetKey(ht, entry);
+        uint64_t hash = hashKey(ht, key);
+        uint8_t h2 = highBits(hash);
+        bool deleted = false;
+
+        for (int table = 0; table <= 1 && !deleted; table++) {
+            if (ht->used[table] == 0) continue;
+            size_t mask = expToMask(ht->bucket_exp[table]);
+            size_t idx = hash & mask;
+            if (table == 0 && ht->rehash_idx >= 0 && idx < (size_t)ht->rehash_idx) {
+                continue;
+            }
+            bucket *top = &ht->tables[table][idx];
+            bucket *b = top;
+            do {
+                for (int pos = 0; pos < numBucketPositions(b); pos++) {
+                    if (isPositionFilled(b, pos) && b->hashes[pos] == h2 && b->entries[pos] == entry) {
+                        b->presence &= ~(1 << pos);
+                        ht->used[table]--;
+                        if (top->chained &&
+                            (affected_buckets == 0 || bucket_index[affected_buckets - 1] != idx || table_index[affected_buckets - 1] != table)) {
+                            bucket_index[affected_buckets] = idx;
+                            table_index[affected_buckets] = table;
+                            affected_buckets++;
+                        }
+                        removed++;
+                        deleted = true;
+                        break;
+                    }
+                }
+                b = deleted ? NULL : getChildBucket(b);
+            } while (b != NULL);
+        }
+    }
+
+    hashtableResumeRehashing(ht);
+    if (!hashtableIsRehashingPaused(ht)) {
+        for (size_t i = 0; i < affected_buckets; i++) {
+            compactBucketChain(ht, bucket_index[i], table_index[i]);
+        }
+    }
+    hashtableResumeAutoShrink(ht);
+
+    return removed;
+}
+
+/* Removes up to `count` arbitrary entries from the table, stores them in
+ * `entries`, and returns the number of removed entries. The entry destructor is
+ * not called. `entries` is output-only. If `cursor` is NULL, each call starts at
+ * the first eligible bucket; otherwise, the per-table cursor avoids rescanning
+ * the same empty bucket prefix when callers repeatedly drain a table in bounded
+ * batches. The cursor is an approximate offset relative to the currently
+ * eligible bucket range, so it remains safe across rehash progress and resizes
+ * even though it may point to a different absolute bucket later. */
+size_t hashtablePopAnyEntries(hashtable *ht, void **entries, size_t count, size_t cursor[2]) {
+    if (count == 0 || hashtableSize(ht) == 0) return 0;
+
+    size_t stack_bucket_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
+    int stack_table_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
+    bool use_stack = count <= HASHTABLE_POP_ENTRIES_STACK_MAX;
+    size_t *bucket_index = use_stack ? stack_bucket_index : zmalloc(sizeof(*bucket_index) * count);
+    int *table_index = use_stack ? stack_table_index : zmalloc(sizeof(*table_index) * count);
+    size_t affected_buckets = 0;
+    size_t removed = 0;
+
+    hashtablePauseRehashing(ht);
+    hashtablePauseAutoShrink(ht);
+
+    for (int table = 0; table <= 1 && removed < count; table++) {
+        if (ht->used[table] == 0) continue;
+        size_t first_idx = 0;
+        if (table == 0 && ht->rehash_idx > 0) first_idx = ht->rehash_idx;
+        size_t buckets = numBuckets(ht->bucket_exp[table]);
+        if (first_idx >= buckets) continue;
+        size_t bucket_count = buckets - first_idx;
+        size_t start_idx = first_idx;
+        if (cursor) start_idx += cursor[table] % bucket_count;
+        size_t next_offset = 0;
+
+        for (size_t bucket_offset = 0; bucket_offset < bucket_count && removed < count; bucket_offset++) {
+            size_t idx = first_idx + ((start_idx - first_idx + bucket_offset) % bucket_count);
+            bucket *top = &ht->tables[table][idx];
+            bool affected_chained_bucket = top->chained;
+            bool removed_from_bucket = false;
+            bucket *b = top;
+
+            do {
+                for (int pos = 0; pos < numBucketPositions(b) && removed < count; pos++) {
+                    if (!isPositionFilled(b, pos)) continue;
+                    entries[removed++] = b->entries[pos];
+                    b->presence &= ~(1 << pos);
+                    ht->used[table]--;
+                    removed_from_bucket = true;
+                }
+                b = getChildBucket(b);
+            } while (b != NULL && removed < count);
+
+            if (removed_from_bucket && affected_chained_bucket) {
+                bucket_index[affected_buckets] = idx;
+                table_index[affected_buckets] = table;
+                affected_buckets++;
+            }
+            next_offset = (idx - first_idx + (removed < count ? 1 : 0)) % bucket_count;
+        }
+        if (cursor) cursor[table] = next_offset;
+    }
+
+    hashtableResumeRehashing(ht);
+    if (!hashtableIsRehashingPaused(ht)) {
+        for (size_t i = 0; i < affected_buckets; i++) {
+            compactBucketChain(ht, bucket_index[i], table_index[i]);
+        }
+    }
+    hashtableResumeAutoShrink(ht);
+
+    if (!use_stack) {
+        zfree(table_index);
+        zfree(bucket_index);
+    }
+
+    return removed;
+}
+
 /* Deletes the entry with the matching key. Returns true if an entry was
  * deleted, false if no matching entry was found. */
 bool hashtableDelete(hashtable *ht, const void *key) {

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1749,7 +1749,7 @@ bool hashtablePop(hashtable *ht, const void *key, void **popped) {
     return 0;
 }
 
-static void hashtableBatchDeleteBatch(hashtable *ht, void **entries, size_t count) {
+static void hashtableBatchDeleteEntriesBatch(hashtable *ht, void **entries, size_t count) {
     assert(count <= HASHTABLE_POP_ENTRIES_STACK_MAX);
     if (count == 0) return;
 
@@ -1813,11 +1813,11 @@ static void hashtableBatchDeleteBatch(hashtable *ht, void **entries, size_t coun
  * destructor is not called. The caller must pass distinct entries that are
  * present in the table. `entries` is input-only. Batching avoids per-delete
  * hole filling and shrink checks. */
-void hashtableBatchDelete(hashtable *ht, void **entries, size_t count) {
+void hashtableBatchDeleteEntries(hashtable *ht, void **entries, size_t count) {
     for (size_t offset = 0; offset < count; offset += HASHTABLE_POP_ENTRIES_STACK_MAX) {
         size_t remaining = count - offset;
         size_t batch = remaining < HASHTABLE_POP_ENTRIES_STACK_MAX ? remaining : HASHTABLE_POP_ENTRIES_STACK_MAX;
-        hashtableBatchDeleteBatch(ht, &entries[offset], batch);
+        hashtableBatchDeleteEntriesBatch(ht, &entries[offset], batch);
     }
 }
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1749,7 +1749,7 @@ bool hashtablePop(hashtable *ht, const void *key, void **popped) {
     return 0;
 }
 
-static void hashtablePopKnownEntriesBatch(hashtable *ht, void **entries, size_t count) {
+static void hashtableBatchDeleteBatch(hashtable *ht, void **entries, size_t count) {
     assert(count <= HASHTABLE_POP_ENTRIES_STACK_MAX);
     if (count == 0) return;
 
@@ -1813,11 +1813,11 @@ static void hashtablePopKnownEntriesBatch(hashtable *ht, void **entries, size_t 
  * destructor is not called. The caller must pass distinct entries that are
  * present in the table. `entries` is input-only. Batching avoids per-delete
  * hole filling and shrink checks. */
-void hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count) {
+void hashtableBatchDelete(hashtable *ht, void **entries, size_t count) {
     for (size_t offset = 0; offset < count; offset += HASHTABLE_POP_ENTRIES_STACK_MAX) {
         size_t remaining = count - offset;
         size_t batch = remaining < HASHTABLE_POP_ENTRIES_STACK_MAX ? remaining : HASHTABLE_POP_ENTRIES_STACK_MAX;
-        hashtablePopKnownEntriesBatch(ht, &entries[offset], batch);
+        hashtableBatchDeleteBatch(ht, &entries[offset], batch);
     }
 }
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -730,6 +730,27 @@ static inline void rehashStepOnReadIfNeeded(hashtable *ht) {
     rehashStep(ht);
 }
 
+static void rehashAfterBulkDelete(hashtable *ht, size_t max_steps) {
+    if (!hashtableIsRehashing(ht) || ht->pause_rehash) return;
+    if (resize_policy != HASHTABLE_RESIZE_ALLOW) return;
+    if (ht->bucket_exp[1] >= ht->bucket_exp[0]) return;
+
+    size_t max_empty_skips = max_steps * 128;
+    while (hashtableIsRehashing(ht)) {
+        while (hashtableIsRehashing(ht) && max_empty_skips > 0) {
+            size_t idx = ht->rehash_idx;
+            bucket *b = ht->tables[0] + idx;
+            if (b->presence != 0 || b->chained) break;
+            rehashStepFinalize(ht);
+            max_empty_skips--;
+        }
+        if (!hashtableIsRehashing(ht)) return;
+        if (max_steps == 0) return;
+        rehashStep(ht);
+        max_steps--;
+    }
+}
+
 /* When inserting or deleting, we first do a find (read) and rehash one step if
  * resize policy is set to ALLOW, so here we only do it if resize policy is
  * AVOID. The reason for doing it on insert and delete is to ensure that we
@@ -1749,75 +1770,82 @@ bool hashtablePop(hashtable *ht, const void *key, void **popped) {
     return 0;
 }
 
-static void hashtableBatchDeleteEntriesBatch(hashtable *ht, void **entries, size_t count) {
-    assert(count <= HASHTABLE_POP_ENTRIES_STACK_MAX);
-    if (count == 0) return;
-
-    size_t bucket_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
-    int table_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
-    size_t affected_buckets = 0;
-
-    hashtablePauseRehashing(ht);
-    hashtablePauseAutoShrink(ht);
-
-    for (size_t i = 0; i < count; i++) {
-        void *entry = entries[i];
-        const void *key = entryGetKey(ht, entry);
-        uint64_t hash = hashKey(ht, key);
-        uint8_t h2 = highBits(hash);
-        bool deleted = false;
-
-        for (int table = 0; table <= 1 && !deleted; table++) {
-            if (ht->used[table] == 0) continue;
-            size_t mask = expToMask(ht->bucket_exp[table]);
-            size_t idx = hash & mask;
-            if (table == 0 && ht->rehash_idx >= 0 && idx < (size_t)ht->rehash_idx) {
-                continue;
-            }
-            bucket *top = &ht->tables[table][idx];
-            bucket *b = top;
-            do {
-                for (int pos = 0; pos < numBucketPositions(b); pos++) {
-                    if (isPositionFilled(b, pos) && b->hashes[pos] == h2 && b->entries[pos] == entry) {
-                        b->presence &= ~(1 << pos);
-                        ht->used[table]--;
-                        if (top->chained &&
-                            (affected_buckets == 0 || bucket_index[affected_buckets - 1] != idx || table_index[affected_buckets - 1] != table)) {
-                            bucket_index[affected_buckets] = idx;
-                            table_index[affected_buckets] = table;
-                            affected_buckets++;
-                        }
-                        deleted = true;
-                        break;
-                    }
-                }
-                b = deleted ? NULL : getChildBucket(b);
-            } while (b != NULL);
-        }
-        assert(deleted);
-    }
-
-    hashtableResumeRehashing(ht);
-    if (!hashtableIsRehashingPaused(ht)) {
-        for (size_t i = 0; i < affected_buckets; i++) {
-            compactBucketChain(ht, bucket_index[i], table_index[i]);
-        }
-        for (size_t i = 0; i < count && hashtableIsRehashing(ht); i++) {
-            rehashStepOnReadIfNeeded(ht);
-        }
-    }
-    hashtableResumeAutoShrink(ht);
-}
-
-/* Removes multiple distinct entries known to be in the table. The entry
+/* Deletes multiple distinct entries known to be in the table. The entry
  * destructor is not called. The caller must pass distinct entries that are
  * present in the table. `entries` is input-only. Batching avoids per-delete
  * hole filling and shrink checks. */
-void hashtableBatchDeleteEntries(hashtable *ht, void **entries, size_t count) {
+void hashtableBatchDeleteEntries(hashtable *ht, void *const *entries, size_t count) {
     for (size_t offset = 0; offset < count; offset += HASHTABLE_POP_ENTRIES_STACK_MAX) {
         size_t remaining = count - offset;
         size_t batch = remaining < HASHTABLE_POP_ENTRIES_STACK_MAX ? remaining : HASHTABLE_POP_ENTRIES_STACK_MAX;
-        hashtableBatchDeleteEntriesBatch(ht, &entries[offset], batch);
+        void *const *batch_entries = &entries[offset];
+
+        size_t bucket_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
+        int table_index[HASHTABLE_POP_ENTRIES_STACK_MAX];
+        uint64_t hashes[HASHTABLE_POP_ENTRIES_STACK_MAX];
+        uint8_t h2s[HASHTABLE_POP_ENTRIES_STACK_MAX];
+        size_t affected_buckets = 0;
+
+        hashtablePauseRehashing(ht);
+        hashtablePauseAutoShrink(ht);
+
+        for (size_t i = 0; i < batch; i++) {
+            if (i + 8 < batch) valkey_prefetch(batch_entries[i + 8]);
+            const void *key = entryGetKey(ht, batch_entries[i]);
+            hashes[i] = hashKey(ht, key);
+            h2s[i] = highBits(hashes[i]);
+            for (int table = 0; table <= 1; table++) {
+                if (ht->used[table] == 0) continue;
+                size_t idx = hashes[i] & expToMask(ht->bucket_exp[table]);
+                if (table == 0 && ht->rehash_idx >= 0 && idx < (size_t)ht->rehash_idx) continue;
+                valkey_prefetch(&ht->tables[table][idx]);
+            }
+        }
+
+        for (size_t i = 0; i < batch; i++) {
+            void *entry = batch_entries[i];
+            uint64_t hash = hashes[i];
+            uint8_t h2 = h2s[i];
+            bool deleted = false;
+
+            for (int table = 0; table <= 1 && !deleted; table++) {
+                if (ht->used[table] == 0) continue;
+                size_t mask = expToMask(ht->bucket_exp[table]);
+                size_t idx = hash & mask;
+                if (table == 0 && ht->rehash_idx >= 0 && idx < (size_t)ht->rehash_idx) {
+                    continue;
+                }
+                bucket *top = &ht->tables[table][idx];
+                bucket *b = top;
+                do {
+                    for (int pos = 0; pos < numBucketPositions(b); pos++) {
+                        if (isPositionFilled(b, pos) && b->hashes[pos] == h2 && b->entries[pos] == entry) {
+                            b->presence &= ~(1 << pos);
+                            ht->used[table]--;
+                            if (top->chained && (affected_buckets == 0 || bucket_index[affected_buckets - 1] != idx ||
+                                                 table_index[affected_buckets - 1] != table)) {
+                                bucket_index[affected_buckets] = idx;
+                                table_index[affected_buckets] = table;
+                                affected_buckets++;
+                            }
+                            deleted = true;
+                            break;
+                        }
+                    }
+                    b = deleted ? NULL : getChildBucket(b);
+                } while (b != NULL);
+            }
+            assert(deleted);
+        }
+
+        hashtableResumeRehashing(ht);
+        if (!hashtableIsRehashingPaused(ht)) {
+            for (size_t i = 0; i < affected_buckets; i++) {
+                compactBucketChain(ht, bucket_index[i], table_index[i]);
+            }
+            rehashAfterBulkDelete(ht, batch);
+        }
+        hashtableResumeAutoShrink(ht);
     }
 }
 
@@ -1877,6 +1905,7 @@ static size_t hashtablePopAnyEntriesBatch(hashtable *ht, void **entries, size_t 
         for (size_t i = 0; i < affected_buckets; i++) {
             compactBucketChain(ht, bucket_index[i], table_index[i]);
         }
+        rehashAfterBulkDelete(ht, removed);
     }
     hashtableResumeAutoShrink(ht);
 

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -93,7 +93,6 @@ typedef void (*hashtableScanFunction)(void *privdata, void *entry);
 
 /* Constants */
 #define HASHTABLE_BUCKET_SIZE 64 /* bytes, the most common cache line size */
-#define HASHTABLE_POP_ENTRIES_STACK_MAX 128
 
 /* Scan flags */
 #define HASHTABLE_SCAN_EMIT_REF (1 << 0)

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -150,7 +150,7 @@ bool hashtableAddOrFind(hashtable *ht, void *entry, void **existing);
 bool hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *position, void **existing);
 void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *position);
 bool hashtablePop(hashtable *ht, const void *key, void **popped);
-size_t hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count);
+void hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count);
 size_t hashtablePopAnyEntries(hashtable *ht, void **entries, size_t count, size_t cursor[2]);
 bool hashtableDelete(hashtable *ht, const void *key);
 void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *position);

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -93,6 +93,7 @@ typedef void (*hashtableScanFunction)(void *privdata, void *entry);
 
 /* Constants */
 #define HASHTABLE_BUCKET_SIZE 64 /* bytes, the most common cache line size */
+#define HASHTABLE_POP_ENTRIES_STACK_MAX 128
 
 /* Scan flags */
 #define HASHTABLE_SCAN_EMIT_REF (1 << 0)
@@ -150,6 +151,8 @@ bool hashtableAddOrFind(hashtable *ht, void *entry, void **existing);
 bool hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *position, void **existing);
 void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *position);
 bool hashtablePop(hashtable *ht, const void *key, void **popped);
+size_t hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count);
+size_t hashtablePopAnyEntries(hashtable *ht, void **entries, size_t count, size_t cursor[2]);
 bool hashtableDelete(hashtable *ht, const void *key);
 void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *position);
 void hashtableTwoPhasePopDelete(hashtable *ht, hashtablePosition *position);

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -150,7 +150,7 @@ bool hashtableAddOrFind(hashtable *ht, void *entry, void **existing);
 bool hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *position, void **existing);
 void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *position);
 bool hashtablePop(hashtable *ht, const void *key, void **popped);
-void hashtablePopKnownEntries(hashtable *ht, void **entries, size_t count);
+void hashtableBatchDelete(hashtable *ht, void **entries, size_t count);
 size_t hashtablePopAnyEntries(hashtable *ht, void **entries, size_t count, size_t cursor[2]);
 bool hashtableDelete(hashtable *ht, const void *key);
 void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *position);

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -150,7 +150,7 @@ bool hashtableAddOrFind(hashtable *ht, void *entry, void **existing);
 bool hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *position, void **existing);
 void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *position);
 bool hashtablePop(hashtable *ht, const void *key, void **popped);
-void hashtableBatchDelete(hashtable *ht, void **entries, size_t count);
+void hashtableBatchDeleteEntries(hashtable *ht, void **entries, size_t count);
 size_t hashtablePopAnyEntries(hashtable *ht, void **entries, size_t count, size_t cursor[2]);
 bool hashtableDelete(hashtable *ht, const void *key);
 void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *position);

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -150,7 +150,7 @@ bool hashtableAddOrFind(hashtable *ht, void *entry, void **existing);
 bool hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *position, void **existing);
 void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *position);
 bool hashtablePop(hashtable *ht, const void *key, void **popped);
-void hashtableBatchDeleteEntries(hashtable *ht, void **entries, size_t count);
+void hashtableBatchDeleteEntries(hashtable *ht, void *const *entries, size_t count);
 size_t hashtablePopAnyEntries(hashtable *ht, void **entries, size_t count, size_t cursor[2]);
 bool hashtableDelete(hashtable *ht, const void *key);
 void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *position);

--- a/src/server.h
+++ b/src/server.h
@@ -146,6 +146,9 @@ struct ValkeyModule;
 #define PROTO_SHARED_SELECT_CMDS 10
 #define OBJ_SHARED_INTEGERS 10000
 #define OBJ_SHARED_BULKHDR_LEN 32
+
+/* Maximum number of hash fields to active-expire per replicated HDEL command. */
+#define HASH_FIELD_EXPIRE_BULK_LIMIT ((size_t)1024)
 #define OBJ_SHARED_HDR_STRLEN(_len_) (((_len_) < 10) ? 4 : 5) /* see shared.mbulkhdr etc. */
 #define LOG_MAX_LEN 1024                                      /* Default maximum length of syslog messages.*/
 #define AOF_REWRITE_ITEMS_PER_CMD 64

--- a/src/server.h
+++ b/src/server.h
@@ -147,8 +147,6 @@ struct ValkeyModule;
 #define OBJ_SHARED_INTEGERS 10000
 #define OBJ_SHARED_BULKHDR_LEN 32
 
-/* Maximum number of hash fields to active-expire per replicated HDEL command. */
-#define HASH_FIELD_EXPIRE_BULK_LIMIT ((size_t)1024)
 #define OBJ_SHARED_HDR_STRLEN(_len_) (((_len_) < 10) ? 4 : 5) /* see shared.mbulkhdr etc. */
 #define LOG_MAX_LEN 1024                                      /* Default maximum length of syslog messages.*/
 #define AOF_REWRITE_ITEMS_PER_CMD 64
@@ -3604,6 +3602,8 @@ robj *setTypeDup(robj *o);
 #define HASH_SET_TAKE_VALUE (1 << 1)
 #define HASH_SET_KEEP_EXPIRY (1 << 2)
 #define HASH_SET_COPY 0
+/* Maximum number of hash fields to active-expire per replicated HDEL command. */
+#define HASH_FIELD_EXPIRE_BULK_LIMIT ((size_t)1024)
 
 
 void hashTypeFreeVolatileSet(robj *o);          /* needed only for freeHashObject */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2414,9 +2414,7 @@ static void hashTypeExpireEntries(void **entries, size_t count, void *c) {
     expiryContext *ctx = c;
     hashtable *ht = objectGetVal(ctx->key);
 
-    size_t deleted_count = hashtablePopKnownEntries(ht, entries, count);
-    /* The volatile set and the hash table body must contain the same entry pointers. */
-    serverAssert(deleted_count == count);
+    hashtablePopKnownEntries(ht, entries, count);
 
     for (size_t i = 0; i < count; i++) {
         entry *expired = entries[i];
@@ -2443,7 +2441,6 @@ size_t hashTypeDeleteExpiredFields(robj *o, mstime_t now, unsigned long max_fiel
     serverAssert(hashtableSize(objectGetVal(o)) > 0);
     expiryContext ctx = {.key = o, .field_cap = max_fields, .n_fields = 0, .fields = out_entries};
     size_t expired = vsetRemoveExpired(vset, entryGetExpiryVsetFunc, hashTypeExpireEntries, now, max_fields, &ctx);
-    serverAssert(ctx.n_fields <= max_fields);
     if (vsetIsEmpty(vset)) {
         hashTypeFreeVolatileSet(o);
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2398,9 +2398,10 @@ void hrandfieldCommand(client *c) {
 
 /* Context structure for tracking expiry operations on hash fields. */
 typedef struct {
-    robj *key;              /* the hash object */
-    unsigned long n_fields; /* number of entries processed */
-    robj **fields;          /* array of expired entries to replicate later */
+    robj *key;               /* the hash object */
+    unsigned long field_cap; /* maximum number of fields that can be queued */
+    unsigned long n_fields;  /* number of entries processed */
+    robj **fields;           /* array of expired entries to replicate later */
 } expiryContext;
 
 /* Callback for popping expired entries from the volatile set.
@@ -2413,16 +2414,16 @@ static void hashTypeExpireEntries(void **entries, size_t count, void *c) {
     expiryContext *ctx = c;
     hashtable *ht = objectGetVal(ctx->key);
 
-    for (size_t offset = 0; offset < count; offset += HASHTABLE_POP_ENTRIES_STACK_MAX) {
-        size_t batch = min(count - offset, HASHTABLE_POP_ENTRIES_STACK_MAX);
-        size_t deleted_count = hashtablePopKnownEntries(ht, &entries[offset], batch);
-        /* The volatile set and the hash table body must contain the same entry pointers. */
-        serverAssert(deleted_count == batch);
-    }
+    size_t deleted_count = hashtablePopKnownEntries(ht, entries, count);
+    /* The volatile set and the hash table body must contain the same entry pointers. */
+    serverAssert(deleted_count == count);
 
     for (size_t i = 0; i < count; i++) {
         entry *expired = entries[i];
-        if (ctx->fields) ctx->fields[ctx->n_fields++] = createStringObjectFromSds(entryGetField(expired));
+        if (ctx->fields) {
+            serverAssert(ctx->n_fields < ctx->field_cap);
+            ctx->fields[ctx->n_fields++] = createStringObjectFromSds(entryGetField(expired));
+        }
         server.stat_expiredfields++;
         entryFree(expired);
     }
@@ -2440,15 +2441,11 @@ size_t hashTypeDeleteExpiredFields(robj *o, mstime_t now, unsigned long max_fiel
 
     serverAssert(!vsetIsEmpty(vset));
     serverAssert(hashtableSize(objectGetVal(o)) > 0);
-    /* skip TTL checks temporarily (to allow hashtable pops) */
-    hashTypeIgnoreTTL(o, true);
-    expiryContext ctx = {.key = o, .fields = out_entries, .n_fields = 0};
+    expiryContext ctx = {.key = o, .field_cap = max_fields, .n_fields = 0, .fields = out_entries};
     size_t expired = vsetRemoveExpired(vset, entryGetExpiryVsetFunc, hashTypeExpireEntries, now, max_fields, &ctx);
     serverAssert(ctx.n_fields <= max_fields);
     if (vsetIsEmpty(vset)) {
         hashTypeFreeVolatileSet(o);
-    } else {
-        hashTypeIgnoreTTL(o, false);
     }
     return expired;
 }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2404,27 +2404,28 @@ typedef struct {
 } expiryContext;
 
 /* Callback for popping expired entries from the volatile set.
- * Deletes the entry from the hash table and tracks it in the expiry context.
+ * Deletes entries from the hash table in batches and tracks them in the expiry
+ * context for later propagation.
  *
  * This function does not incr the dirty counter. Caller needs to increment
- * it themselves if necessary.
- *
- * Returns 1 if deleted, 0 if nothing to do. */
-static int hashTypeExpireEntry(void *entry, void *c) {
+ * it themselves if necessary. */
+static void hashTypeExpireEntries(void **entries, size_t count, void *c) {
     expiryContext *ctx = c;
-    robj *o = ctx->key;
-    serverAssert(objectGetEncoding(o) == OBJ_ENCODING_HASHTABLE && hashtableSize(objectGetVal(o)) > 0);
-    hashtable *ht = objectGetVal(o);
-    void *entry_ptr = NULL;
-    bool deleted = hashtablePop(ht, entry, &entry_ptr);
-    if (deleted) {
-        if (ctx->fields)
-            ctx->fields[ctx->n_fields++] = createStringObjectFromSds(entryGetField(entry));
-        server.stat_expiredfields++;
-        entryFree(entry);
-        return 1;
+    hashtable *ht = objectGetVal(ctx->key);
+
+    for (size_t offset = 0; offset < count; offset += HASHTABLE_POP_ENTRIES_STACK_MAX) {
+        size_t batch = min(count - offset, HASHTABLE_POP_ENTRIES_STACK_MAX);
+        size_t deleted_count = hashtablePopKnownEntries(ht, &entries[offset], batch);
+        /* The volatile set and the hash table body must contain the same entry pointers. */
+        serverAssert(deleted_count == batch);
     }
-    return 0;
+
+    for (size_t i = 0; i < count; i++) {
+        entry *expired = entries[i];
+        if (ctx->fields) ctx->fields[ctx->n_fields++] = createStringObjectFromSds(entryGetField(expired));
+        server.stat_expiredfields++;
+        entryFree(expired);
+    }
 }
 
 /* Extract expired entries from a hash object's volatile set.
@@ -2438,10 +2439,11 @@ size_t hashTypeDeleteExpiredFields(robj *o, mstime_t now, unsigned long max_fiel
     }
 
     serverAssert(!vsetIsEmpty(vset));
+    serverAssert(hashtableSize(objectGetVal(o)) > 0);
     /* skip TTL checks temporarily (to allow hashtable pops) */
     hashTypeIgnoreTTL(o, true);
     expiryContext ctx = {.key = o, .fields = out_entries, .n_fields = 0};
-    size_t expired = vsetRemoveExpired(vset, entryGetExpiryVsetFunc, hashTypeExpireEntry, now, max_fields, &ctx);
+    size_t expired = vsetRemoveExpired(vset, entryGetExpiryVsetFunc, hashTypeExpireEntries, now, max_fields, &ctx);
     serverAssert(ctx.n_fields <= max_fields);
     if (vsetIsEmpty(vset)) {
         hashTypeFreeVolatileSet(o);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2414,7 +2414,7 @@ static void hashTypeExpireEntries(void **entries, size_t count, void *c) {
     expiryContext *ctx = c;
     hashtable *ht = objectGetVal(ctx->key);
 
-    hashtableBatchDelete(ht, entries, count);
+    hashtableBatchDeleteEntries(ht, entries, count);
 
     for (size_t i = 0; i < count; i++) {
         entry *expired = entries[i];

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2414,7 +2414,7 @@ static void hashTypeExpireEntries(void **entries, size_t count, void *c) {
     expiryContext *ctx = c;
     hashtable *ht = objectGetVal(ctx->key);
 
-    hashtablePopKnownEntries(ht, entries, count);
+    hashtableBatchDelete(ht, entries, count);
 
     for (size_t i = 0; i < count; i++) {
         entry *expired = entries[i];

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -187,7 +187,7 @@ TEST_F(HashtableTest, pop_known_entries) {
         known[j] = entries[j * 2];
     }
 
-    ASSERT_EQ(hashtablePopKnownEntries(ht, known, 20), 20u);
+    hashtablePopKnownEntries(ht, known, 20);
     ASSERT_EQ(keyval_destructor_calls, 0u);
     ASSERT_EQ(hashtableSize(ht), 20u);
 
@@ -232,7 +232,7 @@ TEST_F(HashtableTest, pop_known_entries_multiple_batches) {
         known[j] = entries[j * 2];
     }
 
-    ASSERT_EQ(hashtablePopKnownEntries(ht, known, pop_count), (size_t)pop_count);
+    hashtablePopKnownEntries(ht, known, pop_count);
     ASSERT_EQ(keyval_destructor_calls, 0u);
     ASSERT_EQ(hashtableSize(ht), (size_t)(count - pop_count));
 
@@ -283,7 +283,7 @@ TEST_F(HashtableTest, pop_known_entries_completes_shrink_rehash) {
         known[j] = entries[j];
     }
 
-    ASSERT_EQ(hashtablePopKnownEntries(ht, known, pop_count), (size_t)pop_count);
+    hashtablePopKnownEntries(ht, known, pop_count);
     ASSERT_FALSE(hashtableIsRehashing(ht));
     ASSERT_EQ(hashtableSize(ht), (size_t)remaining);
     ASSERT_LT(hashtableMemUsage(ht), mem_before_pop);
@@ -435,7 +435,7 @@ TEST_F(HashtableTest, pop_known_entries_during_rehash) {
         known[j] = entries[j * 3];
     }
 
-    ASSERT_EQ(hashtablePopKnownEntries(ht, known, pop_count), (size_t)pop_count);
+    hashtablePopKnownEntries(ht, known, pop_count);
     ASSERT_TRUE(hashtableIsRehashing(ht));
 
     for (int j = 0; j < count; j++) {

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -209,6 +209,103 @@ TEST_F(HashtableTest, pop_known_entries) {
     ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
 }
 
+TEST_F(HashtableTest, pop_known_entries_multiple_batches) {
+    size_t used_memory_before = zmalloc_used_memory();
+    hashtableType type = keyval_type;
+    type.entryDestructor = freekeyvalCounting;
+    keyval_destructor_calls = 0;
+
+    hashtable *ht = hashtableCreate(&type);
+    const int count = 600;
+    const int pop_count = 300;
+    keyval *entries[count];
+    void *known[pop_count];
+
+    for (int j = 0; j < count; j++) {
+        char key[32], val[32];
+        snprintf(key, sizeof(key), "%d", j);
+        snprintf(val, sizeof(val), "%d", j + 1000);
+        entries[j] = create_keyval(key, val);
+        ASSERT_TRUE(hashtableAdd(ht, entries[j]));
+    }
+    for (int j = 0; j < pop_count; j++) {
+        known[j] = entries[j * 2];
+    }
+
+    ASSERT_EQ(hashtablePopKnownEntries(ht, known, pop_count), (size_t)pop_count);
+    ASSERT_EQ(keyval_destructor_calls, 0u);
+    ASSERT_EQ(hashtableSize(ht), (size_t)(count - pop_count));
+
+    for (int j = 0; j < count; j++) {
+        char key[32];
+        void *found = NULL;
+        snprintf(key, sizeof(key), "%d", j);
+        if (j % 2 == 0) {
+            ASSERT_FALSE(hashtableFind(ht, key, &found));
+            free(entries[j]);
+        } else {
+            ASSERT_TRUE(hashtableFind(ht, key, &found));
+            ASSERT_EQ(found, entries[j]);
+        }
+    }
+
+    hashtableRelease(ht);
+    ASSERT_EQ(keyval_destructor_calls, (size_t)(count - pop_count));
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
+
+TEST_F(HashtableTest, pop_known_entries_completes_shrink_rehash) {
+    size_t used_memory_before = zmalloc_used_memory();
+    hashtableType type = keyval_type;
+    type.entryDestructor = freekeyvalCounting;
+    keyval_destructor_calls = 0;
+
+    hashtable *ht = hashtableCreate(&type);
+    const int count = 2000;
+    const int remaining = 20;
+    const int pop_count = count - remaining;
+    keyval *entries[count];
+    void *known[pop_count];
+
+    for (int j = 0; j < count; j++) {
+        char key[32], val[32];
+        snprintf(key, sizeof(key), "%d", j);
+        snprintf(val, sizeof(val), "%d", j + 1000);
+        entries[j] = create_keyval(key, val);
+        ASSERT_TRUE(hashtableAdd(ht, entries[j]));
+    }
+    while (hashtableIsRehashing(ht)) {
+        hashtableRehashMicroseconds(ht, 1000);
+    }
+    size_t mem_before_pop = hashtableMemUsage(ht);
+
+    for (int j = 0; j < pop_count; j++) {
+        known[j] = entries[j];
+    }
+
+    ASSERT_EQ(hashtablePopKnownEntries(ht, known, pop_count), (size_t)pop_count);
+    ASSERT_FALSE(hashtableIsRehashing(ht));
+    ASSERT_EQ(hashtableSize(ht), (size_t)remaining);
+    ASSERT_LT(hashtableMemUsage(ht), mem_before_pop);
+
+    for (int j = 0; j < count; j++) {
+        char key[32];
+        void *found = NULL;
+        snprintf(key, sizeof(key), "%d", j);
+        if (j < pop_count) {
+            ASSERT_FALSE(hashtableFind(ht, key, &found));
+            free(entries[j]);
+        } else {
+            ASSERT_TRUE(hashtableFind(ht, key, &found));
+            ASSERT_EQ(found, entries[j]);
+        }
+    }
+
+    hashtableRelease(ht);
+    ASSERT_EQ(keyval_destructor_calls, (size_t)remaining);
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
+
 TEST_F(HashtableTest, pop_any_entries) {
     size_t used_memory_before = zmalloc_used_memory();
     hashtableType type = keyval_type;

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -9,6 +9,7 @@
 #include <climits>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <set>
@@ -81,6 +82,36 @@ static void freekeyval(void *keyval) {
     free(keyval);
 }
 
+static size_t keyval_destructor_calls;
+
+static void freekeyvalCounting(void *keyval) {
+    keyval_destructor_calls++;
+    free(keyval);
+}
+
+static uint64_t constant_hashfunc(const void *key) {
+    UNUSED(key);
+    return 42;
+}
+
+static void advanceRehashingHalfwayByFind(hashtable *ht) {
+    size_t from_size, to_size;
+    hashtableRehashingInfo(ht, &from_size, &to_size);
+    UNUSED(to_size);
+    ASSERT_GT(from_size, 1u);
+    ssize_t target = (ssize_t)(from_size / 2);
+
+    for (int j = 0; hashtableGetRehashingIndex(ht) < target; j++) {
+        char key[32];
+        void *found = NULL;
+        ASSERT_TRUE(hashtableIsRehashing(ht));
+        snprintf(key, sizeof(key), "%d", j);
+        hashtableFind(ht, key, &found);
+    }
+    ASSERT_GT(hashtableGetRehashingIndex(ht), 0);
+    ASSERT_TRUE(hashtableIsRehashing(ht));
+}
+
 static void trackmemusage(hashtable *ht, ssize_t delta) {
     UNUSED(ht);
     mem_usage += delta;
@@ -132,6 +163,242 @@ class HashtableTest : public ::testing::Test {
         ASSERT_EQ(mem_usage, 0u);
     }
 };
+
+TEST_F(HashtableTest, pop_known_entries) {
+    size_t used_memory_before = zmalloc_used_memory();
+    hashtableType type = keyval_type;
+    type.hashFunction = constant_hashfunc;
+    type.entryDestructor = freekeyvalCounting;
+    keyval_destructor_calls = 0;
+
+    hashtable *ht = hashtableCreate(&type);
+    keyval *entries[40];
+    void *known[20];
+
+    for (int j = 0; j < 40; j++) {
+        char key[32], val[32];
+        snprintf(key, sizeof(key), "%d", j);
+        snprintf(val, sizeof(val), "%d", j + 1000);
+        entries[j] = create_keyval(key, val);
+        ASSERT_TRUE(hashtableAdd(ht, entries[j]));
+    }
+
+    for (int j = 0; j < 20; j++) {
+        known[j] = entries[j * 2];
+    }
+
+    ASSERT_EQ(hashtablePopKnownEntries(ht, known, 20), 20u);
+    ASSERT_EQ(keyval_destructor_calls, 0u);
+    ASSERT_EQ(hashtableSize(ht), 20u);
+
+    for (int j = 0; j < 40; j++) {
+        char key[32];
+        void *found = NULL;
+        snprintf(key, sizeof(key), "%d", j);
+        if (j % 2 == 0) {
+            ASSERT_FALSE(hashtableFind(ht, key, &found));
+            free(entries[j]);
+        } else {
+            ASSERT_TRUE(hashtableFind(ht, key, &found));
+            ASSERT_EQ(found, entries[j]);
+        }
+    }
+
+    hashtableRelease(ht);
+    ASSERT_EQ(keyval_destructor_calls, 20u);
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
+
+TEST_F(HashtableTest, pop_any_entries) {
+    size_t used_memory_before = zmalloc_used_memory();
+    hashtableType type = keyval_type;
+    type.entryDestructor = freekeyvalCounting;
+    keyval_destructor_calls = 0;
+
+    hashtable *ht = hashtableCreate(&type);
+    bool seen[300] = {false};
+    size_t cursor[2] = {0, 0};
+    void *entries[300];
+
+    for (int j = 0; j < 300; j++) {
+        char key[32], val[32];
+        snprintf(key, sizeof(key), "%d", j);
+        snprintf(val, sizeof(val), "%d", j + 1000);
+        ASSERT_TRUE(hashtableAdd(ht, create_keyval(key, val)));
+    }
+
+    ASSERT_EQ(hashtablePopAnyEntries(ht, entries, 200, cursor), 200u);
+    ASSERT_EQ(keyval_destructor_calls, 0u);
+    ASSERT_EQ(hashtableSize(ht), 100u);
+
+    size_t seen_count = 0;
+    for (int j = 0; j < 200; j++) {
+        keyval *e = (keyval *)entries[j];
+        int idx = atoi((const char *)getkey(e));
+        void *found = NULL;
+        ASSERT_GE(idx, 0);
+        ASSERT_LT(idx, 300);
+        ASSERT_FALSE(seen[idx]);
+        seen[idx] = true;
+        seen_count++;
+        ASSERT_FALSE(hashtableFind(ht, getkey(e), &found));
+        free(e);
+    }
+
+    while (hashtableSize(ht) > 0) {
+        size_t count = hashtablePopAnyEntries(ht, entries, 37, cursor);
+        ASSERT_GT(count, 0u);
+        for (size_t j = 0; j < count; j++) {
+            keyval *e = (keyval *)entries[j];
+            int idx = atoi((const char *)getkey(e));
+            void *found = NULL;
+            ASSERT_GE(idx, 0);
+            ASSERT_LT(idx, 300);
+            ASSERT_FALSE(seen[idx]);
+            seen[idx] = true;
+            seen_count++;
+            ASSERT_FALSE(hashtableFind(ht, getkey(e), &found));
+            free(e);
+        }
+    }
+
+    ASSERT_EQ(seen_count, 300u);
+    ASSERT_EQ(keyval_destructor_calls, 0u);
+    hashtableRelease(ht);
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
+
+TEST_F(HashtableTest, pop_any_entries_keeps_cursor_on_partially_drained_bucket) {
+    size_t used_memory_before = zmalloc_used_memory();
+    hashtableType type = keyval_type;
+    type.hashFunction = constant_hashfunc;
+    type.entryDestructor = freekeyvalCounting;
+    keyval_destructor_calls = 0;
+
+    hashtable *ht = hashtableCreate(&type);
+    void *entries[4];
+    size_t cursor[2] = {0, 0};
+
+    for (int j = 0; j < 20; j++) {
+        char key[32], val[32];
+        snprintf(key, sizeof(key), "%d", j);
+        snprintf(val, sizeof(val), "%d", j + 1000);
+        ASSERT_TRUE(hashtableAdd(ht, create_keyval(key, val)));
+    }
+    ASSERT_FALSE(hashtableIsRehashing(ht));
+
+    size_t bucket_idx = constant_hashfunc(NULL) & (hashtableBuckets(ht) - 1);
+    ASSERT_EQ(hashtablePopAnyEntries(ht, entries, 3, cursor), 3u);
+    ASSERT_EQ(cursor[0], bucket_idx);
+    ASSERT_EQ(hashtableSize(ht), 17u);
+
+    for (int j = 0; j < 3; j++) {
+        free(entries[j]);
+    }
+
+    ASSERT_EQ(hashtablePopAnyEntries(ht, entries, 4, cursor), 4u);
+    ASSERT_EQ(hashtableSize(ht), 13u);
+
+    for (int j = 0; j < 4; j++) {
+        free(entries[j]);
+    }
+
+    hashtableRelease(ht);
+    ASSERT_EQ(keyval_destructor_calls, 13u);
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
+
+TEST_F(HashtableTest, pop_known_entries_during_rehash) {
+    size_t used_memory_before = zmalloc_used_memory();
+    hashtableType type = keyval_type;
+    type.entryDestructor = freekeyvalCounting;
+    keyval_destructor_calls = 0;
+
+    hashtable *ht = hashtableCreate(&type);
+    const int count = 3000;
+    const int pop_count = 30;
+    keyval *entries[count];
+    void *known[pop_count];
+
+    for (int j = 0; j < count; j++) {
+        char key[32], val[32];
+        snprintf(key, sizeof(key), "%d", j);
+        snprintf(val, sizeof(val), "%d", j + 1000);
+        entries[j] = create_keyval(key, val);
+        ASSERT_TRUE(hashtableAdd(ht, entries[j]));
+    }
+    while (hashtableIsRehashing(ht)) {
+        hashtableRehashMicroseconds(ht, 1000);
+    }
+    ASSERT_TRUE(hashtableExpand(ht, 4096));
+    ASSERT_TRUE(hashtableIsRehashing(ht));
+    advanceRehashingHalfwayByFind(ht);
+
+    for (int j = 0; j < pop_count; j++) {
+        known[j] = entries[j * 3];
+    }
+
+    ASSERT_EQ(hashtablePopKnownEntries(ht, known, pop_count), (size_t)pop_count);
+    ASSERT_TRUE(hashtableIsRehashing(ht));
+
+    for (int j = 0; j < count; j++) {
+        char key[32];
+        void *found = NULL;
+        snprintf(key, sizeof(key), "%d", j);
+        if (j % 3 == 0 && j < pop_count * 3) {
+            ASSERT_FALSE(hashtableFind(ht, key, &found));
+            free(entries[j]);
+        } else {
+            ASSERT_TRUE(hashtableFind(ht, key, &found));
+            ASSERT_EQ(found, entries[j]);
+        }
+    }
+
+    hashtableRelease(ht);
+    ASSERT_EQ(keyval_destructor_calls, (size_t)(count - pop_count));
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
+
+TEST_F(HashtableTest, pop_any_entries_during_rehash_with_null_cursor) {
+    size_t used_memory_before = zmalloc_used_memory();
+    hashtableType type = keyval_type;
+    type.entryDestructor = freekeyvalCounting;
+    keyval_destructor_calls = 0;
+
+    hashtable *ht = hashtableCreate(&type);
+    const int count = 3000;
+    const int pop_count = 64;
+    void *entries[pop_count];
+
+    for (int j = 0; j < count; j++) {
+        char key[32], val[32];
+        snprintf(key, sizeof(key), "%d", j);
+        snprintf(val, sizeof(val), "%d", j + 1000);
+        ASSERT_TRUE(hashtableAdd(ht, create_keyval(key, val)));
+    }
+    while (hashtableIsRehashing(ht)) {
+        hashtableRehashMicroseconds(ht, 1000);
+    }
+    ASSERT_TRUE(hashtableExpand(ht, 4096));
+    ASSERT_TRUE(hashtableIsRehashing(ht));
+    advanceRehashingHalfwayByFind(ht);
+
+    size_t popped = hashtablePopAnyEntries(ht, entries, pop_count, NULL);
+    ASSERT_EQ(popped, (size_t)pop_count);
+    ASSERT_TRUE(hashtableIsRehashing(ht));
+    ASSERT_EQ(hashtableSize(ht), (size_t)(count - pop_count));
+
+    for (size_t j = 0; j < popped; j++) {
+        keyval *e = (keyval *)entries[j];
+        void *found = NULL;
+        ASSERT_FALSE(hashtableFind(ht, getkey(e), &found));
+        free(e);
+    }
+
+    hashtableRelease(ht);
+    ASSERT_EQ(keyval_destructor_calls, (size_t)(count - pop_count));
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
 
 TEST_F(HashtableTest, cursor) {
     ASSERT_EQ(nextCursor(0x0000, 0xffff), 0x8000u);

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -164,7 +164,7 @@ class HashtableTest : public ::testing::Test {
     }
 };
 
-TEST_F(HashtableTest, pop_known_entries) {
+TEST_F(HashtableTest, batch_delete) {
     size_t used_memory_before = zmalloc_used_memory();
     hashtableType type = keyval_type;
     type.hashFunction = constant_hashfunc;
@@ -187,7 +187,7 @@ TEST_F(HashtableTest, pop_known_entries) {
         known[j] = entries[j * 2];
     }
 
-    hashtablePopKnownEntries(ht, known, 20);
+    hashtableBatchDelete(ht, known, 20);
     ASSERT_EQ(keyval_destructor_calls, 0u);
     ASSERT_EQ(hashtableSize(ht), 20u);
 
@@ -209,7 +209,7 @@ TEST_F(HashtableTest, pop_known_entries) {
     ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
 }
 
-TEST_F(HashtableTest, pop_known_entries_multiple_batches) {
+TEST_F(HashtableTest, batch_delete_multiple_batches) {
     size_t used_memory_before = zmalloc_used_memory();
     hashtableType type = keyval_type;
     type.entryDestructor = freekeyvalCounting;
@@ -232,7 +232,7 @@ TEST_F(HashtableTest, pop_known_entries_multiple_batches) {
         known[j] = entries[j * 2];
     }
 
-    hashtablePopKnownEntries(ht, known, pop_count);
+    hashtableBatchDelete(ht, known, pop_count);
     ASSERT_EQ(keyval_destructor_calls, 0u);
     ASSERT_EQ(hashtableSize(ht), (size_t)(count - pop_count));
 
@@ -254,7 +254,7 @@ TEST_F(HashtableTest, pop_known_entries_multiple_batches) {
     ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
 }
 
-TEST_F(HashtableTest, pop_known_entries_completes_shrink_rehash) {
+TEST_F(HashtableTest, batch_delete_completes_shrink_rehash) {
     size_t used_memory_before = zmalloc_used_memory();
     hashtableType type = keyval_type;
     type.entryDestructor = freekeyvalCounting;
@@ -283,7 +283,7 @@ TEST_F(HashtableTest, pop_known_entries_completes_shrink_rehash) {
         known[j] = entries[j];
     }
 
-    hashtablePopKnownEntries(ht, known, pop_count);
+    hashtableBatchDelete(ht, known, pop_count);
     ASSERT_FALSE(hashtableIsRehashing(ht));
     ASSERT_EQ(hashtableSize(ht), (size_t)remaining);
     ASSERT_LT(hashtableMemUsage(ht), mem_before_pop);
@@ -405,7 +405,7 @@ TEST_F(HashtableTest, pop_any_entries_keeps_cursor_on_partially_drained_bucket) 
     ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
 }
 
-TEST_F(HashtableTest, pop_known_entries_during_rehash) {
+TEST_F(HashtableTest, batch_delete_during_rehash) {
     size_t used_memory_before = zmalloc_used_memory();
     hashtableType type = keyval_type;
     type.entryDestructor = freekeyvalCounting;
@@ -435,7 +435,7 @@ TEST_F(HashtableTest, pop_known_entries_during_rehash) {
         known[j] = entries[j * 3];
     }
 
-    hashtablePopKnownEntries(ht, known, pop_count);
+    hashtableBatchDelete(ht, known, pop_count);
     ASSERT_TRUE(hashtableIsRehashing(ht));
 
     for (int j = 0; j < count; j++) {

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -164,7 +164,7 @@ class HashtableTest : public ::testing::Test {
     }
 };
 
-TEST_F(HashtableTest, batch_delete) {
+TEST_F(HashtableTest, batch_delete_entries) {
     size_t used_memory_before = zmalloc_used_memory();
     hashtableType type = keyval_type;
     type.hashFunction = constant_hashfunc;
@@ -187,7 +187,7 @@ TEST_F(HashtableTest, batch_delete) {
         known[j] = entries[j * 2];
     }
 
-    hashtableBatchDelete(ht, known, 20);
+    hashtableBatchDeleteEntries(ht, known, 20);
     ASSERT_EQ(keyval_destructor_calls, 0u);
     ASSERT_EQ(hashtableSize(ht), 20u);
 
@@ -209,7 +209,7 @@ TEST_F(HashtableTest, batch_delete) {
     ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
 }
 
-TEST_F(HashtableTest, batch_delete_multiple_batches) {
+TEST_F(HashtableTest, batch_delete_entries_multiple_batches) {
     size_t used_memory_before = zmalloc_used_memory();
     hashtableType type = keyval_type;
     type.entryDestructor = freekeyvalCounting;
@@ -232,7 +232,7 @@ TEST_F(HashtableTest, batch_delete_multiple_batches) {
         known[j] = entries[j * 2];
     }
 
-    hashtableBatchDelete(ht, known, pop_count);
+    hashtableBatchDeleteEntries(ht, known, pop_count);
     ASSERT_EQ(keyval_destructor_calls, 0u);
     ASSERT_EQ(hashtableSize(ht), (size_t)(count - pop_count));
 
@@ -254,7 +254,7 @@ TEST_F(HashtableTest, batch_delete_multiple_batches) {
     ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
 }
 
-TEST_F(HashtableTest, batch_delete_completes_shrink_rehash) {
+TEST_F(HashtableTest, batch_delete_entries_completes_shrink_rehash) {
     size_t used_memory_before = zmalloc_used_memory();
     hashtableType type = keyval_type;
     type.entryDestructor = freekeyvalCounting;
@@ -283,7 +283,7 @@ TEST_F(HashtableTest, batch_delete_completes_shrink_rehash) {
         known[j] = entries[j];
     }
 
-    hashtableBatchDelete(ht, known, pop_count);
+    hashtableBatchDeleteEntries(ht, known, pop_count);
     ASSERT_FALSE(hashtableIsRehashing(ht));
     ASSERT_EQ(hashtableSize(ht), (size_t)remaining);
     ASSERT_LT(hashtableMemUsage(ht), mem_before_pop);
@@ -405,7 +405,7 @@ TEST_F(HashtableTest, pop_any_entries_keeps_cursor_on_partially_drained_bucket) 
     ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
 }
 
-TEST_F(HashtableTest, batch_delete_during_rehash) {
+TEST_F(HashtableTest, batch_delete_entries_during_rehash) {
     size_t used_memory_before = zmalloc_used_memory();
     hashtableType type = keyval_type;
     type.entryDestructor = freekeyvalCounting;
@@ -435,7 +435,7 @@ TEST_F(HashtableTest, batch_delete_during_rehash) {
         known[j] = entries[j * 3];
     }
 
-    hashtableBatchDelete(ht, known, pop_count);
+    hashtableBatchDeleteEntries(ht, known, pop_count);
     ASSERT_TRUE(hashtableIsRehashing(ht));
 
     for (int j = 0; j < count; j++) {

--- a/src/unit/test_vset.cpp
+++ b/src/unit/test_vset.cpp
@@ -59,19 +59,19 @@ static long long mock_entry_get_expiry(const void *entry) {
     return mockGetExpiry(entry);
 }
 
-static int mock_entry_expire(void *entry, void *ctx) {
-    mock_entry *e = (mock_entry *)entry;
+static void mock_entry_expire(void **entries, size_t count, void *ctx) {
     long long now = *(long long *)ctx;
-    (void)now;
-    serverAssert(mock_entry_get_expiry(entry) <= now);
-    for (int i = 0; i < mock_entry_count; i++) {
-        if (mock_entries[i] == e) {
-            mockFreeEntry(e);
-            mock_entries[i] = mock_entries[--mock_entry_count];
-            return 1;
+    for (size_t j = 0; j < count; j++) {
+        mock_entry *e = (mock_entry *)entries[j];
+        serverAssert(mock_entry_get_expiry(e) <= now);
+        for (int i = 0; i < mock_entry_count; i++) {
+            if (mock_entries[i] == e) {
+                mockFreeEntry(e);
+                mock_entries[i] = mock_entries[--mock_entry_count];
+                break;
+            }
         }
     }
-    return 0;
 }
 
 /* --------- Helper Functions --------- */

--- a/src/vset.c
+++ b/src/vset.c
@@ -1529,17 +1529,17 @@ static inline size_t vsetBucketRemoveExpired_HASHTABLE(vsetBucket **bucket, vset
     pointerHashtableMetadata *metadata = hashtableMetadata(ht);
     size_t count = 0;
 
+    /* hashtablePopAnyEntries replaces a safe iterator over this vset bucket.
+     * The old path paused rehashing on the first hashtableNext() call, so
+     * deletions under that iterator did not advance rehashing either. */
     while (count < max_count && hashtableSize(ht) > 0) {
+        /* Limit each pop to the stack_entries output buffer size. */
         size_t want = min(max_count - count, (size_t)VSET_EXPIRE_STACK_ENTRIES);
         size_t got = hashtablePopAnyEntries(ht, stack_entries, want, metadata->pop_scan_cursor);
         if (got == 0) break;
         if (expiryFunc) expiryFunc(stack_entries, got, ctx);
         count += got;
     }
-
-    /* hashtablePopAnyEntries replaces a safe iterator over this vset bucket.
-     * The old path paused rehashing on the first hashtableNext() call, so
-     * deletions under that iterator did not advance rehashing either. */
 
     /* Collapse or downgrade the bucket based on how many entries remain.
      *

--- a/src/vset.c
+++ b/src/vset.c
@@ -1537,9 +1537,9 @@ static inline size_t vsetBucketRemoveExpired_HASHTABLE(vsetBucket **bucket, vset
         count += got;
     }
 
-    /* hashtablePopAnyEntries replaces a safe iterator over this vset bucket;
-     * that path also paused rehashing during deletion, so no extra rehash
-     * progress is needed here for parity. */
+    /* hashtablePopAnyEntries replaces a safe iterator over this vset bucket.
+     * The old path paused rehashing on the first hashtableNext() call, so
+     * deletions under that iterator did not advance rehashing either. */
 
     /* Collapse or downgrade the bucket based on how many entries remain.
      *

--- a/src/vset.c
+++ b/src/vset.c
@@ -1526,14 +1526,20 @@ static inline size_t vsetBucketRemoveExpired_HASHTABLE(vsetBucket **bucket, vset
     UNUSED(now);
     hashtable *ht = vsetBucketHashtable(*bucket);
     void *stack_entries[VSET_EXPIRE_STACK_ENTRIES];
-    size_t pop_count = min(max_count, hashtableSize(ht));
-    bool use_stack = pop_count <= VSET_EXPIRE_STACK_ENTRIES;
-    void **entries = use_stack ? stack_entries : zmalloc(sizeof(*entries) * pop_count);
     pointerHashtableMetadata *metadata = hashtableMetadata(ht);
-    size_t count = hashtablePopAnyEntries(ht, entries, pop_count, metadata->pop_scan_cursor);
+    size_t count = 0;
 
-    if (count > 0 && expiryFunc) expiryFunc(entries, count, ctx);
-    if (!use_stack) zfree(entries);
+    while (count < max_count && hashtableSize(ht) > 0) {
+        size_t want = min(max_count - count, (size_t)VSET_EXPIRE_STACK_ENTRIES);
+        size_t got = hashtablePopAnyEntries(ht, stack_entries, want, metadata->pop_scan_cursor);
+        if (got == 0) break;
+        if (expiryFunc) expiryFunc(stack_entries, got, ctx);
+        count += got;
+    }
+
+    /* hashtablePopAnyEntries replaces a safe iterator over this vset bucket;
+     * that path also paused rehashing during deletion, so no extra rehash
+     * progress is needed here for parity. */
 
     /* Collapse or downgrade the bucket based on how many entries remain.
      *

--- a/src/vset.c
+++ b/src/vset.c
@@ -724,6 +724,7 @@ void pvSort(pVector *pv, int (*compare)(const void *a, const void *b)) {
 #define VOLATILESET_BUCKET_INTERVAL_MIN (1LL << 4LL)  // 2^4 = 16 milliseconds
 
 #define VOLATILESET_VECTOR_BUCKET_MAX_SIZE 127
+#define VSET_EXPIRE_STACK_ENTRIES 128
 
 #define VSET_NONE_BUCKET_PTR ((void *)(uintptr_t) - 1)
 #define VSET_BUCKET_NONE -1      // matching the NULL case
@@ -1073,8 +1074,17 @@ static uint64_t hash_pointer(const void *ptr) {
     return (uint64_t)x;
 }
 
-hashtableType pointerHashtableType = {
+typedef struct {
+    size_t pop_scan_cursor[2];
+} pointerHashtableMetadata;
+
+static size_t pointerHashtableMetadataSize(void) {
+    return sizeof(pointerHashtableMetadata);
+}
+
+static hashtableType pointerHashtableType = {
     .hashFunction = hash_pointer,
+    .getMetadataSize = pointerHashtableMetadataSize,
 };
 
 static inline vsetBucket *findBucket(rax *expiry_buckets, long long expiry, unsigned char *key, size_t *key_len, long long *pbucket_ts, raxNode **node) {
@@ -1485,7 +1495,7 @@ static inline size_t vsetBucketRemoveExpired_SINGLE(vsetBucket **bucket, vsetGet
     if (max_count && getExpiry(entry) <= now) {
         freeVsetBucket(*bucket);
         *bucket = vsetBucketFromNone();
-        if (expiryFunc) expiryFunc(entry, ctx);
+        if (expiryFunc) expiryFunc(&entry, 1, ctx);
         return 1;
     }
     return 0;
@@ -1497,15 +1507,15 @@ static inline size_t vsetBucketRemoveExpired_VECTOR(vsetBucket **bucket, vsetGet
     uint32_t i = 0;
     for (; i < len; i++) {
         void *entry = pvGet(pv, i);
-        /* break as soon as the expiryFunc stops us OR we reached an entry which is not expired */
+        /* break as soon as we reach an entry which is not expired */
         if (getExpiry(entry) > now)
             break;
-        if (expiryFunc) expiryFunc(entry, ctx);
     }
     /* If no expiry occurred, no need to split. */
     if (i > 0) {
         pVector *new_pv = pvSplit(&pv, i);
         *bucket = (new_pv ? vsetBucketFromVector(new_pv) : vsetBucketFromNone());
+        if (expiryFunc) expiryFunc(pv->data, i, ctx);
         pvFree(pv);
     }
     return i;
@@ -1515,16 +1525,15 @@ static inline size_t vsetBucketRemoveExpired_HASHTABLE(vsetBucket **bucket, vset
     UNUSED(getExpiry);
     UNUSED(now);
     hashtable *ht = vsetBucketHashtable(*bucket);
-    hashtableIterator it;
-    void *entry;
-    size_t count = 0;
-    hashtableInitIterator(&it, ht, HASHTABLE_ITER_SAFE);
-    while (count < max_count && hashtableNext(&it, &entry)) {
-        assert(hashtableDelete(ht, entry));
-        expiryFunc(entry, ctx);
-        count++;
-    }
-    hashtableCleanupIterator(&it);
+    void *stack_entries[VSET_EXPIRE_STACK_ENTRIES];
+    size_t pop_count = min(max_count, hashtableSize(ht));
+    bool use_stack = pop_count <= VSET_EXPIRE_STACK_ENTRIES;
+    void **entries = use_stack ? stack_entries : zmalloc(sizeof(*entries) * pop_count);
+    pointerHashtableMetadata *metadata = hashtableMetadata(ht);
+    size_t count = hashtablePopAnyEntries(ht, entries, pop_count, metadata->pop_scan_cursor);
+
+    if (count > 0 && expiryFunc) expiryFunc(entries, count, ctx);
+    if (!use_stack) zfree(entries);
 
     /* Collapse or downgrade the bucket based on how many entries remain.
      *

--- a/src/vset.h
+++ b/src/vset.h
@@ -70,8 +70,8 @@
 
 /* Return the absolute expiration time in milliseconds for the provided entry */
 typedef long long (*vsetGetExpiryFunc)(const void *entry);
-/* Callback to be optionally provided to vsetRemoveExpired. when item is removed from the vset this callback will also be applied. */
-typedef int (*vsetExpiryFunc)(void *entry, void *ctx);
+/* Callback to be optionally provided to vsetRemoveExpired. When items are removed from the vset this callback will also be applied. */
+typedef void (*vsetExpiryFunc)(void **entries, size_t count, void *ctx);
 // vset is just a pointer to a bucket
 typedef void *vset;
 


### PR DESCRIPTION
  ## Problem

  Active expiry is slow when many fields of a hash expire at once.

  Although fields are reclaimed in bounded batches, each field was still deleted individually from both the volatile set
  and the hash table. Each deletion repeated bucket-chain maintenance and shrink checks, making large expiry batches
  unnecessarily expensive.

  ## What changed

  Expired fields are now removed in batches.

  vsetRemoveExpired() now passes all entries removed from a bucket to its callback at once. Two new hashtable helpers
  support this:

  - hashtablePopKnownEntries(ht, entries, count) removes entries whose pointers are already known. This is used for the
    hash table after the volatile set identifies the expired entries.

  - hashtablePopAnyEntries(ht, entries, count, cursor) removes up to count arbitrary entries. This is used to drain
    hashtable-encoded vset buckets, where all entries in the bucket are expired.

  Both helpers pause rehashing and auto-shrink for the batch, then perform cleanup once.

  hashtablePopAnyEntries() maintains a cursor across bounded drains to avoid repeatedly scanning empty bucket prefixes.
  For vset buckets, this adds 16 bytes of metadata only to hashtables containing at least 127 entries. Other server
  hashtables are unaffected.

  ## Safety

  The volatile set and hash table reference the same entries. Removal now follows this order:

  remove from vset
    -> pass the batch to the callback
    -> remove the same entries from the hash table
    -> propagate and free

  Callbacks therefore receive entries only after they have been removed from the vset, consistently across all bucket
  encodings. Previously, the vector path invoked the callback before removing entries from the vector.

  ## Fixed along the way

  The old path could let the vset expired count diverge from the number of fields collected for propagation.

  vsetRemoveExpired() counted each entry handed to the callback, but the old callback skipped ctx->fields[] when
  hashtablePop() failed. In that case, dbReclaimExpiredFields() could pass the larger expired count to
  propagateFieldsDeletion(), causing it to read uninitialized robj * slots as HDEL arguments.

  The batched callback now fills ctx->fields[] for every entry in the batch and asserts that all supplied entries were
  removed from the hash table, so the two counts can no longer diverge.

  ## Benchmark

  Measured with a temporary debug-only command that timed only dbReclaimExpiredFields():

```c
  long long start = ustime();
  size_t expired = dbReclaimExpiredFields(o, c->db, mstime(), max_fields, didx);
  long long elapsed = ustime() - start;
```

  x86-64, default make build. Median of 15 runs.

  | fields | max_fields | baseline us/field | patch us/field | change |
  |---:|---:|---:|---:|---:|
  | 4096 | 80 | 0.283 | 0.151 | -46.6% |
  | 4096 | 256 | 0.244 | 0.175 | -28.3% |
  | 8192 | 80 | 0.326 | 0.136 | -58.3% |
  | 8192 | 256 | 0.225 | 0.142 | -36.9% |
  | 9000 | 80 | 0.327 | 0.133 | -59.3% |
  | 9000 | 256 | 0.236 | 0.141 | -40.3% |
  | 10000 | 80 | 0.316 | 0.133 | -57.9% |
  | 10000 | 256 | 0.223 | 0.145 | -35.0% |

  The patched path stays nearly flat across sizes and batch limits, around 0.133-0.175 us/field by median. The baseline
  varies more, especially with smaller batches, because per-field deletion repeatedly pays bucket-chain maintenance and
  shrink checks.

  I use median instead of minimum because some small cases have large run-to-run variance. For example, the 4096/256
  baseline ranged from 533us to 1065us, while its median was 1000us.

  ## Tests

  Added unit coverage for:

  - chained buckets
  - batches larger than the stack buffer
  - cursor continuation without duplicates or skipped entries
  - partially drained buckets
  - tables undergoing rehash
  - cursor == NULL
  - dbReclaimExpiredFields() through the vset/hash deletion path

  Validated with:

  make
  make -C src test-unit
  ./runtest --single unit/hashexpire
  ./runtest --single unit/type/hash
  ./runtest --single unit/type/other