### PR TITLE
Add missing UPDATE key spec for HGETEX command

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -3905,7 +3905,7 @@ struct COMMAND_ARG HGETDEL_Args[] = {
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
 /* HGETEX key specs */
 keySpec HGETEX_Keyspecs[1] = {
-{NULL,CMD_KEY_RW|CMD_KEY_ACCESS,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+{NULL,CMD_KEY_RW|CMD_KEY_ACCESS|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
 };
 #endif
 

--- a/src/commands/hgetex.json
+++ b/src/commands/hgetex.json
@@ -19,7 +19,8 @@
             {
                 "flags": [
                     "RW",
-                    "ACCESS"
+                    "ACCESS",
+                    "UPDATE"
                 ],
                 "begin_search": {
                     "index": {

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -5034,3 +5034,56 @@ start_server {tags {"hashexpire"}} {
         r DEL myhash
     } {1}
 }
+
+start_server {tags {"hashexpire external:skip"}} {
+    # HGETEX changes field TTLs (and can delete a field via a past EXAT/PXAT),
+    # so its key spec requires both read and write permission on the key.
+    set r2 [valkey_client]
+
+    test {HGETEX under a read-only (%R~) ACL grant is denied} {
+        r DEL myhash
+        r HSET myhash f1 v1 f2 v2
+
+        r ACL SETUSER hgetex-ro on nopass %R~myhash* +@all
+        $r2 auth hgetex-ro password
+        assert_equal PONG [$r2 PING]
+
+        assert_equal "User hgetex-ro has no permissions to access the 'myhash' key" \
+            [r ACL DRYRUN hgetex-ro HGETEX myhash FIELDS 1 f1]
+
+        assert_error {*NOPERM*key*} {$r2 HGETEX myhash FIELDS 1 f1}
+        assert_error {*NOPERM*key*} {$r2 HGETEX myhash PERSIST FIELDS 1 f1}
+        assert_error {*NOPERM*key*} {$r2 HGETEX myhash EX 100 FIELDS 1 f1}
+        assert_error {*NOPERM*key*} {$r2 HGETEX myhash EXAT 1 FIELDS 1 f1}
+
+        assert_equal 2 [r HLEN myhash]
+        assert_equal v1 [r HGET myhash f1]
+        assert_equal -1 [r HTTL myhash FIELDS 1 f1]
+    }
+
+    test {HGETEX under a write-only (%W~) ACL grant is denied} {
+        r DEL myhash
+        r HSET myhash f1 v1
+
+        r ACL SETUSER hgetex-wo on nopass %W~myhash* +@all
+        $r2 auth hgetex-wo password
+        assert_equal PONG [$r2 PING]
+
+        assert_error {*NOPERM*key*} {$r2 HGETEX myhash EX 100 FIELDS 1 f1}
+    }
+
+    test {HGETEX with read+write (%RW~) ACL grant is permitted} {
+        r DEL myhash
+        r HSET myhash f1 v1 f2 v2
+
+        r ACL SETUSER hgetex-rw on nopass %RW~myhash* +@all
+        $r2 auth hgetex-rw password
+        assert_equal PONG [$r2 PING]
+
+        assert_equal v1 [$r2 HGETEX myhash FIELDS 1 f1]
+        assert_equal v1 [$r2 HGETEX myhash EX 1000 FIELDS 1 f1]
+        assert_morethan [r HTTL myhash FIELDS 1 f1] 0
+    }
+
+    $r2 close
+}


### PR DESCRIPTION
HGETEX mutates the key: `EX`/`PX`/`EXAT`/`PXAT` change a field's TTL, and an `EXAT`/`PXAT` in the past deletes the field outright. It is a write command (`@write` category, `CMD_WRITE` flag), but its key spec only declared `["RW","ACCESS"]`. `ACCESS` maps to read permission alone, so the key spec required only read access on the key.

As a result, a user granted read-only access to a key pattern (`%R~`) was allowed to run HGETEX and change field TTLs or delete fields it was only permitted to read.

Add `"UPDATE"` to the key spec so HGETEX requires both read and write permission, matching the command's write semantics and the key specs of the other hash-mutating commands (`HEXPIRE`/`HPEXPIRE`/`HGETDEL`). Regenerate `commands.def` and add ACL regression tests covering read-only, write-only, and read+write grants.

## Testing
- Regenerated `commands.def` from `hgetex.json`; the only change is the HGETEX keyspec line.
- New ACL regression tests in `tests/unit/hashexpire.tcl` pass (read-only denied, write-only denied, read+write permitted).
- Verified live via `ACL DRYRUN`: `%R~` and `%W~` grants are denied, `%RW~` is permitted.