### PR TITLE
Validate the forkless bgsave config pair in an apply function

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -480,13 +480,8 @@ static int updateClientOutputBufferLimit(sds *args, int arg_len, const char **er
  * abnormal aggregate `save T C` functionality. Remove in the future. */
 static int reading_config_file;
 
-/* Invariants that span two configs can't be checked in a per-config validation
- * function: config file directives and CONFIG SET arguments are applied one at a
- * time, in whatever order they appear, so a validation function sees a partially
- * updated state.  They belong in an apply function instead, which runs only
- * after every value of a CONFIG SET has been set and whose failure rolls the
- * whole command back.  Apply functions don't run at startup, so this is also
- * called from the sanity checks below, once the config file has been parsed. */
+/* Verification to make sure forkless is not set as the default behavior without the
+ * underlying infrastructure supporting it. */
 static int applyBgsaveDefaultMethod(const char **err) {
     if (server.bgsave_default_method == RDB_BGSAVE_TYPE_FORKLESS && !server.forkless_infrastructure_enabled) {
         *err = "'bgsave-default-method forkless' requires the server to be started with "

--- a/src/config.c
+++ b/src/config.c
@@ -480,6 +480,22 @@ static int updateClientOutputBufferLimit(sds *args, int arg_len, const char **er
  * abnormal aggregate `save T C` functionality. Remove in the future. */
 static int reading_config_file;
 
+/* Invariants that span two configs can't be checked in a per-config validation
+ * function: config file directives and CONFIG SET arguments are applied one at a
+ * time, in whatever order they appear, so a validation function sees a partially
+ * updated state.  They belong in an apply function instead, which runs only
+ * after every value of a CONFIG SET has been set and whose failure rolls the
+ * whole command back.  Apply functions don't run at startup, so this is also
+ * called from the sanity checks below, once the config file has been parsed. */
+static int applyBgsaveDefaultMethod(const char **err) {
+    if (server.bgsave_default_method == RDB_BGSAVE_TYPE_FORKLESS && !server.forkless_infrastructure_enabled) {
+        *err = "'bgsave-default-method forkless' requires the server to be started with "
+               "'forkless-infrastructure-enabled yes'";
+        return 0;
+    }
+    return 1;
+}
+
 void loadServerConfigFromString(sds config) {
     deprecatedConfig deprecated_configs[] = {
         {"list-max-ziplist-entries", 2, 2},
@@ -651,11 +667,7 @@ void loadServerConfigFromString(sds config) {
         err = "replicaof directive not allowed in cluster mode";
         goto loaderr;
     }
-    if (server.bgsave_default_method == RDB_BGSAVE_TYPE_FORKLESS && !server.forkless_infrastructure_enabled) {
-        err = "'bgsave-default-method forkless' can only be selected when the server was started with "
-              "'forkless-infrastructure-enabled yes'";
-        goto loaderr;
-    }
+    if (!applyBgsaveDefaultMethod(&err)) goto loaderr;
 
     /* To ensure backward compatibility and work while hz is out of range */
     if (server.hz < CONFIG_MIN_HZ) server.hz = CONFIG_MIN_HZ;
@@ -2457,19 +2469,6 @@ static void numericConfigRewrite(standardConfig *config, const char *name, struc
     {.type = SPECIAL_CONFIG,                                                           \
      embedCommonConfig(name, alias, modifiable) embedConfigInterface(NULL, setfn, getfn, rewritefn, applyfn)}
 
-static int isValidBgsaveDefaultMethod(int val, const char **err) {
-    /* During startup config parsing the directives are applied one by one, so
-     * forkless-infrastructure-enabled may not have been read yet when this
-     * value is set. We will check it when loading the config string */
-    if (reading_config_file) return 1;
-    if (val == RDB_BGSAVE_TYPE_FORKLESS && !server.forkless_infrastructure_enabled) {
-        *err = "'forkless' can only be selected when the server was started with "
-               "'forkless-infrastructure-enabled yes'";
-        return 0;
-    }
-    return 1;
-}
-
 static int isValidActiveDefrag(int val, const char **err) {
 #ifndef HAVE_DEFRAG
     if (val) {
@@ -3381,7 +3380,7 @@ standardConfig static_configs[] = {
     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
     createBoolConfig("activerehashing", NULL, MODIFIABLE_CONFIG, server.activerehashing, 1, NULL, NULL),
     createBoolConfig("stop-writes-on-bgsave-error", NULL, MODIFIABLE_CONFIG, server.stop_writes_on_bgsave_err, 1, NULL, NULL),
-    createEnumConfig("bgsave-default-method", NULL, MODIFIABLE_CONFIG, bgsave_method_enum, server.bgsave_default_method, RDB_BGSAVE_TYPE_FORK, isValidBgsaveDefaultMethod, NULL),
+    createEnumConfig("bgsave-default-method", NULL, MODIFIABLE_CONFIG, bgsave_method_enum, server.bgsave_default_method, RDB_BGSAVE_TYPE_FORK, NULL, applyBgsaveDefaultMethod),
     createBoolConfig("set-proc-title", NULL, IMMUTABLE_CONFIG, server.set_proc_title, 1, NULL, NULL), /* Should setproctitle be used? */
     createBoolConfig("lazyfree-lazy-eviction", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_eviction, 1, NULL, NULL),
     createBoolConfig("lazyfree-lazy-expire", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_expire, 1, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -480,6 +480,10 @@ static int updateClientOutputBufferLimit(sds *args, int arg_len, const char **er
  * abnormal aggregate `save T C` functionality. Remove in the future. */
 static int reading_config_file;
 
+/* Nesting depth of loadServerConfigFromString(), which recurses for `include`
+ * directives. Only the outermost parse has seen the whole configuration. */
+static int config_parse_depth;
+
 /* Verification to make sure forkless is not set as the default behavior without the
  * underlying infrastructure supporting it. */
 static int applyBgsaveDefaultMethod(const char **err) {
@@ -510,6 +514,7 @@ void loadServerConfigFromString(sds config) {
     int argc;
 
     reading_config_file = 1;
+    config_parse_depth++;
     lines = sdssplitlen(config, sdslen(config), "\n", 1, &totlines);
 
     for (i = 0; i < totlines; i++) {
@@ -657,12 +662,18 @@ void loadServerConfigFromString(sds config) {
         fclose(logfp);
     }
 
-    /* Sanity checks. */
-    if (server.cluster_enabled && server.primary_host) {
-        err = "replicaof directive not allowed in cluster mode";
-        goto loaderr;
+    /* Sanity checks. These span more than one config, so they can only run once
+     * the outermost parse is done: an `include` is parsed by a nested call, and
+     * both the directives following it and the command line options appended
+     * after the file are meant to override what the included file set. */
+    config_parse_depth--;
+    if (config_parse_depth == 0) {
+        if (server.cluster_enabled && server.primary_host) {
+            err = "replicaof directive not allowed in cluster mode";
+            goto loaderr;
+        }
+        if (!applyBgsaveDefaultMethod(&err)) goto loaderr;
     }
-    if (!applyBgsaveDefaultMethod(&err)) goto loaderr;
 
     /* To ensure backward compatibility and work while hz is out of range */
     if (server.hz < CONFIG_MIN_HZ) server.hz = CONFIG_MIN_HZ;

--- a/src/config.c
+++ b/src/config.c
@@ -475,13 +475,11 @@ static int updateClientOutputBufferLimit(sds *args, int arg_len, const char **er
     return 1;
 }
 
-/* Note this is here to support detecting we're running a config set from
- * within conf file parsing. This is only needed to support the deprecated
- * abnormal aggregate `save T C` functionality. Remove in the future. */
-static int reading_config_file;
-
 /* Nesting depth of loadServerConfigFromString(), which recurses for `include`
- * directives. Only the outermost parse has seen the whole configuration. */
+ * directives. Non-zero means we are parsing a config file rather than running a
+ * CONFIG SET, which the deprecated aggregate `save T C` functionality needs to
+ * tell apart. Only once it drops back to zero has the whole configuration been
+ * seen, so checks that span more than one config wait for that. */
 static int config_parse_depth;
 
 /* Verification to make sure forkless is not set as the default behavior without the
@@ -513,7 +511,6 @@ void loadServerConfigFromString(sds config) {
     sds *argv = NULL;
     int argc;
 
-    reading_config_file = 1;
     config_parse_depth++;
     lines = sdssplitlen(config, sdslen(config), "\n", 1, &totlines);
 
@@ -680,7 +677,6 @@ void loadServerConfigFromString(sds config) {
     if (server.hz > CONFIG_MAX_HZ) server.hz = CONFIG_MAX_HZ;
 
     sdsfreesplitres(lines, totlines);
-    reading_config_file = 0;
     return;
 
 loaderr:
@@ -2999,7 +2995,7 @@ static int setConfigSaveOption(standardConfig *config, sds *argv, int argc, cons
         }
     }
     /* Finally set the new config */
-    if (!reading_config_file) {
+    if (!config_parse_depth) {
         resetServerSaveParams();
     } else {
         /* We don't reset save params before loading, because if they're not part

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -1750,4 +1750,19 @@ test {Server starts with bgsave-default-method before forkless-infrastructure-en
     }
 }
 
+# An `include` is parsed by a nested call, so the infrastructure is only enabled
+# once the outermost parse is done.
+set included_config [file normalize [tmpfile forkless-included.conf]]
+write_file $included_config "maxmemory 0\n"
+set config_lines {}
+lappend config_lines "bgsave-default-method" "forkless"
+lappend config_lines "include" $included_config
+lappend config_lines "forkless-infrastructure-enabled" "yes"
+
+start_server [list overrides {save ""} config_lines $config_lines] {
+    test {Server starts with forkless-infrastructure-enabled yes set after an include} {
+        assert_equal [lindex [r config get bgsave-default-method] 1] "forkless"
+    }
+}
+
 } ;# tags

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1302,6 +1302,14 @@ start_server {tags {"introspection"}} {
         start_server {config "default.conf" overrides {save {900 1}} args {--save {}}} {
             assert_match [r config get save] {save {}}
         }
+
+        # A "save" keyword after an include is still part of the same config file
+        set included_config [file normalize [tmpfile save-included.conf]]
+        write_file $included_config "maxmemory 0\n"
+        start_server [list config "default.conf" overrides [list save {900 1}] \
+                           config_lines [list "include" $included_config "save" "100 100"]] {
+            assert_match [r config get save] {save {900 1 100 100}}
+        }
     } {} {external:skip}
 
     test {CONFIG sanity} {


### PR DESCRIPTION
`bgsave-default-method` cross-checks `forkless-infrastructure-enabled` from its `is_valid_fn`. That hook runs while a `CONFIG SET` is still half applied: `configSetCommand` sets values one at a time in argument order (`src/config.c:981`), so a validator sees either the old or the new value of a sibling config depending on where it appeared on the command line. #4598 works around this by opting out of config file parsing entirely (`if (reading_config_file) return 1;`) and restating the condition and the message in the post-load sanity block.

Two costs from that shape:

* `reading_config_file` is documented at `src/config.c:480` as existing only for the deprecated aggregate `save T C` handling, "Remove in the future". This gave it a second consumer.
* The invariant and its error string live in two places.

## Fix

Put the check in an apply function. Apply runs only after every value of a `CONFIG SET` has been set (`src/config.c:1010`) and a failure rolls the whole command back through `restoreBackupConfig`, so the state it sees is complete and independent of argument order.

Apply functions are never invoked at startup (`interface.apply` is read only by `configSetCommand`), so the sanity block still has to enforce the invariant. It calls the same function now instead of restating it. Command-line options and stdin are concatenated into the config string before parsing (`src/config.c:755-760`), so that one call covers every startup path.

`applyTlsCfg` already uses this pattern to cross-validate ~15 mutable TLS configs. `CONFIG SET tls-cert-file x tls-key-file y` only works because the check sits in apply rather than in per-config validation.

## Testing

The three tests from #4598 pass unmodified:

```
[ok]: bgsave-default-method forkless is rejected without forkless-infrastructure-enabled (1 ms)
[ok]: Server refuses to start with bgsave-default-method forkless and no forkless-infrastructure-enabled (11 ms)
[ok]: Server starts with bgsave-default-method before forkless-infrastructure-enabled yes (284 ms)
```

By hand, reversed order in the config file (`forkless-infrastructure-enabled yes` written first) still starts with `bgsave-default-method` = `forkless`, and a grouped set now fails atomically:

```
> CONFIG SET maxmemory 100mb bgsave-default-method forkless
ERR CONFIG SET failed (possibly related to argument 'bgsave-default-method') - 'bgsave-default-method forkless' requires the server to be started with 'forkless-infrastructure-enabled yes'
> CONFIG GET maxmemory
1) "maxmemory"
2) "0"
```

Left alone: `resolveBgsaveType` asserts the pair is consistent. I traced the reachable paths and did not find a hole, but an assert turns any missed one into a panic where a log plus the fork fallback costs one line. Happy to change it here if you would rather not carry the assert.

*This was generated by AI but verified, with love, by a human.*
