### PR TITLE
Avoid random() lock contention in threaded valkey-benchmark

### DIFF
--- a/src/valkey-benchmark-dataset.c
+++ b/src/valkey-benchmark-dataset.c
@@ -8,7 +8,6 @@
 #include "fmacros.h"
 
 #include "valkey-benchmark-dataset.h"
-#include "cli_common.h"
 #include "zmalloc.h"
 #include <valkey/valkey.h>
 #include <stdbool.h>
@@ -34,7 +33,7 @@ static int findFieldIndex(dataset *ds, const char *field_name, size_t field_name
 static const char *extractDatasetFieldValue(dataset *ds, int field_idx, int record_index);
 static sds replaceOccurrence(sds processed_arg, const char *pos, const char *replacement);
 static sds processFieldsInArg(dataset *ds, sds arg, int record_index);
-static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key, int replace_placeholders, long long keyspacelen, int sequential_replacement);
+static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key, uint64_t *random_state, int replace_placeholders, long long keyspacelen, int sequential_replacement);
 
 dataset *datasetInit(const char *filename, int max_documents, int has_field_placeholders, sds *template_argv, int template_argc, int verbose) {
     if (!filename) return NULL;
@@ -161,7 +160,14 @@ size_t datasetGetRecordCount(dataset *ds) {
     return ds ? ds->record_count : 0;
 }
 
-sds datasetGenerateCommand(dataset *ds, int record_index, sds *template_argv, int template_argc, _Atomic uint64_t *seq_key, int replace_placeholders, long long keyspacelen, int sequential_replacement) {
+uint64_t benchmarkNextRandom(uint64_t *state) {
+    uint64_t value = (*state += 0x9e3779b97f4a7c15ULL);
+    value = (value ^ (value >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    value = (value ^ (value >> 27)) * 0x94d049bb133111ebULL;
+    return value ^ (value >> 31);
+}
+
+sds datasetGenerateCommand(dataset *ds, int record_index, sds *template_argv, int template_argc, _Atomic uint64_t *seq_key, uint64_t *random_state, int replace_placeholders, long long keyspacelen, int sequential_replacement) {
     if (!ds || !template_argv) return NULL;
 
     sds *processed_argv = zmalloc(template_argc * sizeof(sds));
@@ -184,7 +190,7 @@ sds datasetGenerateCommand(dataset *ds, int record_index, sds *template_argv, in
     sds result = sdsnewlen(cmd, len);
     free(cmd);
 
-    result = processRandPlaceholdersForDataSet(result, seq_key, replace_placeholders,
+    result = processRandPlaceholdersForDataSet(result, seq_key, random_state, replace_placeholders,
                                                keyspacelen, sequential_replacement);
 
     for (int i = 0; i < template_argc; i++) {
@@ -415,7 +421,7 @@ static sds processFieldsInArg(dataset *ds, sds arg, int record_index) {
     return arg;
 }
 
-static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key, int replace_placeholders, long long keyspacelen, int sequential_replacement) {
+static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key, uint64_t *random_state, int replace_placeholders, long long keyspacelen, int sequential_replacement) {
     if (!replace_placeholders || keyspacelen == 0) return cmd;
 
     for (int ph = 0; ph < PLACEHOLDER_COUNT; ph++) {
@@ -428,7 +434,7 @@ static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key,
             if (sequential_replacement) {
                 shared_key = atomic_fetch_add_explicit(&seq_key[ph], 1, memory_order_relaxed);
             } else {
-                shared_key = rand62();
+                shared_key = benchmarkNextRandom(random_state);
             }
             shared_key %= keyspacelen;
         }
@@ -442,7 +448,7 @@ static sds processRandPlaceholdersForDataSet(sds cmd, _Atomic uint64_t *seq_key,
                 if (sequential_replacement) {
                     key = atomic_fetch_add_explicit(&seq_key[ph], 1, memory_order_relaxed);
                 } else {
-                    key = rand62();
+                    key = benchmarkNextRandom(random_state);
                 }
                 key %= keyspacelen;
             }

--- a/src/valkey-benchmark-dataset.h
+++ b/src/valkey-benchmark-dataset.h
@@ -11,6 +11,7 @@
 #include "sds.h"
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #ifndef __cplusplus
 #include <stdatomic.h>
 #endif
@@ -56,9 +57,13 @@ void datasetFree(dataset *ds);
 /* Get number of records */
 size_t datasetGetRecordCount(dataset *ds);
 
+/* Advance an independently owned benchmark random stream. Keeping one state
+ * per event loop avoids serialization in libc's process-wide random(). */
+uint64_t benchmarkNextRandom(uint64_t *state);
+
 #ifndef __cplusplus
 /* Generate complete command for given record index (caller must sdsfree) */
-sds datasetGenerateCommand(dataset *ds, int record_index, sds *template_argv, int template_argc, _Atomic uint64_t *seq_key, int replace_placeholders, long long keyspacelen, int sequential_replacement);
+sds datasetGenerateCommand(dataset *ds, int record_index, sds *template_argv, int template_argc, _Atomic uint64_t *seq_key, uint64_t *random_state, int replace_placeholders, long long keyspacelen, int sequential_replacement);
 #endif
 
 #endif /* VALKEY_BENCHMARK_DATASET_H */

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -188,6 +188,7 @@ static struct placeholders {
 /* Set before a benchmark worker enters its event loop. The event loop owns all
  * accesses, and TLS keeps hot random state off cache lines shared by workers. */
 static _Thread_local uint64_t thread_random_state;
+static _Thread_local int thread_random_state_owner = -1;
 
 /* Sequence keys for dataset command generation */
 static _Atomic uint64_t dataset_seq_key[PLACEHOLDER_COUNT] = {0};
@@ -297,6 +298,18 @@ static long long nstime(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+static uint64_t *getClientRandomState(client c) {
+    if (c->thread_id < 0) return &config.random_state;
+
+    if (thread_random_state_owner == c->thread_id) return &thread_random_state;
+
+    /* RDMA registration can invoke writeHandler synchronously while clients
+     * are still being created on the main thread. Advance the worker seed in
+     * that case; pthread_create later publishes the updated value to the
+     * worker, which moves the hot state into TLS before its event loop starts. */
+    return &config.threads[c->thread_id]->random_seed;
 }
 
 static void seedBenchmarkRandom(uint64_t seed) {
@@ -627,7 +640,7 @@ static void scanClusterTags(client c, char *buffer_start) {
     }
 }
 
-static void setClusterKeyHashTag(client c) {
+static void setClusterKeyHashTag(client c, uint64_t *random_state) {
     assert(c->thread_id >= 0);
     clusterNode *node = c->cluster_node;
     assert(node);
@@ -639,7 +652,7 @@ static void setClusterKeyHashTag(client c) {
      * updateClusterSlotsConfiguration won't actually do anything, since
      * the updated_slots_count array will be already NULL. */
     if (is_updating_slots) updateClusterSlotsConfiguration();
-    int slot = node->slots[rand() % node->slots_count];
+    int slot = node->slots[benchmarkNextRandom(random_state) % node->slots_count];
     const char *tag = crc16_slot_table[slot];
     int taglen = strlen(tag);
     size_t i;
@@ -924,9 +937,7 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
 
-        uint64_t *random_state = c->thread_id >= 0
-                                     ? &thread_random_state
-                                     : &config.random_state;
+        uint64_t *random_state = getClientRandomState(c);
 
         /* Dataset field access mode - completely independent command generation */
         if (config.has_field_placeholders && config.current_dataset && config.current_dataset->record_count > 0) {
@@ -955,7 +966,7 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             }
         }
 
-        if (config.cluster_mode && c->staglen > 0) setClusterKeyHashTag(c);
+        if (config.cluster_mode && c->staglen > 0) setClusterKeyHashTag(c, random_state);
         c->slots_last_update = atomic_load_explicit(&config.slots_last_update, memory_order_relaxed);
         c->start = ustime();
         c->latency = -1;
@@ -1406,6 +1417,7 @@ static void freeBenchmarkThreads(void) {
 static void *execBenchmarkThread(void *ptr) {
     benchmarkThread *thread = (benchmarkThread *)ptr;
     thread_random_state = thread->random_seed;
+    thread_random_state_owner = thread->index;
     aeMain(thread->el);
     return NULL;
 }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -123,6 +123,8 @@ static struct config {
     int replace_placeholders;
     long long keyspacelen;
     int sequential_replacement;
+    uint64_t random_state;
+    uint64_t random_stream_state;
     int keepalive;
     int pipeline;
     long long start;
@@ -183,6 +185,10 @@ static struct placeholders {
     size_t *index_data;                 /* allocation holding all index data */
 } placeholders;
 
+/* Set before a benchmark worker enters its event loop. The event loop owns all
+ * accesses, and TLS keeps hot random state off cache lines shared by workers. */
+static _Thread_local uint64_t thread_random_state;
+
 /* Sequence keys for dataset command generation */
 static _Atomic uint64_t dataset_seq_key[PLACEHOLDER_COUNT] = {0};
 
@@ -215,6 +221,7 @@ typedef struct benchmarkThread {
     pthread_t thread;
     aeEventLoop *el;
     list *paused_clients;
+    uint64_t random_seed;
 } benchmarkThread;
 
 /* Cluster. */
@@ -290,6 +297,11 @@ static long long nstime(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+static void seedBenchmarkRandom(uint64_t seed) {
+    config.random_state = seed;
+    config.random_stream_state = seed ^ 0xd1b54a32d192ed03ULL;
 }
 
 static bool isBenchmarkFinished(int request_count) {
@@ -482,7 +494,7 @@ void initPlaceholders(const char *cmd, size_t cmd_len) {
     return;
 }
 
-static void replacePlaceholder(const size_t *indices, const size_t count, char *cmd, _Atomic uint64_t *key_counter) {
+static void replacePlaceholder(const size_t *indices, const size_t count, char *cmd, _Atomic uint64_t *key_counter, uint64_t *random_state) {
     if (count == 0) return;
 
     uint64_t key = 0;
@@ -490,7 +502,7 @@ static void replacePlaceholder(const size_t *indices, const size_t count, char *
         if (config.sequential_replacement) {
             key = atomic_fetch_add_explicit(key_counter, 1, memory_order_relaxed);
         } else {
-            key = rand62();
+            key = benchmarkNextRandom(random_state);
         }
         key %= config.keyspacelen;
     }
@@ -510,7 +522,7 @@ static void replacePlaceholder(const size_t *indices, const size_t count, char *
     }
 }
 
-static void replacePlaceholders(char *cmd_data, int cmd_count) {
+static void replacePlaceholders(char *cmd_data, int cmd_count, uint64_t *random_state) {
     static _Atomic uint64_t seq_key[PLACEHOLDER_COUNT] = {0};
 
     for (int cmd_index = 0; cmd_index < cmd_count; cmd_index++) {
@@ -520,7 +532,7 @@ static void replacePlaceholders(char *cmd_data, int cmd_count) {
         size_t *indices = placeholders.indices[0];
         _Atomic uint64_t *key_counter = &seq_key[0];
         for (size_t i = 0; i < placeholders.count[0]; i++) {
-            replacePlaceholder(indices + i, 1, cmd, key_counter);
+            replacePlaceholder(indices + i, 1, cmd, key_counter, random_state);
         }
 
         /* For other placeholders, multiple occurrences within the command will
@@ -529,7 +541,7 @@ static void replacePlaceholders(char *cmd_data, int cmd_count) {
             size_t *indices = placeholders.indices[placeholder];
             size_t count = placeholders.count[placeholder];
             _Atomic uint64_t *key_counter = &seq_key[placeholder];
-            replacePlaceholder(indices, count, cmd, key_counter);
+            replacePlaceholder(indices, count, cmd, key_counter, random_state);
         }
     }
 }
@@ -912,6 +924,10 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
 
+        uint64_t *random_state = c->thread_id >= 0
+                                     ? &thread_random_state
+                                     : &config.random_state;
+
         /* Dataset field access mode - completely independent command generation */
         if (config.has_field_placeholders && config.current_dataset && config.current_dataset->record_count > 0) {
             static _Atomic uint64_t record_counter = 0;
@@ -922,7 +938,7 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
                 uint64_t record_index = atomic_fetch_add_explicit(&record_counter, 1, memory_order_relaxed) % config.current_dataset->record_count;
                 sds complete_cmd = datasetGenerateCommand(config.current_dataset, record_index,
                                                           config.template_argv, config.template_argc,
-                                                          dataset_seq_key, config.replace_placeholders,
+                                                          dataset_seq_key, random_state, config.replace_placeholders,
                                                           config.keyspacelen, config.sequential_replacement);
                 c->obuf = sdscatlen(c->obuf, complete_cmd, sdslen(complete_cmd));
                 sdsfree(complete_cmd);
@@ -935,7 +951,7 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
         } else {
             /* Standard mode */
             if (config.replace_placeholders) {
-                replacePlaceholders(c->obuf + c->prefixlen, config.pipeline);
+                replacePlaceholders(c->obuf + c->prefixlen, config.pipeline, random_state);
             }
         }
 
@@ -1362,6 +1378,9 @@ static benchmarkThread *createBenchmarkThread(int index) {
     benchmarkThread *thread = zmalloc(sizeof(*thread));
     if (thread == NULL) return NULL;
     thread->index = index;
+    /* Threads are created by the main thread before their event loops start,
+     * so assigning independent streams here requires no synchronization. */
+    thread->random_seed = benchmarkNextRandom(&config.random_stream_state);
     thread->el = aeCreateEventLoop(1024 * 10);
     thread->paused_clients = listCreate();
     aeCreateTimeEvent(thread->el, 1, showThroughput, (void *)thread, NULL);
@@ -1386,6 +1405,7 @@ static void freeBenchmarkThreads(void) {
 
 static void *execBenchmarkThread(void *ptr) {
     benchmarkThread *thread = (benchmarkThread *)ptr;
+    thread_random_state = thread->random_seed;
     aeMain(thread->el);
     return NULL;
 }
@@ -1828,6 +1848,7 @@ int parseOptions(int argc, char **argv) {
             int rand_seed = atoi(argv[++i]);
             srandom(rand_seed);
             init_genrand64(rand_seed);
+            seedBenchmarkRandom((uint64_t)rand_seed);
         } else if (!strcmp(argv[i], "-t")) {
             if (lastarg) goto invalid;
             /* We get the list of tests to run as a string in the form
@@ -2275,8 +2296,10 @@ int main(int argc, char **argv) {
     size_t *argvlen = NULL;
     int seq_len = 0; /* Total number of commands in the sequence. */
 
-    srandom(time(NULL) ^ getpid());
+    uint64_t random_seed = time(NULL) ^ getpid();
+    srandom(random_seed);
     init_genrand64(ustime() ^ getpid());
+    seedBenchmarkRandom(random_seed);
     signal(SIGHUP, SIG_IGN);
     signal(SIGPIPE, SIG_IGN);
 

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -161,6 +161,15 @@ tags {"benchmark network external:skip logreqres:skip"} {
             assert_equal  {keys=50} [regexp -inline {keys=[\d]*} [r info keyspace]]
         }
 
+        test {benchmark: seed reproduces random key selection} {
+            set cmd [valkeybenchmark $master_host $master_port "-c 1 -n 100 -r 1000 --seed 42 -t set"]
+            common_bench_setup $cmd
+            set first_run_keys [lsort [r keys *]]
+
+            common_bench_setup $cmd
+            assert_equal $first_run_keys [lsort [r keys *]]
+        }
+
         test {benchmark: keyspace covered by sequential option} {
             set cmd [valkeybenchmark $master_host $master_port "-r 50 -t set -n 50 --sequential"]
             common_bench_setup $cmd


### PR DESCRIPTION
## Summary

- give each benchmark event loop an independent SplitMix64 random stream
- keep hot worker random state in TLS to avoid lock contention and false sharing
- cover both standard and dataset placeholder expansion while preserving `--seed` and `--sequential` behavior

## Motivation

Random key replacement currently calls `rand62()`, which calls glibc `random()` twice. In a multi-threaded benchmark, `random()` serializes on process-wide state. Client-side perf sampling with 16 benchmark threads showed about 13% of task-clock in futex paths rooted in `writeHandler` and the libc random lock.

## Test environment

Both VMs were in Azure Japan East, availability zone 3, communicating over private VNet addresses.

- client: `Standard_F16als_v7`, 16 vCPUs without SMT exposed to the guest, AMD EPYC 9V45, Linux `6.17.0-1022-azure`
- server: `Standard_L16aos_v4`, 16 vCPUs / 8 physical cores with SMT, AMD EPYC 9V74, Linux `6.17.0-1022-azure`
- server software: Valkey 8.1.9 with 8 I/O threads pinned to CPU list `0,2,4,6,8,10,12,14`; persistence disabled
- dataset: 5 million keys with 128-byte values
- common workload: 16 benchmark threads, pipeline 1, seed 12345, 30 million random GET requests

## Maximum-throughput results at identical concurrency

At 704 clients, removing the client lock raises throughput but pushes the server into a deeper queue.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Throughput | 777,746 req/s | 856,238 req/s | +10.1% |
| Average | 0.645 ms | 0.689 ms | +6.8% |
| p50 | 0.607 ms | 0.567 ms | -6.6% |
| p95 | 1.023 ms | 1.319 ms | +28.9% |
| p99 | 1.295 ms | 3.247 ms | +150.7% |
| p99.9 approximation (99.902% bucket) | 1.879 ms | 4.335 ms | +130.7% |
| 99.988% bucket | 4.087 ms | 6.151 ms | +50.5% |
| 99.994% bucket | 4.719 ms | 6.455 ms | +36.8% |
| Maximum | 10.335 ms | 207.231 ms | +1905.1% |

These values are maximum-throughput results, not a fixed-QPS latency comparison. Throughput and p50 improve, while queue-sensitive tail latency worsens.

## Retuned equal-throughput operating point

The patched client needs fewer connections to sustain the same load. Comparing the old client at 300 connections with the patched client at 260 connections gives slightly higher throughput and lower latency through approximately p99.99.

| Metric | Before, 300 clients | After, 260 clients | Change |
| --- | ---: | ---: | ---: |
| Throughput | 722,491 req/s | 731,208 req/s | +1.21% |
| Average | 0.324 ms | 0.302 ms | -6.8% |
| p50 | 0.303 ms | 0.279 ms | -7.9% |
| p95 | 0.559 ms | 0.527 ms | -5.7% |
| p99 | 0.751 ms | 0.735 ms | -2.1% |
| p99.9 approximation (99.902% bucket) | 1.279 ms | 1.223 ms | -4.4% |
| 99.988% bucket | 3.199 ms | 2.679 ms | -16.3% |
| 99.994% bucket | 4.247 ms | 3.943 ms | -7.2% |
| 99.997% bucket | 4.959 ms | 5.647 ms | +13.9% |
| 99.999% bucket | 6.927 ms | 7.615 ms | +9.9% |
| Maximum | 13.495 ms | 9.679 ms | -28.3% |

This demonstrates a better practical operating point after retuning concurrency; it is not an isolated same-concurrency latency proof. The most extreme emitted percentile buckets still vary in the opposite direction.

## Same-concurrency fixed-rate check

Both versions were also run at 300 clients with `--rps 700000`. Two runs in reversed order reached 696.5k-697.1k req/s. The patched version improved p50, but p99 was higher in both comparisons:

- run A: old p99 0.775 ms; patched p99 0.927 ms
- run B: patched p99 1.007 ms; old p99 0.711 ms

The old global lock appears to provide incidental cross-thread serialization. Removing it changes short-timescale emission behavior even at the same average QPS. If rate-limited tail stability is required, request pacing needs separate follow-up rather than claiming that this PR leaves every latency percentile unchanged.

With a backend that had more remaining server headroom, maximum throughput changed from 783,474 to 989,609 requests/sec, a 26.3% improvement. After the change, `random()`, `random_r()`, and their futex path no longer appeared as client hotspots.

## Testing

- `make -j16 valkey-benchmark`
- `./runtest --single integration/valkey-benchmark --timeout 300`
- 41 benchmark integration tests passed, including a new `--seed` reproducibility test