### PR TITLE
Fix timing issue in WATCHed key in another slot that expired aborts EXEC test

### DIFF
--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -51,15 +51,22 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         # the key having expired can abort the transaction.
         R 0 debug set-active-expire 0
         R 0 del $transaction_key
-        R 0 set $watched_key alive px 50
-        R 0 watch $watched_key
-        set keys_before [R 0 dbsize]
-        after 100
-        assert_equal $keys_before [R 0 dbsize]
 
-        R 0 multi
-        R 0 set $transaction_key committed
-        set reply [R 0 exec]
+        for {set j 0} {$j < 10} {incr j} {
+            R 0 del $transaction_key
+            R 0 set $watched_key alive px 100
+            R 0 watch $watched_key
+            set keys_before [R 0 dbsize]
+            after 101
+            assert_equal $keys_before [R 0 dbsize]
+
+            R 0 multi
+            R 0 set $transaction_key committed
+            set reply [R 0 exec]
+            if {$reply eq {}} break
+        }
+        if {$::verbose} { puts "WATCHed key in another slot that expired aborts EXEC attempts: $j" }
+
         R 0 debug set-active-expire 1
 
         assert_equal {} $reply

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -52,6 +52,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         R 0 debug set-active-expire 0
         R 0 del $transaction_key
 
+        # Retry if timing issues occur on slow CI runners
         for {set j 0} {$j < 10} {incr j} {
             R 0 del $transaction_key
             R 0 set $watched_key alive px 100


### PR DESCRIPTION
The test was added in #4380 and sometimes it fails:
```
*** [err]: WATCHed key in another slot that expired aborts EXEC in tests/unit/cluster/misc.tcl
Expected '' to be equal to 'OK' (context: type eval line 21 cmd {assert_equal {} $reply} proc ::test)
```

The delay between `SET ... PX` and `WATCH` can be long enough for the
watched key to expire before `WATCH` runs. In that case, WATCH marks the
key as already expired, and `EXEC` ignores it when checking for expired
watched keys, so the transaction commits instead of returning a null reply.

Apparently we need to increase the expiration time so that the key can not
expire logically then the WATCH is called. 100ms should be fine, as we use
it this way elsewhere too. Also added retries to make sure it doesn't fail.

Closes #4407.