### PR TITLE
Only scan this test's own AOF writes for the LIMIT token

### DIFF
--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -925,6 +925,7 @@ start_server {tags {"stream needs:debug"} overrides {appendonly yes stream-node-
 
     test {XADD/XTRIM strip redundant LIMIT when rewriting for propagation} {
         set aof [get_last_incr_aof_path r]
+        set aof_offset [file size $aof]
         r config set stream-node-max-entries 10
 
         for {set j 0} {$j < 100} {incr j} {
@@ -942,6 +943,7 @@ start_server {tags {"stream needs:debug"} overrides {appendonly yes stream-node-
 
         set fp [open $aof r]
         fconfigure $fp -translation binary
+        seek $fp $aof_offset
         set blob [read $fp]
         close $fp
         assert_equal -1 [string first "LIMIT" $blob]


### PR DESCRIPTION
`tests/unit/type/stream.tcl:947` reads the entire incr AOF and asserts `LIMIT` appears nowhere. In external server mode the AOF is shared with every preceding test, so it also matches `LIMIT` tokens propagated by unrelated commands (`ZRANGESTORE ... BYSCORE LIMIT` is one). Added in #4063; External Server Tests have been failing on unrelated PRs since:

```
*** [err]: XADD/XTRIM strip redundant LIMIT when rewriting for propagation in tests/unit/type/stream.tcl
Expected '-1' to be equal to '5144546' (context: type eval line 22 cmd {assert_equal -1 [string first "LIMIT" $blob]} proc ::test)
```
https://github.com/valkey-io/valkey/actions/runs/33746019856/job/100618550529

Seek past the bytes that were already there, so only this test's propagation is inspected.

## Testing

External server (`--host 127.0.0.1 --port 7777 --single unit/type/stream`) after issuing one `ZRANGESTORE ... LIMIT` against it: fails at offset 177 before this change, 84 passed / 0 failed after. Local mode: 96 passed / 0 failed. Reverting the `src/t_stream.c` and `src/server.h` hunks of #4063 still fails the assert, so the test keeps its regression value.

*This was generated by AI but verified, with love, by a human.*