### PR TITLE
Move build-debian-old CI job to Debian Bookworm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
 
   build-debian-old:
     runs-on: ubuntu-latest
-    container: debian:bullseye
+    container: debian:bookworm
     steps:
       - name: Install libbacktrace
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### Problem

The `build-debian-old` CI job has been failing on all branches (including
unstable) since ~2026-09-04. Every `apt-get install` in the
`debian:bullseye` container 404s because the bullseye-security mirror
rotated packages (e.g. libperl5.32 moved to a new revision) while the apt
index is stale.

This is not a transient flake. Debian 11 (bullseye) LTS reached
end-of-life on August 31, 2026
(https://www.debian.org/News/2026/20260831). Post-EOL, the suite receives
its final package rotations, no updates will re-converge the mirror index,
and bullseye will eventually be dropped from the main mirrors entirely and
live only on archive.debian.org. Retrying the job cannot fix it.

### Fix

Bump the job's container from `debian:bullseye` to `debian:bookworm`
(Debian 12). Bookworm is now Debian's oldstable, supported until 2028, so
the job keeps doing what it exists to do — validate the build on the
oldest *supported* Debian toolchain (gcc 12, older glibc) — without
depending on a dead distribution's mirrors.

Alternative considered: repointing apt sources at archive.debian.org to
keep bullseye (gcc 10) coverage. Rejected because building on an EOL
distro that no longer receives security updates isn't a configuration we
should encourage or spend CI time validating; users on bullseye should be
upgrading.

This is the only reference to bullseye in the repository's workflows.