### PR TITLE
Deflake "comprehensive modifications on all data types during forkless bgsave"

### DIFF
--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -1135,7 +1135,7 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
         createComplexDatasetForVerification r 1000
         
         # Start save with slow speed to keep it running during modifications
-        r config set rdb-key-save-delay 1000000
+        r config set rdb-key-save-delay 1000
         r config set bgsave-default-method forkless
         r bgsave        
         wait_for_condition 50 100 {
@@ -1144,8 +1144,10 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
             fail "bgsave didn't start"
         }
         
-        # Overwrite keys during save - all data types (pipelined to avoid blocking)
+        # Overwrite keys during save - all data types.
         set rd [valkey_deferring_client]
+        set outstanding 0
+        set saw_save_in_progress 0
         for {set i 0} {$i < 1000} {incr i} {
             $rd append before_$i "value_after_$i"
             $rd incr int_$i
@@ -1163,16 +1165,26 @@ start_server {overrides {forkless-infrastructure-enabled yes save ""}} {
             $rd xadd stream_$i "*" D1 V2
             $rd xreadgroup GROUP group_$i consumer_after_$i COUNT 1 STREAMS stream_$i >
             $rd hsetex hashttl_$i EX 10000 FIELDS 1 HTTL1 a
+            # There is a chance that our client is blocked but we don't know it, because
+            # as a deferring client we never read replies.  If we are blocked we would
+            # keep sending commands forever, which accumulate on the server side and can
+            # overflow the buffers.  So stop periodically and consume replies - that is
+            # the mechanism that waits until we are unblocked.
+            incr outstanding 16
+            if {$outstanding >= 320} {
+                for {set j 0} {$j < $outstanding} {incr j} { $rd read }
+                set outstanding 0
+                if {[s rdb_bgsave_in_progress] == 1} { set saw_save_in_progress 1 }
+            }
         }
         
-        # Verify changes happened and save still in progress
+        # Verify changes happened while the save was running
         assert {[s rdb_changes_since_last_save] > 0}
-        assert_equal [s rdb_bgsave_in_progress] 1
+        assert_equal $saw_save_in_progress 1
         
         # Speed up save and wait for completion
         r config set rdb-key-save-delay 0
         waitForBgsave r
-        # Drain pipelined responses
         $rd close
         
         # Verify snapshot contains original keys


### PR DESCRIPTION
The test pipelined 16000 commands on a deferring client without reading any replies, with the save slowed to a second per key. That would cause the client to not know that it is blocked, keep sending commands anyway which would accumulate on the server side, in the tcp buffer (since the server does not consume them for blocked clients).

Even though this is a deferring client, it can still block once that buffer gets filled, because the blocking here is in the os level (`write()`). So the test's own write would block inside hte loop and never reach `config set rdb-key-save-delay 0`, leaving the save to crawl through 12000 keys a second at a time until the no-progress watchdog reports [TIMEOUT].

Consume replies in batches so nothing can accumulate in case of blocking, and lower the per-key delay to 1ms.  The delay is what a blocked client waits on, so at one second per key a paced loop would take hours. 

The post-loop `rdb_bgsave_in_progress` assertion is replaced by checking that the save was seen running while the modifications were made: with a smaller delay the save can finish as the last batch is written.