### PR TITLE
Avoid offloading ACK's reads to IO threads for the slot migration export job while snapshotting

### DIFF
--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -523,6 +523,9 @@ int trySendReadToIOThreads(client *c) {
     /* For simplicity let the main-thread handle the blocked clients */
     if (c->flag.blocked || c->flag.unblocked) return C_ERR;
     if (c->flag.close_asap) return C_ERR;
+    /* Avoid offloading reads to IO thread for the slot migration export job while snapshotting.
+     * During this phase, the main thread writes snapshot data directly via connWrite(). */
+    if (c->slot_migration_job && !clusterSlotMigrationShouldInstallWriteHandler(c)) return C_ERR;
 
     c->read_flags = canParseCommand(c) ? 0 : READ_FLAGS_DONT_PARSE;
     c->read_flags |= authRequired(c) ? READ_FLAGS_AUTH_REQUIRED : 0;


### PR DESCRIPTION
Similar to https://github.com/valkey-io/valkey/pull/4104

**Problem Description**

Atomic slot migration is failing when io-threads and TLS enabled with the following error.

```
    62140:M 30 Aug 2026 00:45:00.415 * Beginning snapshot of slot migration {name: 6ee6fedd106bd7070566149034b64c385daaa039, operation: export, target_node_id: 4ae33372e6ead2a2e642dee5988e74ecc007168c, slots: 0-2730}.
    62140:M 30 Aug 2026 00:45:00.455 * Started child process 62223 for slot migration {name: 6ee6fedd106bd7070566149034b64c385daaa039, operation: export, target_node_id: 4ae33372e6ead2a2e642dee5988e74ecc007168c, slots: 0-2730}
    62140:M 30 Aug 2026 00:45:00.455 * Slot migration {name: 6ee6fedd106bd7070566149034b64c385daaa039, operation: export, target_node_id: 4ae33372e6ead2a2e642dee5988e74ecc007168c, slots: 0-2730} state transition: waiting-to-snapshot ->
  snapshotting
    62140:M 30 Aug 2026 00:45:03.389 # Slot migration transfer, write error sending DB to target: Resource temporarily unavailable
    62140:M 30 Aug 2026 00:45:03.389 * Slot migration {name: 6ee6fedd106bd7070566149034b64c385daaa039, operation: export, target_node_id: 4ae33372e6ead2a2e642dee5988e74ecc007168c, slots: 0-2730} connection lost
    62140:M 30 Aug 2026 00:45:03.389 * Slot migration {name: 6ee6fedd106bd7070566149034b64c385daaa039, operation: export, target_node_id: 4ae33372e6ead2a2e642dee5988e74ecc007168c, slots: 0-2730} state transition: snapshotting -> failed
    62140:M 30 Aug 2026 00:45:03.389 # Slot migration {name: 6ee6fedd106bd7070566149034b64c385daaa039, operation: export, target_node_id: 4ae33372e6ead2a2e642dee5988e74ecc007168c, slots: 0-2730} finished. State: failed, Message: Connection
  lost to target. Check CLUSTER GETSLOTMIGRATIONS on the target node for more information.
```


**Proposed Fix**
During `SLOT_EXPORT_SNAPSHOTTING`, incoming `CLUSTER SYNCSLOTS ACK`s  from target node are read by  I/O worker thread calling `SSL_read(conn->ssl)` concurrently while the main thread was calling `SSL_write(conn->ssl)` on the exact same SSL  handle. 

Because OpenSSL SSL  contexts are not thread-safe for concurrent read and write operations, OpenSSL internal state was corrupted, causing `SSL_write()` to fail with `SSL_ERROR_SYSCALL (errno = EAGAIN)`

So, avoid offloading  `CLUSTER SYNCSLOTS ACK`s reads to IO thread for the slot migration export job while snapshotting, which ensure all OpenSSL operations on the connection remain strictly single-threaded.