### PR TITLE
Fix valkey-benchmark hang in showReport() percentile iteration

### DIFF
--- a/deps/README.md
+++ b/deps/README.md
@@ -114,6 +114,13 @@ We use a customized version based on master branch commit e4448cf6d1cd08fff51981
 2. Copy updated files from newer version onto files in /hdr_histogram.
 3. Apply the changes from 1 above to the updated files.
 
+Local modifications carried on top of upstream:
+1. `percentile_iter_next`, `iter_linear_next` and `log_iter_next` are bounded by the
+   end of the counts array, so that a histogram whose `total_count` disagrees with the
+   sum of its bucket counts terminates the iteration instead of spinning forever.
+   `has_next()` alone never becomes false on such a histogram. Upstream is still
+   affected; re-check before dropping this patch.
+
 ffc.h
 ---
 ffc.h is a pure C99 port of the fast_float library, providing fast string-to-double

--- a/deps/hdr_histogram/hdr_histogram.c
+++ b/deps/hdr_histogram/hdr_histogram.c
@@ -952,7 +952,15 @@ static bool percentile_iter_next(struct hdr_iter* iter)
     }
     while (basic_iter_next(iter));
 
-    return true;
+    /* The scan reached the end of the counts array without finding another value
+     * to report. On a well formed histogram this is unreachable: cumulative_count
+     * reaches total_count first and has_next() ends the iteration above. It
+     * becomes reachable when total_count disagrees with the recorded counts, in
+     * which case has_next() never returns false. Stop instead of returning true
+     * forever and leaving the caller spinning. Reporting a final percentile here
+     * would publish iter->highest_equivalent_value as left by the exhausted scan,
+     * which is the largest representable value rather than one that was recorded. */
+    return false;
 }
 
 void hdr_iter_percentile_init(struct hdr_iter* iter, const struct hdr_histogram* h, int32_t ticks_per_half_distance)
@@ -1045,9 +1053,14 @@ static bool iter_linear_next(struct hdr_iter* iter)
 
     linear->count_added_in_this_iteration_step = 0;
 
-    if (has_next(iter) ||
-        next_value_greater_than_reporting_level_upper_bound(
-            iter, linear->next_value_reporting_level_lowest_equivalent))
+    /* has_buckets() bounds the walk by the counts array. Without it a histogram
+     * whose total_count disagrees with the recorded counts keeps has_next() true,
+     * and move_next() below then returns true past the end of the array on every
+     * call, so the caller spins forever and counts_index grows without bound. */
+    if (has_buckets(iter) &&
+        (has_next(iter) ||
+         next_value_greater_than_reporting_level_upper_bound(
+             iter, linear->next_value_reporting_level_lowest_equivalent)))
     {
         do
         {
@@ -1107,9 +1120,14 @@ static bool log_iter_next(struct hdr_iter *iter)
 
     logarithmic->count_added_in_this_iteration_step = 0;
 
-    if (has_next(iter) ||
-        next_value_greater_than_reporting_level_upper_bound(
-            iter, logarithmic->next_value_reporting_level_lowest_equivalent))
+    /* has_buckets() bounds the walk by the counts array. Without it a histogram
+     * whose total_count disagrees with the recorded counts keeps has_next() true,
+     * and move_next() below then returns true past the end of the array on every
+     * call, so the caller spins forever and counts_index grows without bound. */
+    if (has_buckets(iter) &&
+        (has_next(iter) ||
+         next_value_greater_than_reporting_level_upper_bound(
+             iter, logarithmic->next_value_reporting_level_lowest_equivalent)))
     {
         do
         {

--- a/src/unit/test_hdr_histogram.cpp
+++ b/src/unit/test_hdr_histogram.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+
+#include <cstring>
+
+extern "C" {
+#include "hdr_histogram.h"
+#include "server.h"
+}
+
+class HdrHistogramTest : public ::testing::Test {};
+
+/* Returns the sum of every recorded count, which is what total_count is
+ * supposed to track. */
+static int64_t sum_of_counts(const struct hdr_histogram *h) {
+    int64_t sum = 0;
+    for (int32_t i = 0; i < h->counts_len; i++) sum += hdr_count_at_index(h, i);
+    return sum;
+}
+
+/* Reproduces the state a torn hdr_reset() leaves behind: the buckets have been
+ * cleared but total_count still counts concurrently recorded values. */
+static void tearHistogram(struct hdr_histogram *h) {
+    hdr_record_value(h, 500);
+    hdr_record_value(h, 1200);
+    hdr_record_value(h, 25000);
+    memset(h->counts, 0, sizeof(int64_t) * h->counts_len);
+    h->total_count = 3;
+}
+
+/* valkey-benchmark records latencies into one shared histogram from every
+ * thread while showThroughput() resets that same histogram at the end of the
+ * warmup period. hdr_reset() is a plain store followed by a memset, so a
+ * concurrent hdr_record_value_atomic() can leave total_count larger than the
+ * sum of the recorded counts.
+ *
+ * has_next() compares the running cumulative count against a snapshot of
+ * total_count, so on such a histogram it never becomes false. The percentile
+ * iterator must still terminate rather than spin forever, otherwise
+ * showReport() hangs the whole process after the run has already finished. */
+TEST_F(HdrHistogramTest, PercentileIterTerminatesWhenTotalCountExceedsCounts) {
+    struct hdr_histogram *h;
+    ASSERT_EQ(hdr_init(10, 3000000, 3, &h), 0);
+
+    tearHistogram(h);
+    ASSERT_GT(h->total_count, sum_of_counts(h));
+
+    struct hdr_iter iter;
+    hdr_iter_percentile_init(&iter, h, 1);
+
+    /* Bounded so that a regression fails the test instead of hanging the suite. */
+    const int max_iterations = 1000;
+    int iterations = 0;
+    while (hdr_iter_next(&iter)) {
+        if (++iterations >= max_iterations) break;
+    }
+    ASSERT_LT(iterations, max_iterations) << "percentile iterator failed to terminate";
+
+    hdr_close(h);
+}
+
+/* showReport() walks the histogram a second time with the linear iterator
+ * (src/valkey-benchmark.c:1248), and LATENCY HISTOGRAM walks it with the
+ * logarithmic iterator (src/latency.c:515). Both are gated only by has_next(),
+ * so on the same torn histogram they never terminate either: move_next() keeps
+ * returning true past the end of the counts array, incrementing counts_index
+ * without bound. Guarding only the percentile iterator would move the hang
+ * rather than remove it. */
+TEST_F(HdrHistogramTest, LinearIterTerminatesWhenTotalCountExceedsCounts) {
+    struct hdr_histogram *h;
+    ASSERT_EQ(hdr_init(10, 3000000, 3, &h), 0);
+    tearHistogram(h);
+
+    struct hdr_iter iter;
+    hdr_iter_linear_init(&iter, h, 100);
+
+    const int max_iterations = 100000;
+    int iterations = 0;
+    while (hdr_iter_next(&iter)) {
+        if (++iterations >= max_iterations) break;
+    }
+    ASSERT_LT(iterations, max_iterations) << "linear iterator failed to terminate";
+    /* counts_index must not be walked past the end of the array. */
+    ASSERT_LE(iter.counts_index, h->counts_len);
+
+    hdr_close(h);
+}
+
+TEST_F(HdrHistogramTest, LogIterTerminatesWhenTotalCountExceedsCounts) {
+    struct hdr_histogram *h;
+    ASSERT_EQ(hdr_init(10, 3000000, 3, &h), 0);
+    tearHistogram(h);
+
+    struct hdr_iter iter;
+    hdr_iter_log_init(&iter, h, 1024, 2);
+
+    const int max_iterations = 100000;
+    int iterations = 0;
+    while (hdr_iter_next(&iter)) {
+        if (++iterations >= max_iterations) break;
+    }
+    ASSERT_LT(iterations, max_iterations) << "log iterator failed to terminate";
+    ASSERT_LE(iter.counts_index, h->counts_len);
+
+    hdr_close(h);
+}
+
+/* A torn histogram cannot be reported accurately, but it must not invent data.
+ * The percentile iterator reports one row per recorded value, so every value it
+ * publishes has to be one that was actually recorded -- not the largest
+ * representable value left behind by a scan that ran off the end of the counts
+ * array. (The linear and logarithmic iterators are excluded on purpose: they
+ * report fixed reporting levels, so walking into the empty buckets above the
+ * last recorded value is their normal behaviour on any histogram.) */
+TEST_F(HdrHistogramTest, PercentileIterDoesNotReportUnrecordedValueWhenCorrupt) {
+    struct hdr_histogram *h;
+    ASSERT_EQ(hdr_init(10, 3000000, 3, &h), 0);
+
+    const int64_t values[] = {150, 400, 900, 2500, 11000};
+    for (size_t i = 0; i < numElements(values); i++) {
+        ASSERT_TRUE(hdr_record_value(h, values[i]));
+    }
+    const int64_t recorded_max = hdr_max(h);
+    /* Only total_count is inflated here, so every bucket still holds real data
+     * and anything reported must fall at or below the largest recorded value. */
+    h->total_count += 2;
+    ASSERT_GT(h->total_count, sum_of_counts(h));
+
+    struct hdr_iter iter;
+    hdr_iter_percentile_init(&iter, h, 1);
+    int iterations = 0;
+    while (hdr_iter_next(&iter) && ++iterations < 100000) {
+        ASSERT_LE(iter.highest_equivalent_value, recorded_max)
+            << "percentile iterator reported a value that was never recorded";
+    }
+    ASSERT_LT(iterations, 100000);
+
+    hdr_close(h);
+}
+
+/* The termination guards must not cut a well-formed histogram short for the
+ * linear and logarithmic iterators either. */
+TEST_F(HdrHistogramTest, LinearAndLogItersStillReportFullDistribution) {
+    struct hdr_histogram *h;
+    ASSERT_EQ(hdr_init(10, 3000000, 3, &h), 0);
+
+    const int64_t values[] = {150, 400, 900, 2500, 11000};
+    for (size_t i = 0; i < numElements(values); i++) {
+        ASSERT_TRUE(hdr_record_value(h, values[i]));
+    }
+
+    struct hdr_iter iter;
+    hdr_iter_linear_init(&iter, h, 100);
+    int64_t last_cumulative_count = 0;
+    int iterations = 0;
+    while (hdr_iter_next(&iter) && ++iterations < 100000) {
+        last_cumulative_count = iter.cumulative_count;
+    }
+    ASSERT_GT(iterations, 0);
+    ASSERT_EQ(last_cumulative_count, h->total_count);
+
+    hdr_iter_log_init(&iter, h, 1024, 2);
+    last_cumulative_count = 0;
+    iterations = 0;
+    while (hdr_iter_next(&iter) && ++iterations < 100000) {
+        last_cumulative_count = iter.cumulative_count;
+    }
+    ASSERT_GT(iterations, 0);
+    ASSERT_EQ(last_cumulative_count, h->total_count);
+
+    hdr_close(h);
+}
+
+/* The same guard must not cut a well-formed histogram short: every recorded
+ * value still has to be reported, and the iteration still has to end on the
+ * 100th percentile. */
+TEST_F(HdrHistogramTest, PercentileIterStillReportsFullDistribution) {
+    struct hdr_histogram *h;
+    ASSERT_EQ(hdr_init(10, 3000000, 3, &h), 0);
+
+    const int64_t values[] = {150, 400, 900, 2500, 11000};
+    for (size_t i = 0; i < numElements(values); i++) {
+        ASSERT_TRUE(hdr_record_value(h, values[i]));
+    }
+    ASSERT_EQ(h->total_count, sum_of_counts(h));
+
+    struct hdr_iter iter;
+    hdr_iter_percentile_init(&iter, h, 1);
+    struct hdr_iter_percentiles *percentiles = &iter.specifics.percentiles;
+
+    const int max_iterations = 10000;
+    int iterations = 0;
+    double last_percentile = 0;
+    int64_t last_cumulative_count = 0;
+    while (hdr_iter_next(&iter)) {
+        last_percentile = percentiles->percentile;
+        last_cumulative_count = iter.cumulative_count;
+        if (++iterations >= max_iterations) break;
+    }
+
+    ASSERT_LT(iterations, max_iterations) << "percentile iterator failed to terminate";
+    ASSERT_GT(iterations, 0);
+    /* All recorded values accounted for, and the walk ends at 100%. */
+    ASSERT_EQ(last_cumulative_count, h->total_count);
+    ASSERT_DOUBLE_EQ(last_percentile, 100.0);
+
+    hdr_close(h);
+}

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -113,6 +113,7 @@ static struct config {
     int duration;
     int warmup_duration;
     _Atomic int current_warmup_duration;
+    _Atomic int warmup_transition_claimed;
     _Atomic int requests_issued;
     _Atomic int requests_finished;
     _Atomic int previous_requests_finished;
@@ -125,7 +126,7 @@ static struct config {
     int sequential_replacement;
     int keepalive;
     int pipeline;
-    long long start;
+    _Atomic long long start;
     long long totlatency;
     const char *title;
     list *clients;
@@ -148,7 +149,12 @@ static struct config {
     int cluster_node_count;
     struct clusterNode **cluster_nodes;
     struct serverConfig *server_config;
-    struct hdr_histogram *latency_histogram;
+    struct hdr_histogram *_Atomic latency_histogram;
+    /* Pre-allocated replacement swapped in when the warmup period ends, so the
+     * histogram the recording threads are writing to is never cleared underneath
+     * them. Holds the retired warmup histogram afterwards, so both allocations
+     * stay reachable for hdr_close(). */
+    struct hdr_histogram *spare_latency_histogram;
     struct hdr_histogram *current_sec_latency_histogram;
     struct hdr_histogram *rps_histogram;
     _Atomic int is_fetching_slots;
@@ -294,7 +300,7 @@ static long long nstime(void) {
 
 static bool isBenchmarkFinished(int request_count) {
     /* don't end in warmup period */
-    int warmup_duration = atomic_load_explicit(&config.current_warmup_duration, memory_order_relaxed);
+    int warmup_duration = atomic_load_explicit(&config.current_warmup_duration, memory_order_acquire);
     if (warmup_duration > 0) return false;
 
     if (config.duration > 0) {
@@ -791,8 +797,13 @@ static void readHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
                 }
                 int requests_finished = atomic_fetch_add_explicit(&config.requests_finished, 1, memory_order_relaxed);
                 if (!isBenchmarkFinished(requests_finished)) {
+                    /* Loaded once: the warmup transition may swap this pointer, and
+                     * a thread that still holds the previous one simply records into
+                     * the retired warmup histogram, whose samples are discarded. */
+                    struct hdr_histogram *latency_histogram =
+                        atomic_load_explicit(&config.latency_histogram, memory_order_acquire);
                     if (config.num_threads == 0) {
-                        hdr_record_value(config.latency_histogram, // Histogram to record to
+                        hdr_record_value(latency_histogram, // Histogram to record to
                                          (long)c->latency <= CONFIG_LATENCY_HISTOGRAM_MAX_VALUE
                                              ? (long)c->latency
                                              : CONFIG_LATENCY_HISTOGRAM_MAX_VALUE); // Value to record
@@ -801,7 +812,7 @@ static void readHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
                                              ? (long)c->latency
                                              : CONFIG_LATENCY_HISTOGRAM_INSTANT_MAX_VALUE); // Value to record
                     } else {
-                        hdr_record_value_atomic(config.latency_histogram, // Histogram to record to
+                        hdr_record_value_atomic(latency_histogram, // Histogram to record to
                                                 (long)c->latency <= CONFIG_LATENCY_HISTOGRAM_MAX_VALUE
                                                     ? (long)c->latency
                                                     : CONFIG_LATENCY_HISTOGRAM_MAX_VALUE); // Value to record
@@ -1308,10 +1319,19 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     config.previous_requests_finished = 0;
     config.last_printed_bytes = 0;
     config.current_warmup_duration = config.warmup_duration;
-    hdr_init(CONFIG_LATENCY_HISTOGRAM_MIN_VALUE,         // Minimum value
-             CONFIG_LATENCY_HISTOGRAM_MAX_VALUE,         // Maximum value
-             config.precision,                           // Number of significant figures
-             &config.latency_histogram);                 // Pointer to initialise
+    config.warmup_transition_claimed = 0;
+    struct hdr_histogram *latency_histogram = NULL;
+    hdr_init(CONFIG_LATENCY_HISTOGRAM_MIN_VALUE, // Minimum value
+             CONFIG_LATENCY_HISTOGRAM_MAX_VALUE, // Maximum value
+             config.precision,                   // Number of significant figures
+             &latency_histogram);                // Pointer to initialise
+    atomic_store_explicit(&config.latency_histogram, latency_histogram, memory_order_relaxed);
+    config.spare_latency_histogram = NULL;
+    if (config.warmup_duration > 0) {
+        /* Swapped in at the end of the warmup period in place of hdr_reset(). */
+        hdr_init(CONFIG_LATENCY_HISTOGRAM_MIN_VALUE, CONFIG_LATENCY_HISTOGRAM_MAX_VALUE, config.precision,
+                 &config.spare_latency_histogram);
+    }
     hdr_init(CONFIG_LATENCY_HISTOGRAM_MIN_VALUE,         // Minimum value
              CONFIG_LATENCY_HISTOGRAM_INSTANT_MAX_VALUE, // Maximum value
              config.precision,                           // Number of significant figures
@@ -1348,6 +1368,7 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     if (config.threads) freeBenchmarkThreads();
     if (config.current_sec_latency_histogram) hdr_close(config.current_sec_latency_histogram);
     if (config.latency_histogram) hdr_close(config.latency_histogram);
+    if (config.spare_latency_histogram) hdr_close(config.spare_latency_histogram);
     if (config.rps_histogram) hdr_close(config.rps_histogram);
 }
 
@@ -2151,17 +2172,38 @@ long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clie
         fprintf(stderr, "All clients disconnected... aborting.\n");
         exit(1);
     }
-    int warmup_duration = atomic_load_explicit(&config.current_warmup_duration, memory_order_relaxed);
+    int warmup_duration = atomic_load_explicit(&config.current_warmup_duration, memory_order_acquire);
     if (warmup_duration > 0) {
         if ((current_tick - config.start) >= (warmup_duration * 1000LL)) {
-            /* exit the warmup period, clear all stats */
-            atomic_store_explicit(&config.current_warmup_duration, 0, memory_order_relaxed);
-
-            config.start = current_tick;
-            atomic_store_explicit(&config.requests_finished, 0, memory_order_relaxed);
-            atomic_store_explicit(&config.requests_issued, 0, memory_order_relaxed);
-            atomic_store_explicit(&config.previous_requests_finished, 0, memory_order_relaxed);
-            hdr_reset(config.latency_histogram);
+            /* Exit the warmup period and clear all stats. In multi-threaded mode
+             * showThroughput() runs on a timer in every thread, so the transition
+             * is claimed with a dedicated flag rather than by clearing the warmup
+             * duration itself: that value is also the gate which lets the recording
+             * threads write to the latency histogram, so it has to stay non-zero
+             * until every reset below has been published. */
+            int unclaimed = 0;
+            if (atomic_compare_exchange_strong_explicit(&config.warmup_transition_claimed, &unclaimed, 1,
+                                                        memory_order_acq_rel, memory_order_relaxed)) {
+                config.start = current_tick;
+                atomic_store_explicit(&config.requests_finished, 0, memory_order_relaxed);
+                atomic_store_explicit(&config.requests_issued, 0, memory_order_relaxed);
+                atomic_store_explicit(&config.previous_requests_finished, 0, memory_order_relaxed);
+                /* Swap in the spare histogram instead of resetting the live one.
+                 * hdr_reset() is a plain store followed by a memset, so running it
+                 * here would race with the hdr_record_value_atomic() calls still in
+                 * flight on the other threads and could leave total_count
+                 * disagreeing with the sum of the bucket counts. */
+                if (config.spare_latency_histogram != NULL) {
+                    struct hdr_histogram *retired =
+                        atomic_load_explicit(&config.latency_histogram, memory_order_relaxed);
+                    atomic_store_explicit(&config.latency_histogram, config.spare_latency_histogram,
+                                          memory_order_relaxed);
+                    config.spare_latency_histogram = retired;
+                }
+                /* Published last, with release ordering, so that any thread which
+                 * observes the warmup gate closed also observes everything above. */
+                atomic_store_explicit(&config.current_warmup_duration, 0, memory_order_release);
+            }
         }
     } else if (isBenchmarkFinished(requests_finished)) {
         aeStop(eventLoop);


### PR DESCRIPTION
Fixes #4583.

`valkey-benchmark` can hang forever at 100 % CPU *after* a test has finished measuring, spinning inside the latency report. The measured run completes, the final progress line is written, and then the process never returns and prints nothing further. I hit it twice in roughly 40 benchmark cells; one cell that should have taken 25 s sat spinning for 26 minutes before I killed it.

```
#0  percentile_iter_next
#1  showReport
#2  benchmarkSequence
#3  main
```

### Cause

`showThroughput()` is registered on a timer in **every** benchmark thread (`src/valkey-benchmark.c:1367`), and at the end of the warmup period it called `hdr_reset()` on the shared latency histogram while the other threads were still recording into it through `hdr_record_value_atomic()`. `hdr_reset()` is a plain store followed by a `memset`, and the recorders increment the bucket and `total_count` as two separate atomic operations, so an increment to `total_count` can survive while the bucket it incremented is zeroed. The histogram is then left with `total_count > sum(counts)`.

That state is terminal for the report iterators, because `has_next()` compares the running cumulative count against a snapshot of `total_count` taken at iterator init, so it never becomes false.

### Fix

**Stop resetting a histogram that other threads are writing to.** A second histogram is allocated up front when a warmup period is configured, and the warmup transition swaps it in instead of clearing the live one. A thread still holding the previous pointer records into the retired warmup histogram, whose samples are discarded anyway, so no sample is ever written to storage that is being cleared. Electing a single resetter would not have been enough: the corruption comes from the reset racing the *recorders*, not from two threads both resetting.

**Claim the transition with a dedicated flag** rather than by clearing `current_warmup_duration`, because that value is also the gate which lets the recording threads write to the histogram. It now stays non-zero until `config.start`, the request counters and the histogram pointer have all been published, and is released last, so any thread that observes the gate closed also observes everything reset behind it.

**`config.start` becomes `_Atomic`.** It was a plain `long long`, written by the thread performing the transition and read concurrently by every other thread from `isBenchmarkFinished()` on the reply path. ThreadSanitizer reports this race on the previous code and is clean on this one.

**Bound the histogram iterators by the end of the counts array.** `percentile_iter_next()`, `iter_linear_next()` and `log_iter_next()` were all gated only by `has_next()`, so on an inconsistent histogram each of them returns `true` forever while `move_next()` walks `counts_index` past the end of the array without bound. `showReport()` iterates twice — percentile at `src/valkey-benchmark.c:1234` and linear at `:1248` — and `LATENCY HISTOGRAM` uses the logarithmic iterator through `src/latency.c:515`, so guarding only the percentile iterator would have moved the hang rather than removed it. The percentile iterator also no longer reports a final row once its scan is exhausted: the value it would publish is the largest *representable* value left behind by that scan, printed as `100.000% <= 4194.303 milliseconds`, rather than one that was actually recorded.

`deps/README.md` records the local modification so a future re-vendor of HdrHistogram_c does not silently drop it. Upstream is still affected.

### Tests

`src/unit/test_hdr_histogram.cpp` covers all three iterators against the state a torn reset leaves behind, under bounded loops so that a regression **fails an assertion rather than hanging the suite**, plus the matching well-formed cases so the guards cannot cut a good histogram short. The termination tests fail before this change (they hit the iteration cap, `100000 vs 100000`) and pass after it; the no-fabrication test fails with `4194303 vs 11007`.

Verified locally:

- ThreadSanitizer over repeated 8-thread `--warmup --duration` runs: 4 data races before, 0 after. All four were `config.start` — write in `showThroughput()` against a read in `isBenchmarkFinished()` reached from `readHandler()`.
- A randomized differential over 400 well-formed histograms of varying precision and range, dumping every row of all four iterators: byte-identical to the unmodified upstream source, so the guards change nothing for a consistent histogram.
- `valgrind --leak-check=full` clean on both the swap path and the no-warmup path, confirming the second allocation is released and nothing is freed twice.
- gtest suite: 648 passed, 0 failed. `integration/valkey-benchmark`: 40/40.
- End to end across 8-thread, single-threaded, warmup, no-warmup, `--duration` and `--csv`, with the reported cumulative count matching the request count exactly in each case.

### Known remaining issue

`hdr_reset(config.current_sec_latency_histogram)` at the end of `showThroughput()` is reached only by thread 0, but other threads still record into that histogram concurrently, so the same torn-reset race remains there. It cannot hang, because that histogram is only consumed through `hdr_mean()` and the iterators are now bounded, but it can skew the instantaneous average. Fixing it properly means per-thread histograms merged at report time, which felt out of scope here.
