### PR TITLE
Tests: scale wait_process_paused when the pause depends on a fork

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -827,19 +827,27 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             resume_process $replica_pid
             set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 200 100]
             set loglines [lindex $res 1]
+
+            # Waiting for the primary to enter the paused state, that is, make sure that bgsave is triggered.
+            wait_process_paused [srv -1 pid]
+            wait_for_log_messages 0 {"*Done loading RDB*"} $replica_loglines 5000 10
+            $replica replicaof no one
+            # Resume the primary and make sure the sync is dropped.
+            resume_process [srv -1 pid]
+            $primary debug pause-after-fork 0
+            wait_for_condition 500 1000 {
+                [s -1 rdb_bgsave_in_progress] eq 0
+            } else {
+                fail "Primary should abort sync"
+            }
         }
-        # Waiting for the primary to enter the paused state, that is, make sure that bgsave is triggered.
-        wait_process_paused [srv -1 pid]
-        wait_for_log_messages 0 {"*Done loading RDB*"} $replica_loglines 5000 10
-        $replica replicaof no one
-        # Resume the primary and make sure the sync is dropped.
+        # On failure the test skips its own resume_process, leaving the primary armed with
+        # pause-after-fork. It then stops itself when the fork lands and blocks the commands below,
+        # which have no read timeout. Resume, disarm, resume again in case the fork landed in
+        # between. No-ops when the test passed.
         resume_process [srv -1 pid]
         $primary debug pause-after-fork 0
-        wait_for_condition 500 1000 {
-            [s -1 rdb_bgsave_in_progress] eq 0
-        } else {
-            fail "Primary should abort sync"
-        }
+        resume_process [srv -1 pid]
         stop_write_load $load_handle0
         stop_write_load $load_handle1
         stop_write_load $load_handle2

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -738,8 +738,16 @@ proc process_is_paused pid {
 }
 
 # Wait until the process enters a paused state.
-proc wait_process_paused pid {
-    wait_for_condition 50 100 {
+#
+# Callers that arm a self-stopping debug point (DEBUG PAUSE-AFTER-FORK,
+# DEBUG PAUSE-BEFORE-PSYNC) also wait for the server to reach it, which under
+# valgrind can take longer than 5 seconds. Scale the budget for them, but only
+# under valgrind so normal runs keep failing fast.
+proc wait_process_paused {pid {retries auto}} {
+    if {$retries eq "auto"} {
+        if {$::valgrind} {set retries 1000} else {set retries 50}
+    }
+    wait_for_condition $retries 100 {
         [process_is_paused $pid]
     } else {
         puts [exec ps j $pid]
@@ -749,7 +757,8 @@ proc wait_process_paused pid {
 
 proc pause_process pid {
     exec kill -SIGSTOP $pid
-    wait_process_paused $pid
+    # We sent the signal, so the stop is near-immediate. Keep the short budget.
+    wait_process_paused $pid 50
 }
 
 proc resume_process pid {


### PR DESCRIPTION
## Problem

Every valgrind `integration-type` shard failure in the last two weeks of dailies is this, 12 out of 12, across 8 of 14 runs. [Run 33283093695](https://github.com/valkey-io/valkey/actions/runs/33283093695/job/99181479965):

```
[exception]: Executing test client: assertion:process didn't stop.
 in wait_process_paused at tests/support/util.tcl:742
 in wait_process_paused at tests/integration/dual-channel-replication.tcl:832
 in start_server at tests/integration/dual-channel-replication.tcl:784
```

`wait_process_paused` had a fixed `wait_for_condition 50 100`, so 5 seconds. That is right for `pause_process`, which sends SIGSTOP itself, but line 832 waits for the primary to stop *itself* via `DEBUG PAUSE-AFTER-FORK`, and that hook is after the fork (`replication.c:1054`), so the budget has to cover a full sync fork. With the fix the enclosing test takes 27-31s under valgrind in CI.

The primary's log shows it on track, just past the window. No `Starting BGSAVE for SYNC`, no `Process is about to stop.`, and `ps j` reports `Rl`:

```
00:57:00.495 * Unable to partial resync with replica ... for lack of backlog
00:57:01.521 - Client closed connection id=8 ... cmd=psync
00:57:04.296 * Replica ... asks for synchronization / Full resync requested
00:57:06.676   signal-handler Received SIGTERM scheduling shutdown...
```

Dual channel needs two handshake rounds before forking, ~1.7s apart when healthy and ~3.8s here.

There is no issue for this because `wait_process_paused` is called from the `start_server` body, not a `test` block, so the failure is an `[exception]` rather than an `[err]`. `write_test_failures` never sees it and every one of those jobs uploaded a 141 byte `all-test-failures` containing `[]`.

## Fix

Give `wait_process_paused` a retry count that scales under valgrind, using the same idiom as `server.tcl:698`. `pause_process` opts out and keeps 5s so a real hang there is still reported quickly.

Move the tail of the dual-channel test inside its `test` block. It is continuation of that test's logic, and it matches the sibling test at line 882 which already keeps `wait_and_resume_process` inside the body with only `stop_write_load` outside.

Disarm `pause-after-fork` in the teardown. `server.debug_pause_after_fork` is sticky, and on failure the test skips its own `resume_process`, so a fork landing after the budget expires stops the primary and blocks `config set shutdown-timeout 0` forever.

## Testing

Ran the file 8-10 times in parallel under valgrind on a fork, `--valgrind --no-latency --clients 1 --timeout 2400`:

| | result |
| --- | --- |
| unstable | 4/6 failed |
| with the fix | 0/10 failed, then 0/8 |

All four baseline-failing attempts pass with the fix. Since this failure produces an empty failures artifact, I checked the job logs directly rather than trusting the JSON: `Test dual-channel-replication primary gets cob overrun before established psync (27189/31030/31060/27107 ms)`, `Test Summary: 43 passed, 0 failed`.

For the teardown change, forcing the wait to fail with `wait_process_paused [srv -1 pid] 1`:

| | result |
| --- | --- |
| without it | run stalls, cut short at 24 passed / 2 failed with a `[TIMEOUT]` |
| with it | 43 passed / 1 failed, recorded as `{"test_name": "Test dual-channel-replication primary gets cob overrun before established psync", "status": "err", "error": "process didn't stop"}` |

Locally: `integration/dual-channel-replication`, `integration/replication-busy-psync` and `unit/wait` pass, and a full local valgrind run of the file passes in 1682s.

`wait_for_sync` and `wait_replica_online` in the same file have the same shape - fixed 5s budgets on waits that need the primary to fork and ship an RDB - but neither has shown up in the dailies, so I left them.

This was generated by AI but verified, with love, by a human.