### PR TITLE
valkey-benchmark: fix cluster node pointer array allocation size

### DIFF
--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1430,7 +1430,8 @@ static void freeClusterNodes(void) {
 
 static clusterNode **addClusterNode(clusterNode *node) {
     int count = config.cluster_node_count + 1;
-    config.cluster_nodes = zrealloc(config.cluster_nodes, count * sizeof(*node));
+    config.cluster_nodes =
+        zrealloc(config.cluster_nodes, count * sizeof(*config.cluster_nodes));
     if (!config.cluster_nodes) return NULL;
     config.cluster_nodes[config.cluster_node_count++] = node;
     return config.cluster_nodes;


### PR DESCRIPTION


`config.cluster_nodes` is an array of `clusterNode *`, but `addClusterNode()` used `sizeof(*node)`, which evaluates to `sizeof(clusterNode)`.

This allocates each array entry using the size of the pointed-to structure instead of the pointer size, unnecessarily overallocating the cluster node array in cluster benchmark mode.

Use `sizeof(*config.cluster_nodes)` so the allocation size is derived from the array element type.



