### PR TITLE
Fix leaked slot-migration snapshot child after abort (#4546)

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1591,19 +1591,12 @@ int childSnapshotForSyncSlot(rio *aof, slotMigrationJob *job) {
 }
 
 /* Kill the slot migration child using SIGUSR1 (so that the parent will know
- * the child did not exit for an error, but because we wanted), and performs
- * the cleanup needed. */
+ * the child did not exit for an error, but because we wanted). Closing the
+ * exit pipe only drops the parent's write end; the child may still be alive,
+ * so always signal. */
 void killSlotMigrationChild(void) {
     /* No slot migration child? return. */
     if (server.child_type != CHILD_TYPE_SLOT_MIGRATION) return;
-
-    /* If we already closed the exit pipe, the child is already exiting.
-     * Sending SIGUSR1 now might cause a race condition/deadlock in the child,
-     * especially when compiled with coverage. */
-    if (server.slot_migration_child_exit_pipe == -1) {
-        serverLog(LL_NOTICE, "Slot migration child %ld is already exiting, not killing.", (long)server.child_pid);
-        return;
-    }
 
     serverLog(LL_NOTICE, "Killing running slot migration child: %ld", (long)server.child_pid);
 


### PR DESCRIPTION
Fixes #4546

## Problem

After a failed atomic slot migration, the source can keep a live
`valkey-slot-migration-to-target` child. `server.child_pid` never
returns to `-1`, so later migrations stay in `waiting-to-snapshot`
and log every 5s:
waiting before snapshotting due to active child process
RDB / AOF / slot-migration share `hasActiveChildProcess()`
(`server.child_pid != -1`). One leaked child blocks every later
exclusive child on that node.

## Why the skip was removed

`killSlotMigrationChild()` skipped `kill(pid, SIGUSR1)` when
`server.slot_migration_child_exit_pipe == -1`.

That fd being `-1` only means the **parent already closed its write
end** of the exit-handshake pipe (after EOF on the snapshot data
pipe). The child can still be in `pause()` / `write()` / `read()`.
No SIGUSR1 → no `_exit()` → `waitpid(WNOHANG)` in cron never reaps
→ the exclusive child lock is never released.

This skip was not in the original slot-migration child kill path
(#2533, same shape as `killRDBChild()`). It was added in #4104 as a
coverage workaround: under `COVERAGE_TEST`, `exitFromChild()` uses
`exit()` instead of `_exit()`, and a second `exit()` from the
SIGUSR1 handler can deadlock on gcov. Production uses `_exit()`,
which is async-signal-safe, so the extra SIGUSR1 on abort is
correct and does not turn a successful snapshot into a failed job.

Abort still goes `freeClient` → `clusterHandleSlotMigrationClientClose`
→ `unlinkClient` → `killSlotMigrationChild()`. We always send
SIGUSR1 when `child_type == CHILD_TYPE_SLOT_MIGRATION`.

## Test plan

- [x] Locally reproduced the leak with a temporary
      `DEBUG SLOTMIGRATION PAUSE-CHILD-EXIT` hook (child pauses
      after closing the data pipe, before the exit handshake) plus
      `CANCELSLOTMIGRATIONS` / abort during snapshot.
      Before: log `already exiting, not killing`, child still
      alive, `slot_migration_fork_in_progress` stays 1.
      After: SIGUSR1 is sent, child is reaped, a later migration
      can snapshot.