### PR TITLE
Check close() before publishing temp files with rename() in AOF manifest, CONFIG, ACL and replica RDB load

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2785,7 +2785,14 @@ static int ACLSaveToFile(const char *filename) {
         serverLog(LL_WARNING, "Syncing ACL file for ACL SAVE: %s", strerror(errno));
         goto cleanup;
     }
-    close(fd);
+    /* A write error the kernel deferred is reported by close() and by nothing
+     * before it, so the result has to be checked before the temp file is
+     * published, or a truncated file replaces a good one. */
+    if (close(fd) == -1) {
+        fd = -1;
+        serverLog(LL_WARNING, "Failed to close temp ACL file for ACL SAVE. %s.", strerror(errno));
+        goto cleanup;
+    }
     fd = -1;
 
     /* Let's replace the new file with the old one. */

--- a/src/aof.c
+++ b/src/aof.c
@@ -564,6 +564,20 @@ int writeAofManifestFile(sds buf) {
         goto cleanup;
     }
 
+    /* Close the temp file before publishing it with rename(). A write error the
+     * kernel deferred is reported by close() and by nothing before it, so a
+     * truncated manifest would otherwise replace a good one, and
+     * aofLoadManifestFromFile() refuses to start on a corrupt manifest. */
+    if (close(fd) != 0) {
+        int close_errno = errno;
+        fd = -1;
+        serverLog(LL_WARNING, "Fail to close the temp AOF manifest file %s: %s.", tmp_am_name, strerror(close_errno));
+
+        ret = C_ERR;
+        goto cleanup;
+    }
+    fd = -1;
+
     if (rename(tmp_am_filepath, am_filepath) != 0) {
         serverLog(LL_WARNING, "Error trying to rename the temporary AOF manifest file %s into %s: %s", tmp_am_name,
                   am_name, strerror(errno));

--- a/src/config.c
+++ b/src/config.c
@@ -1780,6 +1780,7 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
     size_t offset = 0;
     ssize_t written_bytes = 0;
     int old_errno;
+    int close_errno = 0;
 
     int tmp_path_len = snprintf(tmp_conffile, sizeof(tmp_conffile), "%s%s", configfile, tmp_suffix);
     if (tmp_path_len <= 0 || (unsigned int)tmp_path_len >= sizeof(tmp_conffile)) {
@@ -1810,22 +1811,39 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
         offset += written_bytes;
     }
 
-    if (fsync(fd))
+    if (fsync(fd)) {
         serverLog(LL_WARNING, "Could not sync tmp config file to disk (%s)", strerror(errno));
-    else if (fchmod(fd, 0644 & ~server.umask) == -1)
-        serverLog(LL_WARNING, "Could not chmod config file (%s)", strerror(errno));
-    else if (rename(tmp_conffile, configfile) == -1)
-        serverLog(LL_WARNING, "Could not rename tmp config file (%s)", strerror(errno));
-    else if (fsyncFileDir(configfile) == -1)
-        serverLog(LL_WARNING, "Could not sync config file dir (%s)", strerror(errno));
-    else {
-        retval = 0;
-        serverLog(LL_DEBUG, "Rewritten config file (%s) successfully", configfile);
+        goto cleanup;
     }
+    if (fchmod(fd, 0644 & ~server.umask) == -1) {
+        serverLog(LL_WARNING, "Could not chmod config file (%s)", strerror(errno));
+        goto cleanup;
+    }
+    /* Close the temp file before publishing it with rename(). A write error the
+     * kernel deferred is reported by close() and by nothing before it, so a
+     * truncated config would otherwise replace a good one. The chmod above
+     * needs the descriptor, so this is the earliest the close can happen. */
+    close_errno = close(fd) == -1 ? errno : 0;
+    fd = -1;
+    if (close_errno) {
+        serverLog(LL_WARNING, "Could not close tmp config file (%s)", strerror(close_errno));
+        errno = close_errno;
+        goto cleanup;
+    }
+    if (rename(tmp_conffile, configfile) == -1) {
+        serverLog(LL_WARNING, "Could not rename tmp config file (%s)", strerror(errno));
+        goto cleanup;
+    }
+    if (fsyncFileDir(configfile) == -1) {
+        serverLog(LL_WARNING, "Could not sync config file dir (%s)", strerror(errno));
+        goto cleanup;
+    }
+    retval = 0;
+    serverLog(LL_DEBUG, "Rewritten config file (%s) successfully", configfile);
 
 cleanup:
     old_errno = errno;
-    close(fd);
+    if (fd != -1) close(fd);
     if (retval) unlink(tmp_conffile);
     errno = old_errno;
     return retval;

--- a/src/replication.c
+++ b/src/replication.c
@@ -2615,16 +2615,42 @@ int replicaLoadPrimaryRDBFromDisk(rdbSaveInfo *rsi) {
         return C_ERR;
     }
 
+    /* Close the temp file before publishing it with rename(). A write error the
+     * kernel deferred is reported by close() and by nothing before it, so a
+     * truncated RDB would otherwise be renamed over a good one. rdbLoad() below
+     * reopens the file by name, so the descriptor is not needed past this point.
+     *
+     * repl_transfer_fd and repl_transfer_tmpfile have to be unset together or
+     * the assertions in cleanupTransferResources() fire on the error paths
+     * below, so take ownership of the name here and clear both at once. */
+    char *tmpfilename = server.repl_transfer_tmpfile;
+    int close_errno = close(server.repl_transfer_fd) == -1 ? errno : 0;
+    server.repl_transfer_fd = -1;
+    server.repl_transfer_tmpfile = NULL;
+
+    if (close_errno) {
+        serverLog(LL_WARNING,
+                  "Failed trying to close the temp DB in "
+                  "PRIMARY <-> REPLICA synchronization: %s",
+                  strerror(close_errno));
+        bg_unlink(tmpfilename);
+        zfree(tmpfilename);
+        return C_ERR;
+    }
+
     /* Rename rdb like renaming rewrite aof asynchronously. */
     int old_rdb_fd = open(server.rdb_filename, O_RDONLY | O_NONBLOCK);
-    if (rename(server.repl_transfer_tmpfile, server.rdb_filename) == -1) {
+    if (rename(tmpfilename, server.rdb_filename) == -1) {
         serverLog(LL_WARNING,
                   "Failed trying to rename the temp DB into %s in "
                   "PRIMARY <-> REPLICA synchronization: %s",
                   server.rdb_filename, strerror(errno));
         if (old_rdb_fd != -1) close(old_rdb_fd);
+        bg_unlink(tmpfilename);
+        zfree(tmpfilename);
         return C_ERR;
     }
+    zfree(tmpfilename);
     /* Close old rdb asynchronously. */
     if (old_rdb_fd != -1) bioCreateCloseJob(old_rdb_fd, 0, 0);
 
@@ -2682,10 +2708,8 @@ int replicaLoadPrimaryRDBFromDisk(rdbSaveInfo *rsi) {
         bg_unlink(server.rdb_filename);
     }
 
-    zfree(server.repl_transfer_tmpfile);
-    close(server.repl_transfer_fd);
-    server.repl_transfer_fd = -1;
-    server.repl_transfer_tmpfile = NULL;
+    /* The transfer file descriptor and its name were already released before
+     * the rename above. */
     return C_OK;
 }
 

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1784,3 +1784,49 @@ start_server {tags {"repl external:skip cluster:skip"}} {
         }
     }
 }
+
+# replicaLoadPrimaryRDBFromDisk() closes the transfer descriptor before it
+# renames the temp RDB into place, so that a write error the kernel only
+# reports at close() cannot publish a truncated RDB. The descriptor and its
+# filename have to be released together, because cleanupTransferResources()
+# asserts on that pairing while the handshake is being cancelled. Turning the
+# replica's dbfilename into a directory makes the rename fail with EISDIR,
+# which reaches that teardown with the descriptor already closed.
+start_server {tags {"repl external:skip"}} {
+    start_server {} {
+        set primary [srv -1 client]
+        set primary_host [srv -1 host]
+        set primary_port [srv -1 port]
+        set replica [srv 0 client]
+
+        $primary set k v
+
+        test {Replica survives a full sync whose RDB rename fails} {
+            $replica config set save {}
+            $replica config set repl-diskless-load disabled
+
+            set replica_dir [lindex [$replica config get dir] 1]
+            set rdb_path [file join $replica_dir [lindex [$replica config get dbfilename] 1]]
+            file delete -force $rdb_path
+            file mkdir $rdb_path
+
+            set loglines [count_log_lines 0]
+            $replica replicaof $primary_host $primary_port
+            wait_for_log_messages 0 {"*Failed trying to rename the temp DB*"} $loglines 100 100
+
+            # The replica has to survive the failed sync: no assertion, no crash.
+            assert_equal {PONG} [$replica ping]
+
+            # Clearing the obstruction lets the retry through, which shows the
+            # aborted attempt left the replication state usable.
+            $replica replicaof no one
+            file delete -force $rdb_path
+            $replica replicaof $primary_host $primary_port
+            wait_for_sync $replica
+            assert_equal v [$replica get k]
+
+            # The abandoned temp file must not be left behind either.
+            assert_equal {} [glob -nocomplain [file join $replica_dir temp-*.rdb]]
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #4489, opened at @enjoy-binbin's suggestion there: he asked whether RDB/AOF/CONFIG/ACL share the close-before-rename problem being fixed for `nodes.conf`. They do.

## The problem

A write error the kernel deferred is not reported by `write()` or `fsync()` — only by `close()`. Publishing a temp file with `rename()` before checking `close()` can therefore install a truncated file over a good one.

```
write()  ──▶ ok        (buffered, error not yet surfaced)
fsync()  ──▶ ok        (does not surface a deferred error either)
rename() ──▶ published ◀── truncated file is now live
close()  ──▶ EIO       ◀── too late, and the result was discarded
```

## Audit of every rename() in src/

| Path | closes before `rename()` | result checked | |
| --- | --- | --- | --- |
| RDB save, `rdb.c:1690` → rename `1743` | yes | yes | already correct |
| AOF rewrite, `aof.c:2555` → rename `2563` | yes | yes | already correct |
| AOF manifest, rename `aof.c:567` | **no** | no | fixed |
| CONFIG REWRITE, rename `config.c:1817` | **no** | no | fixed |
| Replica RDB load, rename `replication.c:2620` | **no** | no | fixed |
| ACL, `acl.c:2788` → rename `2792` | yes | **no** | fixed |

RDB save and AOF rewrite already do it right and are the precedent followed here. One commit per subsystem.

## Impact

- **AOF manifest** is the closest analogue to `nodes.conf`: small, rewritten on every AOF state change, and `aofLoadManifestFromFile()` refuses to start on a corrupt manifest.
- **Replica RDB load** publishes the file a replica will then load and persist.
- **CONFIG REWRITE** is operator-triggered, so less exposed, but a truncated config is silently persisted.
- **ACL** already had the ordering right; only the check was missing.

## Notes on each change

**AOF manifest** — close and check between the `fsync()` and the `rename()`. The error path leaves the temp manifest behind, matching the existing `fsync()`-failure path.

**CONFIG REWRITE** — `fchmod()` needs the descriptor, so the close goes between it and the rename. That turns the `fsync`/`fchmod`/`rename`/`fsyncFileDir` else-if chain into guard clauses. Short-circuiting is unchanged: the first failure logs, leaves `retval` at `-1`, and reaches `cleanup:`, which unlinks the temp. The cleanup `close()` is now guarded against a double close, and `close_errno` is placed in `errno` so the caller still gets a meaningful error, as the function contract promises.

**ACL** — check the existing `close()`.

**Replica RDB load** — this one needs care. The descriptor cannot simply be closed and set to `-1`, because `cleanupTransferResources()` asserts that `repl_transfer_fd` and `repl_transfer_tmpfile` are unset together:

```c
if (server.repl_transfer_fd == -1) {
    serverAssert(server.repl_transfer_tmpfile == NULL);
    return;
}
serverAssert(server.repl_transfer_tmpfile != NULL);
```

Every error path in `replicaLoadPrimaryRDBFromDisk()` reaches that function via `cancelReplicationHandshake()`, so clearing only the descriptor makes the assertion fail and takes the replica down. I confirmed that by building it: the replica dies with `=== ASSERTION FAILED ===`.

So the filename is taken into a local instead and both fields are cleared at once, with the temp file unlinked and freed on the paths that previously relied on `cleanupTransferResources()` to do it. `rdbLoad()` reopens the file by name, so nothing needs the descriptor after the close.

Every exit leaves the pairing intact:

| Exit | `repl_transfer_fd` | `repl_transfer_tmpfile` |
| --- | --- | --- |
| `fsync` fails (before the change) | open | set — unchanged |
| `close` fails | `-1` | `NULL`, freed |
| `rename` fails | `-1` | `NULL`, freed |
| `fsyncFileDir` / `rdbLoad` fail | `-1` | `NULL`, freed |
| success | `-1` | `NULL`, freed |

## Tests

`Replica survives a full sync whose RDB rename fails` obstructs the rename by turning the replica's `dbfilename` into a directory, giving `EISDIR`, which reaches the teardown above with the descriptor already closed. It asserts the replica is still answering, that a retry then syncs, and that no temp RDB is left behind.

Its value is guarding the pairing, so I checked it actually does that:

| Build | Result |
| --- | --- |
| before this change | passes (`fd` open + filename set is self-consistent) |
| with this change | passes |
| descriptor cleared without the filename | **`=== ASSERTION FAILED ===`** |

1148 tests pass across `unit/acl`, `unit/acl-v2`, `unit/introspection`, `unit/introspection-2`, `unit/other`, `unit/auth`, `unit/info`, `unit/info-command`, `unit/commandlog`, `integration/aof`, `integration/aof-multi-part`, `integration/rdb`, `integration/replication{,-2,-3,-4,-psync,-buffer}`, `integration/dual-channel-replication`, `unit/cluster/diskless-load-swapdb`, and the cluster suites that call `CONFIG REWRITE`.

No test covers a failing `close()` itself: it cannot be forced from Tcl, the same limitation noted in #4489. No existing test asserts on these failure messages, so the CONFIG restructure changes no expectations. On-disk formats are unchanged.

## Still not addressed: open handles across a rename

Separate from the integrity bug above, two places deliberately hold a handle across a rename. `replication.c` opens the rename *destination* on purpose so `bioCreateCloseJob()` can drop the old inode off the main thread, and `aof.c:2828` renames the temp incr AOF while `server.aof_fd` is still appending to it. Both are correct on POSIX and are not integrity bugs, but they are why AOF and replica full-sync still fail on SMB-backed volumes. Neither #4489 nor this PR makes Valkey generally SMB-safe.
