### PR TITLE
Include module version in module load log message

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -13476,9 +13476,9 @@ static int moduleInitPostOnLoadResolved(ModuleLoadFunc onload,
         ACLRecomputeCommandBitsFromCommandRulesAllUsers();
     }
     if (is_static) {
-        serverLog(LL_NOTICE, "Static Module '%s' (version %d) successfully loaded", ctx.module->name, ctx.module->ver);
+        serverLog(LL_NOTICE, "Static Module '%s' successfully loaded (version %d)", ctx.module->name, ctx.module->ver);
     } else {
-        serverLog(LL_NOTICE, "Module '%s' (version %d) loaded from %s", ctx.module->name, ctx.module->ver, display_name);
+        serverLog(LL_NOTICE, "Module '%s' loaded from %s (version %d)", ctx.module->name, display_name, ctx.module->ver);
     }
     ctx.module->onload = 0;
 

--- a/src/module.c
+++ b/src/module.c
@@ -13476,9 +13476,9 @@ static int moduleInitPostOnLoadResolved(ModuleLoadFunc onload,
         ACLRecomputeCommandBitsFromCommandRulesAllUsers();
     }
     if (is_static) {
-        serverLog(LL_NOTICE, "Static Module '%s' successfully loaded", ctx.module->name);
+        serverLog(LL_NOTICE, "Static Module '%s' (version %d) successfully loaded", ctx.module->name, ctx.module->ver);
     } else {
-        serverLog(LL_NOTICE, "Module '%s' loaded from %s", ctx.module->name, display_name);
+        serverLog(LL_NOTICE, "Module '%s' (version %d) loaded from %s", ctx.module->name, ctx.module->ver, display_name);
     }
     ctx.module->onload = 0;
 


### PR DESCRIPTION
The module load log lines only reported the module name (and the path
it was loaded from). Also log the module version, so it is easy to tell
which version of a module was loaded.