### PR TITLE
fix(pubsub): return CROSSSLOT for cross-slot SHARDNUMSUB

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -5433,7 +5433,9 @@ struct COMMAND_ARG PUBSUB_SHARDCHANNELS_Args[] = {
 
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
 /* PUBSUB SHARDNUMSUB key specs */
-#define PUBSUB_SHARDNUMSUB_Keyspecs NULL
+keySpec PUBSUB_SHARDNUMSUB_Keyspecs[1] = {
+{NULL,CMD_KEY_NOT_KEY,KSPEC_BS_INDEX,.bs.index={2},KSPEC_FK_RANGE,.fk.range={-1,1,0}}
+};
 #endif
 
 /* PUBSUB SHARDNUMSUB argument table */
@@ -5448,7 +5450,7 @@ struct COMMAND_STRUCT PUBSUB_Subcommands[] = {
 {MAKE_CMD("numpat","Returns a count of unique pattern subscriptions.","O(1)","2.8.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,PUBSUB_NUMPAT_History,0,PUBSUB_NUMPAT_Tips,0,pubsubCommand,2,CMD_PUBSUB|CMD_LOADING|CMD_STALE,ACL_CATEGORY_PUBSUB|ACL_CATEGORY_SLOW,NULL,PUBSUB_NUMPAT_Keyspecs,0,NULL,0)},
 {MAKE_CMD("numsub","Returns a count of subscribers to channels.","O(N) for the NUMSUB subcommand, where N is the number of requested channels","2.8.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,PUBSUB_NUMSUB_History,0,PUBSUB_NUMSUB_Tips,0,pubsubCommand,-2,CMD_PUBSUB|CMD_LOADING|CMD_STALE,ACL_CATEGORY_PUBSUB|ACL_CATEGORY_SLOW,NULL,PUBSUB_NUMSUB_Keyspecs,0,NULL,1),.args=PUBSUB_NUMSUB_Args},
 {MAKE_CMD("shardchannels","Returns the active shard channels.","O(N) where N is the number of active shard channels, and assuming constant time pattern matching (relatively short shard channels).","7.0.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,PUBSUB_SHARDCHANNELS_History,0,PUBSUB_SHARDCHANNELS_Tips,0,pubsubCommand,-2,CMD_PUBSUB|CMD_LOADING|CMD_STALE,ACL_CATEGORY_PUBSUB|ACL_CATEGORY_SLOW,NULL,PUBSUB_SHARDCHANNELS_Keyspecs,0,NULL,1),.args=PUBSUB_SHARDCHANNELS_Args},
-{MAKE_CMD("shardnumsub","Returns the count of subscribers of shard channels.","O(N) for the SHARDNUMSUB subcommand, where N is the number of requested shard channels","7.0.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,PUBSUB_SHARDNUMSUB_History,0,PUBSUB_SHARDNUMSUB_Tips,0,pubsubCommand,-2,CMD_PUBSUB|CMD_LOADING|CMD_STALE,ACL_CATEGORY_PUBSUB|ACL_CATEGORY_SLOW,NULL,PUBSUB_SHARDNUMSUB_Keyspecs,0,NULL,1),.args=PUBSUB_SHARDNUMSUB_Args},
+{MAKE_CMD("shardnumsub","Returns the count of subscribers of shard channels.","O(N) for the SHARDNUMSUB subcommand, where N is the number of requested shard channels","7.0.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,PUBSUB_SHARDNUMSUB_History,0,PUBSUB_SHARDNUMSUB_Tips,0,pubsubCommand,-2,CMD_PUBSUB|CMD_LOADING|CMD_STALE,ACL_CATEGORY_PUBSUB|ACL_CATEGORY_SLOW,NULL,PUBSUB_SHARDNUMSUB_Keyspecs,1,NULL,1),.args=PUBSUB_SHARDNUMSUB_Args},
 {0}
 };
 

--- a/src/commands/pubsub-shardnumsub.json
+++ b/src/commands/pubsub-shardnumsub.json
@@ -20,6 +20,25 @@
                 "multiple": true
             }
         ],
+        "key_specs": [
+            {
+                "flags": [
+                    "NOT_KEY"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
         "reply_schema": {
             "description": "The number of subscribers per shard channel, each even element (including 0th) is channel name, each odd element is the number of subscribers.",
             "type": "array"

--- a/tests/unit/cluster/pubsubshard.tcl
+++ b/tests/unit/cluster/pubsubshard.tcl
@@ -47,6 +47,14 @@ test "client can't subscribe to multiple shard channels across different slots i
     assert_match {CROSSSLOT Keys*} $err
 }
 
+test "PUBSUB SHARDNUMSUB across different slots returns CROSSSLOT" {
+    # Send directly to a node: the cross-slot check runs before slot routing,
+    # so any node rejects shard channels that hash to different slots.
+    set node [valkey_client_by_addr $publishnode(host) $publishnode(port)]
+    assert_error "CROSSSLOT*" {$node pubsub shardnumsub channel.0 channel.1}
+    $node close
+}
+
 test "client can subscribe to multiple shard channels across different slots in separate call" {
     $cluster ssubscribe ch3
     $cluster ssubscribe ch7


### PR DESCRIPTION
## Summary

In cluster mode, `PUBSUB SHARDNUMSUB ch1 ch2` accepted shard channels that map
to different slots and silently returned local subscriber counts instead of a
`-CROSSSLOT` error. This breaks cluster clients that route by slot (e.g. the Go
client can't decide where to send the command), as discussed in #560.

This adds a `NOT_KEY` key specification to the command so the generic cluster
machinery treats the shard channels as slot keys and returns `-CROSSSLOT` for
cross-slot input, consistent with `SSUBSCRIBE` and `SPUBLISH`.

## Changes

- `src/commands/pubsub-shardnumsub.json`: add `key_specs` (`NOT_KEY`, begin at
  arg pos 2, all remaining args as keys).
- `src/commands.def`: regenerated via `utils/generate-command-code.py`.
- `tests/unit/cluster/pubsubshard.tcl`: add a test that sends
  `PUBSUB SHARDNUMSUB` directly to a node and asserts `-CROSSSLOT` for shard
  channels in different slots (the cross-slot check runs before slot routing,
  so no test-harness routing change is needed).

## Breaking change

This is intentionally a breaking change for `PUBSUB SHARDNUMSUB` with multiple
shard channels in different slots (previously succeeded, now errors), as agreed
in #560. Single-channel usage is unaffected in the common case. Targeting
`unstable` accordingly.

## Testing

- `./runtest --single unit/cluster/pubsubshard` -> all tests pass, including the
  new `PUBSUB SHARDNUMSUB across different slots returns CROSSSLOT`.

## AI assistance disclosure

Parts of this change were drafted with AI assistance (GitHub Copilot / Claude).
I have reviewed, built, and tested every line, understand the change, and take
responsibility for this contribution. The implementation was written
independently for Valkey.

Fixes #560
