### PR TITLE
Initialize vll in ziplist-to-listpack conversion callbacks

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1867,7 +1867,7 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename) {
 static int _ziplistPairsEntryConvertAndValidate(unsigned char *p, unsigned int head_count, void *userdata) {
     unsigned char *str;
     unsigned int slen;
-    long long vll;
+    long long vll = 0;
 
     struct {
         long count;
@@ -1929,7 +1929,7 @@ static int _ziplistEntryConvertAndValidate(unsigned char *p, unsigned int head_c
     UNUSED(head_count);
     unsigned char *str;
     unsigned int slen;
-    long long vll;
+    long long vll = 0;
     unsigned char **lp = (unsigned char **)userdata;
 
     if (!ziplistGet(p, &str, &slen, &vll)) return 0;
@@ -1948,7 +1948,7 @@ static int _listZiplistEntryConvertAndValidate(unsigned char *p, unsigned int he
     UNUSED(head_count);
     unsigned char *str;
     unsigned int slen;
-    long long vll;
+    long long vll = 0;
     char longstr[32] = {0};
     quicklist *ql = (quicklist *)userdata;
 


### PR DESCRIPTION
GCC 13 reports `vll` as maybe-uninitialized in the three ziplist->listpack
conversion callbacks in `rdb.c`. This isn't a live bug: `ziplistGet()` writes
`*sval` on exactly the integer-entry branch (`str == NULL`) that reads `vll`.
But that invariant spans a function boundary the compiler can't see, so it's a
latent trap today and a warning under GCC 13. Initializing `vll` makes the
invariant explicit and silences the warning.

`str`/`slen` are left unchanged: `ziplistGet()` always writes `*sstr`, and
`slen` is only read on the string branch where it is written.