### PR TITLE
Shrink valkey binary by ~10KB

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -7,7 +7,7 @@
     name, summary, complexity, since, doc_flags, replaced, deprecated, group_enum, history, num_history, tips,  \
         num_tips, function, arity, flags, acl, get_dbid_args, key_specs, key_specs_num, get_keys, numargs
 #define MAKE_ARG(name, type, key_spec_index, token, summary, since, flags, numsubargs, deprecated_since) \
-    name, type, key_spec_index, token, summary, since, flags, deprecated_since, numsubargs
+    name, type, key_spec_index, token, summary, since, flags, numsubargs, deprecated_since
 #define COMMAND_STRUCT serverCommand
 #define COMMAND_ARG serverCommandArg
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -70,8 +70,8 @@ typedef struct serverCommandArg {
     const char *summary;
     const char *since;
     int flags;
-    const char *deprecated_since;
     int num_args;
+    const char *deprecated_since;
     struct serverCommandArg *subargs;
     const char *display_text;
 } serverCommandArg;


### PR DESCRIPTION
Currently the serverCommandArg structure has an 8 byte memory hole

```
(gdb) ptype /o struct serverCommandArg
/* offset      |    size */  type = struct serverCommandArg {
/*      0      |       8 */    const char *name;
/*      8      |       4 */    serverCommandArgType type;
/*     12      |       4 */    int key_spec_index;
/*     16      |       8 */    const char *token;
/*     24      |       8 */    const char *summary;
/*     32      |       8 */    const char *since;
/*     40      |       4 */    int flags;
/* XXX  4-byte hole      */
/*     48      |       8 */    const char *deprecated_since;
/*     56      |       4 */    int num_args;
/* XXX  4-byte hole      */
/*     64      |       8 */    struct serverCommandArg *subargs;
/*     72      |       8 */    const char *display_text;

                               /* total size (bytes):   80 */
                             }
```

By moving the variables inside the structure we can close this hole saving 8 bytes per serverCommandArg definition.

This structure is heavily used in the `commands.def` so by optimizing it we can save a lot of memory

**Before Change:** 21238712 bytes
**After Change:** 21227928 bytes
**Reduction:** 10784 bytes => ~10.5KB
