### PR TITLE
RFC: grow the RDMA receive window on the same MR under sender pressure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ redis.code-workspace
 .cscope*
 .swp
 nodes*.conf
+rdma-phase-results/
 tests/cluster/tmp/*
 tests/rdma/rdma-test
 tags

--- a/deps/libvalkey/include/valkey/rdma.h
+++ b/deps/libvalkey/include/valkey/rdma.h
@@ -37,6 +37,8 @@
 
 #include "visibility.h"
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -61,6 +63,17 @@ extern "C" {
     } while (0)
 
 LIBVALKEY_API int valkeyInitiateRdma(void);
+
+typedef struct valkeyRdmaStats {
+    uint64_t tx_bytes;
+    uint64_t tx_wait_for_rx_count;
+    uint64_t tx_wait_for_rx_ns;
+    uint64_t rx_window_reannounce_count; /* RegisterXferMemory after the initial handoff */
+} valkeyRdmaStats;
+
+struct valkeyContext;
+LIBVALKEY_API int valkeyGetRdmaStats(struct valkeyContext *c, valkeyRdmaStats *stats);
+LIBVALKEY_API int valkeyResetRdmaStats(struct valkeyContext *c);
 
 #ifdef __cplusplus
 }

--- a/deps/libvalkey/include/valkey/rdma.h
+++ b/deps/libvalkey/include/valkey/rdma.h
@@ -69,6 +69,8 @@ typedef struct valkeyRdmaStats {
     uint64_t tx_wait_for_rx_count;
     uint64_t tx_wait_for_rx_ns;
     uint64_t rx_window_reannounce_count; /* RegisterXferMemory after the initial handoff */
+    uint64_t tx_grow_request_count;      /* chunks that signalled RX-window pressure */
+    uint32_t tx_window_peak;             /* max announced server RX window seen */
 } valkeyRdmaStats;
 
 struct valkeyContext;

--- a/deps/libvalkey/src/rdma.c
+++ b/deps/libvalkey/src/rdma.c
@@ -283,12 +283,38 @@ typedef struct RdmaContext {
      * VALKEY_RDMA_MAX_WQE ~ 2 * VALKEY_RDMA_MAX_WQE -1 for send buffer */
     valkeyRdmaCmd *cmd_buf;
     struct ibv_mr *cmd_mr;
+
+    uint64_t tx_bytes;
+    uint64_t tx_wait_for_rx_count;
+    uint64_t tx_wait_for_rx_ns;
+    uint64_t rx_window_reannounce_count;
+    int tx_waiting_for_rx;
+    int64_t tx_wait_start_ns;
 } RdmaContext;
 
 /* Apparently CHERI uintptr_t can be 128 bits */
 vk_static_assert(sizeof(uintptr_t) <= sizeof(uint64_t));
 
 static int valkeyRdmaCM(valkeyContext *c, long timeout);
+
+static inline int64_t vk_nsec_now(void) {
+    return vk_usec_now() * 1000LL;
+}
+
+static void rdmaEndTxWaitForRx(RdmaContext *ctx) {
+    if (!ctx->tx_waiting_for_rx)
+        return;
+    ctx->tx_wait_for_rx_ns += (uint64_t)(vk_nsec_now() - ctx->tx_wait_start_ns);
+    ctx->tx_waiting_for_rx = 0;
+}
+
+static void rdmaBeginTxWaitForRx(RdmaContext *ctx) {
+    if (ctx->tx_waiting_for_rx)
+        return;
+    ctx->tx_wait_start_ns = vk_nsec_now();
+    ctx->tx_waiting_for_rx = 1;
+    ctx->tx_wait_for_rx_count++;
+}
 
 static int valkeyRdmaSetFdBlocking(valkeyContext *c, int fd, int blocking) {
     int flags;
@@ -543,6 +569,10 @@ static int connRdmaHandleRecv(valkeyContext *c, RdmaContext *ctx, struct rdma_cm
 
     switch (ntohs(cmd->keepalive.opcode)) {
     case RegisterXferMemory:
+        /* Initial handoff has tx_length == 0; later announcements are RX re-registers. */
+        if (ctx->tx_length != 0)
+            ctx->rx_window_reannounce_count++;
+        rdmaEndTxWaitForRx(ctx);
         ctx->tx_addr = (char *)(uintptr_t)be64toh(cmd->memory.addr);
         ctx->tx_length = ntohl(cmd->memory.length);
         ctx->tx_key = ntohl(cmd->memory.key);
@@ -796,6 +826,7 @@ static size_t connRdmaSend(RdmaContext *ctx, struct rdma_cm_id *cm_id, const voi
     }
 
     ctx->tx_offset += data_len;
+    ctx->tx_bytes += data_len;
 
     return data_len;
 }
@@ -819,20 +850,27 @@ static ssize_t valkeyRdmaWrite(valkeyContext *c) {
     do {
         assert(ctx->tx_offset <= ctx->tx_length);
         if (ctx->tx_offset == ctx->tx_length) {
-            /* wait a new TX buffer */
+            /* wait a new TX buffer (server RX window exhausted) */
+            if (wrote >= data_len)
+                break;
+
+            rdmaBeginTxWaitForRx(ctx);
             elapsed = vk_msec_now() - start;
             if (elapsed >= timed) {
+                rdmaEndTxWaitForRx(ctx);
                 valkeySetError(c, VALKEY_ERR_IO, "RDMA: IO timeout");
                 return VALKEY_ERR;
             }
 
             if (valkeyRdmaWaitEvent(c, timed - elapsed) == VALKEY_ERR) {
+                rdmaEndTxWaitForRx(ctx);
                 return VALKEY_ERR;
             }
 
             continue;
         }
 
+        rdmaEndTxWaitForRx(ctx);
         towrite = valkeyMin(ctx->tx_length - ctx->tx_offset, data_len - wrote);
         ret = connRdmaSend(ctx, cm_id, c->obuf + wrote, towrite);
         if (ret == (size_t)VALKEY_ERR) {
@@ -865,6 +903,8 @@ static void valkeyRdmaClose(valkeyContext *c) {
     if (!ctx) {
         return; /* connect failed? */
     }
+
+    rdmaEndTxWaitForRx(ctx);
 
     cm_id = ctx->cm_id;
     connRdmaHandleCq(c);
@@ -1280,6 +1320,50 @@ int valkeyInitiateRdma(void) {
 #endif
     valkeyContextRegisterFuncs(&valkeyContextRdmaFuncs, VALKEY_CONN_RDMA);
 
+    return VALKEY_OK;
+}
+
+int valkeyGetRdmaStats(valkeyContext *c, valkeyRdmaStats *stats) {
+    RdmaContext *ctx;
+
+    if (!c || !stats || c->connection_type != VALKEY_CONN_RDMA) {
+        return VALKEY_ERR;
+    }
+
+    ctx = c->privctx;
+    if (!ctx) {
+        return VALKEY_ERR;
+    }
+
+    stats->tx_bytes = ctx->tx_bytes;
+    stats->tx_wait_for_rx_count = ctx->tx_wait_for_rx_count;
+    stats->tx_wait_for_rx_ns = ctx->tx_wait_for_rx_ns;
+    stats->rx_window_reannounce_count = ctx->rx_window_reannounce_count;
+    if (ctx->tx_waiting_for_rx) {
+        stats->tx_wait_for_rx_ns += (uint64_t)(vk_nsec_now() - ctx->tx_wait_start_ns);
+    }
+    return VALKEY_OK;
+}
+
+int valkeyResetRdmaStats(valkeyContext *c) {
+    RdmaContext *ctx;
+
+    if (!c || c->connection_type != VALKEY_CONN_RDMA) {
+        return VALKEY_ERR;
+    }
+
+    ctx = c->privctx;
+    if (!ctx) {
+        return VALKEY_ERR;
+    }
+
+    ctx->tx_bytes = 0;
+    ctx->tx_wait_for_rx_count = 0;
+    ctx->tx_wait_for_rx_ns = 0;
+    ctx->rx_window_reannounce_count = 0;
+    if (ctx->tx_waiting_for_rx) {
+        ctx->tx_wait_start_ns = vk_nsec_now();
+    }
     return VALKEY_OK;
 }
 

--- a/deps/libvalkey/src/rdma.c
+++ b/deps/libvalkey/src/rdma.c
@@ -254,6 +254,14 @@ typedef enum valkeyRdmaOpcode {
 #define VALKEY_RDMA_DEFAULT_RX_LEN (1024 * 1024)
 #define VALKEY_RDMA_INVALID_OPCODE 0xffff
 
+/* Feature bits carried in valkeyRdmaCmd.feature.features (u64, network order). */
+#define VALKEY_RDMA_FEATURE_RX_GROW_WINDOW (1ULL << 0)
+/* Grow-request flag in the IMM data of RDMA_WRITE_WITH_IMM. The payload
+ * length uses bits [0..30]; bit 31 is the flag (max window 16M < 2^31). */
+#define VALKEY_RDMA_IMM_GROW_REQUEST 0x80000000u
+/* Offset of the u32 (network order) RX window capacity in feature.rsvd[20]. */
+#define VALKEY_RDMA_FEATURE_CAPACITY_OFF 0
+
 typedef struct RdmaContext {
     struct rdma_cm_id *cm_id;
     struct rdma_event_channel *cm_channel;
@@ -290,6 +298,13 @@ typedef struct RdmaContext {
     uint64_t rx_window_reannounce_count;
     int tx_waiting_for_rx;
     int64_t tx_wait_start_ns;
+
+    /* RX window growth (v1): features negotiated with the server, the
+     * advertised RX capacity, and pressure-signal stats. */
+    uint64_t server_features;
+    uint32_t tx_window_max;
+    uint64_t tx_grow_request_count;
+    uint32_t tx_window_peak;
 } RdmaContext;
 
 /* Apparently CHERI uintptr_t can be 128 bits */
@@ -479,7 +494,10 @@ destroy_iobuf:
 static int rdmaAdjustSendbuf(valkeyContext *c, RdmaContext *ctx, unsigned int length) {
     int access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
 
-    if (length == ctx->send_length) {
+    if (length <= ctx->send_length) {
+        /* grow-only: an existing buffer covers the requested window; a
+         * realloc here could free memory referenced by in-flight work
+         * requests */
         return VALKEY_OK;
     }
 
@@ -568,7 +586,21 @@ static int connRdmaHandleRecv(valkeyContext *c, RdmaContext *ctx, struct rdma_cm
     }
 
     switch (ntohs(cmd->keepalive.opcode)) {
-    case RegisterXferMemory:
+    case GetServerFeature: {
+        uint64_t features = be64toh(cmd->feature.features);
+        const uint8_t *r = cmd->feature.rsvd + VALKEY_RDMA_FEATURE_CAPACITY_OFF;
+        uint32_t cap = ((uint32_t)r[0] << 24) | ((uint32_t)r[1] << 16) | ((uint32_t)r[2] << 8) | r[3];
+
+        if (features & VALKEY_RDMA_FEATURE_RX_GROW_WINDOW) {
+            ctx->server_features = features;
+            /* capacity must be sane and cover the current window */
+            if (cap >= ctx->tx_length) ctx->tx_window_max = cap;
+        }
+        break;
+    }
+
+    case RegisterXferMemory: {
+        unsigned int want;
         /* Initial handoff has tx_length == 0; later announcements are RX re-registers. */
         if (ctx->tx_length != 0)
             ctx->rx_window_reannounce_count++;
@@ -577,8 +609,19 @@ static int connRdmaHandleRecv(valkeyContext *c, RdmaContext *ctx, struct rdma_cm
         ctx->tx_length = ntohl(cmd->memory.length);
         ctx->tx_key = ntohl(cmd->memory.key);
         ctx->tx_offset = 0;
-        rdmaAdjustSendbuf(c, ctx, ctx->tx_length);
+        if (ctx->tx_length > ctx->tx_window_peak) ctx->tx_window_peak = ctx->tx_length;
+
+        /* Pre-size the staging buffer to the negotiated capacity once. This is
+         * the safe point: the initial handoff has nothing posted yet, and later
+         * announcements arrive only after the old window fully drained, so no
+         * in-flight work request can reference the buffer being replaced. */
+        want = ctx->tx_length;
+        if ((ctx->server_features & VALKEY_RDMA_FEATURE_RX_GROW_WINDOW) && ctx->tx_window_max > want) {
+            want = ctx->tx_window_max;
+        }
+        if (rdmaAdjustSendbuf(c, ctx, want) != VALKEY_OK) return VALKEY_ERR;
         break;
+    }
 
     case Keepalive:
         break;
@@ -797,7 +840,8 @@ static ssize_t valkeyRdmaReadZCDone(valkeyContext *c) {
     return VALKEY_OK;
 }
 
-static size_t connRdmaSend(RdmaContext *ctx, struct rdma_cm_id *cm_id, const void *data, size_t data_len) {
+static size_t connRdmaSend(RdmaContext *ctx, struct rdma_cm_id *cm_id, const void *data, size_t data_len,
+                           int grow_request) {
     struct ibv_send_wr send_wr, *bad_wr;
     struct ibv_sge sge;
     uint32_t off = ctx->tx_offset;
@@ -816,7 +860,7 @@ static size_t connRdmaSend(RdmaContext *ctx, struct rdma_cm_id *cm_id, const voi
     send_wr.num_sge = 1;
     send_wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
     send_wr.send_flags = (++ctx->send_ops % VALKEY_RDMA_MAX_WQE) ? 0 : IBV_SEND_SIGNALED;
-    send_wr.imm_data = htonl(data_len);
+    send_wr.imm_data = htonl((uint32_t)data_len | (grow_request ? VALKEY_RDMA_IMM_GROW_REQUEST : 0u));
     send_wr.wr.rdma.remote_addr = (uint64_t)(uintptr_t)remote_addr;
     send_wr.wr.rdma.rkey = ctx->tx_key;
     send_wr.next = NULL;
@@ -872,7 +916,20 @@ static ssize_t valkeyRdmaWrite(valkeyContext *c) {
 
         rdmaEndTxWaitForRx(ctx);
         towrite = valkeyMin(ctx->tx_length - ctx->tx_offset, data_len - wrote);
-        ret = connRdmaSend(ctx, cm_id, c->obuf + wrote, towrite);
+
+        /* Window pressure: this chunk fills the announced window exactly and
+         * more data is still pending, i.e. the next loop iteration would have
+         * to wait for a new window. Signal it on this WRITE's immediate data,
+         * but only when the server advertised the grow-window feature (an
+         * un-negotiated flag would trip an old server's length validation). */
+        int grow_req = 0;
+        if ((ctx->server_features & VALKEY_RDMA_FEATURE_RX_GROW_WINDOW) &&
+            (towrite == ctx->tx_length - ctx->tx_offset) && (wrote + towrite < data_len)) {
+            grow_req = 1;
+            ctx->tx_grow_request_count++;
+        }
+
+        ret = connRdmaSend(ctx, cm_id, c->obuf + wrote, towrite, grow_req);
         if (ret == (size_t)VALKEY_ERR) {
             return VALKEY_ERR;
         }
@@ -1017,12 +1074,29 @@ error:
     return VALKEY_ERR;
 }
 
+static int connRdmaGetServerFeature(valkeyContext *c, struct rdma_cm_id *cm_id) {
+    valkeyRdmaCmd cmd = {0};
+
+    cmd.feature.opcode = htons(GetServerFeature);
+    cmd.feature.select = 0; /* all features */
+
+    return rdmaSendCommand(c, cm_id, &cmd);
+}
+
 static int valkeyRdmaEstablished(valkeyContext *c, struct rdma_cm_id *cm_id) {
+    int ret;
+
     /* it's time to tell upper layer we have already connected */
     c->flags |= VALKEY_CONNECTED;
     c->funcs = &valkeyContextRdmaFuncs;
 
-    return connRdmaRegisterRx(c, cm_id);
+    ret = connRdmaRegisterRx(c, cm_id);
+    if (ret != VALKEY_OK) return ret;
+
+    /* ask which optional features the server supports; a server without the
+     * grow-window feature (or an older one) answers features=0 and the
+     * connection simply stays in static-window mode */
+    return connRdmaGetServerFeature(c, cm_id);
 }
 
 static int valkeyRdmaCM(valkeyContext *c, long timeout) {
@@ -1339,6 +1413,8 @@ int valkeyGetRdmaStats(valkeyContext *c, valkeyRdmaStats *stats) {
     stats->tx_wait_for_rx_count = ctx->tx_wait_for_rx_count;
     stats->tx_wait_for_rx_ns = ctx->tx_wait_for_rx_ns;
     stats->rx_window_reannounce_count = ctx->rx_window_reannounce_count;
+    stats->tx_grow_request_count = ctx->tx_grow_request_count;
+    stats->tx_window_peak = ctx->tx_window_peak;
     if (ctx->tx_waiting_for_rx) {
         stats->tx_wait_for_rx_ns += (uint64_t)(vk_nsec_now() - ctx->tx_wait_start_ns);
     }
@@ -1361,6 +1437,8 @@ int valkeyResetRdmaStats(valkeyContext *c) {
     ctx->tx_wait_for_rx_count = 0;
     ctx->tx_wait_for_rx_ns = 0;
     ctx->rx_window_reannounce_count = 0;
+    ctx->tx_grow_request_count = 0;
+    /* tx_window_peak is a high-water mark, not a windowed counter: keep it */
     if (ctx->tx_waiting_for_rx) {
         ctx->tx_wait_start_ns = vk_nsec_now();
     }

--- a/src/config.c
+++ b/src/config.c
@@ -3194,6 +3194,14 @@ static int applyRdmaBind(const char **err) {
     return 1;
 }
 
+static int isValidRdmaRxMaxSize(long long val, const char **err) {
+    if (val && val < server.rdma_ctx_config.rx_size) {
+        *err = "rdma-rx-max-size must be 0 or greater than or equal to rdma-rx-size";
+        return 0;
+    }
+    return 1;
+}
+
 static int updateRdmaPort(const char **err) {
     connListener *listener = listenerByType(CONN_TYPE_RDMA);
 
@@ -3538,6 +3546,7 @@ standardConfig static_configs[] = {
     createIntConfig("repl-diskless-sync-max-replicas", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_diskless_sync_max_replicas, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("rdma-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.rdma_ctx_config.port, 0, INTEGER_CONFIG, NULL, updateRdmaPort),
     createIntConfig("rdma-rx-size", NULL, IMMUTABLE_CONFIG, 64 * 1024, 16 * 1024 * 1024, server.rdma_ctx_config.rx_size, 1024 * 1024, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("rdma-rx-max-size", NULL, IMMUTABLE_CONFIG, 0, 16 * 1024 * 1024, server.rdma_ctx_config.rx_max_size, 0, INTEGER_CONFIG, isValidRdmaRxMaxSize, NULL),
     createIntConfig("rdma-completion-vector", NULL, IMMUTABLE_CONFIG, -1, 1024, server.rdma_ctx_config.completion_vector, -1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-message-gossip-perc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1, 100, server.cluster_message_gossip_perc, 10, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("hotkeys-sampling-percentage", NULL, MODIFIABLE_CONFIG, 1, 100, server.hotkeys_sampling_percentage, 1, INTEGER_CONFIG, NULL, hotkeysSamplingCallback),

--- a/src/connection.h
+++ b/src/connection.h
@@ -522,6 +522,7 @@ int RedisRegisterConnectionTypeSocket(void);
 int RedisRegisterConnectionTypeUnix(void);
 int RedisRegisterConnectionTypeTLS(void);
 int RegisterConnectionTypeRdma(void);
+sds genRdmaInfoString(sds info);
 
 /* Return 1 if connection is using TLS protocol, 0 if otherwise. */
 static inline int connIsTLS(connection *conn) {

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -125,6 +125,8 @@ typedef struct RdmaContext {
      * VALKEY_RDMA_MAX_WQE ~ 2 * VALKEY_RDMA_MAX_WQE -1 for send buffer */
     ValkeyRdmaCmd *cmd_buf;
     struct ibv_mr *cmd_mr;
+
+    uint64_t rx_window_reannounce_count; /* RX buffer exhausted, excluding initial handoff */
 } RdmaContext;
 
 typedef struct rdma_listener {
@@ -138,6 +140,9 @@ static list *pending_list;
 
 static rdma_listener *rdma_listeners;
 static serverRdmaContextConfig *rdma_config;
+
+/* RX windows re-announced after exhaustion (excludes connection setup). */
+static uint64_t rdma_total_rx_window_reannounce_count;
 
 static size_t page_size;
 
@@ -749,6 +754,8 @@ static void connRdmaEventHandler(struct aeEventLoop *el, int fd, void *clientDat
 
     /* recv buf is full, register a new RX buffer */
     if (ctx->rx.pos == ctx->rx.length) {
+        ctx->rx_window_reannounce_count++;
+        rdma_total_rx_window_reannounce_count++;
         connRdmaRegisterRx(ctx, cm_id);
     }
 
@@ -1891,11 +1898,23 @@ ConnectionType *connectionTypeRdma(void) {
     return ct_rdma;
 }
 
+sds genRdmaInfoString(sds info) {
+    info = sdscatprintf(info,
+                        "# RDMA\r\n"
+                        "rx_window_reannounce_count:%llu\r\n",
+                        (unsigned long long)rdma_total_rx_window_reannounce_count);
+    return info;
+}
+
 int RegisterConnectionTypeRdma(void) {
     return connTypeRegister(&CT_RDMA);
 }
 
 #else
+
+sds genRdmaInfoString(sds info) {
+    return info;
+}
 
 int RegisterConnectionTypeRdma(void) {
     serverLog(LL_VERBOSE, "Connection type %s not builtin", getConnectionTypeName(CONN_TYPE_RDMA));
@@ -1943,6 +1962,10 @@ int ValkeyModule_OnUnload(void *arg) {
 #endif /* BUILD_RDMA_MODULE */
 
 #else /* __linux__ */
+
+sds genRdmaInfoString(sds info) {
+    return info;
+}
 
 int RegisterConnectionTypeRdma(void) {
     serverLog(LL_VERBOSE, "Connection type %s is supported on Linux only", getConnectionTypeName(CONN_TYPE_RDMA));

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -82,6 +82,19 @@ typedef enum ValkeyRdmaOpcode {
 #define VALKEY_RDMA_INVALID_OPCODE 0xffff
 #define VALKEY_RDMA_KEEPALIVE_MS 3000
 
+/* Feature bits carried in ValkeyRdmaCmd.feature.features (u64, network order). */
+#define VALKEY_RDMA_FEATURE_RX_GROW_WINDOW (1ULL << 0)
+/* Grow-request flag in the IMM data of RDMA_WRITE_WITH_IMM. The payload
+ * length uses bits [0..30]; bit 31 is the flag (max window 16M < 2^31). */
+#define VALKEY_RDMA_IMM_GROW_REQUEST 0x80000000u
+/* Offset of the u32 (network order) RX window capacity in feature.rsvd[20]. */
+#define VALKEY_RDMA_FEATURE_CAPACITY_OFF 0
+
+/* RX window growth policy (v1): consecutive pressured windows required for
+ * one growth step, and window boundaries skipped after a growth. */
+#define RDMA_RX_GROW_THRESHOLD 2
+#define RDMA_RX_GROW_COOLDOWN_WINDOWS 4
+
 
 typedef struct rdma_connection {
     connection c;
@@ -127,6 +140,13 @@ typedef struct RdmaContext {
     struct ibv_mr *cmd_mr;
 
     uint64_t rx_window_reannounce_count; /* RX buffer exhausted, excluding initial handoff */
+
+    /* RX window growth (v1). rx_capacity is the MR extent registered once at
+     * connect; ctx->rx.length stays the logical window announced to the peer. */
+    uint32_t rx_capacity;
+    uint8_t rx_peer_grow_request; /* peer asked for a larger window (sticky per window) */
+    uint8_t rx_pressure_streak;   /* consecutive pressured windows */
+    uint8_t rx_grow_cooldown;     /* window boundaries to skip before next growth */
 } RdmaContext;
 
 typedef struct rdma_listener {
@@ -143,6 +163,11 @@ static serverRdmaContextConfig *rdma_config;
 
 /* RX windows re-announced after exhaustion (excludes connection setup). */
 static uint64_t rdma_total_rx_window_reannounce_count;
+static uint64_t rdma_total_rx_window_grow_request_count;
+static uint64_t rdma_total_rx_window_grow_count;
+static uint64_t rdma_total_rx_window_grow_suppressed_count;
+static uint64_t rdma_total_rx_window_peak_size;
+static uint64_t rdma_total_rx_mr_register_count;
 
 static size_t page_size;
 
@@ -261,7 +286,7 @@ static void rdmaDestroyIoBuf(RdmaContext *ctx) {
         ctx->rx.mr = NULL;
     }
 
-    rdmaMemoryFree(ctx->rx.addr, ctx->rx.length);
+    rdmaMemoryFree(ctx->rx.addr, ctx->rx_capacity);
     ctx->rx.addr = NULL;
 
     if (ctx->tx.mr) {
@@ -308,16 +333,20 @@ static int rdmaSetupIoBuf(RdmaContext *ctx, struct rdma_cm_id *cm_id) {
         cmd->keepalive.opcode = VALKEY_RDMA_INVALID_OPCODE;
     }
 
-    /* setup recv buf & MR */
+    /* setup recv buf & MR: register the full capacity once so the window can
+     * grow without re-registration; rx.length stays the logical window that
+     * gets announced to the peer. */
     access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
-    length = rdma_config->rx_size;
+    ctx->rx_capacity = rdma_config->rx_max_size ? rdma_config->rx_max_size : rdma_config->rx_size;
+    length = ctx->rx_capacity;
     ctx->rx.addr = rdmaMemoryAlloc(length);
-    ctx->rx.length = length;
     ctx->rx.mr = ibv_reg_mr(ctx->pd, ctx->rx.addr, length, access);
     if (!ctx->rx.mr) {
         serverLog(LL_WARNING, "RDMA: reg mr for recv buffer failed: %s", strerror(errno));
         goto destroy_iobuf;
     }
+    ctx->rx.length = rdma_config->rx_size;
+    rdma_total_rx_mr_register_count++;
 
     return C_OK;
 
@@ -489,12 +518,63 @@ static int connRdmaRegisterRx(RdmaContext *ctx, struct rdma_cm_id *cm_id) {
     return rdmaSendCommand(ctx, cm_id, &cmd);
 }
 
+/* Called at the safe window-exhaustion boundary (rx.pos == rx.length, hence
+ * rx.offset == rx.length: every byte the peer posted has landed and been
+ * consumed). Consumes the peer's sticky grow-request flag and may double the
+ * announced window (same MR, same rkey) before the re-announce is posted. */
+static void connRdmaMaybeGrowRxWindow(RdmaContext *ctx) {
+    int pressured = ctx->rx_peer_grow_request;
+    ctx->rx_peer_grow_request = 0;
+
+    /* static mode (max unset or == rx-size): nothing was advertised, behave
+     * exactly as before */
+    if (ctx->rx_capacity <= (uint32_t)rdma_config->rx_size) return;
+
+    if (ctx->rx.length == ctx->rx_capacity) {
+        if (pressured) rdma_total_rx_window_grow_suppressed_count++;
+        ctx->rx_pressure_streak = 0;
+        return;
+    }
+
+    if (ctx->rx_grow_cooldown > 0) {
+        ctx->rx_grow_cooldown--;
+        return;
+    }
+
+    if (pressured) {
+        ctx->rx_pressure_streak++;
+    } else {
+        ctx->rx_pressure_streak = 0;
+    }
+
+    if (ctx->rx_pressure_streak >= RDMA_RX_GROW_THRESHOLD) {
+        uint32_t new_len = ctx->rx.length * 2;
+        if (new_len > ctx->rx_capacity) new_len = ctx->rx_capacity;
+        ctx->rx.length = new_len;
+        ctx->rx_pressure_streak = 0;
+        ctx->rx_grow_cooldown = RDMA_RX_GROW_COOLDOWN_WINDOWS;
+        rdma_total_rx_window_grow_count++;
+        if (new_len > rdma_total_rx_window_peak_size) rdma_total_rx_window_peak_size = new_len;
+    }
+}
+
 static int connRdmaGetFeature(RdmaContext *ctx, struct rdma_cm_id *cm_id, ValkeyRdmaCmd *cmd) {
     ValkeyRdmaCmd _cmd = {0};
+    uint64_t features = 0;
+
+    if (rdma_config->rx_max_size > rdma_config->rx_size) {
+        /* dynamic RX window: advertise the feature bit plus the capacity so
+         * the peer can size its staging buffer once */
+        features |= VALKEY_RDMA_FEATURE_RX_GROW_WINDOW;
+        _cmd.feature.rsvd[VALKEY_RDMA_FEATURE_CAPACITY_OFF + 0] = (rdma_config->rx_max_size >> 24) & 0xff;
+        _cmd.feature.rsvd[VALKEY_RDMA_FEATURE_CAPACITY_OFF + 1] = (rdma_config->rx_max_size >> 16) & 0xff;
+        _cmd.feature.rsvd[VALKEY_RDMA_FEATURE_CAPACITY_OFF + 2] = (rdma_config->rx_max_size >> 8) & 0xff;
+        _cmd.feature.rsvd[VALKEY_RDMA_FEATURE_CAPACITY_OFF + 3] = rdma_config->rx_max_size & 0xff;
+    }
 
     _cmd.feature.opcode = htons(GetServerFeature);
     _cmd.feature.select = cmd->feature.select;
-    _cmd.feature.features = htonu64(0); /* currently no feature support */
+    _cmd.feature.features = htonu64(features);
 
     return rdmaSendCommand(ctx, cm_id, &_cmd);
 }
@@ -580,10 +660,21 @@ static int connRdmaHandleSend(ValkeyRdmaCmd *cmd) {
     return C_OK;
 }
 
-static int connRdmaHandleRecvImm(RdmaContext *ctx, struct rdma_cm_id *cm_id, ValkeyRdmaCmd *cmd, uint32_t byte_len) {
-    assert(byte_len + ctx->rx.offset <= ctx->rx.length);
+static int connRdmaHandleRecvImm(RdmaContext *ctx, struct rdma_cm_id *cm_id, ValkeyRdmaCmd *cmd, uint32_t byte_len,
+                                 int grow_req) {
+    /* real validation, not just assert: a malformed imm (oversized length or
+     * the grow bit from an un-negotiated peer) must fail the connection */
+    if (byte_len > ctx->rx.length - ctx->rx.offset) {
+        serverLog(LL_WARNING, "RDMA: FATAL error, rx window overflow (len=%u off=%u)", byte_len, ctx->rx.offset);
+        return C_ERR;
+    }
 
     ctx->rx.offset += byte_len;
+
+    if (grow_req && ctx->rx_capacity > (uint32_t)rdma_config->rx_size) {
+        ctx->rx_peer_grow_request = 1;
+        rdma_total_rx_window_grow_request_count++;
+    }
 
     return rdmaPostRecv(ctx, cm_id, cmd);
 }
@@ -646,14 +737,18 @@ pollcq:
         }
         break;
 
-    case IBV_WC_RECV_RDMA_WITH_IMM:
+    case IBV_WC_RECV_RDMA_WITH_IMM: {
+        uint32_t imm = ntohl(wc.imm_data);
+        uint32_t byte_len = imm & ~VALKEY_RDMA_IMM_GROW_REQUEST;
+        int grow_req = !!(imm & VALKEY_RDMA_IMM_GROW_REQUEST);
         cmd = (ValkeyRdmaCmd *)(uintptr_t)wc.wr_id;
-        if (connRdmaHandleRecvImm(ctx, cm_id, cmd, ntohl(wc.imm_data)) == C_ERR) {
+        if (connRdmaHandleRecvImm(ctx, cm_id, cmd, byte_len, grow_req) == C_ERR) {
             rdma_conn->c.state = CONN_STATE_ERROR;
             return C_ERR;
         }
 
         break;
+    }
     case IBV_WC_RDMA_WRITE:
         if (connRdmaHandleWrite(ctx, wc.byte_len) == C_ERR) {
             return C_ERR;
@@ -752,8 +847,9 @@ static void connRdmaEventHandler(struct aeEventLoop *el, int fd, void *clientDat
         }
     }
 
-    /* recv buf is full, register a new RX buffer */
+    /* recv buf is full: maybe grow the RX window, then announce it again */
     if (ctx->rx.pos == ctx->rx.length) {
+        connRdmaMaybeGrowRxWindow(ctx);
         ctx->rx_window_reannounce_count++;
         rdma_total_rx_window_reannounce_count++;
         connRdmaRegisterRx(ctx, cm_id);
@@ -1643,7 +1739,16 @@ int connRdmaListen(connListener *listener) {
     int bindaddr_count = listener->bindaddr_count;
     int port = listener->port;
     char *default_bindaddr[2] = {"*", "-::*"};
+    serverRdmaContextConfig *cfg = listener->priv;
     rdma_listener *rdma_listener;
+
+    /* secondary cross-check: is_valid during config load is order-dependent,
+     * so verify the final values here before any connection is created */
+    if (cfg->rx_max_size && cfg->rx_max_size < cfg->rx_size) {
+        serverLog(LL_WARNING, "RDMA: rdma-rx-max-size (%d) must be 0 or >= rdma-rx-size (%d)", cfg->rx_max_size,
+                  cfg->rx_size);
+        return C_ERR;
+    }
 
     assert(server.proto_max_bulk_len <= 512ll * 1024 * 1024);
 
@@ -1901,8 +2006,18 @@ ConnectionType *connectionTypeRdma(void) {
 sds genRdmaInfoString(sds info) {
     info = sdscatprintf(info,
                         "# RDMA\r\n"
-                        "rx_window_reannounce_count:%llu\r\n",
-                        (unsigned long long)rdma_total_rx_window_reannounce_count);
+                        "rx_window_reannounce_count:%llu\r\n"
+                        "rx_window_grow_request_count:%llu\r\n"
+                        "rx_window_grow_count:%llu\r\n"
+                        "rx_window_grow_suppressed_count:%llu\r\n"
+                        "rx_window_peak_size:%llu\r\n"
+                        "rx_mr_register_count:%llu\r\n",
+                        (unsigned long long)rdma_total_rx_window_reannounce_count,
+                        (unsigned long long)rdma_total_rx_window_grow_request_count,
+                        (unsigned long long)rdma_total_rx_window_grow_count,
+                        (unsigned long long)rdma_total_rx_window_grow_suppressed_count,
+                        (unsigned long long)rdma_total_rx_window_peak_size,
+                        (unsigned long long)rdma_total_rx_mr_register_count);
     return info;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -6423,6 +6423,13 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         info = getListensInfoString(info);
     }
 
+#ifdef USE_RDMA
+    if (all_sections || (dictFind(section_dict, "rdma") != NULL)) {
+        if (sections++) info = sdscat(info, "\r\n");
+        info = genRdmaInfoString(info);
+    }
+#endif
+
     /* TLS */
     if (all_sections || (dictFind(section_dict, "tls") != NULL)) {
         if (sections++) info = sdscat(info, "\r\n");
@@ -7492,8 +7499,8 @@ void dismissMemoryInChild(void) {
     /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
     if (server.thp_enabled) return;
 
-        /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
-         * so we avoid these pointless loops when they're not going to do anything. */
+    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
+     * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     listIter li;
     listNode *ln;

--- a/src/server.h
+++ b/src/server.h
@@ -1737,6 +1737,7 @@ typedef struct serverRdmaContextConfig {
     int bindaddr_count;
     int port;
     int rx_size;
+    int rx_max_size; /* 0 = static window (capacity == rx_size) */
     int completion_vector;
 } serverRdmaContextConfig;
 

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -64,6 +64,7 @@
 #include "valkey-benchmark-dataset.h"
 
 #define UNUSED(V) ((void)V)
+#define DATA_SIZE_PHASES_MAX 32
 #define RANDPTR_INITIAL_SIZE 8
 #define DEFAULT_LATENCY_PRECISION 3
 #define MAX_LATENCY_PRECISION 4
@@ -172,6 +173,23 @@ static struct config {
     int template_argc;
     sds *template_argv;
     int has_field_placeholders;
+    /* Experimental: keep connections alive while cycling SET value sizes. */
+    struct {
+        int value_size;
+        int duration_sec;
+    } phases[DATA_SIZE_PHASES_MAX];
+    int num_phases;
+    int phase_index;
+    int phase_draining;
+    int phase_armed;
+    int phase_all_done;
+    long long phase_start;
+    long long workload_start;
+    _Atomic int phase_reconnects;
+    _Atomic int phase_errors;
+    char *phase_cmd;
+    int phase_cmd_len;
+    const char *key_tag;
 } config;
 
 /* Locations of the placeholders __rand_int__, __rand_1st__,
@@ -266,6 +284,8 @@ static void updateClusterSlotsConfiguration(void);
 static long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData);
 int runFuzzerClients(const char *host, int port, int max_commands, int parallel_clients, int cluster_mode, long long num_keys, cliSSLconfig *ssl_config, const char *log_level, int fuzz_flags);
 static int parseCommandTemplate(int argc, char **argv);
+static void genBenchmarkRandomData(char *data, int count);
+static int parseDataSizePhases(const char *spec);
 
 /* Dict callbacks */
 static uint64_t dictSdsHash(const void *key);
@@ -296,6 +316,9 @@ static bool isBenchmarkFinished(int request_count) {
     /* don't end in warmup period */
     int warmup_duration = atomic_load_explicit(&config.current_warmup_duration, memory_order_relaxed);
     if (warmup_duration > 0) return false;
+
+    /* Phase workload is finished only after the last phase drains. */
+    if (config.num_phases > 0) return config.phase_all_done != 0;
 
     if (config.duration > 0) {
         /* end after the specified duration */
@@ -567,6 +590,10 @@ static void freeClient(client c) {
     zfree(c);
     if (config.num_threads) pthread_mutex_lock(&(config.liveclients_mutex));
     config.liveclients--;
+    if (config.num_phases > 0 && !config.phase_all_done) {
+        atomic_fetch_add_explicit(&config.phase_reconnects, 1, memory_order_relaxed);
+        atomic_fetch_add_explicit(&config.phase_errors, 1, memory_order_relaxed);
+    }
     ln = listSearchKey(config.clients, c);
     assert(ln != NULL);
     listDelNode(config.clients, ln);
@@ -702,6 +729,15 @@ static void clientDone(client c) {
     if (isBenchmarkFinished(requests_finished)) {
         freeClient(c);
         if (!config.num_threads && config.el) aeStop(config.el);
+        return;
+    }
+    if (config.num_phases > 0 && (config.phase_draining ||
+                                  (config.phase_armed && (mstime() - config.phase_start) >=
+                                                             (config.phases[config.phase_index].duration_sec * 1000LL)))) {
+        /* Stay connected; do not issue another pipeline of the old size. */
+        aeEventLoop *el = CLIENT_GET_EVENTLOOP(c);
+        aeDeleteFileEvent(el, c->context->fd, AE_WRITABLE);
+        aeDeleteFileEvent(el, c->context->fd, AE_READABLE);
         return;
     }
     if (config.keepalive) {
@@ -904,6 +940,17 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
 
     /* Initialize request when nothing was written. */
     if (c->written == 0) {
+        if (config.num_phases > 0 && (config.phase_draining ||
+                                      (config.phase_armed && (mstime() - config.phase_start) >=
+                                                                 (config.phases[config.phase_index].duration_sec * 1000LL)))) {
+            /* resetClient already reserved the next pipeline in pending; it was
+             * not sent. Drop WRITABLE and clear pending so the phase can idle.
+             * Do not delete READABLE: in-flight replies use written > 0. */
+            aeDeleteFileEvent(el, c->context->fd, AE_WRITABLE);
+            c->pending = 0;
+            return;
+        }
+
         /* Enforce upper bound to number of requests. */
         int requests_issued = atomic_fetch_add_explicit(&config.requests_issued,
                                                         config.pipeline * c->seqlen,
@@ -1161,6 +1208,188 @@ static void createMissingClients(client c) {
     }
 }
 
+static int phaseDurationElapsed(void) {
+    if (!config.phase_armed || config.num_phases <= 0) return 0;
+    return (mstime() - config.phase_start) >= (config.phases[config.phase_index].duration_sec * 1000LL);
+}
+
+static int allPhaseClientsIdle(void) {
+    listIter li;
+    listNode *ln;
+    listRewind(config.clients, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        client c = ln->value;
+        if (c->pending > 0 || c->written > 0) return 0;
+    }
+    return 1;
+}
+
+static void rebuildClientCommandBuffer(client c, const char *cmd, int len) {
+    if (c->prefixlen > 0)
+        sdsrange(c->obuf, 0, c->prefixlen - 1);
+    else
+        sdssetlen(c->obuf, 0);
+    for (int j = 0; j < config.pipeline; j++) c->obuf = sdscatlen(c->obuf, cmd, len);
+    c->written = 0;
+    c->pending = config.pipeline * c->seqlen;
+    if (config.cluster_mode) scanClusterTags(c, c->obuf + c->prefixlen);
+}
+
+static void resetPhaseRdmaClientStats(void) {
+#ifdef USE_RDMA
+    listIter li;
+    listNode *ln;
+
+    if (config.ct != VALKEY_CONN_RDMA) return;
+    listRewind(config.clients, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        client c = ln->value;
+        valkeyResetRdmaStats(c->context);
+    }
+#endif
+}
+
+static void collectPhaseRdmaClientStats(uint64_t *tx_bytes, uint64_t *tx_wait_count, uint64_t *tx_wait_ns, uint64_t *rx_reannounce) {
+    *tx_bytes = 0;
+    *tx_wait_count = 0;
+    *tx_wait_ns = 0;
+    *rx_reannounce = 0;
+#ifdef USE_RDMA
+    listIter li;
+    listNode *ln;
+
+    if (config.ct != VALKEY_CONN_RDMA) return;
+    listRewind(config.clients, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        client c = ln->value;
+        valkeyRdmaStats stats;
+
+        if (valkeyGetRdmaStats(c->context, &stats) != VALKEY_OK) continue;
+        *tx_bytes += stats.tx_bytes;
+        *tx_wait_count += stats.tx_wait_for_rx_count;
+        *tx_wait_ns += stats.tx_wait_for_rx_ns;
+        *rx_reannounce += stats.rx_window_reannounce_count;
+    }
+#endif
+}
+
+static int buildPhaseSetCommand(int datasize, char **cmd_out) {
+    char *data = zmalloc((size_t)datasize + 1);
+    int len;
+    genBenchmarkRandomData(data, datasize);
+    data[datasize] = '\0';
+    len = valkeyFormatCommand(cmd_out, "SET key%s:__rand_int__ %s", config.key_tag ? config.key_tag : "", data);
+    zfree(data);
+    return len;
+}
+
+static void beginPhaseMeasurement(void) {
+    config.phase_start = mstime();
+    config.phase_armed = 1;
+    config.phase_draining = 0;
+    resetPhaseRdmaClientStats();
+    atomic_store_explicit(&config.requests_issued, 0, memory_order_relaxed);
+    atomic_store_explicit(&config.requests_finished, 0, memory_order_relaxed);
+    atomic_store_explicit(&config.previous_requests_finished, 0, memory_order_relaxed);
+    atomic_store_explicit(&config.phase_reconnects, 0, memory_order_relaxed);
+    atomic_store_explicit(&config.phase_errors, 0, memory_order_relaxed);
+    if (config.latency_histogram) hdr_reset(config.latency_histogram);
+    if (config.current_sec_latency_histogram) hdr_reset(config.current_sec_latency_histogram);
+    fprintf(stderr, "PHASE_BEGIN index=%d value_size=%d duration_sec=%d elapsed_ms=%lld\n", config.phase_index,
+            config.phases[config.phase_index].value_size, config.phases[config.phase_index].duration_sec,
+            config.phase_start - config.workload_start);
+    fflush(stderr);
+}
+
+static void reportPhaseEnd(void) {
+    long long now = mstime();
+    double measured_sec = (now - config.phase_start) / 1000.0;
+    int requests = atomic_load_explicit(&config.requests_finished, memory_order_relaxed);
+    int value_size = config.phases[config.phase_index].value_size;
+    double rps = (measured_sec > 0) ? (requests / measured_sec) : 0;
+    double payload_gbps = (measured_sec > 0) ? (requests * (double)value_size * 8.0 / measured_sec / 1e9) : 0;
+    double avg_us = config.latency_histogram ? hdr_mean(config.latency_histogram) : 0;
+    int64_t p50 = config.latency_histogram ? hdr_value_at_percentile(config.latency_histogram, 50.0) : 0;
+    int64_t p99 = config.latency_histogram ? hdr_value_at_percentile(config.latency_histogram, 99.0) : 0;
+    int reconnects = atomic_load_explicit(&config.phase_reconnects, memory_order_relaxed);
+    int errors = atomic_load_explicit(&config.phase_errors, memory_order_relaxed);
+    uint64_t tx_bytes, tx_wait_count, tx_wait_ns, rx_reannounce;
+    double gib, reannounces_per_gib, stall_ratio;
+
+    collectPhaseRdmaClientStats(&tx_bytes, &tx_wait_count, &tx_wait_ns, &rx_reannounce);
+    gib = tx_bytes / (double)(1ULL << 30);
+    reannounces_per_gib = (gib > 0.0) ? (rx_reannounce / gib) : 0.0;
+    stall_ratio = (measured_sec > 0.0 && config.numclients > 0)
+                      ? (tx_wait_ns / (measured_sec * 1e9 * config.numclients))
+                      : 0.0;
+
+    if (config.csv) {
+        printf("%d,%d,%d,%.6f,%d,%.3f,%.6f,%.3f,%.3f,%.3f,%d,%d,%llu,%llu,%llu,%llu,%.6f,%.6f\n",
+               config.phase_index, value_size, config.phases[config.phase_index].duration_sec, measured_sec, requests,
+               rps, payload_gbps, avg_us, (double)p50, (double)p99, reconnects, errors,
+               (unsigned long long)tx_bytes, (unsigned long long)tx_wait_count, (unsigned long long)tx_wait_ns,
+               (unsigned long long)rx_reannounce, reannounces_per_gib, stall_ratio);
+        fflush(stdout);
+    }
+    fprintf(stderr,
+            "PHASE_END index=%d value_size=%d measured_sec=%.6f requests=%d rps=%.3f payload_gbps=%.6f "
+            "avg_latency_us=%.3f p50_latency_us=%.3f p99_latency_us=%.3f reconnects=%d errors=%d "
+            "tx_bytes=%llu tx_wait_count=%llu tx_wait_ns=%llu rx_reannounce=%llu reannounces_per_gib=%.6f "
+            "stall_ratio=%.6f\n",
+            config.phase_index, value_size, measured_sec, requests, rps, payload_gbps, avg_us, (double)p50,
+            (double)p99, reconnects, errors, (unsigned long long)tx_bytes, (unsigned long long)tx_wait_count,
+            (unsigned long long)tx_wait_ns, (unsigned long long)rx_reannounce, reannounces_per_gib, stall_ratio);
+    fflush(stderr);
+}
+
+static void applyPhaseCommand(int datasize) {
+    char *cmd = NULL;
+    int len = buildPhaseSetCommand(datasize, &cmd);
+    listIter li;
+    listNode *ln;
+
+    initPlaceholders(cmd, len);
+    listRewind(config.clients, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        rebuildClientCommandBuffer(ln->value, cmd, len);
+    }
+    if (config.phase_cmd) free(config.phase_cmd);
+    config.phase_cmd = cmd;
+    config.phase_cmd_len = len;
+    config.datasize = datasize;
+}
+
+static void resumePhaseClients(void) {
+    listIter li;
+    listNode *ln;
+    listRewind(config.clients, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        resetClient(ln->value);
+    }
+}
+
+static int switchToNextPhase(void) {
+    int old_size = config.phases[config.phase_index].value_size;
+    int new_size;
+    long long elapsed;
+
+    reportPhaseEnd();
+    if (config.phase_index + 1 >= config.num_phases) {
+        config.phase_all_done = 1;
+        return 0;
+    }
+    config.phase_index++;
+    new_size = config.phases[config.phase_index].value_size;
+    elapsed = mstime() - config.workload_start;
+    fprintf(stderr, "PHASE_TRANSITION index=%d elapsed_ms=%lld old_value_size=%d new_value_size=%d\n",
+            config.phase_index, elapsed, old_size, new_size);
+    fflush(stderr);
+    applyPhaseCommand(new_size);
+    beginPhaseMeasurement();
+    resumePhaseClients();
+    return 1;
+}
+
 static void showRPSReport(void) {
     if (config.rps_histogram && config.rps_histogram->total_count > 0) {
         const float target_rps = (float)config.rps;
@@ -1337,14 +1566,43 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     c = createClient(cmd, len, seqlen, NULL, thread_id);
     createMissingClients(c);
 
+    if (config.num_phases > 0) {
+        config.phase_cmd = NULL;
+        config.phase_cmd_len = len;
+        config.workload_start = mstime();
+        config.phase_index = 0;
+        config.phase_draining = 0;
+        config.phase_armed = 0;
+        config.phase_all_done = 0;
+        fprintf(stderr, "PHASE_WORKLOAD pid=%d phases=%d clients=%d pipeline=%d keepalive=%d\n", getpid(),
+                config.num_phases, config.numclients, config.pipeline, config.keepalive);
+        fflush(stderr);
+        if (config.csv) {
+            printf("phase_index,value_size,duration,measured_sec,requests,rps,payload_gbps,avg_latency_us,"
+                   "p50_latency_us,p99_latency_us,reconnects,errors,tx_bytes,tx_wait_count,tx_wait_ns,"
+                   "rx_reannounce,reannounces_per_gib,stall_ratio\n");
+            fflush(stdout);
+        }
+    }
+
     config.start = mstime();
+    if (config.num_phases > 0) beginPhaseMeasurement();
     if (!config.num_threads) {
         aeMain(config.el);
     } else
         startBenchmarkThreads();
     config.totlatency = mstime() - config.start;
-    showReport();
+    if (config.num_phases == 0)
+        showReport();
+    else {
+        fprintf(stderr, "PHASE_WORKLOAD done phases=%d pid=%d\n", config.num_phases, getpid());
+        fflush(stderr);
+    }
     freeAllClients();
+    if (config.phase_cmd) {
+        free(config.phase_cmd);
+        config.phase_cmd = NULL;
+    }
     if (config.threads) freeBenchmarkThreads();
     if (config.current_sec_latency_histogram) hdr_close(config.current_sec_latency_histogram);
     if (config.latency_histogram) hdr_close(config.latency_histogram);
@@ -1709,6 +1967,40 @@ static void genBenchmarkRandomData(char *data, int count) {
     }
 }
 
+/* Parse "size:seconds[,size:seconds...]". Fills config.phases / num_phases. */
+static int parseDataSizePhases(const char *spec) {
+    const char *p = spec;
+    int n = 0;
+
+    if (!spec || !*spec) return -1;
+    while (*p) {
+        char *end = NULL;
+        long long size, dur;
+        const char *colon, *comma;
+
+        if (n >= DATA_SIZE_PHASES_MAX) return -1;
+        errno = 0;
+        size = strtoll(p, &end, 10);
+        if (errno || end == p || *end != ':' || size < 1 || size > 1024LL * 1024 * 1024) return -1;
+        colon = end;
+        errno = 0;
+        dur = strtoll(colon + 1, &end, 10);
+        if (errno || end == colon + 1 || dur < 1 || dur > 7 * 24 * 3600) return -1;
+        comma = end;
+        if (*comma != '\0' && *comma != ',') return -1;
+        config.phases[n].value_size = (int)size;
+        config.phases[n].duration_sec = (int)dur;
+        n++;
+        if (*comma == '\0') break;
+        p = comma + 1;
+        if (*p == '\0') return -1;
+    }
+    if (n < 1) return -1;
+    config.num_phases = n;
+    config.datasize = config.phases[0].value_size;
+    return 0;
+}
+
 /* Returns number of consumed options. */
 int parseOptions(int argc, char **argv) {
     int i;
@@ -1730,15 +2022,15 @@ int parseOptions(int argc, char **argv) {
             exit(0);
         } else if (!strcmp(argv[i], "-n")) {
             if (lastarg) goto invalid;
-            if (config.duration > 0) {
-                fprintf(stderr, "Options -n and --duration are mutually exclusive.\n");
+            if (config.duration > 0 || config.num_phases > 0) {
+                fprintf(stderr, "Options -n and --duration/--data-size-phases are mutually exclusive.\n");
                 exit(1);
             }
             config.requests = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--duration")) {
             if (lastarg) goto invalid;
-            if (config.requests > 0) {
-                fprintf(stderr, "Options -n and --duration are mutually exclusive.\n");
+            if (config.requests > 0 || config.num_phases > 0) {
+                fprintf(stderr, "Options --duration and -n/--data-size-phases are mutually exclusive.\n");
                 exit(1);
             }
             config.duration = atoi(argv[++i]);
@@ -1746,6 +2038,22 @@ int parseOptions(int argc, char **argv) {
             if (lastarg) goto invalid;
             config.warmup_duration = atoi(argv[++i]);
 
+        } else if (!strcmp(argv[i], "--data-size-phases")) {
+            if (lastarg) goto invalid;
+            if (config.requests > 0) {
+                fprintf(stderr, "Options -n and --data-size-phases are mutually exclusive.\n");
+                exit(1);
+            }
+            if (config.duration > 0) {
+                fprintf(stderr, "Options --duration and --data-size-phases are mutually exclusive.\n");
+                exit(1);
+            }
+            {
+                if (parseDataSizePhases(argv[++i]) != 0) {
+                    fprintf(stderr, "Invalid --data-size-phases spec (want size:seconds[,size:seconds...]).\n");
+                    exit(1);
+                }
+            }
         } else if (!strcmp(argv[i], "-k")) {
             if (lastarg) goto invalid;
             config.keepalive = atoi(argv[++i]);
@@ -2081,6 +2389,9 @@ usage:
         "                    then the full command sequence counts as one and -P controls\n"
         "                    the number of times the command sequence is sent in each\n"
         "                    pipeline.\n",
+        " --data-size-phases <size:sec[,size:sec...]>\n"
+        "                    Keep the same process and connections while cycling SET\n"
+        "                    value sizes (experimental). Mutually exclusive with -n/--duration.\n"
         " -q                 Quiet. Just show query/sec values\n"
         " --precision        Number of decimal places to display in latency output\n"
         "                    (default 0)\n"
@@ -2151,6 +2462,18 @@ long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clie
         fprintf(stderr, "All clients disconnected... aborting.\n");
         exit(1);
     }
+
+    if (config.num_phases > 0 && !config.phase_all_done) {
+        if (config.phase_armed && !config.phase_draining && phaseDurationElapsed()) {
+            config.phase_draining = 1;
+        } else if (config.phase_draining && allPhaseClientsIdle()) {
+            if (!switchToNextPhase()) {
+                aeStop(eventLoop);
+                if (config.num_threads) return AE_NOMORE;
+            }
+        }
+    }
+
     int warmup_duration = atomic_load_explicit(&config.current_warmup_duration, memory_order_relaxed);
     if (warmup_duration > 0) {
         if ((current_tick - config.start) >= (warmup_duration * 1000LL)) {
@@ -2333,6 +2656,16 @@ int main(int argc, char **argv) {
     config.template_argc = 0;
     config.template_argv = NULL;
     config.has_field_placeholders = 0;
+    config.num_phases = 0;
+    config.phase_index = 0;
+    config.phase_draining = 0;
+    config.phase_armed = 0;
+    config.phase_all_done = 0;
+    config.phase_cmd = NULL;
+    config.phase_cmd_len = 0;
+    config.key_tag = "";
+    atomic_store_explicit(&config.phase_reconnects, 0, memory_order_relaxed);
+    atomic_store_explicit(&config.phase_errors, 0, memory_order_relaxed);
     resetPlaceholders();
 
     i = parseOptions(argc, argv);
@@ -2376,9 +2709,46 @@ int main(int argc, char **argv) {
         }
     }
     /* Set default for requests if not specified */
-    if (config.requests < 0) config.requests = 100000;
+    if (config.num_phases > 0) {
+        if (config.num_threads) {
+            fprintf(stderr, "--data-size-phases requires --threads 0 (single event loop).\n");
+            exit(1);
+        }
+        if (config.keepalive == 0) {
+            fprintf(stderr, "--data-size-phases requires keepalive (do not pass -k 0).\n");
+            exit(1);
+        }
+        if (config.cluster_mode) {
+            fprintf(stderr, "--data-size-phases does not support --cluster.\n");
+            exit(1);
+        }
+        if (config.dataset_file) {
+            fprintf(stderr, "--data-size-phases cannot be combined with --dataset.\n");
+            exit(1);
+        }
+        if (config.idlemode || config.fuzz_mode || config.loop) {
+            fprintf(stderr, "--data-size-phases cannot be combined with -I, --fuzz, or -l.\n");
+            exit(1);
+        }
+        if (config.tests == NULL) {
+            config.tests = sdsnew(",set,");
+        } else if (strcmp(config.tests, ",set,") != 0) {
+            fprintf(stderr, "--data-size-phases only supports -t set.\n");
+            exit(1);
+        }
+        if (argc > 0) {
+            fprintf(stderr, "--data-size-phases does not support custom command sequences.\n");
+            exit(1);
+        }
+        config.requests = -1;
+        config.duration = -1;
+        config.warmup_duration = -1;
+    } else if (config.requests < 0) {
+        config.requests = 100000;
+    }
 
     tag = "";
+    config.key_tag = tag;
 
 #ifdef USE_OPENSSL
     if (config.tls) {
@@ -2551,6 +2921,7 @@ int main(int argc, char **argv) {
     if (argc > 0 && config.tests != NULL) {
         fprintf(stderr, "WARNING: Option -t is ignored.\n");
     }
+    config.key_tag = tag;
 
     if (config.idlemode) {
         printf("Creating %d idle connections and waiting forever (Ctrl+C when done)\n", config.numclients);
@@ -2567,7 +2938,7 @@ int main(int argc, char **argv) {
             aeMain(config.el);
         /* and will wait for every */
     }
-    if (config.csv) {
+    if (config.csv && config.num_phases == 0) {
         printf("\"test\",\"rps\",\"avg_latency_ms\",\"min_latency_ms\",\"p50_latency_ms\",\"p95_latency_ms\",\"p99_"
                "latency_ms\",\"max_latency_ms\"\n");
     }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1249,11 +1249,14 @@ static void resetPhaseRdmaClientStats(void) {
 #endif
 }
 
-static void collectPhaseRdmaClientStats(uint64_t *tx_bytes, uint64_t *tx_wait_count, uint64_t *tx_wait_ns, uint64_t *rx_reannounce) {
+static void collectPhaseRdmaClientStats(uint64_t *tx_bytes, uint64_t *tx_wait_count, uint64_t *tx_wait_ns,
+                                        uint64_t *rx_reannounce, uint64_t *tx_grow_request, uint32_t *tx_window_peak) {
     *tx_bytes = 0;
     *tx_wait_count = 0;
     *tx_wait_ns = 0;
     *rx_reannounce = 0;
+    *tx_grow_request = 0;
+    *tx_window_peak = 0;
 #ifdef USE_RDMA
     listIter li;
     listNode *ln;
@@ -1269,6 +1272,9 @@ static void collectPhaseRdmaClientStats(uint64_t *tx_bytes, uint64_t *tx_wait_co
         *tx_wait_count += stats.tx_wait_for_rx_count;
         *tx_wait_ns += stats.tx_wait_for_rx_ns;
         *rx_reannounce += stats.rx_window_reannounce_count;
+        *tx_grow_request += stats.tx_grow_request_count;
+        /* window size is a high-water mark per client: take the max, not the sum */
+        if (stats.tx_window_peak > *tx_window_peak) *tx_window_peak = stats.tx_window_peak;
     }
 #endif
 }
@@ -1313,10 +1319,12 @@ static void reportPhaseEnd(void) {
     int64_t p99 = config.latency_histogram ? hdr_value_at_percentile(config.latency_histogram, 99.0) : 0;
     int reconnects = atomic_load_explicit(&config.phase_reconnects, memory_order_relaxed);
     int errors = atomic_load_explicit(&config.phase_errors, memory_order_relaxed);
-    uint64_t tx_bytes, tx_wait_count, tx_wait_ns, rx_reannounce;
+    uint64_t tx_bytes, tx_wait_count, tx_wait_ns, rx_reannounce, tx_grow_request;
+    uint32_t tx_window_peak;
     double gib, reannounces_per_gib, stall_ratio;
 
-    collectPhaseRdmaClientStats(&tx_bytes, &tx_wait_count, &tx_wait_ns, &rx_reannounce);
+    collectPhaseRdmaClientStats(&tx_bytes, &tx_wait_count, &tx_wait_ns, &rx_reannounce, &tx_grow_request,
+                                &tx_window_peak);
     gib = tx_bytes / (double)(1ULL << 30);
     reannounces_per_gib = (gib > 0.0) ? (rx_reannounce / gib) : 0.0;
     stall_ratio = (measured_sec > 0.0 && config.numclients > 0)
@@ -1324,21 +1332,23 @@ static void reportPhaseEnd(void) {
                       : 0.0;
 
     if (config.csv) {
-        printf("%d,%d,%d,%.6f,%d,%.3f,%.6f,%.3f,%.3f,%.3f,%d,%d,%llu,%llu,%llu,%llu,%.6f,%.6f\n",
+        printf("%d,%d,%d,%.6f,%d,%.3f,%.6f,%.3f,%.3f,%.3f,%d,%d,%llu,%llu,%llu,%llu,%.6f,%.6f,%llu,%u\n",
                config.phase_index, value_size, config.phases[config.phase_index].duration_sec, measured_sec, requests,
                rps, payload_gbps, avg_us, (double)p50, (double)p99, reconnects, errors,
                (unsigned long long)tx_bytes, (unsigned long long)tx_wait_count, (unsigned long long)tx_wait_ns,
-               (unsigned long long)rx_reannounce, reannounces_per_gib, stall_ratio);
+               (unsigned long long)rx_reannounce, reannounces_per_gib, stall_ratio, (unsigned long long)tx_grow_request,
+               tx_window_peak);
         fflush(stdout);
     }
     fprintf(stderr,
             "PHASE_END index=%d value_size=%d measured_sec=%.6f requests=%d rps=%.3f payload_gbps=%.6f "
             "avg_latency_us=%.3f p50_latency_us=%.3f p99_latency_us=%.3f reconnects=%d errors=%d "
             "tx_bytes=%llu tx_wait_count=%llu tx_wait_ns=%llu rx_reannounce=%llu reannounces_per_gib=%.6f "
-            "stall_ratio=%.6f\n",
+            "stall_ratio=%.6f tx_grow_request=%llu tx_window_peak=%u\n",
             config.phase_index, value_size, measured_sec, requests, rps, payload_gbps, avg_us, (double)p50,
             (double)p99, reconnects, errors, (unsigned long long)tx_bytes, (unsigned long long)tx_wait_count,
-            (unsigned long long)tx_wait_ns, (unsigned long long)rx_reannounce, reannounces_per_gib, stall_ratio);
+            (unsigned long long)tx_wait_ns, (unsigned long long)rx_reannounce, reannounces_per_gib, stall_ratio,
+            (unsigned long long)tx_grow_request, tx_window_peak);
     fflush(stderr);
 }
 
@@ -1580,7 +1590,7 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
         if (config.csv) {
             printf("phase_index,value_size,duration,measured_sec,requests,rps,payload_gbps,avg_latency_us,"
                    "p50_latency_us,p99_latency_us,reconnects,errors,tx_bytes,tx_wait_count,tx_wait_ns,"
-                   "rx_reannounce,reannounces_per_gib,stall_ratio\n");
+                   "rx_reannounce,reannounces_per_gib,stall_ratio,tx_grow_request,tx_window_peak\n");
             fflush(stdout);
         }
     }

--- a/tests/rdma/run.py
+++ b/tests/rdma/run.py
@@ -189,6 +189,29 @@ def server_base_cmd(svrpath, tmpdir, ipaddr):
             "--rdma-port", str(RDMA_PORT), "--rdma-bind", ipaddr]
 
 
+def parse_info_rdma(text):
+    stats = {}
+    for line in text.splitlines():
+        if ":" not in line:
+            continue
+        key, val = line.split(":", 1)
+        if key.startswith("rx_"):
+            stats[key] = int(val)
+    return stats
+
+
+def fetch_info_rdma(clipath, ipaddr):
+    cmd = [clipath, "--rdma", "-h", ipaddr, "-p", str(RDMA_PORT), "INFO", "rdma"]
+    try:
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                timeout=10, text=True)
+    except subprocess.TimeoutExpired:
+        return None
+    if result.returncode:
+        return None
+    return parse_info_rdma(result.stdout)
+
+
 def test_rdma(ipaddr):
     valkeydir = os.path.dirname(os.path.abspath(__file__)) + "/../.."
     tmpdir = valkeydir + "/tests/rdma/tmp"
@@ -196,7 +219,8 @@ def test_rdma(ipaddr):
 
     svrpath = valkeydir + "/src/valkey-server"
     benchpath = valkeydir + "/src/valkey-benchmark"
-    clipath = valkeydir + "/tests/rdma/rdma-test"
+    clipath = valkeydir + "/src/valkey-cli"
+    rdma_test = valkeydir + "/tests/rdma/rdma-test"
     svr = None
     try:
         # Phase 1: basic RDMA CM/verbs smoke (no IO threads), same as upstream.
@@ -205,7 +229,7 @@ def test_rdma(ipaddr):
         if svr is None:
             return 1
 
-        clicmd = [clipath, "--thread", "4", "-h", ipaddr, "-p", str(RDMA_PORT)]
+        clicmd = [rdma_test, "--thread", "4", "-h", ipaddr, "-p", str(RDMA_PORT)]
         retval = run_cmd("rdma-test", clicmd, 60)
         if retval:
             print_server_log(svr_log, "rdma-test")
@@ -229,6 +253,49 @@ def test_rdma(ipaddr):
         if retval:
             print_server_log(svr_log, "valkey-benchmark")
             return retval
+        stop_server(svr)
+        svr = None
+
+        # Phase 3: dynamic RX window growth (new client + dynamic server).
+        svr_log = tmpdir + "/server-dynamic-grow.log"
+        svrcmd = server_base_cmd(svrpath, tmpdir, ipaddr) + [
+            "--rdma-rx-size", "65536", "--rdma-rx-max-size", "1048576"]
+        svr = start_server(svrcmd, svr_log)
+        if svr is None:
+            return 1
+
+        info_before = fetch_info_rdma(clipath, ipaddr)
+        if info_before is None:
+            print("Valkey Over RDMA INFO rdma before dynamic grow benchmark [FAILED]")
+            return 1
+
+        benchcmd = [benchpath, "-h", ipaddr, "-p", str(RDMA_PORT), "--rdma",
+                    "-d", "4096", "-c", "16", "-P", "16", "-n", "200000", "-t", "set,get"]
+        print("Valkey Over RDMA valkey-benchmark dynamic grow " + " ".join(benchcmd[1:]))
+        retval = run_cmd("valkey-benchmark dynamic grow", benchcmd, BENCH_TIMEOUT)
+        if retval:
+            print_server_log(svr_log, "valkey-benchmark dynamic grow")
+            return retval
+
+        info_after = fetch_info_rdma(clipath, ipaddr)
+        if info_after is None:
+            print("Valkey Over RDMA INFO rdma after dynamic grow benchmark [FAILED]")
+            return 1
+
+        grow_count = info_after.get("rx_window_grow_count", 0)
+        if grow_count < 16:
+            print("Valkey Over RDMA rx_window_grow_count=%d expected >= 16 [FAILED]" % grow_count)
+            return 1
+
+        mr_before = info_before.get("rx_mr_register_count", -1)
+        mr_after = info_after.get("rx_mr_register_count", -1)
+        if mr_before != mr_after or mr_before <= 0:
+            print("Valkey Over RDMA rx_mr_register_count changed (%d -> %d) [FAILED]"
+                  % (mr_before, mr_after))
+            return 1
+
+        print("Valkey Over RDMA dynamic grow rx_window_grow_count=%d "
+              "rx_mr_register_count=%d [OK]" % (grow_count, mr_after))
         return 0
     finally:
         stop_server(svr)

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1360,6 +1360,7 @@ start_server {tags {"introspection"}} {
             dual-channel-replication-enabled
             rdma-completion-vector
             rdma-rx-size
+            rdma-rx-max-size
             rdma-bind
             rdma-port
             forkless-infrastructure-enabled

--- a/utils/rdma-rx-phase-benchmark.sh
+++ b/utils/rdma-rx-phase-benchmark.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+#
+# utils/rdma-rx-phase-benchmark.sh
+#
+# Run a persistent-connection, phase-changing SET workload against Valkey/RDMA.
+# One valkey-benchmark process and the same RDMA QPs stay alive across phases.
+#
+# Changing rdma-rx-size requires a new server (MR is registered at connect).
+# --static-bounds repeats the same KV sequence at rx=1M, 4M, 16M (independent
+# server+benchmark per cell) so a later dynamic-resize branch can compare.
+#
+#   --transport rxe        software RXE (creates dummy/rxe if needed)
+#   --transport physical   existing NIC; never create/delete RDMA devices
+#
+# Default phases (growth → shrink):
+#   4KiB:20s, 64KiB:20s, 1MiB:30s, 4MiB:30s, 64KiB:30s, 4KiB:60s
+#
+# Results: <repo>/rdma-phase-results/<timestamp>/
+#
+set -Eeuo pipefail
+export LC_ALL=C
+export VALKEY_RDMA_BENCH_STATS=1
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+RDMA_TRANSPORT="${RDMA_TRANSPORT:-rxe}"
+RDMA_NETDEV="${RDMA_NETDEV:-dummy0}"
+RDMA_DEVICE="${RDMA_DEVICE:-rxe_dummy}"
+RDMA_BIND_IP="${RDMA_BIND_IP:-${RDMA_IP:-10.200.0.1}}"
+RDMA_SERVER_HOST="${RDMA_SERVER_HOST:-$RDMA_BIND_IP}"
+RDMA_PREFIX="${RDMA_PREFIX:-24}"
+RDMA_PORT="${RDMA_PORT:-16379}"
+RDMA_SKIP_MEMLOCK="${RDMA_SKIP_MEMLOCK:-0}"
+KEEP_RXE=0
+CREATED_NETDEV=0
+CREATED_RXE=0
+ROLE="all"
+RX_SIZE="${RX_SIZE:-1048576}"
+RX_SIZES=""
+REPEATS=1
+CLIENTS=4
+PIPELINE=16
+THREADS=0
+PHASES="4096:20,65536:20,1048576:30,4194304:30,65536:30,4096:60"
+SMOKE=0
+SERVER_PID=""
+SERVER_LOG=""
+
+PHASES_CSV_HEADER='commit,run_id,rx_size,repeat,phase_index,value_size,duration,clients,pipeline,requests,rps,payload_gbps,avg_latency_us,p50_latency_us,p99_latency_us,reconnects,errors,tx_bytes,tx_wait_count,tx_wait_ns,rx_reannounce,reannounces_per_gib,stall_ratio'
+
+log()  { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+warn() { log "WARNING: $*"; }
+die()  { log "ERROR: $*"; exit 1; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--transport rxe|physical] [--smoke] [options]
+
+  --transport rxe|physical   default: rxe (or RDMA_TRANSPORT)
+  --bind <ip>                server --rdma-bind (physical / dual-host)
+  --server-host <ip>         client -h (defaults to bind ip)
+  --port <port>              RDMA port (default 16379)
+  --rx-size <bytes>          server rdma-rx-size (default 1048576)
+  --rx-sizes <list>          comma list (bytes or 1M/4M/16M); restart server per size
+  --repeats <n>              independent runs per rx-size (default 1)
+  --static-bounds            rx=1M,4M,16M × 3 repeats, same KV sequence
+  --clients <n>              default 4
+  --pipeline <n>             default 16
+  --phases <spec>            size:seconds,... (default 6-phase growth/shrink)
+  --smoke                    32:2,64:2,32:2 for a quick harness check
+  --role all|client          all starts a local server; client uses --server-host
+  --skip-memlock             do not raise memlock
+  --keep-rxe                 do not delete dummy/RXE created by this script
+
+Physical mode never creates, deletes, or modifies RDMA/network devices.
+Changing RX size always starts a new server; phases within one run keep the same QPs.
+EOF
+    exit "${1:-0}"
+}
+
+parse_bytes() {
+    local s="$1"
+    case "$s" in
+        *[Kk]) echo $(( ${s%[Kk]} * 1024 )) ;;
+        *[Mm]) echo $(( ${s%[Mm]} * 1048576 )) ;;
+        *) echo "$s" ;;
+    esac
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --transport)
+                [[ $# -ge 2 ]] || die "--transport requires rxe|physical"
+                RDMA_TRANSPORT="$2"; shift 2 ;;
+            --bind) RDMA_BIND_IP="$2"; RDMA_SERVER_HOST="${RDMA_SERVER_HOST:-$2}"; shift 2 ;;
+            --server-host) RDMA_SERVER_HOST="$2"; shift 2 ;;
+            --port) RDMA_PORT="$2"; shift 2 ;;
+            --rx-size) RX_SIZE="$(parse_bytes "$2")"; shift 2 ;;
+            --rx-sizes) RX_SIZES="$2"; shift 2 ;;
+            --repeats) REPEATS="$2"; shift 2 ;;
+            --static-bounds)
+                RX_SIZES="1M,4M,16M"
+                REPEATS=3
+                KEEP_RXE=1
+                shift ;;
+            --clients) CLIENTS="$2"; shift 2 ;;
+            --pipeline) PIPELINE="$2"; shift 2 ;;
+            --phases) PHASES="$2"; shift 2 ;;
+            --smoke) SMOKE=1; shift ;;
+            --role) ROLE="$2"; shift 2 ;;
+            --skip-memlock) RDMA_SKIP_MEMLOCK=1; shift ;;
+            --keep-rxe) KEEP_RXE=1; shift ;;
+            -h|--help) usage 0 ;;
+            *) die "unknown argument: $1" ;;
+        esac
+    done
+    [[ "$RDMA_TRANSPORT" == "rxe" || "$RDMA_TRANSPORT" == "physical" ]] \
+        || die "--transport must be rxe or physical"
+    [[ "$ROLE" == "all" || "$ROLE" == "client" ]] || die "--role must be all or client"
+    [[ "$REPEATS" =~ ^[1-9][0-9]*$ ]] || die "--repeats must be a positive integer"
+    if (( SMOKE )); then
+        PHASES="32:2,64:2,32:2"
+        CLIENTS=2
+        PIPELINE=2
+    fi
+}
+
+rxe_link_exists() {
+    rdma link show 2>/dev/null | grep -q "^[[:space:]]*link $RDMA_DEVICE/"
+}
+
+setup_memlock() {
+    [[ $EUID -ne 0 ]] || die "run as a normal user; sudo only for memlock/RXE"
+    if [[ "$RDMA_SKIP_MEMLOCK" == "1" ]]; then
+        warn "RDMA_SKIP_MEMLOCK=1: not raising memlock"
+        return 0
+    fi
+    sudo -v || die "sudo -v failed"
+    sudo prlimit --memlock=unlimited --pid "$$" || die "prlimit --memlock failed"
+    [[ "$(ulimit -l)" == "unlimited" ]] || die "memlock is not unlimited"
+    log "memlock: unlimited (PID $$, inherited by children)"
+}
+
+setup_transport() {
+    if [[ "$RDMA_TRANSPORT" == "physical" ]]; then
+        log "transport=physical: skipping dummy/RXE create/delete"
+        log "  bind=$RDMA_BIND_IP host=$RDMA_SERVER_HOST port=$RDMA_PORT"
+        ibv_devices 2>/dev/null | head -5 || warn "ibv_devices returned nothing"
+        return 0
+    fi
+    log "transport=rxe: dummy netdev + rdma_rxe"
+    sudo modprobe dummy
+    sudo modprobe rdma_rxe
+    if ! ip link show dev "$RDMA_NETDEV" >/dev/null 2>&1; then
+        sudo ip link add "$RDMA_NETDEV" type dummy
+        CREATED_NETDEV=1
+    fi
+    if ! ip -4 -o addr show dev "$RDMA_NETDEV" | awk -v ip="$RDMA_BIND_IP" '{split($4,a,"/"); if (a[1]==ip) found=1} END {exit !found}'; then
+        sudo ip addr add "$RDMA_BIND_IP/$RDMA_PREFIX" dev "$RDMA_NETDEV"
+    fi
+    sudo ip link set "$RDMA_NETDEV" up
+    if ! rxe_link_exists; then
+        sudo rdma link add "$RDMA_DEVICE" type rxe netdev "$RDMA_NETDEV"
+        CREATED_RXE=1
+        local i
+        for i in $(seq 1 50); do
+            rxe_link_exists && break
+            sleep 0.1
+        done
+    fi
+    rxe_link_exists || die "RXE link $RDMA_DEVICE did not come up"
+    log "RXE ready: $RDMA_DEVICE on $RDMA_NETDEV ($RDMA_BIND_IP)"
+}
+
+stop_server() {
+    if [[ -n "${SERVER_PID:-}" ]]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        SERVER_PID=""
+        # RXE/CM can still hold large MRs after wait(2) returns. Immediate
+        # re-listen + 4x16MiB reg_mr has hung the next client's first write
+        # (ae blocked in valkeyRdmaWrite, no PHASE_END until timeout).
+        sleep "${CELL_SETTLE_SEC:-3}"
+    fi
+}
+
+cleanup() {
+    stop_server
+    if [[ "$RDMA_TRANSPORT" == "physical" || "$KEEP_RXE" == "1" ]]; then
+        return 0
+    fi
+    if (( CREATED_RXE )) && rxe_link_exists; then
+        sudo -n rdma link delete "$RDMA_DEVICE" 2>/dev/null || true
+    fi
+    if (( CREATED_NETDEV )) && ip link show dev "$RDMA_NETDEV" >/dev/null 2>&1; then
+        sudo -n ip link delete "$RDMA_NETDEV" 2>/dev/null || true
+    fi
+}
+
+start_server() {
+    local log_name="${1:-valkey-server.log}"
+    mkdir -p "$RESULTS_DIR/server-logs"
+    SERVER_LOG="$RESULTS_DIR/server-logs/$log_name"
+    VALKEY_RDMA_BENCH_STATS=1 ./src/valkey-server "$REPO_ROOT/valkey.conf" \
+        --port 0 --protected-mode no --save "" --appendonly no --daemonize no \
+        --rdma-bind "$RDMA_BIND_IP" --rdma-port "$RDMA_PORT" --rdma-rx-size "$RX_SIZE" \
+        >"$SERVER_LOG" 2>&1 &
+    SERVER_PID=$!
+    local i
+    for i in $(seq 1 50); do
+        if timeout 5 ./src/valkey-cli --rdma -h "$RDMA_BIND_IP" -p "$RDMA_PORT" PING 2>/dev/null | grep -q PONG; then
+            log "server up pid=$SERVER_PID rdma=$RDMA_BIND_IP:$RDMA_PORT rx-size=$RX_SIZE"
+            return 0
+        fi
+        kill -0 "$SERVER_PID" 2>/dev/null || die "server died; see $SERVER_LOG"
+        sleep 0.2
+    done
+    die "server did not become ready; see $SERVER_LOG"
+}
+
+append_phases_csv() {
+    local err="$1" out="$2" rx="$3" rep="$4"
+    awk -v commit="$GIT_COMMIT" -v run="$RUN_ID" -v rx="$rx" -v rep="$rep" \
+        -v c="$CLIENTS" -v p="$PIPELINE" '
+        /^PHASE_END / {
+            split($0, a, " ")
+            delete kv
+            for (i = 2; i <= length(a); i++) {
+                n = index(a[i], "=")
+                if (n > 0) kv[substr(a[i], 1, n-1)] = substr(a[i], n+1)
+            }
+            printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
+                commit, run, rx, rep, kv["index"], kv["value_size"], kv["measured_sec"],
+                c, p, kv["requests"], kv["rps"], kv["payload_gbps"],
+                kv["avg_latency_us"], kv["p50_latency_us"], kv["p99_latency_us"],
+                kv["reconnects"], kv["errors"],
+                kv["tx_bytes"], kv["tx_wait_count"], kv["tx_wait_ns"], kv["rx_reannounce"],
+                kv["reannounces_per_gib"], kv["stall_ratio"]
+        }
+    ' "$err" >> "$out"
+}
+
+check_run_ok() {
+    local err="$1" slog="$2" rc="$3"
+    if grep -qiE 'error writing|all clients disconnected|unexpected error|RDMA: FATAL|ASSERTION FAILED' "$err" ${slog:+"$slog"} 2>/dev/null; then
+        die "errors in benchmark/server logs; see $err and $slog"
+    fi
+    if grep -q 'reconnects=[1-9]' "$err"; then
+        die "phase reconnects reported; connections did not stay up (see $err)"
+    fi
+    if ! grep -q 'PHASE_WORKLOAD done' "$err"; then
+        die "benchmark did not complete all phases (rc=$rc); see $err"
+    fi
+    local nbegin nend
+    nbegin="$(grep -c 'PHASE_BEGIN ' "$err" || true)"
+    nend="$(grep -c 'PHASE_END ' "$err" || true)"
+    [[ "$nbegin" == "$nend" && "$nend" -gt 0 ]] || die "phase begin/end mismatch ($nbegin vs $nend)"
+    [[ $rc -eq 0 ]] || die "valkey-benchmark exit $rc"
+}
+
+run_one_benchmark() {
+    local csv="$1" err="$2"
+    local timeout_sec=400
+    (( SMOKE )) && timeout_sec=60
+    log "running phase workload: $PHASES (rx=$RX_SIZE c=$CLIENTS P=$PIPELINE)"
+    set +e
+    VALKEY_RDMA_BENCH_STATS=1 timeout -k 10 "$timeout_sec" ./src/valkey-benchmark \
+        --rdma \
+        -h "$RDMA_SERVER_HOST" \
+        -p "$RDMA_PORT" \
+        -t set \
+        -c "$CLIENTS" \
+        -P "$PIPELINE" \
+        --threads "$THREADS" \
+        --csv \
+        --data-size-phases "$PHASES" \
+        >"$csv" 2>"$err"
+    local rc=$?
+    set -e
+    return "$rc"
+}
+
+write_summary() {
+    local all="$1" out="$2"
+    awk -F, '
+        NR == 1 { next }
+        {
+            k = $3 "," $5 "," $6
+            n[k]++
+            gbps[k] += $12
+            stall[k] += $23
+            reann[k] += $22
+            rps[k] += $11
+            p50[k] += $14
+        }
+        END {
+            print "rx_size,phase_index,value_size,n,mean_rps,mean_payload_gbps,mean_p50_us,mean_reannounces_per_gib,mean_stall_ratio"
+            for (k in n) {
+                split(k, a, ",")
+                printf "%s,%s,%s,%d,%.3f,%.6f,%.3f,%.6f,%.6f\n",
+                    a[1], a[2], a[3], n[k],
+                    rps[k] / n[k], gbps[k] / n[k], p50[k] / n[k],
+                    reann[k] / n[k], stall[k] / n[k]
+            }
+        }
+    ' "$all" | (read -r hdr; echo "$hdr"; sort -t, -k1,1n -k2,2n) > "$out"
+}
+
+main() {
+    parse_args "$@"
+    trap cleanup EXIT
+
+    [[ -x ./src/valkey-benchmark && -x ./src/valkey-server ]] \
+        || die "build first: make -j\$(nproc) BUILD_RDMA=yes USE_FAST_FLOAT=yes"
+
+    local -a sizes=()
+    if [[ -n "$RX_SIZES" ]]; then
+        local tok
+        IFS=',' read -ra tok <<< "$RX_SIZES"
+        local t
+        for t in "${tok[@]}"; do
+            sizes+=("$(parse_bytes "$t")")
+        done
+    else
+        sizes+=("$RX_SIZE")
+    fi
+
+    setup_memlock
+    if [[ "$ROLE" == "all" ]]; then
+        setup_transport
+    fi
+
+    local ts
+    ts="$(date +%Y%m%d-%H%M%S)"
+    RUN_ID="$ts"
+    RESULTS_DIR="$REPO_ROOT/rdma-phase-results/$ts"
+    mkdir -p "$RESULTS_DIR/raw"
+    GIT_COMMIT="$(git rev-parse HEAD)"
+    git rev-parse HEAD > "$RESULTS_DIR/git-commit.txt"
+    printf '%s\n' "$0 $*" > "$RESULTS_DIR/cmdline.txt"
+    cat > "$RESULTS_DIR/metadata.json" <<EOF
+{"commit":"$GIT_COMMIT","transport":"$RDMA_TRANSPORT","bind":"$RDMA_BIND_IP","host":"$RDMA_SERVER_HOST","port":$RDMA_PORT,"rx_sizes":"$RX_SIZES","rx_size":$RX_SIZE,"repeats":$REPEATS,"clients":$CLIENTS,"pipeline":$PIPELINE,"threads":$THREADS,"phases":"$PHASES","role":"$ROLE"}
+EOF
+
+    printf '%s\n' "$PHASES_CSV_HEADER" > "$RESULTS_DIR/phases.csv"
+
+    local rx rep cell=0 total=$(( ${#sizes[@]} * REPEATS ))
+    for rx in "${sizes[@]}"; do
+        RX_SIZE="$rx"
+        for rep in $(seq 1 "$REPEATS"); do
+            cell=$((cell + 1))
+            log "cell $cell/$total rx=$RX_SIZE repeat=$rep/$REPEATS"
+            if [[ "$ROLE" == "all" ]]; then
+                stop_server
+                start_server "server-rx${RX_SIZE}-r${rep}.log"
+            fi
+            local csv="$RESULTS_DIR/raw/rx${RX_SIZE}-r${rep}.csv"
+            local err="$RESULTS_DIR/raw/rx${RX_SIZE}-r${rep}.err"
+            local rc=0
+            run_one_benchmark "$csv" "$err" || rc=$?
+            check_run_ok "$err" "${SERVER_LOG:-}" "$rc"
+            append_phases_csv "$err" "$RESULTS_DIR/phases.csv" "$RX_SIZE" "$rep"
+        done
+    done
+
+    if [[ "$ROLE" == "all" ]]; then
+        stop_server
+    fi
+
+    write_summary "$RESULTS_DIR/phases.csv" "$RESULTS_DIR/summary.csv"
+    cp "$RESULTS_DIR/phases.csv" "$RESULTS_DIR/benchmark.stdout.csv" 2>/dev/null || true
+
+    log "results: $RESULTS_DIR"
+    log "phases.csv rows: $(( $(wc -l < "$RESULTS_DIR/phases.csv") - 1 ))"
+    column -s, -t "$RESULTS_DIR/summary.csv" 2>/dev/null || cat "$RESULTS_DIR/summary.csv"
+    log "ALL RUNS PASSED (persistent connections within each cell; new server per rx-size/repeat)"
+}
+
+main "$@"

--- a/utils/rdma-rx-phase-benchmark.sh
+++ b/utils/rdma-rx-phase-benchmark.sh
@@ -37,6 +37,7 @@ CREATED_NETDEV=0
 CREATED_RXE=0
 ROLE="all"
 RX_SIZE="${RX_SIZE:-1048576}"
+RX_MAX_SIZE="${RX_MAX_SIZE:-0}"
 RX_SIZES=""
 REPEATS=1
 CLIENTS=4
@@ -47,7 +48,7 @@ SMOKE=0
 SERVER_PID=""
 SERVER_LOG=""
 
-PHASES_CSV_HEADER='commit,run_id,rx_size,repeat,phase_index,value_size,duration,clients,pipeline,requests,rps,payload_gbps,avg_latency_us,p50_latency_us,p99_latency_us,reconnects,errors,tx_bytes,tx_wait_count,tx_wait_ns,rx_reannounce,reannounces_per_gib,stall_ratio'
+PHASES_CSV_HEADER='commit,run_id,rx_size,rx_max_size,repeat,phase_index,value_size,duration,clients,pipeline,requests,rps,payload_gbps,avg_latency_us,p50_latency_us,p99_latency_us,reconnects,errors,tx_bytes,tx_wait_count,tx_wait_ns,rx_reannounce,reannounces_per_gib,stall_ratio,tx_grow_request,tx_window_peak'
 
 log()  { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
 warn() { log "WARNING: $*"; }
@@ -62,6 +63,7 @@ Usage: $0 [--transport rxe|physical] [--smoke] [options]
   --server-host <ip>         client -h (defaults to bind ip)
   --port <port>              RDMA port (default 16379)
   --rx-size <bytes>          server rdma-rx-size (default 1048576)
+  --rx-max-size <bytes>      server rdma-rx-max-size (default 0 = static window)
   --rx-sizes <list>          comma list (bytes or 1M/4M/16M); restart server per size
   --repeats <n>              independent runs per rx-size (default 1)
   --static-bounds            rx=1M,4M,16M × 3 repeats, same KV sequence
@@ -98,6 +100,7 @@ parse_args() {
             --server-host) RDMA_SERVER_HOST="$2"; shift 2 ;;
             --port) RDMA_PORT="$2"; shift 2 ;;
             --rx-size) RX_SIZE="$(parse_bytes "$2")"; shift 2 ;;
+            --rx-max-size) RX_MAX_SIZE="$(parse_bytes "$2")"; shift 2 ;;
             --rx-sizes) RX_SIZES="$2"; shift 2 ;;
             --repeats) REPEATS="$2"; shift 2 ;;
             --static-bounds)
@@ -206,12 +209,13 @@ start_server() {
     VALKEY_RDMA_BENCH_STATS=1 ./src/valkey-server "$REPO_ROOT/valkey.conf" \
         --port 0 --protected-mode no --save "" --appendonly no --daemonize no \
         --rdma-bind "$RDMA_BIND_IP" --rdma-port "$RDMA_PORT" --rdma-rx-size "$RX_SIZE" \
+        --rdma-rx-max-size "$RX_MAX_SIZE" \
         >"$SERVER_LOG" 2>&1 &
     SERVER_PID=$!
     local i
     for i in $(seq 1 50); do
         if timeout 5 ./src/valkey-cli --rdma -h "$RDMA_BIND_IP" -p "$RDMA_PORT" PING 2>/dev/null | grep -q PONG; then
-            log "server up pid=$SERVER_PID rdma=$RDMA_BIND_IP:$RDMA_PORT rx-size=$RX_SIZE"
+            log "server up pid=$SERVER_PID rdma=$RDMA_BIND_IP:$RDMA_PORT rx-size=$RX_SIZE rx-max-size=$RX_MAX_SIZE"
             return 0
         fi
         kill -0 "$SERVER_PID" 2>/dev/null || die "server died; see $SERVER_LOG"
@@ -221,8 +225,8 @@ start_server() {
 }
 
 append_phases_csv() {
-    local err="$1" out="$2" rx="$3" rep="$4"
-    awk -v commit="$GIT_COMMIT" -v run="$RUN_ID" -v rx="$rx" -v rep="$rep" \
+    local err="$1" out="$2" rx="$3" rxmax="$4" rep="$5"
+    awk -v commit="$GIT_COMMIT" -v run="$RUN_ID" -v rx="$rx" -v rxmax="$rxmax" -v rep="$rep" \
         -v c="$CLIENTS" -v p="$PIPELINE" '
         /^PHASE_END / {
             split($0, a, " ")
@@ -231,15 +235,21 @@ append_phases_csv() {
                 n = index(a[i], "=")
                 if (n > 0) kv[substr(a[i], 1, n-1)] = substr(a[i], n+1)
             }
-            printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
-                commit, run, rx, rep, kv["index"], kv["value_size"], kv["measured_sec"],
+            printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
+                commit, run, rx, rxmax, rep, kv["index"], kv["value_size"], kv["measured_sec"],
                 c, p, kv["requests"], kv["rps"], kv["payload_gbps"],
                 kv["avg_latency_us"], kv["p50_latency_us"], kv["p99_latency_us"],
                 kv["reconnects"], kv["errors"],
                 kv["tx_bytes"], kv["tx_wait_count"], kv["tx_wait_ns"], kv["rx_reannounce"],
-                kv["reannounces_per_gib"], kv["stall_ratio"]
+                kv["reannounces_per_gib"], kv["stall_ratio"],
+                kv["tx_grow_request"], kv["tx_window_peak"]
         }
     ' "$err" >> "$out"
+}
+
+capture_rdma_info() {
+    local out="$1"
+    ./src/valkey-cli --rdma -h "$RDMA_BIND_IP" -p "$RDMA_PORT" INFO rdma >"$out" 2>/dev/null || true
 }
 
 check_run_ok() {
@@ -287,25 +297,25 @@ write_summary() {
     awk -F, '
         NR == 1 { next }
         {
-            k = $3 "," $5 "," $6
+            k = $3 "," $4 "," $6 "," $7
             n[k]++
-            gbps[k] += $12
-            stall[k] += $23
-            reann[k] += $22
-            rps[k] += $11
-            p50[k] += $14
+            gbps[k] += $13
+            stall[k] += $24
+            reann[k] += $23
+            rps[k] += $12
+            p50[k] += $15
         }
         END {
-            print "rx_size,phase_index,value_size,n,mean_rps,mean_payload_gbps,mean_p50_us,mean_reannounces_per_gib,mean_stall_ratio"
+            print "rx_size,rx_max_size,phase_index,value_size,n,mean_rps,mean_payload_gbps,mean_p50_us,mean_reannounces_per_gib,mean_stall_ratio"
             for (k in n) {
                 split(k, a, ",")
-                printf "%s,%s,%s,%d,%.3f,%.6f,%.3f,%.6f,%.6f\n",
-                    a[1], a[2], a[3], n[k],
+                printf "%s,%s,%s,%s,%d,%.3f,%.6f,%.3f,%.6f,%.6f\n",
+                    a[1], a[2], a[3], a[4], n[k],
                     rps[k] / n[k], gbps[k] / n[k], p50[k] / n[k],
                     reann[k] / n[k], stall[k] / n[k]
             }
         }
-    ' "$all" | (read -r hdr; echo "$hdr"; sort -t, -k1,1n -k2,2n) > "$out"
+    ' "$all" | (read -r hdr; echo "$hdr"; sort -t, -k1,1n -k2,2n -k3,3n) > "$out"
 }
 
 main() {
@@ -341,7 +351,7 @@ main() {
     git rev-parse HEAD > "$RESULTS_DIR/git-commit.txt"
     printf '%s\n' "$0 $*" > "$RESULTS_DIR/cmdline.txt"
     cat > "$RESULTS_DIR/metadata.json" <<EOF
-{"commit":"$GIT_COMMIT","transport":"$RDMA_TRANSPORT","bind":"$RDMA_BIND_IP","host":"$RDMA_SERVER_HOST","port":$RDMA_PORT,"rx_sizes":"$RX_SIZES","rx_size":$RX_SIZE,"repeats":$REPEATS,"clients":$CLIENTS,"pipeline":$PIPELINE,"threads":$THREADS,"phases":"$PHASES","role":"$ROLE"}
+{"commit":"$GIT_COMMIT","transport":"$RDMA_TRANSPORT","bind":"$RDMA_BIND_IP","host":"$RDMA_SERVER_HOST","port":$RDMA_PORT,"rx_sizes":"$RX_SIZES","rx_size":$RX_SIZE,"rx_max_size":$RX_MAX_SIZE,"repeats":$REPEATS,"clients":$CLIENTS,"pipeline":$PIPELINE,"threads":$THREADS,"phases":"$PHASES","role":"$ROLE"}
 EOF
 
     printf '%s\n' "$PHASES_CSV_HEADER" > "$RESULTS_DIR/phases.csv"
@@ -351,7 +361,7 @@ EOF
         RX_SIZE="$rx"
         for rep in $(seq 1 "$REPEATS"); do
             cell=$((cell + 1))
-            log "cell $cell/$total rx=$RX_SIZE repeat=$rep/$REPEATS"
+            log "cell $cell/$total rx=$RX_SIZE rx-max=$RX_MAX_SIZE repeat=$rep/$REPEATS"
             if [[ "$ROLE" == "all" ]]; then
                 stop_server
                 start_server "server-rx${RX_SIZE}-r${rep}.log"
@@ -361,7 +371,10 @@ EOF
             local rc=0
             run_one_benchmark "$csv" "$err" || rc=$?
             check_run_ok "$err" "${SERVER_LOG:-}" "$rc"
-            append_phases_csv "$err" "$RESULTS_DIR/phases.csv" "$RX_SIZE" "$rep"
+            append_phases_csv "$err" "$RESULTS_DIR/phases.csv" "$RX_SIZE" "$RX_MAX_SIZE" "$rep"
+            if [[ "$ROLE" == "all" ]]; then
+                capture_rdma_info "$RESULTS_DIR/raw/rx${RX_SIZE}-max${RX_MAX_SIZE}-r${rep}.info-rdma"
+            fi
         done
     done
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -359,6 +359,17 @@ tcp-keepalive 300
 #
 # rdma-rx-size 1048576
 
+# The RDMA receive memory region is registered once with rdma-rx-max-size capacity
+# at connection setup, while only rdma-rx-size is announced to the peer as the
+# initial receive window. When a client signals that it is blocked on a full
+# window with more data to send, the server may grow the announced window in
+# doubling steps up to this capacity, without re-registering the memory region.
+# 0 (the default) disables growth: the window stays at rdma-rx-size, which is
+# fully backward compatible. Must be 0 or >= rdma-rx-size. Note that every
+# connection pins this much memory on both ends, so mind the memlock limit.
+#
+# rdma-rx-max-size 16777216
+
 # The RDMA completion queue will use the completion vector to signal completion events
 # via hardware interrupts. A large number of hardware interrupts can affect CPU performance.
 # It is possible to tune the performance using rdma-completion-vector.


### PR DESCRIPTION
## Summary

This is an **experimental RFC**, not a merge candidate.

A filled RDMA receive window currently forces `RegisterXferMemory` on the
same QP. For bulk SET traffic, re-announce rate is essentially
`1GiB / rdma-rx-size`, and the sender stalls until the new window is
posted. Raising a *static* window (e.g. 1MiB → 16MiB) helps medium values
a lot, but large values still spend most of their time waiting on the
next window rather than on the extra credit.

The plan is to grow the *logical* receive window on a live connection,
driven by sender pressure (window full **and** more data pending), without
disconnecting and without calling `ibv_reg_mr()` again.

This PR contains the measurement harness plus **v1 grow-only**. Shrink,
MR pooling, and rendezvous are explicitly out of scope until v1 numbers
on a physical NIC justify them.

## Problem

Valkey Over RDMA's data path is:

1. Server announces `{addr, length, rkey}` with `RegisterXferMemory`.
2. Client `RDMA_WRITE_WITH_IMM` into that region.
3. When the application has consumed `length` bytes, the server announces
   again (same QP, offset reset to 0).

`length` is fixed at `rdma-rx-size` (default 1MiB). That size is also the
`ibv_reg_mr` extent, so changing it today means a new connection.

Early RXE measurements with a persistent-connection, phase-changing SET
workload (4KiB → 64KiB → 1MiB → 4MiB → 64KiB → 4KiB):

- `reannounces_per_gib` tracks `1GiB / rx_size` (≈1024 at 1MiB, ≈64 at 16MiB).
- Static 16MiB vs static 1MiB helped 64KiB values substantially; 4MiB
  values moved much less, because the stall is dominated by waiting for
  the next window, not by the advertised size itself.

Growth therefore has to be **pressure-driven**, not keyed off KV size or
re-announce count.

## Plan

| Stage | Goal | Status in this PR |
| --- | --- | --- |
| 0 | Instrument both ends; keep one `valkey-benchmark` process and the same QPs across KV-size phases | done |
| **v1** | Grow-only logical window on an MR registered once at capacity | **this PR** |
| v2 | Decide shrink / idle decay from the v1 A/B (growth→shrink phases already in the harness) | not started |
| later | Alternate designs only if v1 is wrong: extra MR, re-reg, rendezvous | not started |

v1 constraints (deliberate):

- One MR per connection, registered at `rdma-rx-max-size` during accept.
- `ctx->rx.length` is the announced credit; it starts at `rdma-rx-size`
  and doubles under pressure up to capacity.
- Same `addr` / `rkey`; `RegisterXferMemory` still runs at every window
  wrap (offset reset), but `length` may be larger.
- Default `rdma-rx-max-size 0` ⇒ capacity == `rdma-rx-size`, old
  static behavior, old clients unaffected.
- No shrink, no second MR, no `ibv_reg_mr` on the grow path.

## Protocol (v1)

- Feature bit `VALKEY_RDMA_FEATURE_RX_GROW_WINDOW` via existing
  `GetServerFeature`. Capacity is a BE u32 in `feature.rsvd[0..3]`.
- Client sets IMM bit 31 (`VALKEY_RDMA_IMM_GROW_REQUEST`) only if the
  feature was negotiated **and** this WRITE fills the announced window
  **and** `obuf` still has more data. An old server never sees the bit.
- Server grows only at the window-exhaustion boundary (every posted byte
  has been consumed), after `RDMA_RX_GROW_THRESHOLD` consecutive
  pressured windows, with `RDMA_RX_GROW_COOLDOWN_WINDOWS` skipped after
  a growth.
- Client staging buffer is grow-only and pre-sized at the first
  `RegisterXferMemory` (not in the feature reply, which can arrive while
  a WRITE CQ poll is in progress).

HCA checks `[remote_addr, remote_addr+len) ⊆ MR`. The logical window is
software credit; the hardware bound is the MR. That is why capacity is
pinned up front, and why 16MiB mode needs `RLIMIT_MEMLOCK` large enough
to pin the full region at connect time.

## How to compare

Same initial window; only `rdma-rx-max-size` changes. Do **not** compare
against a static `--rx-size 16M` (that is a different experiment: new
connection, new MR).

```bash
./utils/rdma-rx-phase-benchmark.sh --rx-size 1048576 --rx-max-size 0
./utils/rdma-rx-phase-benchmark.sh --rx-size 1048576 --rx-max-size 16777216
```