### PR TITLE
revert typo config change

### DIFF
--- a/.config/typos.toml
+++ b/.config/typos.toml
@@ -25,9 +25,10 @@ dbe = "dbe"
 
 [default]
 extend-ignore-re = [
-    "[A-Z]{2,}",   # Acronyms (all caps)
-    "[A-Z]{2,}ed", # SELECTed, WATCHed, etc.
-    "[A-Z]{2,}s",  # SELECTs, etc.
+    "SELECTed",
+    "SELECTs",
+    "WATCHed",
+    "AIMD",
 ]
 
 [type.c]


### PR DESCRIPTION
Maddy asked to revert the change to typos.  Don't want to blanket ignore all caps.