### PR TITLE
Revert redundant #630 re-pick that duplicated expand_unit_spec

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -108,34 +108,6 @@ proc expand_unit_spec {spec} {
     return $result
 }
 
-# Expand a unit specification (test name, file, or directory) into a list
-# of canonical unit names relative to the tests directory.
-proc expand_unit_spec {spec} {
-    set tests_dir [file normalize [file join [pwd] tests]]
-
-    if {[file isdirectory $spec]} {
-        set files [glob -nocomplain [file join [file normalize $spec] *.tcl]]
-    } elseif {[file exists $spec]} {
-        set files [list [file normalize $spec]]
-    } elseif {[file exists [file join $tests_dir "${spec}.tcl"]]} {
-        set files [list [file normalize [file join $tests_dir "${spec}.tcl"]]]
-    } else {
-        return [list $spec]
-    }
-
-    set result {}
-    foreach test_file $files {
-        set norm [file normalize $test_file]
-        if {[string match "$tests_dir/*" $norm]} {
-            set rel [string range $norm [expr {[string length $tests_dir]+1}] end]
-            lappend result [file rootname $rel]
-        } else {
-            lappend result [file rootname $norm]
-        }
-    }
-    return $result
-}
-
 # Set to 1 when we are running in client mode. The server test uses a
 # server-client model to run tests simultaneously. The server instance
 # runs the specified number of client instances that will actually run tests.


### PR DESCRIPTION
https://github.com/valkey-io/valkey/pull/4555 re-picks #630, which is already on 8.0 as df7f1f8c1 (2025-07-07). The cherry-pick appended an identical copy of proc `expand_unit_spec` instead of matching the existing definition and unlike the module.c case in this same sweep, Tcl has no redefinition error, so nothing caught it at build or test time.

Reverting restores a single definition. No other change.