### PR TITLE
tests/rdma: isolate RXE from host RDMA devices

### DIFF
--- a/tests/rdma/rdma_env.py
+++ b/tests/rdma/rdma_env.py
@@ -13,8 +13,13 @@ the top-level directory.
 import os
 import subprocess
 import netifaces
-import time
 import argparse
+import json
+
+
+TEST_NETDEV = "valkeyrdma0"
+TEST_IP = "192.0.2.1"
+TEST_IP_CIDR = TEST_IP + "/24"
 
 
 def prepare_ib():
@@ -27,6 +32,66 @@ def prepare_ib():
         os._exit(1);
 
     print("Valkey Over RDMA probe modules of IB [OK]")
+
+
+def is_dummy_netdev(interface):
+    p = subprocess.run(["ip", "-details", "-json", "link", "show", "dev", interface],
+                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    try:
+        link_info = json.loads(p.stdout)
+    except json.JSONDecodeError:
+        return False
+    return (not p.returncode and link_info
+            and link_info[0].get("linkinfo", {}).get("info_kind") == "dummy")
+
+
+def prepare_test_netdev():
+    p = subprocess.run(["modprobe", "dummy"], stdout=subprocess.PIPE,
+                       stderr=subprocess.STDOUT, text=True)
+    if p.returncode:
+        print("Valkey Over RDMA load dummy netdev driver [FAILED]")
+        print("---------------\n" + p.stdout + "---------------\n")
+        os._exit(1)
+
+    if os.path.exists("/sys/class/net/" + TEST_NETDEV):
+        if not is_dummy_netdev(TEST_NETDEV):
+            print("Valkey Over RDMA existing interface <%s> is not a dummy netdev [FAILED]" % TEST_NETDEV)
+            os._exit(1)
+    else:
+        p = subprocess.run(["ip", "link", "add", TEST_NETDEV, "type", "dummy"],
+                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        if p.returncode:
+            print("Valkey Over RDMA create dummy netdev <%s> [FAILED]" % TEST_NETDEV)
+            print("---------------\n" + p.stdout + "---------------\n")
+            os._exit(1)
+
+    for interface in netifaces.interfaces():
+        if interface == TEST_NETDEV:
+            continue
+        addresses = netifaces.ifaddresses(interface).get(netifaces.AF_INET, [])
+        if any(address.get("addr") == TEST_IP for address in addresses):
+            print("Valkey Over RDMA test IP <%s> is already in use by <%s> [FAILED]"
+                  % (TEST_IP, interface))
+            os._exit(1)
+
+    addresses = netifaces.ifaddresses(TEST_NETDEV).get(netifaces.AF_INET, [])
+    if not any(address.get("addr") == TEST_IP for address in addresses):
+        p = subprocess.run(["ip", "address", "add", TEST_IP_CIDR, "dev", TEST_NETDEV],
+                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        if p.returncode:
+            print("Valkey Over RDMA configure dummy netdev <%s> [FAILED]" % TEST_NETDEV)
+            print("---------------\n" + p.stdout + "---------------\n")
+            os._exit(1)
+
+    p = subprocess.run(["ip", "link", "set", TEST_NETDEV, "up"],
+                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    if p.returncode:
+        print("Valkey Over RDMA enable dummy netdev <%s> [FAILED]" % TEST_NETDEV)
+        print("---------------\n" + p.stdout + "---------------\n")
+        os._exit(1)
+
+    print("Valkey Over RDMA prepare dummy netdev <%s %s> [OK]" % (TEST_NETDEV, TEST_IP))
+    return TEST_NETDEV
 
 
 def prepare_rxe(interface):
@@ -70,55 +135,40 @@ def prepare_rxe(interface):
     print("Valkey Over RDMA add RXE device <%s> [OK]" % softrdma)
 
 
-# find any IPv4 available networking interface
-def find_iface():
-    interfaces = netifaces.interfaces()
-    for interface in interfaces:
-        if interface == "lo":
-            continue
-
-        addrs = netifaces.ifaddresses(interface)
-        if netifaces.AF_INET not in addrs:
-            continue
-
-        return interface
-
-
 def setup_rdma(driver, interface):
-    if interface == None:
-        interface = find_iface()
-
     prepare_ib()
     if driver == "rxe":
+        if interface is None:
+            interface = prepare_test_netdev()
         prepare_rxe(interface)
     else:
         print("rxe is currently supported only")
         os._exit(1);
 
 
-# iterate /sys/class/infiniband, find any all virtual RDMA device, and remove them
-def cleanup_rdma():
-    # Ex, /sys/class/infiniband/mlx5_0
-    # Ex, /sys/class/infiniband/rxe_eth0
-    # Ex, /sys/class/infiniband/siw_eth0
-    ibclass = "/sys/class/infiniband/"
-    try:
-        for dev in os.listdir(ibclass):
-            # Ex, /sys/class/infiniband/rxe_eth0/ports/1/gid_attrs/ndevs/0
-            origpath = os.readlink(ibclass + dev)
-            if "virtual" in origpath:
-                subprocess.Popen("rdma link del " + dev, shell=True).wait()
-                print("Remove virtual RDMA device : " + dev + " [OK]")
-    except os.error:
-        return None
+def cleanup_rdma(interface):
+    if interface is None:
+        interface = TEST_NETDEV
 
-    # try to remove RXE driver from kernel, ignore error
-    subprocess.Popen("rmmod rdma_rxe 2> /dev/null", shell=True).wait()
+    softrdma = "rxe_" + interface
+    if os.path.exists("/sys/class/infiniband/" + softrdma):
+        p = subprocess.run(["rdma", "link", "del", softrdma],
+                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        if p.returncode:
+            print("Valkey Over RDMA remove RXE device <%s> [FAILED]" % softrdma)
+            print("---------------\n" + p.stdout + "---------------\n")
+        else:
+            print("Valkey Over RDMA remove RXE device <%s> [OK]" % softrdma)
 
-    # try to remove SIW driver from kernel, ignore error
-    subprocess.Popen("rmmod rdma_siw 2> /dev/null", shell=True).wait()
-
-    return None
+    if (interface == TEST_NETDEV and os.path.exists("/sys/class/net/" + TEST_NETDEV)
+            and is_dummy_netdev(TEST_NETDEV)):
+        p = subprocess.run(["ip", "link", "del", TEST_NETDEV],
+                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        if p.returncode:
+            print("Valkey Over RDMA remove dummy netdev <%s> [FAILED]" % TEST_NETDEV)
+            print("---------------\n" + p.stdout + "---------------\n")
+        else:
+            print("Valkey Over RDMA remove dummy netdev <%s> [OK]" % TEST_NETDEV)
 
 
 if __name__ == "__main__":
@@ -130,7 +180,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--driver", type=str, default="rxe",
         help="[rxe|siw] specify soft RDMA driver, rxe by default")
     parser.add_argument("-i", "--interface", type=str,
-        help="[IFACE] network interface, auto-select any available interface by default")
+        help="[IFACE] network interface, use a dedicated dummy interface by default")
     args = parser.parse_args()
 
     # test UID. none-root user must stop on none RDMA platform, show some hints and exit.
@@ -142,7 +192,7 @@ if __name__ == "__main__":
         os._exit(1);
 
     if args.operation == "cleanup":
-        cleanup_rdma()
+        cleanup_rdma(args.interface)
     elif args.operation == "setup":
         setup_rdma(args.driver, args.interface)
 

--- a/tests/rdma/run.py
+++ b/tests/rdma/run.py
@@ -16,10 +16,14 @@ import time
 import argparse
 import sys
 import signal
+import rdma_env
 
 RDMA_PORT = 6379
 IO_THREADS = 4
 BENCH_TIMEOUT = 120
+RXE_TEST_NETDEV = rdma_env.TEST_NETDEV
+RXE_TEST_DEVICE = "rxe_" + RXE_TEST_NETDEV
+RXE_TEST_IP = rdma_env.TEST_IP
 
 
 def build_program():
@@ -45,26 +49,15 @@ def ipaddr_from_iface(iface):
     return None
 
 
-def find_default_iface():
-    for interface in netifaces.interfaces():
-        if interface == "lo":
-            continue
-        addrs = netifaces.ifaddresses(interface)
-        if netifaces.AF_INET in addrs:
-            return interface
-    return None
-
-
-def is_rxe_device(ibclass, dev):
-    # RXE driver sets node_desc to "rxe" (see kernel drivers/infiniband/sw/rxe/rxe_verbs.c).
+def is_rdma_port_active(ibclass, dev):
     try:
-        with open(os.path.join(ibclass, dev, "node_desc")) as fp:
-            return fp.read().strip() == "rxe"
+        with open(os.path.join(ibclass, dev, "ports", "1", "state")) as fp:
+            return fp.read().strip().startswith("4:")
     except OSError:
         return False
 
 
-def find_rdma_ip_from_sysfs(rxe_only=False):
+def find_rdma_ip_from_sysfs(expected_dev=None):
     # Ex, /sys/class/infiniband/mlx5_0
     # Ex, /sys/class/infiniband/rxe_eth0
     # Ex, /sys/class/infiniband/siw_eth0
@@ -74,48 +67,56 @@ def find_rdma_ip_from_sysfs(rxe_only=False):
     except OSError:
         return None
 
-    candidates = sorted(devices)
-    if rxe_only:
-        candidates = [dev for dev in candidates if is_rxe_device(ibclass, dev)]
+    candidates = [expected_dev] if expected_dev else sorted(devices)
 
     for dev in candidates:
-        # Ex, /sys/class/infiniband/rxe_eth0/ports/1/gid_attrs/ndevs/0
-        netdev = ibclass + dev + "/ports/1/gid_attrs/ndevs/0"
+        if dev not in devices:
+            continue
+        if not is_rdma_port_active(ibclass, dev):
+            continue
+
+        # A RoCE device can expose several GID entries. Use one that has a
+        # non-zero GID and maps to a netdev with an IP address.
+        ndevs = os.path.join(ibclass, dev, "ports", "1", "gid_attrs", "ndevs")
         try:
-            with open(netdev) as fp:
-                iface = fp.readline().strip()
-            if not iface:
-                continue
-            ipaddr = ipaddr_from_iface(iface)
-            if ipaddr is None:
-                continue
-            print("Valkey Over RDMA test prepare " + dev + " <" + ipaddr + "> [OK]")
-            return ipaddr
+            gid_indexes = sorted(os.listdir(ndevs), key=int)
         except (OSError, ValueError):
             continue
+
+        for gid_index in gid_indexes:
+            try:
+                with open(os.path.join(ndevs, gid_index)) as fp:
+                    iface = fp.readline().strip()
+                with open(os.path.join(ibclass, dev, "ports", "1", "gids", gid_index)) as fp:
+                    gid = fp.readline().strip()
+            except OSError:
+                continue
+
+            if not iface or not gid.replace(":", "").strip("0"):
+                continue
+            if expected_dev and iface != RXE_TEST_NETDEV:
+                continue
+            ipaddr = ipaddr_from_iface(iface)
+            if ipaddr is None or (expected_dev and ipaddr != RXE_TEST_IP):
+                continue
+            print("Valkey Over RDMA test prepare " + dev + " <" + iface + " " + ipaddr + "> [OK]")
+            return ipaddr
 
     return None
 
 
 def find_rdma_dev(install_rxe=False):
-    # After rdma link add, gid_attrs/ndevs can lag behind the device node.
-    # Retry briefly when we just installed RXE. Prefer RXE over host NICs
-    # (e.g. GitHub Actions mana_0) which share an IP but fail rdma_resolve_addr.
-    retries = 10 if install_rxe else 1
+    # After rdma link add, the port and GID table can lag behind the device
+    # node. When RXE was installed for this test, require that exact device;
+    # an IP address alone cannot distinguish RXE from a hardware RDMA provider.
+    expected_dev = RXE_TEST_DEVICE if install_rxe else None
+    retries = 20 if install_rxe else 1
     for attempt in range(retries):
-        ipaddr = find_rdma_ip_from_sysfs(rxe_only=install_rxe)
+        ipaddr = find_rdma_ip_from_sysfs(expected_dev)
         if ipaddr is not None:
             return ipaddr
         if attempt + 1 < retries:
             time.sleep(0.2)
-
-    if install_rxe:
-        iface = find_default_iface()
-        if iface is not None:
-            ipaddr = ipaddr_from_iface(iface)
-            if ipaddr is not None:
-                print("Valkey Over RDMA test prepare rxe_" + iface + " <" + ipaddr + "> [OK]")
-                return ipaddr
 
     return None
 
@@ -242,8 +243,8 @@ def test_exit(retval, install_rxe):
 
     if install_rxe and not os.geteuid():
         rdma_env_py = os.path.dirname(os.path.abspath(__file__)) + "/rdma_env.py"
-        cmd = rdma_env_py + " -o cleanup"
-        subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).wait()
+        cmd = [rdma_env_py, "-o", "cleanup", "-i", RXE_TEST_NETDEV]
+        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     sys.stdout.flush()
     sys.stderr.flush()
@@ -277,8 +278,8 @@ if __name__ == "__main__":
                 test_exit(1, False)
 
             rdma_env_py = os.path.dirname(os.path.abspath(__file__)) + "/rdma_env.py"
-            cmd = rdma_env_py + " -o setup -d rxe"
-            if subprocess.call(cmd, shell=True):
+            cmd = [rdma_env_py, "-o", "setup", "-d", "rxe"]
+            if subprocess.call(cmd):
                 print("Valkey Over RDMA setup RXE [FAILED]")
                 test_exit(1, args.install_rxe)
 


### PR DESCRIPTION
Fixes #4579 

## Summary

The diagnostics added in #4586 showed that sporadic RDMA CI failures were using the Azure `mana_0` provider instead of the test-created RXE device.

Both providers shared the host `eth0` address, so selecting an IP from `rxe_eth0` did not guarantee that RDMA CM would select RXE. This caused MANA QP transitions to fail with `EPROTO`.

Create a dedicated dummy netdev with a test-only IP and attach RXE to it. This gives the test an isolated GID/address mapping and prevents RDMA CM from selecting host RDMA providers.

Cleanup is also limited to test-owned devices.

## Test plan

- Run repeated RXE setup and cleanup cycles.
- Run `sudo ./runtest-rdma --install-rxe` four times.
- Verify both `rdma-test` and `valkey-benchmark --rdma` pass.
- Verify Python syntax and `git diff --check`.