### PR TITLE
Deflake throttle-repl test due to timeout disconnect

### DIFF
--- a/tests/integration/throttle-repl.tcl
+++ b/tests/integration/throttle-repl.tcl
@@ -34,6 +34,7 @@ proc setup_throttle_replication {primary replica primary_host primary_port} {
     $primary flushall
     $primary config set repl-throttling-enabled yes
     $primary config set client-output-buffer-limit "replica 1024mb 64kb 3600"
+    $primary config set repl-timeout 1800
     $replica replicaof no one
     $replica flushall
     $replica replicaof $primary_host $primary_port


### PR DESCRIPTION
Throttling test is found to be flaky: https://github.com/valkey-io/valkey/actions/runs/33553136840/job/100007324384?pr=4460

```
52023:M 01 Sep 2026 20:09:16.495 # Disconnecting timedout replica (streaming sync): 127.0.0.1:21192
52023:M 01 Sep 2026 20:09:16.495 * Connection with replica 127.0.0.1:21192 lost.
```

The throttling tests deliberately freeze the replica so that its COB on the primary grows while the replica stops sending REPLCONF ACK. The default 60s repl-timeout then disconnects the replica out from under the throttler before the test can observe throttling. Raising repl-timeout fixes this flakiness.
