### PR TITLE
Fix scripts_mem accounting for LRU script SHA copies

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -158,6 +158,12 @@ void freeEvalScripts(dict *scripts, list *scripts_lru_list, list *engine_callbac
     }
 }
 
+static void scriptsLRUDeleteNode(listNode *node) {
+    sds sha = listNodeValue(node);
+    evalCtx.scripts_mem -= sdsAllocSize(sha);
+    listDelNode(evalCtx.scripts_lru_list, node);
+}
+
 static void resetEngineEvalEnvCallback(scriptingEngine *engine, void *context) {
     int async = context != NULL;
     callableLazyEnvReset *callback = scriptingEngineCallResetEnvFunc(engine, VMSE_EVAL, async);
@@ -193,7 +199,8 @@ void evalRemoveScriptsFromEngine(scriptingEngine *engine) {
             sds sha = dictGetKey(entry);
             evalCtx.scripts_mem -= sdsAllocSize(sha) + getStringObjectSdsUsedMemory(es->body);
             if (es->node) {
-                listDelNode(evalCtx.scripts_lru_list, es->node);
+                scriptsLRUDeleteNode(es->node);
+                es->node = NULL;
             }
             dictDelete(evalCtx.scripts, sha);
         }
@@ -356,12 +363,14 @@ static listNode *scriptsLRUAdd(client *c, sds sha) {
         listNode *ln = listFirst(evalCtx.scripts_lru_list);
         sds oldest = listNodeValue(ln);
         evalDeleteScript(c, oldest);
-        listDelNode(evalCtx.scripts_lru_list, ln);
+        scriptsLRUDeleteNode(ln);
         server.stat_evictedscripts++;
     }
 
     /* Add current. */
-    listAddNodeTail(evalCtx.scripts_lru_list, sdsdup(sha));
+    sds lru_sha = sdsdup(sha);
+    listAddNodeTail(evalCtx.scripts_lru_list, lru_sha);
+    evalCtx.scripts_mem += sdsAllocSize(lru_sha);
     return listLast(evalCtx.scripts_lru_list);
 }
 
@@ -382,7 +391,7 @@ static int evalRegisterNewScript(client *c, robj *body, char **sha) {
         if (entry != NULL) {
             evalScript *es = dictGetVal(entry);
             if (es->node) {
-                listDelNode(evalCtx.scripts_lru_list, es->node);
+                scriptsLRUDeleteNode(es->node);
                 es->node = NULL;
             }
 

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1909,7 +1909,7 @@ start_server {tags {"scripting external:skip"}} {
         }
         set mem_after [s used_memory_scripts_eval]
 
-        # Each script differs by at least 40 SHAs + 24 listNodes.
+        # Each script differs by at least 40 bytes SHA + 24 bytes listNode.
         assert_morethan [expr $mem_before - $mem_after] [expr 64 * 500]
     }
 }

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1909,8 +1909,14 @@ start_server {tags {"scripting external:skip"}} {
         }
         set mem_after [s used_memory_scripts_eval]
 
-        # Each script differs by at least 40 bytes SHA + 24 bytes listNode.
-        assert_morethan [expr $mem_before - $mem_after] [expr 64 * 500]
+        # Each script differs by at least 40 bytes SHA + 24 (or 12) bytes listNode.
+        set arch_bits [s arch_bits]
+        set diff [expr $mem_before - $mem_after]
+        if {$arch_bits == 64} {
+            assert_morethan $diff [expr 64 * 500]
+        } elseif {$arch_bits == 32} {
+            assert_morethan $diff [expr 52 * 500]
+        }
     }
 }
 

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1885,7 +1885,6 @@ start_server {tags {"scripting external:skip"}} {
 
     test {Lua scripts promoted from eval to script load} {
         r script flush
-        r config resetstat
 
         r eval "return 'hello world'" 0
         set sha [r script load "return 'hello world'"]
@@ -1894,6 +1893,24 @@ start_server {tags {"scripting external:skip"}} {
             r eval "return 'str_$j'" 0
         }
         assert_equal {hello world} [r evalsha $sha 0]
+    }
+
+    test {Lua scripts memory for LRU script SHA copies} {
+        r script flush
+
+        # Perform 500 EVAL cycles, then use script to load the same data to
+        # discard all LRU list nodes.
+        for {set j 1} {$j <= 500} {incr j} {
+            r eval "return $j" 0
+        }
+        set mem_before [s used_memory_scripts_eval]
+        for {set j 1} {$j <= 500} {incr j} {
+            r script load "return $j"
+        }
+        set mem_after [s used_memory_scripts_eval]
+
+        # Each script differs by at least 40 SHAs + 24 listNodes.
+        assert_morethan [expr $mem_before - $mem_after] [expr 64 * 500]
     }
 }
 


### PR DESCRIPTION
The LRU list stores a duplicated SDS copy of each EVAL script SHA,
but its allocation was not included in scripts_mem. Account for the
duplicated SHA when adding an LRU node and subtract it when the node
is removed.

Also see #1310 for more details.