### PR TITLE
Initialize locals reported as maybe-uninitialized

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2731,7 +2731,7 @@ static size_t get_ready_to_signal_threads_tids(int sig_num, pid_t tids[TIDS_MAX_
             if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) continue;
 
             /* the thread's directory name is equivalent to its tid. */
-            long tid;
+            long tid = 0;
             string2l(entry->d_name, strlen(entry->d_name), &tid);
 
             if (!is_thread_ready_to_signal(path_buff, entry->d_name, sig_num)) continue;

--- a/src/debug.c
+++ b/src/debug.c
@@ -2771,7 +2771,7 @@ static size_t get_ready_to_signal_threads_tids(int sig_num, pid_t tids[TIDS_MAX_
 
             /* the thread's directory name is equivalent to its tid. */
             long tid = 0;
-            string2l(entry->d_name, strlen(entry->d_name), &tid);
+            if (!string2l(entry->d_name, strlen(entry->d_name), &tid)) continue;
 
             if (!is_thread_ready_to_signal(path_buff, entry->d_name, sig_num)) continue;
 

--- a/src/module.c
+++ b/src/module.c
@@ -6338,7 +6338,7 @@ const char *VM_CallReplyStringPtr(ValkeyModuleCallReply *reply, size_t *len) {
  * integer. Otherwise, (wrong reply type) return NULL. */
 ValkeyModuleString *VM_CreateStringFromCallReply(ValkeyModuleCallReply *reply) {
     ValkeyModuleCtx *ctx = callReplyGetPrivateData(reply);
-    size_t len;
+    size_t len = 0;
     const char *str;
     switch (callReplyType(reply)) {
     case VALKEYMODULE_REPLY_STRING:

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1867,7 +1867,7 @@ robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename) {
 static int _ziplistPairsEntryConvertAndValidate(unsigned char *p, unsigned int head_count, void *userdata) {
     unsigned char *str;
     unsigned int slen;
-    long long vll;
+    long long vll = 0;
 
     struct {
         long count;
@@ -1929,7 +1929,7 @@ static int _ziplistEntryConvertAndValidate(unsigned char *p, unsigned int head_c
     UNUSED(head_count);
     unsigned char *str;
     unsigned int slen;
-    long long vll;
+    long long vll = 0;
     unsigned char **lp = (unsigned char **)userdata;
 
     if (!ziplistGet(p, &str, &slen, &vll)) return 0;
@@ -1948,7 +1948,7 @@ static int _listZiplistEntryConvertAndValidate(unsigned char *p, unsigned int he
     UNUSED(head_count);
     unsigned char *str;
     unsigned int slen;
-    long long vll;
+    long long vll = 0;
     char longstr[32] = {0};
     quicklist *ql = (quicklist *)userdata;
 


### PR DESCRIPTION
-Wmaybe-uninitialized reports several locals as maybe-uninitialized. None is a
live bug.

- `rdb.c`, the three ziplist->listpack conversion callbacks: `vll` is a false
  positive — `ziplistGet()` writes `*sval` on exactly the integer-entry branch
  (`str == NULL`) that reads `vll`. `str`/`slen` need no change.
- `module.c` `VM_CreateStringFromCallReply`: `len` is a false positive — written
  by `callReplyGetString()` in the reply-type cases that read it; the integer
  case shadows it and `default` returns early.
- `debug.c` `get_ready_to_signal_threads_tids`: `string2l()`'s return is
  unchecked, so a non-numeric task dir name would read `tid` uninitialized
  (can't happen today — /proc task names are numeric).

Initialize each to make the reads well-defined and silence the warning.