### PR TITLE
Compare the certificate CN over its whole length

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1290,8 +1290,13 @@ static void updateSSLState(connection *conn_) {
     updatePendingData(conn);
 }
 
-static int getCertSubjectFieldByName(X509 *cert, const char *field, char *out, size_t outlen) {
-    if (!cert || !field || !out || outlen == 0) return 0;
+/* Return the named field of cert's subject, or NULL if it is absent or empty.
+ * Caller frees.
+ *
+ * sds rather than a C string, so the caller sees what the CA signed even when
+ * the value contains a NUL. */
+static sds getCertSubjectFieldByName(X509 *cert, const char *field) {
+    if (!cert || !field) return NULL;
 
     int nid = -1;
 
@@ -1301,35 +1306,32 @@ static int getCertSubjectFieldByName(X509 *cert, const char *field, char *out, s
         nid = NID_organizationName;
     /* Add more mappings here as needed */
 
-    if (nid == -1) return 0;
+    if (nid == -1) return NULL;
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     const X509_NAME *subject = X509_get_subject_name(cert);
 #else
     X509_NAME *subject = X509_get_subject_name(cert);
 #endif
-    if (!subject) return 0;
+    if (!subject) return NULL;
 
-    /* X509_NAME_get_text_by_NID is deprecated in OpenSSL 4.0 */
+    /* Not X509_NAME_get_text_by_NID(): it NUL terminates into a caller buffer,
+     * hiding an embedded NUL and truncating a long value. Also deprecated in
+     * OpenSSL 4.0. */
     int idx = X509_NAME_get_index_by_NID(subject, nid, -1);
-    if (idx < 0) return 0;
+    if (idx < 0) return NULL;
 
     const X509_NAME_ENTRY *entry = X509_NAME_get_entry(subject, idx);
-    if (!entry) return 0;
+    if (!entry) return NULL;
 
     const ASN1_STRING *data = X509_NAME_ENTRY_get_data(entry);
-    if (!data) return 0;
+    if (!data) return NULL;
 
     const unsigned char *str = ASN1_STRING_get0_data(data);
-    int len = ASN1_STRING_length(data);
-    if (!str || len <= 0) return 0;
+    int str_len = ASN1_STRING_length(data);
+    if (!str || str_len <= 0) return NULL;
 
-    /* Copy to output buffer, ensuring null termination */
-    size_t copy_len = (size_t)len < outlen - 1 ? (size_t)len : outlen - 1;
-    memcpy(out, str, copy_len);
-    out[copy_len] = '\0';
-
-    return 1;
+    return sdsnewlen(str, str_len);
 }
 
 /* Extract URI from Subject Alternative Name extension and return the first
@@ -1403,16 +1405,28 @@ user *tlsGetPeerUser(connection *conn_, sds *cert_username) {
         break;
 
     case TLS_CLIENT_FIELD_CN: {
-        char field_value[256];
-        if (getCertSubjectFieldByName(cert, "CN", field_value, sizeof(field_value))) {
-            if (cert_username) *cert_username = sdsnew(field_value);
-            result = ACLGetUserByName(field_value, strlen(field_value));
-            if (!result || !(result->flags & USER_FLAG_ENABLED)) {
-                serverLog(LL_VERBOSE, "TLS: No matching user found for certificate CN '%s'", field_value);
-                result = NULL;
-            }
-        } else {
+        sds cn = getCertSubjectFieldByName(cert, "CN");
+        if (!cn) {
             serverLog(LL_DEBUG, "TLS: Failed to extract CN in certificate subject");
+            break;
+        }
+
+        /* Compared over the whole CN, so "CN=admin\0attacker" does not match the
+         * user "admin". */
+        result = ACLGetUserByName(cn, sdslen(cn));
+        if (!result || !(result->flags & USER_FLAG_ENABLED)) {
+            sds repr = server.hide_user_data_from_log ? NULL : sdscatrepr(sdsempty(), cn, sdslen(cn));
+            serverLog(LL_VERBOSE, "TLS: No matching user found for certificate CN %s",
+                      repr ? repr : "*redacted*");
+            sdsfree(repr);
+            result = NULL;
+        }
+
+        /* Hand over the CN even when it does not match, so it reaches the ACL log. */
+        if (cert_username) {
+            *cert_username = cn;
+        } else {
+            sdsfree(cn);
         }
         break;
     }

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -186,6 +186,25 @@ start_server {tags {"tls"}} {
             $s close
         }
 
+        test {TLS: Certificate CN with an embedded NUL does not authenticate as the truncated user} {
+            r ACL SETUSER {Client-only} on allcommands allkeys
+            r CONFIG SET tls-auth-clients-user CN
+            r CONFIG RESETSTAT
+
+            # The CN is "Client-only\0attacker". Read as a C string it is "Client-only".
+            set s [valkey [srv 0 host] [srv 0 port]]
+            ::tls::import [$s channel] -cafile $::tlsdir/ca.crt \
+                -certfile $::tlsdir/client-nul-cn.crt -keyfile $::tlsdir/client-nul-cn.key
+            assert_equal "default" [$s ACL WHOAMI]
+            $s close
+
+            # The rejected identity reaches the ACL log.
+            assert_equal 1 [s acl_access_denied_tls_cert]
+
+            r ACL DELUSER {Client-only}
+            r CONFIG SET tls-auth-clients-user off
+        }
+
         test {TLS: Auto-authenticate using tls-auth-clients-user (URI)} {
             # Enable the feature to auto-authenticate based on URI
             r CONFIG SET tls-auth-clients-user URI

--- a/utils/gen-test-certs.sh
+++ b/utils/gen-test-certs.sh
@@ -13,6 +13,7 @@
 #   tests/tls/client-{expired,notyet}.crt        Invalid certificates restricted for SSL client usage.
 #   tests/tls/server.{crt,key}                   A certificate restricted for SSL server usage.
 #   tests/tls/server-{expired,notyet}.crt        Invalid certificates restricted for SSL server usage.
+#   tests/tls/client-nul-cn.{crt,key}            Client certificate whose CN contains an embedded NUL.
 #   tests/tls/valkey.dh                          DH Params file.
 
 generate_cert() {
@@ -66,6 +67,55 @@ _END_
 generate_cert server "Server-only" "-extfile tests/tls/openssl.cnf -extensions server_cert"
 generate_cert client "Client-only" "-extfile tests/tls/openssl.cnf -extensions client_cert"
 generate_cert valkey "Generic-cert" "-extfile tests/tls/openssl.cnf -extensions generic_cert"
+
+# A client certificate with the CN "Client-only\0attacker", which anything
+# reading the CN as a C string sees as "Client-only".
+#
+# The openssl CLI will not put a NUL in a name, so issue with a placeholder
+# byte, overwrite it with a NUL, and re-sign tbsCertificate. The signature is
+# the same length, so the DER layout is unchanged.
+generate_cert client-nul-cn "Client-only@attacker" "-extfile tests/tls/openssl.cnf -extensions client_cert"
+python3 - tests/tls/client-nul-cn.crt tests/tls/ca.key 'Client-only@' <<'_PYEND_'
+import base64, re, subprocess, sys
+
+cert_path, ca_key_path, marker = sys.argv[1:4]
+
+pem = open(cert_path).read()
+der = bytearray(base64.b64decode(re.sub(r"-----[^-]*-----|\s", "", pem)))
+
+# Overwrite the last byte of the marker with a NUL.
+der[der.index(marker.encode()) + len(marker) - 1] = 0
+
+# tbsCertificate and signatureValue are direct children of Certificate.
+fields = subprocess.run(["openssl", "asn1parse", "-in", cert_path],
+                        capture_output=True, text=True, check=True).stdout.splitlines()
+
+def span(line):
+    """(element start, content start, content end)"""
+    off, hl, length = map(int, re.match(r"\s*(\d+):d=1\s+hl=\s*(\d+)\s+l=\s*(\d+)", line).groups())
+    return off, off + hl, off + hl + length
+
+tbs_start, _, tbs_end = span(fields[1])
+_, sig_start, sig_end = span([f for f in fields if "BIT STRING" in f][-1])
+
+# The signature covers tbsCertificate including its header.
+open(cert_path + ".tbs", "wb").write(bytes(der[tbs_start:tbs_end]))
+subprocess.run(["openssl", "dgst", "-sha256", "-sign", ca_key_path,
+                "-out", cert_path + ".sig", cert_path + ".tbs"], check=True)
+sig = open(cert_path + ".sig", "rb").read()
+
+# Skip the BIT STRING's unused-bit count octet.
+assert sig_end - sig_start - 1 == len(sig), "signature length changed"
+der[sig_start + 1:sig_end] = sig
+
+b64 = base64.b64encode(bytes(der)).decode()
+with open(cert_path, "w") as out:
+    out.write("-----BEGIN CERTIFICATE-----\n")
+    for i in range(0, len(b64), 64):
+        out.write(b64[i:i + 64] + "\n")
+    out.write("-----END CERTIFICATE-----\n")
+_PYEND_
+rm -f tests/tls/client-nul-cn.crt.tbs tests/tls/client-nul-cn.crt.sig
 
 # Create a CA bundle and hashed CA directory used by TLS tests.
 # (ca-multi.crt and ca-dir/)


### PR DESCRIPTION
`tlsGetPeerUser()` derived the ACL username from the certificate CN with `strlen()`, so an embedded NUL truncated the identity before the lookup. A certificate whose CA vouched subject is `CN=admin\0attacker` authenticated as the ACL user `admin` and got its privileges. The sibling SAN URI path already passed an explicit length to `ACLGetUserByName()`. The CN path did not.

No explicit NUL check is needed. `ACL SETUSER` refuses a username containing one, so comparing the full length is sufficient. Dropping the buffer also removes the silent truncation of a CN longer than 255 bytes.

The CN is handed back whether or not it matches, so a failed authentication now produces an `ACL LOG` entry and bumps `acl_access_denied_tls_cert` instead of leaving no trace at the default loglevel.

Affects 9.0 and 9.1, CN path only. The feature arrived in #1920.

Not fixed here: `X509_NAME_get_index_by_NID()` takes the first CN and ignores the rest, so `CN=admin, CN=attacker` authenticates as `admin`. Refusing that would break certificates that authenticate today and contradicts `valkey.conf:275-277`, which documents first match wins for URI mode. Its own PR.

The openssl CLI strips a NUL from a name, which is why #3078 could not cover this when it added the URI path, so the fixture is issued with a placeholder byte and re-signed. The new test fails on unstable and passes with the fix. `unit/tls` and `unit/acl` pass under `--tls` and `--tls-module`, and `unit/tls` is clean under `SANITIZER=address`.

> [!NOTE]
> Reported by Christopher Lusk, North Echo Security Research (GHSA-wcx3-8mjv-6cjc). This was generated by AI but verified, with love, by a human.
