### PR TITLE
Bump fast-uri to 3.1.6 in reply-schema-linter to clear CVEs

### DIFF
--- a/utils/reply-schema-linter/package-lock.json
+++ b/utils/reply-schema-linter/package-lock.json
@@ -32,9 +32,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -44,7 +44,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",


### PR DESCRIPTION
`utils/reply-schema-linter` pins fast-uri 3.1.0 transitively via ajv, flagged by [CVE-2026-6321](https://nvd.nist.gov/vuln/detail/CVE-2026-6321), [CVE-2026-6322](https://nvd.nist.gov/vuln/detail/CVE-2026-6322), [CVE-2026-13676](https://nvd.nist.gov/vuln/detail/CVE-2026-13676), [CVE-2026-16221](https://nvd.nist.gov/vuln/detail/CVE-2026-16221) and [CVE-2026-18446](https://nvd.nist.gov/vuln/detail/CVE-2026-18446).

Bumped to 3.1.6, the newest release still inside ajv's `^3.0.1` range, so `package.json` is unchanged.

The lockfile was regenerated with `npm update fast-uri --package-lock-only` rather than hand-edited.

Verified locally: `npm ci --ignore-scripts` on an empty cache installs with no `EINTEGRITY`, `npm audit` reports 0 vulnerabilities, the linter exits 0 over `src/commands` (398 of 427 command entries carry a `reply_schema` and are compiled), and a deliberately corrupted schema still exits 1.
