### PR TITLE
Make test-unit build reliably: fix bitcode lowering, missing prerequisite, and stale object list

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -800,7 +800,7 @@ distclean: clean
 test: $(ALL_BUILD_PREREQUISITES)
 	@(cd ..; VALKEY_PROG_SUFFIX="$(PROG_SUFFIX)" ./runtest)
 
-test-unit:
+test-unit: $(ENGINE_LIB_NAME)
 	@(cd unit && $(MAKE) test-unit)
 
 # valkey-unit-gtests

--- a/src/Makefile
+++ b/src/Makefile
@@ -695,7 +695,6 @@ persist-settings: distclean
 	echo SERVER_LDFLAGS=$(SERVER_LDFLAGS) >> .make-settings
 	echo PREV_FINAL_CFLAGS=$(FINAL_CFLAGS) >> .make-settings
 	echo PREV_FINAL_LDFLAGS=$(FINAL_LDFLAGS) >> .make-settings
-	echo ENGINE_SERVER_OBJ=$(ENGINE_SERVER_OBJ) >> .make-settings
 	-(cd ../deps && $(MAKE) $(DEPENDENCY_TARGETS))
 
 .PHONY: persist-settings
@@ -801,11 +800,11 @@ test: $(ALL_BUILD_PREREQUISITES)
 	@(cd ..; VALKEY_PROG_SUFFIX="$(PROG_SUFFIX)" ./runtest)
 
 test-unit: $(ENGINE_LIB_NAME)
-	@(cd unit && $(MAKE) test-unit)
+	@(cd unit && $(MAKE) test-unit ENGINE_SERVER_OBJ="$(ENGINE_SERVER_OBJ)")
 
 # valkey-unit-gtests
 $(ENGINE_UNIT_GTESTS): $(ENGINE_LIB_NAME)
-	@(cd unit && $(MAKE) $(ENGINE_UNIT_GTESTS))
+	@(cd unit && $(MAKE) $(ENGINE_UNIT_GTESTS) ENGINE_SERVER_OBJ="$(ENGINE_SERVER_OBJ)")
 
 test-modules: $(SERVER_NAME)
 	@(cd ..; ./runtest-moduleapi)

--- a/src/unit/Makefile
+++ b/src/unit/Makefile
@@ -137,7 +137,7 @@ $(WRAP_DIR):
 define wrap-object
 	@mkdir -p $(dir $@)
 	@if file $< | grep -q "LLVM bitcode"; then \
-		llc $< -filetype=obj -o $(WRAP_DIR)/$*_temp.o; \
+		$(CC) -x ir -c $< -o $(WRAP_DIR)/$*_temp.o; \
 		python3 generate-redefine-syms.py $(WRAP_DIR)/$*_temp.o > $(WRAP_DIR)/$*-wrap-syms; \
 		llvm-objcopy --redefine-syms=$(WRAP_DIR)/$*-wrap-syms $(WRAP_DIR)/$*_temp.o $@; \
 		rm -f $(WRAP_DIR)/$*_temp.o; \


### PR DESCRIPTION
## Problem

`make test-unit` does not work on macOS in the default configuration, and is fragile on every platform in two other ways.

**1. Bitcode objects are lowered by the wrong toolchain.** `src/Makefile:24-29` appends `-flto` whenever `OPTIMIZATION` is exactly `-O3` and the compiler is clang, so the server objects are LLVM bitcode, not Mach-O. The Darwin `--wrap` emulation at `src/unit/Makefile:139-140` then runs homebrew LLVM's `llc` over them:

```
LLVM ERROR: Unsupported stack probing method
PLEASE submit a bug report to https://github.com/Homebrew/homebrew-core/issues
Stack dump:
0.	Program arguments: llc ../acl.o -filetype=obj -o wrapped/acl_temp.o
1.	Running pass 'Function Pass Manager' on module '../acl.o'.
2.	Running pass 'AArch64 Instruction Selection' on function '@ACLAddCommandCategory'
 #7 0x000000010c86d9b8 llvm::AArch64FunctionInfo::AArch64FunctionInfo(llvm::Function const&, llvm::AArch64Subtarget const*) (/opt/homebrew/Cellar/llvm/22.1.2/lib/libLLVM.dylib+0x20f99b8)
/bin/sh: line 1: 68637 Abort trap: 6           llc ../acl.o -filetype=obj -o wrapped/acl_temp.o
llvm-objcopy: error: 'wrapped/acl_temp.o': No such file or directory
```

Apple clang stamps every function with the Apple-private attribute `"probe-stack"="__chkstk_darwin"`, confirmed with `llvm-dis acl.o`:

```
attributes #0 = { nounwind ssp uwtable(sync) "frame-pointer"="non-leaf" ... "probe-stack"="__chkstk_darwin" ... }
```

Upstream LLVM's AArch64 backend only accepts `"inline-asm"` there and calls `report_fatal_error` on anything else. Minimal reproduction, no Valkey involved:

```
$ printf 'int f(int x){int a[70000]; a[x]=x; return a[0];}\n' > lt.c
$ /usr/bin/clang -O3 -flto -c lt.c -o lt.o && file lt.o
lt.o: LLVM bitcode, wrapper
$ /opt/homebrew/opt/llvm/bin/llc lt.o -filetype=obj -o out.o
LLVM ERROR: Unsupported stack probing method
```

**2. `test-unit` has no prerequisites.** `src/Makefile:803` recurses into `unit/` immediately. `src/unit/Makefile:152` declares `wrapped/%.o: ../%.o` but has no rule to build `../%.o`, so the sub-make falls back to GNU make's built-in implicit rule:

```
cc    -c -o ../db.o ../db.c
../compression_lz4.c:14:10: fatal error: 'lz4frame.h' file not found
../debug.c:37:10: fatal error: 'fpconv_dtoa.h' file not found
make[1]: *** [../compression_lz4.o] Error 1
```

That `cc` carries none of the project CFLAGS and no `-I../../deps` paths. Which header it dies on depends on which translation unit wins the parallel race and on how much of `deps/` happens to exist, so this also shows up as `'jemalloc/jemalloc.h' file not found` via the stale `MALLOC` read at `src/unit/Makefile:174-178`. `test-unit` is the only test target with nothing: `test:` has `$(ALL_BUILD_PREREQUISITES)` and `$(ENGINE_UNIT_GTESTS)` on the very next line already has `$(ENGINE_LIB_NAME)`.

**3. `.make-settings` caches a stale source list.** `persist-settings` writes `ENGINE_SERVER_OBJ` into `.make-settings`, which is regenerated only when `FINAL_CFLAGS` or `FINAL_LDFLAGS` change (`src/Makefile:708-714`). Adding a `src/*.c` changes neither. `src/Makefile:473` re-assigns the variable after the `-include`, so the parent never notices, but `src/unit/Makefile` has no assignment of its own and consumes the cached copy, so `wrapped/wrappedlibvalkey.a` is built from the old list:

```
Undefined symbols for architecture arm64:
  "_ztestDummyValue", referenced from:
make[1]: *** [valkey-unit-gtests] Error 1
```

That is the reason for the current folklore that you must `make distclean` before running `test-unit` after a branch switch.

## Fix

Three independent commits, one per problem. None makes `test-unit` reliable on macOS alone.

1. `test-unit: $(ENGINE_LIB_NAME)`, matching `$(ENGINE_UNIT_GTESTS)` on the next line. Prerequisite ordering is the only available fix: `src/unit/Makefile:4` does `-include ../.make-settings`, which is evaluated at parse time, so the existing `make-prerequisites` target at `src/unit/Makefile:170` cannot help.
2. Drop `ENGINE_SERVER_OBJ` from `persist-settings` and pass it on the recursive make command line instead. It is a source list, not a build setting.
3. `$(CC) -x ir -c` instead of `llc`, so the producer and consumer of the bitcode are the same compiler by construction.

On the alternative for 3: keeping `llc` and adding a guard that fails with "rebuild with `OPT="-O3 -fno-omit-frame-pointer"`" instead of an LLVM crash dump would be smaller, but it loses. It leaves macOS developers unable to run unit tests on a default `-O3` build, which is the default, and it treats toolchain drift as a user error. `$(CC)` is the correct compiler exactly when this branch is taken: `src/Makefile:25` only adds plain `-flto` for clang and uses `-flto=auto -ffat-lto-objects` otherwise, so a non-clang build does not produce pure bitcode and the `file $< | grep -q "LLVM bitcode"` guard is not entered. GNU make's built-in default supplies `CC=cc`, and the PATH prepend at `src/unit/Makefile:129` does not shadow it, because homebrew's llvm bin directory has `clang` but no `cc`. `llvm-objcopy` is still needed, since Apple ships no `objcopy`, but it no longer does code generation.

## Decisions for the reviewer

1. **Command line vs `export` for `ENGINE_SERVER_OBJ`.** A command-line variable propagates through `MAKEFLAGS` into nested makes, so `ENGINE_SERVER_OBJ+=$(ENGINE_TRACE_OBJ)` (`src/Makefile:590`) becomes a no-op in the nested `make libvalkey.a` invoked from `src/unit/Makefile:166`. Harmless today: the value passed down already contains `ENGINE_TRACE_OBJ`, visible in the `ar` line, and `ENGINE_TRACE_OBJ` (`src/Makefile:465`) is unconditional. `export ENGINE_SERVER_OBJ` would avoid it, since an environment variable loses to the makefile assignment at `src/Makefile:473`. Proposal: keep the command-line form because it is explicit at the call site, and revisit if a conditional append is ever added.
2. **Codegen optimization level.** `llc` defaults to `-O2`; `$(CC) -x ir -c` with no `-O` uses the `-O0` codegen pipeline over already-optimized IR. Proposal: leave it, these objects exist only for unit tests. Say the word and I will add `-O2` for parity.
3. **Should macOS use `-flto` at all?** Disabling it there would sidestep problem 1 entirely, but it changes what macOS developers build. Proposal: no, fix the wrap path instead.

## Testing

macOS 15 arm64, Apple clang 17.0.0, GNU Make 3.81, `MALLOC=libc`, homebrew LLVM 22.1.2 present. All runs from `src/`.

**Problem 1, with LTO left on. No `OPT` override, so this is the configuration that fails today.** Confirmed the failing path was genuinely exercised rather than sidestepped:

```
$ make distclean && make -j10
$ file acl.o server.o
acl.o:    LLVM bitcode, wrapper
server.o: LLVM bitcode, wrapper
$ PATH=/opt/homebrew/opt/llvm/bin:$PATH llc acl.o -filetype=obj -o /tmp/acl_llc.o
LLVM ERROR: Unsupported stack probing method
llc exit=134
$ make -j10 test-unit
[645/645] QuicklistTest.quicklistComprassionPlainNode (5614 ms)
All UNIT TESTS PASSED!
exit=0
$ file unit/wrapped/acl.o
unit/wrapped/acl.o: Mach-O 64-bit object arm64
```

645 tests, 645 passed, 0 failed.

**Problem 2, `make test-unit` as the very first command after `distclean`:** passes, 645/645, 40.6s. Counterfactual with only that one line reverted, same starting state: fails with the `cc -c -o ../db.o ../db.c` output quoted above, `exit=2`.

**Problem 3**, scaffolded a new `src/ztest_dummy.c` referenced from a real `TEST_F` so the symbol is required at link time, then `make -j10 test-unit` with no `distclean`:

```
    CC ztest_dummy.o
ar rcs wrapped/wrappedlibvalkey.a wrapped/acl.o ... wrapped/ztest_dummy.o wrapped/trace/trace.o ...
[1/646] ExampleTest.ZtestDummyLinks (13 ms)
All UNIT TESTS PASSED!
```

Counterfactual with the commit reverted and the pre-change list injected into `.make-settings`: `Undefined symbols ... "_ztestDummyValue"`, `exit=2`, and `grep -c 'wrapped/ztest_dummy.o'` is 0. Scaffolding removed afterwards.

**What I could not test.** No Linux run, so Linux safety is by inspection: commits 2 and 3 both touch code inside the `ifeq ($(uname_S), Darwin)` block at `src/unit/Makefile:119-162`, and `ENGINE_SERVER_OBJ` has exactly one consumer in that file, line 122. Linux links with `-Wl,--wrap` at `src/unit/Makefile:235-240` and never expands `wrap-object`. Commit 1 is not platform-gated, but the same work already happens on Linux from inside the sub-make, so it only changes ordering, and the nested make reports `libvalkey.a is up to date` rather than rebuilding. I also did not test `BUILD_TLS=yes`, any sanitizer, `-m32`, `MALLOC=jemalloc`, or a non-default `CC`. CI covers those.

This was generated by AI but verified, with love, by a human.
