### PR TITLE
zset bugfix - Fix btree score range resolution and prefix staleness

### DIFF
--- a/src/fbtree.c
+++ b/src/fbtree.c
@@ -1562,6 +1562,10 @@ static leafNode *descendSubPath(node *start,
 }
 
 /* Wrappers to match the findChildFn signature */
+static int findChildByScoreWrapper(innerNode *inner, const void *key) {
+    return findChildIndexByScore(inner, (const char *)key);
+}
+
 static int findChildByValueWrapper(innerNode *inner, const void *key) {
     return findChildIndex(inner, (const_sds)key);
 }
@@ -2136,33 +2140,39 @@ static bool scorePrefixNext(const char *in, char *out) {
 }
 
 /* Rank of the first element whose score prefix is >= `score`, or the tree
- * length when no such element exists. This is a whole-tree lower bound: unlike
- * the per-leaf boundary resolution it stays correct when a run of elements
- * sharing `score` spans several leaves. */
+ * length when no such element exists. This is a whole-tree lower bound: it
+ * stays correct when a run of elements sharing `score` spans several leaves.
+ * Used for the rare unbounded-upper edge (the upper bound reaches past the
+ * largest representable score prefix) where a shared two-boundary descent has
+ * no finite hi key. */
 static unsigned long lowerBoundRankByScore(fbtreeIndex *fbt, const char *score) {
     fbtreeIterator iterator;
     fbtreeInitIterator(&iterator, fbt);
     long rank = fbtreeSeekToScore(score, &iterator);
-    return rank < 0 ? 0 : (unsigned long)rank;
+    /* fbtreeSeekToScore returns the count of elements before the position, so
+     * it is never negative (0 for an empty tree). */
+    assert(rank >= 0);
+    return (unsigned long)rank;
 }
 
-/* Translate a score range with inclusive/exclusive bounds into the half-open
- * rank range [*out_start, *out_end). Returns false when the range is empty.
+/* Turn a score range with inclusive/exclusive bounds into the half-open
+ * score-prefix window [lo, hi): every element with lo <= score(e) < hi is in
+ * range. Returns false when the window is provably empty. When the upper edge
+ * would exceed the largest representable prefix, *hi_unbounded is set (the
+ * window runs to the tree end) and hi is left unset.
  *
- * Both edges are computed with the same whole-tree lower-bound seek, which is
- * why this is robust to duplicate scores: the range is
- *   { e : LO <= score(e) < HI }
- * with LO = min (or the next prefix above it when min is exclusive) and
- * HI = the next prefix above max (or max itself when max is exclusive). */
-static bool scoreRangeToRanks(fbtreeIndex *fbt,
-                              const char *min_score,
-                              const char *max_score,
-                              int min_ex,
-                              int max_ex,
-                              unsigned long *out_start,
-                              unsigned long *out_end) {
-    char lo[SCORE_SIZE], hi[SCORE_SIZE];
-    bool hi_unbounded = false;
+ * Both edges are expressed as lower-bound prefixes (the first prefix at or
+ * above a value), which is what makes the range duplicate-safe: a run of
+ * elements sharing a score is included or excluded as a unit even when it spans
+ * several leaves. */
+static bool scoreRangeBounds(const char *min_score,
+                             const char *max_score,
+                             int min_ex,
+                             int max_ex,
+                             char lo[SCORE_SIZE],
+                             char hi[SCORE_SIZE],
+                             bool *hi_unbounded) {
+    *hi_unbounded = false;
 
     if (min_ex) {
         if (!scorePrefixNext(min_score, lo)) return false; /* nothing sorts above min */
@@ -2173,18 +2183,76 @@ static bool scoreRangeToRanks(fbtreeIndex *fbt,
     if (max_ex) {
         memcpy(hi, max_score, SCORE_SIZE);
     } else if (!scorePrefixNext(max_score, hi)) {
-        hi_unbounded = true; /* max is the largest possible prefix: no upper cut */
+        *hi_unbounded = true; /* max is the largest possible prefix: no upper cut */
     }
 
-    if (!hi_unbounded && memcmp(lo, hi, SCORE_SIZE) >= 0) return false;
-
-    unsigned long start = lowerBoundRankByScore(fbt, lo);
-    unsigned long end = hi_unbounded ? fbtreeLength(fbt) : lowerBoundRankByScore(fbt, hi);
-    if (end <= start) return false;
-
-    *out_start = start;
-    *out_end = end;
+    if (!*hi_unbounded && memcmp(lo, hi, SCORE_SIZE) >= 0) return false;
     return true;
+}
+
+/* Two independent lower-bound searches (first element with score prefix >= key)
+ * over two DIFFERENT leaves, stepped in lockstep so both leaves' pointer-chase
+ * cache misses are outstanding at once (memory-level parallelism). Each
+ * values[mid] is a separately allocated sds, so every probe is a miss;
+ * interleaving the two searches and prefetching both payloads per step lets the
+ * out-of-order core overlap them instead of serializing 2*log2(leaf) misses.
+ * Mirrors resolveBothIdxPrefetch but resolves pure lower bounds (both edges are
+ * "first >= key"), which is the half-open form the score range needs. */
+static void lowerBoundBothByScore(const leafNode *lo_leaf, const char *lo, const leafNode *hi_leaf, const char *hi, int *out_lo_idx, int *out_hi_idx) {
+    int llo = 0, lhi = lo_leaf->header.num_items;
+    int hlo = 0, hhi = hi_leaf->header.num_items;
+    while (llo < lhi || hlo < hhi) {
+        int lmid = (llo + lhi) / 2;
+        int hmid = (hlo + hhi) / 2;
+        if (llo < lhi) __builtin_prefetch(lo_leaf->values[lmid]);
+        if (hlo < hhi) __builtin_prefetch(hi_leaf->values[hmid]);
+        if (llo < lhi) {
+            if (memcmp(lo_leaf->values[lmid], lo, SCORE_SIZE) < 0)
+                llo = lmid + 1;
+            else
+                lhi = lmid;
+        }
+        if (hlo < hhi) {
+            if (memcmp(hi_leaf->values[hmid], hi, SCORE_SIZE) < 0)
+                hlo = hmid + 1;
+            else
+                hhi = hmid;
+        }
+    }
+    *out_lo_idx = llo;
+    *out_hi_idx = hlo;
+}
+
+/* Resolve a finite half-open score window [lo, hi) with ONE shared tree descent
+ * (see buildBoundaryPaths). Fills `bp` with both boundary leaves and their
+ * sub-paths, records the lower-bound leaf indices (bp->start_idx = first element
+ * >= lo; the hi lower bound is returned via *out_hi_idx), and reports the global
+ * ranks of both edges. Returns whether both edges fall in the same leaf.
+ *
+ * Both leaf-local edges use lower-bound ("first element with score prefix >=
+ * key") resolution; the child_sizes accumulation in rankFromBoundaryPath turns
+ * each leaf-local index into a global rank, all from a single root->leaf
+ * descent. Because both edges are lower bounds the window is duplicate-score
+ * safe: hi marks the first element excluded from the range, so an equal-score
+ * run is kept or dropped as a unit even when it continues into the next leaf. */
+static bool scoreRangeSharedDescent(fbtreeIndex *fbt, const char *lo, const char *hi, BoundaryPaths *bp, int *out_hi_idx, unsigned long *out_start_rank, unsigned long *out_end_rank) {
+    bool same_leaf = buildBoundaryPaths(fbt, bp, lo, hi, findChildByScoreWrapper);
+
+    int lo_idx, hi_idx;
+    if (same_leaf) {
+        /* One leaf: nothing independent to overlap, resolve directly. */
+        lo_idx = leafNodeBinarySearchByScore(bp->start_leaf, lo);
+        hi_idx = leafNodeBinarySearchByScore(bp->end_leaf, hi);
+    } else {
+        /* Two leaves: software-pipeline the searches so the misses overlap. */
+        lowerBoundBothByScore(bp->start_leaf, lo, bp->end_leaf, hi, &lo_idx, &hi_idx);
+    }
+
+    bp->start_idx = lo_idx;
+    *out_hi_idx = hi_idx;
+    *out_start_rank = rankFromBoundaryPath(bp, false, lo_idx);
+    *out_end_rank = rankFromBoundaryPath(bp, true, hi_idx);
+    return same_leaf;
 }
 
 /* Delete elements with score prefix in [min_score, max_score].
@@ -2201,9 +2269,49 @@ unsigned long fbtreeDeleteRangeByScore(fbtreeIndex *fbt,
                                        void *callback_ctx) {
     if (!fbt->root) return 0;
 
-    unsigned long start, end;
-    if (!scoreRangeToRanks(fbt, min_score, max_score, min_ex, max_ex, &start, &end)) return 0;
-    return fbtreeDeleteRangeByRank(fbt, start, end - 1, callback, callback_ctx);
+    /* Delete-all short-circuit: when both bounds fall outside the stored score
+     * range every element qualifies, so free the whole tree in one pass rather
+     * than descending for boundaries. */
+    const_sds first = leafNodeLowKey(fbt->leftmost_leaf);
+    const_sds last = leafNodeHighKey(fbt->rightmost_leaf);
+    int min_covers = min_ex ? memcmp(min_score, first, SCORE_SIZE) < 0 : memcmp(min_score, first, SCORE_SIZE) <= 0;
+    int max_covers = max_ex ? memcmp(max_score, last, SCORE_SIZE) > 0 : memcmp(max_score, last, SCORE_SIZE) >= 0;
+    if (min_covers && max_covers) {
+        unsigned long count = fbtreeLength(fbt);
+        fbtreeDeleteAll(fbt, callback, callback_ctx);
+        return count;
+    }
+
+    char lo[SCORE_SIZE], hi[SCORE_SIZE];
+    bool hi_unbounded;
+    if (!scoreRangeBounds(min_score, max_score, min_ex, max_ex, lo, hi, &hi_unbounded)) return 0;
+
+    if (hi_unbounded) {
+        /* Range runs to the tree end: the upper bound reaches past the largest
+         * representable score prefix, so there is no finite hi key to anchor the
+         * right boundary of a shared descent. min is finite here (the fully
+         * covered range was handled by the delete-all short-circuit above). One
+         * lower-bound seek plus the rank-based delete. */
+        unsigned long start = lowerBoundRankByScore(fbt, lo);
+        unsigned long length = fbtreeLength(fbt);
+        if (length <= start) return 0;
+        return fbtreeDeleteRangeByRank(fbt, start, length - 1, callback, callback_ctx);
+    }
+
+    /* Single shared descent locates both boundary leaves and records the paths
+     * that deleteRangeCore / deleteRangeSameLeaf consume. The hi lower bound is
+     * the first element NOT in range, so the last element to delete sits one
+     * position before it (end_idx = hi_idx - 1). When hi_idx == 0 the end leaf
+     * holds no in-range element and end_idx becomes -1, the "end leaf untouched"
+     * case the delete engine handles for the value path as well. */
+    BoundaryPaths bp;
+    int hi_idx;
+    unsigned long start_rank, end_rank;
+    bool same_leaf = scoreRangeSharedDescent(fbt, lo, hi, &bp, &hi_idx, &start_rank, &end_rank);
+    if (end_rank <= start_rank) return 0; /* empty range */
+    bp.end_idx = hi_idx - 1;
+    return same_leaf ? deleteRangeSameLeaf(fbt, &bp, callback, callback_ctx)
+                     : deleteRangeCore(fbt, &bp, callback, callback_ctx);
 }
 
 /* Delete elements with value in [min_val, max_val] using full sds comparison.
@@ -2264,9 +2372,20 @@ unsigned long fbtreeCountRangeByScore(fbtreeIndex *fbt,
     int max_covers = max_ex ? memcmp(max_score, last, SCORE_SIZE) > 0 : memcmp(max_score, last, SCORE_SIZE) >= 0;
     if (min_covers && max_covers) return fbtreeLength(fbt);
 
-    unsigned long start, end;
-    if (!scoreRangeToRanks(fbt, min_score, max_score, min_ex, max_ex, &start, &end)) return 0;
-    return end - start;
+    char lo[SCORE_SIZE], hi[SCORE_SIZE];
+    bool hi_unbounded;
+    if (!scoreRangeBounds(min_score, max_score, min_ex, max_ex, lo, hi, &hi_unbounded)) return 0;
+
+    /* Unbounded upper edge (upper bound reaches past the largest representable
+     * score prefix): one lower-bound seek; the rest of the tree is in range. */
+    if (hi_unbounded) return fbtreeLength(fbt) - lowerBoundRankByScore(fbt, lo);
+
+    /* Finite window: one shared descent yields both boundary ranks. */
+    BoundaryPaths bp;
+    int hi_idx;
+    unsigned long start_rank, end_rank;
+    scoreRangeSharedDescent(fbt, lo, hi, &bp, &hi_idx, &start_rank, &end_rank);
+    return end_rank > start_rank ? end_rank - start_rank : 0;
 }
 
 /* Count elements with packed value in [min_val, max_val] via a single shared

--- a/src/fbtree.c
+++ b/src/fbtree.c
@@ -226,7 +226,21 @@ static inline void innerNodeMoveChildren(innerNode *node, int dst_idx, int src_i
 }
 
 static bool updateCommonPrefix(innerNode *inner) {
-    if (inner->header.num_items < 2) return false;
+    if (inner->header.num_items < 2) {
+        /* A node reduced to one child (by a range delete removing all its
+         * siblings) can still be holding the prefix it derived when it had
+         * >= 2 anchors. The surviving child is child 0, whose key range
+         * extends BELOW its own high key, so when the range delete truncates
+         * it innerNodeRefreshChildMeta() installs a smaller anchor that need
+         * not start with the retained prefix. Drop compression here:
+         * prefix_len 0 is trivially a prefix of every anchor. */
+        if (inner->prefix_len != 0) {
+            innerNodeSetPrefix(inner, "", 0);
+            recomputeFeatures(inner);
+            return true;
+        }
+        return false;
+    }
 
     /* Compute the common prefix of this node's first and last anchors.
      * Anchors are high keys of children, so this is the common prefix among
@@ -1524,7 +1538,7 @@ typedef struct {
  * Returns the leaf node reached.
  *
  * When called with a compile-time-constant function pointer (e.g.,
- * findChildByScoreWrapper), the compiler can inline both this helper and the
+ * findChildByValueWrapper), the compiler can inline both this helper and the
  * callback at -O2, producing specialized code with no indirect calls. */
 typedef int (*findChildFn)(innerNode *inner, const void *key);
 
@@ -1548,10 +1562,6 @@ static leafNode *descendSubPath(node *start,
 }
 
 /* Wrappers to match the findChildFn signature */
-static int findChildByScoreWrapper(innerNode *inner, const void *key) {
-    return findChildIndexByScore(inner, (const char *)key);
-}
-
 static int findChildByValueWrapper(innerNode *inner, const void *key) {
     return findChildIndex(inner, (const_sds)key);
 }
@@ -1559,10 +1569,6 @@ static int findChildByValueWrapper(innerNode *inner, const void *key) {
 /* Comparison function for leaf-level index resolution.
  * Returns <0, 0, or >0 like memcmp/sdscmp. */
 typedef int (*leafCmpFn)(const_sds element, const void *key);
-
-static int leafCmpByScore(const_sds element, const void *key) {
-    return memcmp(element, key, SCORE_SIZE);
-}
 
 static int leafCmpByValue(const_sds element, const void *key) {
     return sdscmp(element, (const_sds)key);
@@ -2110,6 +2116,77 @@ unsigned long fbtreeDeleteRangeByRank(fbtreeIndex *fbt,
     return deleteRangeSameLeaf(fbt, &bp, callback, callback_ctx);
 }
 
+/* Lexicographically next 8-byte score prefix. Returns false when `in` is all
+ * 0xFF, i.e. no score prefix sorts above it. Incrementing the big-endian
+ * 8-byte value yields the next possible prefix in memcmp order, so an
+ * exclusive score bound can be rewritten as an inclusive bound on the next
+ * prefix. This is pure byte-string reasoning; it does not assume anything
+ * about how scores are normalized. */
+static bool scorePrefixNext(const char *in, char *out) {
+    memcpy(out, in, SCORE_SIZE);
+    for (int i = SCORE_SIZE - 1; i >= 0; i--) {
+        unsigned char c = (unsigned char)out[i];
+        if (c != 0xFF) {
+            out[i] = (char)(c + 1);
+            return true;
+        }
+        out[i] = 0;
+    }
+    return false;
+}
+
+/* Rank of the first element whose score prefix is >= `score`, or the tree
+ * length when no such element exists. This is a whole-tree lower bound: unlike
+ * the per-leaf boundary resolution it stays correct when a run of elements
+ * sharing `score` spans several leaves. */
+static unsigned long lowerBoundRankByScore(fbtreeIndex *fbt, const char *score) {
+    fbtreeIterator iterator;
+    fbtreeInitIterator(&iterator, fbt);
+    long rank = fbtreeSeekToScore(score, &iterator);
+    return rank < 0 ? 0 : (unsigned long)rank;
+}
+
+/* Translate a score range with inclusive/exclusive bounds into the half-open
+ * rank range [*out_start, *out_end). Returns false when the range is empty.
+ *
+ * Both edges are computed with the same whole-tree lower-bound seek, which is
+ * why this is robust to duplicate scores: the range is
+ *   { e : LO <= score(e) < HI }
+ * with LO = min (or the next prefix above it when min is exclusive) and
+ * HI = the next prefix above max (or max itself when max is exclusive). */
+static bool scoreRangeToRanks(fbtreeIndex *fbt,
+                              const char *min_score,
+                              const char *max_score,
+                              int min_ex,
+                              int max_ex,
+                              unsigned long *out_start,
+                              unsigned long *out_end) {
+    char lo[SCORE_SIZE], hi[SCORE_SIZE];
+    bool hi_unbounded = false;
+
+    if (min_ex) {
+        if (!scorePrefixNext(min_score, lo)) return false; /* nothing sorts above min */
+    } else {
+        memcpy(lo, min_score, SCORE_SIZE);
+    }
+
+    if (max_ex) {
+        memcpy(hi, max_score, SCORE_SIZE);
+    } else if (!scorePrefixNext(max_score, hi)) {
+        hi_unbounded = true; /* max is the largest possible prefix: no upper cut */
+    }
+
+    if (!hi_unbounded && memcmp(lo, hi, SCORE_SIZE) >= 0) return false;
+
+    unsigned long start = lowerBoundRankByScore(fbt, lo);
+    unsigned long end = hi_unbounded ? fbtreeLength(fbt) : lowerBoundRankByScore(fbt, hi);
+    if (end <= start) return false;
+
+    *out_start = start;
+    *out_end = end;
+    return true;
+}
+
 /* Delete elements with score prefix in [min_score, max_score].
  * min_ex/max_ex: if true, the corresponding bound is exclusive.
  * Score is an 8-byte big-endian normalized prefix (as stored in the tree).
@@ -2124,28 +2201,9 @@ unsigned long fbtreeDeleteRangeByScore(fbtreeIndex *fbt,
                                        void *callback_ctx) {
     if (!fbt->root) return 0;
 
-    /* Delete-all short-circuit */
-    sds first = leafNodeLowKey(fbt->leftmost_leaf);
-    sds last = leafNodeHighKey(fbt->rightmost_leaf);
-    int min_covers = min_ex ? memcmp(min_score, first, SCORE_SIZE) < 0 : memcmp(min_score, first, SCORE_SIZE) <= 0;
-    int max_covers = max_ex ? memcmp(max_score, last, SCORE_SIZE) > 0 : memcmp(max_score, last, SCORE_SIZE) >= 0;
-    if (min_covers && max_covers) {
-        unsigned long count = fbtreeLength(fbt);
-        fbtreeDeleteAll(fbt, callback, callback_ctx);
-        return count;
-    }
-
-    /* Quick check: empty range */
-    int range_cmp = memcmp(min_score, max_score, SCORE_SIZE);
-    if (range_cmp > 0 || (range_cmp == 0 && (min_ex || max_ex))) return 0;
-
-    /* Descend once to build the boundary paths, then delete. */
-    BoundaryPaths bp;
-    bool same_leaf = buildBoundaryPaths(fbt, &bp, min_score, max_score, findChildByScoreWrapper);
-    bp.start_idx = resolveStartIdx(bp.start_leaf, min_score, min_ex, leafCmpByScore);
-    bp.end_idx = resolveEndIdx(bp.end_leaf, max_score, max_ex, leafCmpByScore);
-    return same_leaf ? deleteRangeSameLeaf(fbt, &bp, callback, callback_ctx)
-                     : deleteRangeCore(fbt, &bp, callback, callback_ctx);
+    unsigned long start, end;
+    if (!scoreRangeToRanks(fbt, min_score, max_score, min_ex, max_ex, &start, &end)) return 0;
+    return fbtreeDeleteRangeByRank(fbt, start, end - 1, callback, callback_ctx);
 }
 
 /* Delete elements with value in [min_val, max_val] using full sds comparison.
@@ -2196,34 +2254,19 @@ unsigned long fbtreeCountRangeByScore(fbtreeIndex *fbt,
                                       int max_ex) {
     if (!fbt->root) return 0;
 
-    /* Whole-tree short-circuit */
-    sds first = leafNodeLowKey(fbt->leftmost_leaf);
-    sds last = leafNodeHighKey(fbt->rightmost_leaf);
+    /* Whole-tree short-circuit: when both bounds fall outside the stored score
+     * range every element qualifies, so answer with the tree length rather than
+     * paying for the two boundary descents. `ZCOUNT key -inf +inf` is the common
+     * case this serves. */
+    const_sds first = leafNodeLowKey(fbt->leftmost_leaf);
+    const_sds last = leafNodeHighKey(fbt->rightmost_leaf);
     int min_covers = min_ex ? memcmp(min_score, first, SCORE_SIZE) < 0 : memcmp(min_score, first, SCORE_SIZE) <= 0;
     int max_covers = max_ex ? memcmp(max_score, last, SCORE_SIZE) > 0 : memcmp(max_score, last, SCORE_SIZE) >= 0;
     if (min_covers && max_covers) return fbtreeLength(fbt);
 
-    /* Empty range */
-    int range_cmp = memcmp(min_score, max_score, SCORE_SIZE);
-    if (range_cmp > 0 || (range_cmp == 0 && (min_ex || max_ex))) return 0;
-
-    BoundaryPaths bp;
-    bool same_leaf = buildBoundaryPaths(fbt, &bp, min_score, max_score, findChildByScoreWrapper);
-    if (same_leaf) {
-        /* One leaf: nothing to overlap, resolve directly. */
-        bp.start_idx = resolveStartIdx(bp.start_leaf, min_score, min_ex, leafCmpByScore);
-        bp.end_idx = resolveEndIdx(bp.end_leaf, max_score, max_ex, leafCmpByScore);
-    } else {
-        /* Two leaves: software-pipeline the searches so both misses overlap. */
-        resolveBothIdxPrefetch(bp.start_leaf, min_score, min_ex, bp.end_leaf, max_score, max_ex,
-                               leafCmpByScore, &bp.start_idx, &bp.end_idx);
-    }
-
-    /* start_idx is the first in-range element; end_idx is the last in-range
-     * element (inclusive), so its one-past position is end_idx + 1. */
-    unsigned long start_rank = rankFromBoundaryPath(&bp, false, bp.start_idx);
-    unsigned long end_rank = rankFromBoundaryPath(&bp, true, bp.end_idx + 1);
-    return end_rank > start_rank ? end_rank - start_rank : 0;
+    unsigned long start, end;
+    if (!scoreRangeToRanks(fbt, min_score, max_score, min_ex, max_ex, &start, &end)) return 0;
+    return end - start;
 }
 
 /* Count elements with packed value in [min_val, max_val] via a single shared

--- a/src/fbtree.c
+++ b/src/fbtree.c
@@ -1810,14 +1810,25 @@ static unsigned long deleteRangeSameLeaf(fbtreeIndex *fbt,
  * If callback is non-NULL, it is invoked for each deleted item before sdsfree.
  * Returns the number of elements deleted. */
 static unsigned long deleteRangeCore(fbtreeIndex *fbt, BoundaryPaths *bp, fbtreeItemCallback callback, void *callback_ctx) {
-    /* Empty range check: score/value path builders can produce boundary
-     * indices that fall outside the leaf (no matching elements in that leaf).
-     * Rank paths never hit this since ranks are pre-validated. */
-    if (bp->start_idx >= bp->start_leaf->header.num_items && bp->end_idx < 0) return 0;
+    /* No whole-range empty short-circuit is needed here for the
+     * leaf-untouched-on-both-sides case: unlike deleteRangeSameLeaf (where
+     * an out-of-range boundary index unambiguously means nothing to delete
+     * within that single leaf), a diverged-path range can still be
+     * non-empty even when both boundary leaves are untouched, because
+     * whole subtrees strictly between the two descent paths -- at the split
+     * node's own children, or at any level below either boundary's descent
+     * path -- may lie wholly inside [min_key, max_key]. Checking only the
+     * split node's immediate children (as an adjacency test) misses middle
+     * subtrees that appear one or more levels further down, so no local
+     * check here can be both cheap and correct. The splice and fixup below
+     * handle the truly-empty case naturally: when there is really nothing
+     * in range, every per-level loop below finds no boundary-untouched
+     * work and no middle children to free, and the function falls through
+     * having deleted (and returned) zero elements. */
+    int split_depth = bp->shared_depth - 1;
     if (bp->end_idx < 0 && bp->start_leaf == bp->end_leaf) return 0;
 
     /* --- Phase 1: Boundaries diverged. Process the split. --- */
-    int split_depth = bp->shared_depth - 1;
     innerNode *split_node = (innerNode *)bp->shared_path[split_depth];
     int li = bp->shared_left_idx[split_depth];
     int ri = bp->shared_right_idx[split_depth];

--- a/src/unit/test_fbtree.cpp
+++ b/src/unit/test_fbtree.cpp
@@ -3026,6 +3026,86 @@ TEST_F(FbtreeTest, DeleteRangeByRankThenInsert) {
     EXPECT_EQ(all.size(), 20u);
 }
 
+/* A range delete that strips every sibling from an inner node leaves that node
+ * with a single child. If updateCommonPrefix() skips the recompute for such a
+ * node, it retains the prefix derived when the node still had >= 2 anchors,
+ * while innerNodeRefreshChildMeta() has just rewritten the surviving child-0
+ * anchor. Child 0's key range extends BELOW its own high key, so the refreshed
+ * anchor can fall below the retained prefix, breaking the "every anchor starts
+ * with the node prefix" invariant. This test guards that path.
+ *
+ * Needs a >= 3-level tree, and the delete must (a) start inside child 0 of a
+ * depth-1 inner node, (b) extend past the end of that node's subtree, and
+ * (c) stop short of the last root child so the node is not collapsed away.
+ * Keys are equal length, so the tree shape depends only on the element count:
+ * the first pass learns the shape, the second builds the triggering content. */
+TEST_F(FbtreeTest, RangeDeleteLeavingSingleChildKeepsPrefixValid) {
+    const int N = TEST_THREE_LEVEL_ITEMS * 3; /* comfortably 3 levels */
+
+    /* Pass 1: uniform keys, purely to locate a suitable depth-1 inner node. */
+    for (int i = 0; i < N; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "b%08d", i);
+        fbtreeInsert(fbt, createString(buf));
+    }
+    ASSERT_FALSE(fbt->root->is_leaf);
+    ASSERT_GT(fbtreeHeight(fbt), 2UL) << "test needs a >= 3-level tree";
+
+    int flip = -1, del_start = -1, del_end = -1;
+    {
+        innerNode *root = (innerNode *)(void *)fbt->root;
+        size_t rank = 0;
+        for (int i = 0; i < root->header.num_items; i++) {
+            node *child = root->children[i];
+            size_t subtree = root->child_sizes[i];
+            /* Skip root child 0: its child 0 has no lower neighbour to dip into. */
+            if (i >= 1 && !child->is_leaf && flip < 0) {
+                innerNode *d = (innerNode *)(void *)child;
+                if (d->header.num_items >= 2) {
+                    size_t c0 = d->child_sizes[0];
+                    flip = (int)(rank + c0 / 2);     /* inside child 0 of this node */
+                    del_start = (int)(rank + 1);     /* keep >= 1 survivor in child 0 */
+                    del_end = (int)(rank + subtree); /* one past this subtree */
+                }
+            }
+            rank += subtree;
+        }
+    }
+    ASSERT_GE(flip, 0) << "no suitable depth-1 inner node found";
+
+    /* Pass 2: rebuild so the key prefix flips 'a' -> 'b' at `flip`. Ordering is
+     * still by index, so the shape is identical to pass 1. */
+    fbtreeFree(fbt);
+    fbt = fbtreeCreate();
+    for (int i = 0; i < N; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%c%08d", i < flip ? 'a' : 'b', i);
+        fbtreeInsert(fbt, createString(buf));
+    }
+    expectValid();
+
+    unsigned long deleted = fbtreeDeleteRangeByRank(fbt, del_start, del_end, NULL, NULL);
+    EXPECT_EQ(deleted, (unsigned long)(del_end - del_start + 1));
+
+    char errmsg[256];
+    ASSERT_TRUE(fbtreeDebugValidate(fbt, false, errmsg, sizeof(errmsg))) << errmsg;
+
+    /* The surviving elements must still be exactly the expected set, in order. */
+    fbtreeIterator it;
+    fbtreeInitIterator(&it, fbt);
+    const_sds pos;
+    for (int i = 0; i < N; i++) {
+        if (i >= del_start && i <= del_end) continue;
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%c%08d", i < flip ? 'a' : 'b', i);
+        sds expected = createString(buf);
+        ASSERT_NE(pos = fbtreeNext(&it), nullptr) << "tree exhausted at index " << i;
+        EXPECT_EQ(sdscmp(pos, expected), 0);
+        sdsfree(expected);
+    }
+    EXPECT_EQ(pos = fbtreeNext(&it), nullptr);
+}
+
 TEST_F(FbtreeTest, DeleteRangeByRankDeepTree) {
     /* Build a 3+ level tree */
     const int N = TEST_THREE_LEVEL_ITEMS;

--- a/src/unit/test_fbtree.cpp
+++ b/src/unit/test_fbtree.cpp
@@ -3420,6 +3420,112 @@ TEST_F(FbtreeTest, DeleteRangeByValueNoMatch) {
     expectValid();
 }
 
+/* Regression test for a false-empty short-circuit in deleteRangeCore.
+ *
+ * The tree spans multiple leaves (NODE_SIZE=61 forces this with 300+
+ * elements). After trimming the first leaf down to a single low member, a
+ * later range delete has BOTH boundaries land in leaves with no locally
+ * matching elements ("leaf-untouched") while the split node still has one
+ * or more middle children strictly between the boundary subtrees, wholly
+ * inside the deleted range and non-empty. The buggy guard only checked
+ * leaf-local untouched-ness and returned 0 (deleted nothing) even though
+ * those middle leaves' elements were still in range. */
+TEST_F(FbtreeTest, DeleteRangeByValueSkipsNoMiddleLeafFalseEmpty) {
+    /* Seed enough elements to force several leaves/levels: an empty-string
+     * low sentinel plus 300 zero-padded members "m0001".."m0300". */
+    insert("");
+    char buf[16];
+    for (int i = 1; i <= 300; i++) {
+        snprintf(buf, sizeof(buf), "m%04d", i);
+        insert(buf);
+    }
+    EXPECT_EQ(fbtreeLength(fbt), 301u);
+
+    /* Trim the first leaf down to just the empty-string member: removes
+     * [m0001, m0060] inclusive, leaving the low leaf with a single element
+     * and no members in the immediately following range. */
+    sds trim_min = createString("m0001");
+    sds trim_max = createString("m0060");
+    EXPECT_EQ(fbtreeDeleteRangeByValue(fbt, trim_min, trim_max, 0, 0, NULL, NULL), 60u);
+    sdsfree(trim_min);
+    sdsfree(trim_max);
+    expectValid();
+    EXPECT_EQ(fbtreeLength(fbt), 241u);
+
+    /* Exclusive lower bound just past the trimmed leaf's remaining element,
+     * and an upper bound landing in the gap just after "m0121" (no stored
+     * element equals "m0121x"). Both boundary leaves are leaf-locally
+     * untouched, but middle leaves fully inside the range still exist. */
+    sds range_min = createString("");
+    sds range_max = createString("m0121x");
+    unsigned long expected = fbtreeCountRangeByValue(fbt, range_min, range_max, 1, 0);
+    ASSERT_GT(expected, 0u) << "range must be non-empty for this regression to be meaningful";
+
+    unsigned long removed = fbtreeDeleteRangeByValue(fbt, range_min, range_max, 1, 0, NULL, NULL);
+    sdsfree(range_min);
+    sdsfree(range_max);
+    expectValid();
+
+    EXPECT_EQ(removed, expected) << "deleteRangeCore must not short-circuit to 0 when non-empty middle leaves lie between untouched boundary leaves";
+}
+
+/* Regression test for a DEEPER false-empty short-circuit in deleteRangeCore
+ * than the one covered above. The prior fix's guard (no_middle_child) only
+ * checks adjacency of the SPLIT NODE's own boundary children (shared_left_idx
+ * / shared_right_idx at split_depth). It says nothing about levels below the
+ * split: when the split happens at the root and the root has exactly two
+ * children (a common shape once a two-level tree overflows into a third
+ * level), those two children are trivially "adjacent" (li=0, ri=1) even
+ * though each child is itself a whole inner-node subtree with many leaves.
+ * If the min boundary's descent path picks a non-rightmost child at some
+ * level under root->children[li], the right-siblings at that level are
+ * middle subtrees fully inside the deleted range that the split-node-only
+ * guard cannot see (symmetric on the right side under root->children[ri]).
+ *
+ * 5000 zero-padded members force height 3: NODE_SIZE=61 fans out to at most
+ * 61 leaves per level-2 inner node (61*61=3721 items per full level-2
+ * subtree), so 5000 items split across exactly two such level-2 subtrees
+ * under the root -- the shape this test needs.
+ *
+ * The chosen bounds land both boundaries in an untouched state at the LEAF
+ * level (exclusive bound resolves past/before the boundary leaf's members),
+ * which is exactly what makes the split-node guard's no_middle_child==true
+ * wrongly conclude the whole range is empty -- while leaves strictly between
+ * the min's leaf and the max's leaf, one level below the root, still hold
+ * thousands of in-range elements. */
+TEST_F(FbtreeTest, DeleteRangeByValueSkipsDeeperMiddleLeafFalseEmpty) {
+    /* 5000 zero-padded members "m00001".."m05000", forcing height 3. */
+    char buf[16];
+    for (int i = 1; i <= 5000; i++) {
+        snprintf(buf, sizeof(buf), "m%05d", i);
+        insert(buf);
+    }
+    EXPECT_EQ(fbtreeLength(fbt), 5000u);
+    EXPECT_EQ(fbtreeHeight(fbt), 3u);
+
+    /* Exclusive bounds discovered by direct probing of this exact 5000-item
+     * tree shape: min excludes "m00061" (the last member of the leftmost
+     * leaf, landing start_idx just past that leaf -- leaf-untouched), max
+     * excludes "m02868" (the first member of some leaf under the root's
+     * second child, landing end_idx just before that leaf -- also
+     * leaf-untouched). Both boundary leaves are untouched, root's two
+     * children are (trivially) adjacent, yet 2806 elements strictly between
+     * them are in range. */
+    sds range_min = createString("m00061");
+    sds range_max = createString("m02868");
+    unsigned long expected = fbtreeCountRangeByValue(fbt, range_min, range_max, 1, 1);
+    ASSERT_EQ(expected, 2806u) << "expected count must match the probed shape for this regression to be meaningful";
+
+    unsigned long removed = fbtreeDeleteRangeByValue(fbt, range_min, range_max, 1, 1, NULL, NULL);
+    sdsfree(range_min);
+    sdsfree(range_max);
+    expectValid();
+
+    EXPECT_EQ(removed, expected) << "deleteRangeCore must not short-circuit to 0 when non-empty middle "
+                                    "leaves lie one or more levels below the split node between "
+                                    "leaf-untouched boundaries";
+}
+
 TEST_F(FbtreeTest, DeleteRangeByValueExactMatch) {
     insert("aaa");
     insert("bbb");

--- a/src/unit/test_fbtree.cpp
+++ b/src/unit/test_fbtree.cpp
@@ -3526,6 +3526,149 @@ TEST_F(FbtreeTest, DeleteRangeByValueSkipsDeeperMiddleLeafFalseEmpty) {
                                     "leaf-untouched boundaries";
 }
 
+/* Exclusive range bounds that land exactly on a real member sitting at a
+ * leaf's fill edge (the last member of the leaf below the bound, or the
+ * first member of the leaf above it) have repeatedly disagreed between
+ * fbtreeCountRangeByValue and fbtreeDeleteRangeByValue: excluding the
+ * actual last item of a leaf pushes the descent index past that leaf's
+ * item count, which upstream code has mistaken for "this side is out of
+ * range" even when whole leaves and subtrees strictly between the two
+ * boundaries remain in range. Synthetic between-member values do not
+ * reach this state -- they land at the next leaf's insertion point without
+ * ever aligning with a real fill edge -- so this sweep only uses bounds
+ * equal to real inserted members, concentrated at multiples of NODE_SIZE
+ * (61) where a leaf actually fills, plus a coarser stride for background
+ * coverage away from those edges. The score-comparison path is not swept
+ * here: probing it directly showed no equivalent alignment sensitivity,
+ * so it is omitted to keep the property scoped to the code path that is
+ * actually affected. */
+TEST_F(FbtreeTest, DeleteRangeMatchesCountAcrossExclusiveBounds) {
+    /* --- Tree A: 300 members, height 2. --- */
+    {
+        const int kTotalA = 300;
+        const int leaf_edges_a[] = {61, 122, 183, 244};
+        const int num_leaf_edges_a = 4;
+        const int stride_a = 23;
+        const int j_stride_a = 31;
+        const int j_extra_a[] = {122, 183, 244};
+        const int num_j_extra_a = 3;
+
+        int min_indexes[64];
+        int num_mins = 0;
+        for (int k = 0; k < num_leaf_edges_a; k++) min_indexes[num_mins++] = leaf_edges_a[k];
+        for (int i = stride_a; i < kTotalA; i += stride_a) {
+            int dup = 0;
+            for (int k = 0; k < num_mins; k++) {
+                if (min_indexes[k] == i) dup = 1;
+            }
+            if (!dup) min_indexes[num_mins++] = i;
+        }
+
+        int max_indexes[64];
+        int num_maxs = 0;
+        for (int j = j_stride_a; j < kTotalA; j += j_stride_a) max_indexes[num_maxs++] = j;
+        for (int k = 0; k < num_j_extra_a; k++) {
+            int dup = 0;
+            for (int m = 0; m < num_maxs; m++) {
+                if (max_indexes[m] == j_extra_a[k]) dup = 1;
+            }
+            if (!dup) max_indexes[num_maxs++] = j_extra_a[k];
+        }
+
+        int num_pairs_a = 0;
+        char buf[16];
+        for (int mi = 0; mi < num_mins; mi++) {
+            for (int mj = 0; mj < num_maxs; mj++) {
+                int i = min_indexes[mi];
+                int j = max_indexes[mj];
+                if (i >= j) continue;
+                if (num_pairs_a >= 120) continue;
+                num_pairs_a++;
+
+                fbtreeIndex *sweep_fbt = fbtreeCreate();
+                for (int n = 1; n <= kTotalA; n++) {
+                    snprintf(buf, sizeof(buf), "m%04d", n);
+                    fbtreeInsert(sweep_fbt, createString(buf));
+                }
+
+                snprintf(buf, sizeof(buf), "m%04d", i);
+                sds range_min = createString(buf);
+                snprintf(buf, sizeof(buf), "m%04d", j);
+                sds range_max = createString(buf);
+
+                unsigned long expected = fbtreeCountRangeByValue(sweep_fbt, range_min, range_max, 1, 1);
+                unsigned long removed = fbtreeDeleteRangeByValue(sweep_fbt, range_min, range_max, 1, 1, NULL, NULL);
+                EXPECT_EQ(removed, expected) << "tree A pair (i=" << i << ", j=" << j << ") disagreed";
+                ASSERT_TRUE(fbtreeDebugValidate(sweep_fbt, false, NULL, 0)) << "tree A pair (i=" << i << ", j=" << j
+                                                                            << ") left an invalid tree";
+
+                sdsfree(range_min);
+                sdsfree(range_max);
+                fbtreeFree(sweep_fbt);
+            }
+        }
+        ASSERT_GT(num_pairs_a, 0) << "tree A sweep must exercise at least one pair";
+    }
+
+    /* --- Tree B: 5000 members, height 3. Must include the known failing
+     * pair (61, 2868). --- */
+    {
+        const int leaf_edges_b[] = {61, 610, 1220, 2440, 3721};
+        const int num_leaf_edges_b = 5;
+        const int stride_b = 173;
+        const int known_max_b = 2868;
+
+        int min_indexes[64];
+        int num_mins = 0;
+        for (int k = 0; k < num_leaf_edges_b; k++) min_indexes[num_mins++] = leaf_edges_b[k];
+
+        int max_indexes[64];
+        int num_maxs = 0;
+        max_indexes[num_maxs++] = known_max_b;
+        for (int j = stride_b; j < 5000; j += stride_b) {
+            if (j == known_max_b) continue;
+            max_indexes[num_maxs++] = j;
+        }
+
+        int num_pairs_b = 0;
+        char buf[16];
+        int saw_known_pair = 0;
+        for (int mi = 0; mi < num_mins; mi++) {
+            for (int mj = 0; mj < num_maxs; mj++) {
+                int i = min_indexes[mi];
+                int j = max_indexes[mj];
+                if (i >= j) continue;
+                if (num_pairs_b >= 30) continue;
+                num_pairs_b++;
+                if (i == 61 && j == known_max_b) saw_known_pair = 1;
+
+                fbtreeIndex *sweep_fbt = fbtreeCreate();
+                for (int n = 1; n <= 5000; n++) {
+                    snprintf(buf, sizeof(buf), "m%05d", n);
+                    fbtreeInsert(sweep_fbt, createString(buf));
+                }
+
+                snprintf(buf, sizeof(buf), "m%05d", i);
+                sds range_min = createString(buf);
+                snprintf(buf, sizeof(buf), "m%05d", j);
+                sds range_max = createString(buf);
+
+                unsigned long expected = fbtreeCountRangeByValue(sweep_fbt, range_min, range_max, 1, 1);
+                unsigned long removed = fbtreeDeleteRangeByValue(sweep_fbt, range_min, range_max, 1, 1, NULL, NULL);
+                EXPECT_EQ(removed, expected) << "tree B pair (i=" << i << ", j=" << j << ") disagreed";
+                ASSERT_TRUE(fbtreeDebugValidate(sweep_fbt, false, NULL, 0)) << "tree B pair (i=" << i << ", j=" << j
+                                                                            << ") left an invalid tree";
+
+                sdsfree(range_min);
+                sdsfree(range_max);
+                fbtreeFree(sweep_fbt);
+            }
+        }
+        ASSERT_GT(num_pairs_b, 0) << "tree B sweep must exercise at least one pair";
+        ASSERT_TRUE(saw_known_pair) << "tree B sweep must include the known failing pair (61, 2868)";
+    }
+}
+
 TEST_F(FbtreeTest, DeleteRangeByValueExactMatch) {
     insert("aaa");
     insert("bbb");

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1895,6 +1895,92 @@ start_server {tags {"zset"}} {
             assert_equal 0 $delta
         }
 
+        # The fuzzy tests above draw every score from [expr rand()], so no two
+        # members ever share a score. That distribution cannot produce a range
+        # boundary that lands *inside* a run of equal scores spanning more than
+        # one btree leaf, which is the shape that stresses boundary resolution.
+        # These two variants keep the same oracles but draw scores from a small
+        # discrete set, so each score run is far wider than one leaf.
+        test "ZCOUNT/ZRANGEBYSCORE fuzzy test with dense duplicate scores - $encoding" {
+            set err {}
+            set n 400
+            set nscores 3
+            # keep the arm's encoding at 400 members: listpack needs a raised
+            # limit, btree needs it pinned at 0
+            set lp_entries [expr {$encoding eq "listpack" ? 100000 : 0}]
+            with_config zset-max-ziplist-entries $lp_entries {
+            r del zset
+            for {set i 0} {$i < $n} {incr i} {
+                r zadd zset [expr {int(rand() * $nscores) * 2 + 2}] "m$i"
+            }
+            assert_encoding $encoding zset
+
+            # ~133 members per score: well beyond one 61-item leaf
+            for {set i 0} {$i < 60} {incr i} {
+                set a [expr {int(rand() * ($nscores + 2)) * 2}]
+                set b [expr {int(rand() * ($nscores + 2)) * 2}]
+                if {$a > $b} { set aux $a; set a $b; set b $aux }
+                foreach {min max} [list $a $b ($a $b $a ($b ($a ($b] {
+                    set got [r zrangebyscore zset $min $max]
+                    if {[r zcount zset $min $max] != [llength $got]} {
+                        append err "zcount zset $min $max = [r zcount zset $min $max] but zrangebyscore returned [llength $got]\n"
+                    }
+                }
+            }
+            }
+            assert_equal {} $err
+        }
+
+        test "ZREMRANGEBYSCORE fuzzy test with dense duplicate scores - $encoding" {
+            set err {}
+            set n 400
+            set nscores 3
+            set lp_entries [expr {$encoding eq "listpack" ? 100000 : 0}]
+            with_config zset-max-ziplist-entries $lp_entries {
+            for {set i 0} {$i < 25} {incr i} {
+                r del zset
+                for {set j 0} {$j < $n} {incr j} {
+                    r zadd zset [expr {int(rand() * $nscores) * 2 + 2}] "m$j"
+                }
+                assert_encoding $encoding zset
+
+                set a [expr {int(rand() * ($nscores + 2)) * 2}]
+                set b [expr {int(rand() * ($nscores + 2)) * 2}]
+                if {$a > $b} { set aux $a; set a $b; set b $aux }
+                set variants [list [list $a $b] [list ($a $b] [list $a ($b] [list ($a ($b]]
+                set pick [lindex $variants [expr {int(rand() * 4)}]]
+                set min [lindex $pick 0]
+                set max [lindex $pick 1]
+
+                # establish ground truth before mutating
+                set doomed [lsort [r zrangebyscore zset $min $max]]
+                set expected_count [llength $doomed]
+                set before [lsort [r zrange zset 0 -1]]
+                if {[r zcount zset $min $max] != $expected_count} {
+                    append err "zcount disagrees with zrangebyscore for $min $max\n"
+                }
+
+                set removed [r zremrangebyscore zset $min $max]
+                if {$removed != $expected_count} {
+                    append err "zremrangebyscore zset $min $max removed $removed, expected $expected_count\n"
+                }
+                if {[r zcard zset] != [expr {$n - $expected_count}]} {
+                    append err "zcard after zremrangebyscore $min $max is [r zcard zset], expected [expr {$n - $expected_count}]\n"
+                }
+
+                set expected_survivors {}
+                foreach m $before {
+                    if {[lsearch -exact -sorted $doomed $m] == -1} { lappend expected_survivors $m }
+                }
+                if {$expected_survivors ne [lsort [r zrange zset 0 -1]]} {
+                    append err "surviving members wrong after zremrangebyscore $min $max\n"
+                }
+                if {$err ne {}} break
+            }
+            }
+            assert_equal {} $err
+        }
+
         test "ZRANGEBYSCORE fuzzy test, 100 ranges in $elements element sorted set - $encoding" {
             set err {}
             r del zset
@@ -3458,6 +3544,143 @@ start_server {tags {"zset" "cluster:skip"}} {
             assert_equal 4 [r zcount zset 3 6]
             assert_equal 2 [r zcount zset (3 (6]
             assert_equal 0 [r zcount zset 20 30]
+        }
+    }
+
+    # Regression tests for boundary resolution in the btree (fbtree) backend.
+    # A btree leaf holds NODE_SIZE (61) items, so a run of members sharing one
+    # score only spans multiple leaves once it exceeds that. A boundary resolved
+    # per leaf cannot express a bound that lands inside such a run, and getting it
+    # wrong yields bad counts and bad deletions while leaving the tree
+    # structurally valid. Every case below keeps the run well above one leaf so
+    # the multi-leaf path is always exercised.
+    test {ZCOUNT with a duplicate-score run spanning multiple btree leaves} {
+        with_config zset-max-ziplist-entries 0 {
+            r del zset
+            # 200 members per score: > 61, so each run spans several leaves
+            foreach score {2 4 6} {
+                for {set i 0} {$i < 200} {incr i} {
+                    r zadd zset $score "s${score}:m$i"
+                }
+            }
+            assert_encoding btree zset
+            assert_equal 600 [r zcard zset]
+
+            # ZCOUNT must agree with enumerating the same range
+            foreach {min max} {2 2 4 4 6 6 2 4 4 6 2 6 (2 (6 (2 6 2 (6 (2 +inf -inf (6 1 3 -inf +inf} {
+                assert_equal [llength [r zrangebyscore zset $min $max]] \
+                    [r zcount zset $min $max] "zcount zset $min $max"
+            }
+
+            # explicit expectations, so the test still pins behaviour if
+            # ZRANGEBYSCORE ever regressed in the same way
+            assert_equal 200 [r zcount zset 2 2]
+            assert_equal 200 [r zcount zset 4 4]
+            assert_equal 400 [r zcount zset 2 4]
+            assert_equal 200 [r zcount zset (2 (6]
+            assert_equal 0 [r zcount zset (6 +inf]
+        }
+    }
+
+    test {ZREMRANGEBYSCORE with duplicate-score runs spanning multiple btree leaves} {
+        with_config zset-max-ziplist-entries 0 {
+            foreach {min max expected_deleted} {
+                2 2 200
+                4 4 200
+                (2 (6 200
+                2 4 400
+                (2 6 400
+                2 (6 400
+                (6 +inf 0
+                (1 (3 200
+            } {
+                r del zset
+                foreach score {2 4 6} {
+                    for {set i 0} {$i < 200} {incr i} {
+                        r zadd zset $score "s${score}:m$i"
+                    }
+                }
+                assert_encoding btree zset
+
+                # the count must agree with the deletion, and the deletion must
+                # remove exactly the members the equivalent range enumerates
+                set doomed [lsort [r zrangebyscore zset $min $max]]
+                set survivors_before [lsort [r zrange zset 0 -1]]
+                assert_equal $expected_deleted [llength $doomed] "range $min $max"
+                assert_equal $expected_deleted [r zcount zset $min $max] "zcount $min $max"
+
+                assert_equal $expected_deleted [r zremrangebyscore zset $min $max] \
+                    "zremrangebyscore zset $min $max"
+                assert_equal [expr {600 - $expected_deleted}] [r zcard zset] \
+                    "zcard after $min $max"
+
+                # nothing outside the range may be touched
+                set expected_survivors {}
+                foreach m $survivors_before {
+                    if {[lsearch -exact -sorted $doomed $m] == -1} {
+                        lappend expected_survivors $m
+                    }
+                }
+                assert_equal $expected_survivors [lsort [r zrange zset 0 -1]] \
+                    "survivors after $min $max"
+            }
+        }
+    }
+
+    test {ZREMRANGEBYSCORE exclusive bound keeps members sitting on the bound} {
+        with_config zset-max-ziplist-entries 0 {
+            # Every member shares one score, so an exclusive bound on that score
+            # must match nothing at all. Resolving the bound per leaf instead
+            # deletes most of the set and leaves roughly one leaf behind.
+            r del zset
+            for {set i 0} {$i < 300} {incr i} {
+                r zadd zset 5 "m[format %04d $i]"
+            }
+            assert_encoding btree zset
+
+            assert_equal 0 [r zcount zset (5 +inf]
+            assert_equal 0 [r zremrangebyscore zset (5 +inf]
+            assert_equal 300 [r zcard zset]
+
+            assert_equal 0 [r zcount zset -inf (5]
+            assert_equal 0 [r zremrangebyscore zset -inf (5]
+            assert_equal 300 [r zcard zset]
+
+            # the inclusive range still removes everything
+            assert_equal 300 [r zremrangebyscore zset 5 5]
+            assert_equal 0 [r zcard zset]
+        }
+    }
+
+    test {btree range delete over a deep tree keeps the full set consistent} {
+        with_config zset-max-ziplist-entries 0 {
+            # >61*31 members forces a >=3-level tree, where a range delete can
+            # reduce an inner node to a single child -- the shape that can
+            # leave a stale prefix on that node.
+            r del zset
+            set n 4000
+            for {set i 0} {$i < $n} {incr i} {
+                r zadd zset $i "m[format %05d $i]"
+            }
+            assert_encoding btree zset
+
+            # delete an asymmetric interior range
+            assert_equal 1830 [r zremrangebyscore zset 1831 3660]
+            assert_equal [expr {$n - 1830}] [r zcard zset]
+
+            # every surviving member must still be findable, correctly ranked,
+            # and enumerated in order
+            set expected {}
+            for {set i 0} {$i < $n} {incr i} {
+                if {$i < 1831 || $i > 3660} { lappend expected "m[format %05d $i]" }
+            }
+            assert_equal $expected [r zrange zset 0 -1]
+            assert_equal [llength $expected] [r zcount zset -inf +inf]
+            assert_equal 0 [r zrank zset [lindex $expected 0]]
+            assert_equal [expr {[llength $expected] - 1}] [r zrank zset [lindex $expected end]]
+            # a member inside the deleted range is really gone
+            assert_equal {} [r zscore zset "m[format %05d 2000]"]
+            assert_equal 0 [r zcount zset 1831 3660]
         }
     }
 

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2529,6 +2529,39 @@ start_server {tags {"zset"}} {
         }
     }
 
+    test {ZSET btree lex range delete does not skip non-empty middle leaves} {
+        with_config zset-max-ziplist-entries 0 {
+            r del zk
+            # Build a multi-leaf btree with enough members that a lex range
+            # spans several leaves under the boundary leaves.
+            r zadd zk 0 {}
+            for {set i 1} {$i <= 300} {incr i} {
+                r zadd zk 0 [format "m%04d" $i]
+            }
+            assert_encoding btree zk
+
+            # Trim the first leaf down to just the empty-string member: the
+            # start boundary of a later range will land in this now-mostly-
+            # empty leaf with no matching elements of its own (leaf-local
+            # "untouched"), while non-empty middle leaves still lie further
+            # to the right, inside the range about to be deleted.
+            r zremrangebylex zk \[m0001 \[m0060
+
+            # The exclusive lower bound "(" and the upper bound landing in a
+            # gap just past "m0121" (a value between two stored members)
+            # together make BOTH boundary leaves leaf-locally untouched, but
+            # the range still fully contains several middle leaves. The
+            # delete short-circuit must not treat this as an empty range.
+            set expected [r zlexcount zk \( \[m0121x]
+            assert {$expected > 0}
+            set removed [r zremrangebylex zk \( \[m0121x]
+            assert_equal $expected $removed
+
+            # Nothing in the deleted range should remain.
+            assert_equal 0 [r zlexcount zk \( \[m0121x]
+        }
+    }
+
     test {ZSET btree MEMORY USAGE reflects member sizes} {
         with_config zset-max-ziplist-entries 0 {
             r del zmem


### PR DESCRIPTION
Fixes #4558 

Two bugs in the fbtree sorted-set backend, both only reachable once a zset spans multiple btree leaves. There hasn't been a release since the ZSET work was merged, so neither affects any released version. The first causes silent data loss.

**1. Wrong results and silent data loss for score ranges**

`resolveStartIdx()`/`resolveEndIdx()` applied the inclusive/exclusive "advance past equals" adjustment within a single leaf, clamped at `leaf->num_items`, so they could not express "the boundary lies in a later leaf". `descendSubPath()` compounded this by clamping a past-the-end child index to `num_items - 1` instead of advancing to the next sibling. The max boundary was also located with a lower-bound child search, which cannot represent a run of equal scores extending into later children.

Whenever members sharing a boundary score spanned more than one leaf, ZCOUNT returned wrong counts and ZREMRANGEBYSCORE deleted the wrong set, both under-deleting and over-deleting. The tree stayed structurally valid, so `fbtreeDebugValidate()` never flagged it. With 300 members all at score 5, an exclusive bound on that score should match nothing:

```
ZCOUNT k (5 +inf            -> 239   (correct: 0)
ZREMRANGEBYSCORE k (5 +inf  -> 239   (correct: 0; only 61 of 300 members survive)
```

Score ranges are now reformulated as a half-open rank range whose two edges are resolved by the same whole-tree lower-bound seek, then handed to the existing rank-based delete. Both edges therefore stay correct regardless of how many leaves an equal-score run occupies. An exclusive bound is rewritten as an inclusive bound on the next 8-byte score prefix, which is exact byte ordering rather than an assumption about how scores are normalized. The whole-tree short-circuit is retained so counting everything still avoids the boundary descents.

**2. Stale prefix on an inner node reduced to a single child**

`updateCommonPrefix()` returned early for `num_items < 2`, so a range delete that stripped every sibling from an inner node left it holding the prefix it derived when it still had two or more anchors. `innerNodeRefreshChildMeta()` had meanwhile rewritten the surviving child-0 anchor, and child 0's key range extends below its own high key, so the refreshed anchor could fall below the retained prefix, giving `inner at depth 1 child 0: anchor missing node prefix`. Such nodes now drop prefix compression, which is trivially valid. This one is latent: it produces no wrong answers on its own and the node self-heals on the next insert.

Bug 2 was reported by Khalilov moe (3ntr0py1337) at leetprotect.com.

**Tests**

The existing range tests are single-leaf with distinct scores, so neither bug was reachable by them, and there was no ZREMRANGEBYSCORE fuzzy test at all. Added a gtest that builds a three-level tree and starves an inner node to a single child, plus TCL cases for equal-score runs spanning leaves, exclusive bounds landing on a duplicated boundary, and dense duplicate-score fuzz for ZCOUNT/ZRANGEBYSCORE and ZREMRANGEBYSCORE. The dense fuzz runs in both encoding arms so listpack acts as the reference. Six of the seven new tests fail before this change; the seventh is a deep-tree integrity guard.

646 gtests and 356 zset TCL tests pass, verified under ASan/UBSan and against a differential harness comparing btree to listpack on identical data.