### PR TITLE
Shrink valkey binary by ~14KB

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -4,8 +4,8 @@
 #define MAKE_CMD(name, summary, complexity, since, doc_flags, replaced, deprecated, group, group_enum, history, \
                  num_history, tips, num_tips, function, arity, flags, acl, get_dbid_args, key_specs,            \
                  key_specs_num, get_keys, numargs)                                                              \
-    name, summary, complexity, since, doc_flags, replaced, deprecated, group_enum, history, num_history, tips,  \
-        num_tips, function, arity, flags, acl, get_dbid_args, key_specs, key_specs_num, get_keys, numargs
+    name, summary, complexity, since, replaced, deprecated, history, tips, function, flags, acl, get_dbid_args, \
+        key_specs, get_keys, doc_flags, group_enum, num_history, num_tips, arity, key_specs_num, numargs
 #define MAKE_ARG(name, type, key_spec_index, token, summary, since, flags, numsubargs, deprecated_since) \
     name, type, key_spec_index, token, summary, since, flags, deprecated_since, numsubargs
 #define COMMAND_STRUCT serverCommand

--- a/src/server.h
+++ b/src/server.h
@@ -2754,31 +2754,38 @@ typedef int *commandDbIdArgs(robj **argv, int argc, int *count);
  *    TYPE, EXPIRE*, PEXPIRE*, TTL, PTTL, ...
  */
 struct serverCommand {
-    /* Declarative data */
-    const char *declared_name;    /* A string representing the command declared_name.
-                                   * It is a const char * for native commands and SDS for module commands. */
-    const char *summary;          /* Summary of the command (optional). */
-    const char *complexity;       /* Complexity description (optional). */
-    const char *since;            /* Debut version of the command (optional). */
-    int doc_flags;                /* Flags for documentation (see CMD_DOC_*). */
-    const char *replaced_by;      /* In case the command is deprecated, this is the successor command. */
-    const char *deprecated_since; /* In case the command is deprecated, when did it happen? */
-    serverCommandGroup group;     /* Command group */
-    commandHistory *history;      /* History of the command */
-    int num_history;
-    const char **tips; /* An array of strings that are meant to be tips for clients/proxies regarding this command */
-    int num_tips;
+    /* Declarative data. */
+    const char *declared_name;      /* A string representing the command declared_name.
+                                     * It is a const char * for native commands and SDS for module commands. */
+    const char *summary;            /* Summary of the command (optional). */
+    const char *complexity;         /* Complexity description (optional). */
+    const char *since;              /* Debut version of the command (optional). */
+    const char *replaced_by;        /* In case the command is deprecated, this is the successor command. */
+    const char *deprecated_since;   /* In case the command is deprecated, when did it happen? */
+    commandHistory *history;        /* History of the command */
+    const char **tips;              /* An array of strings that are meant to be tips for clients/proxies regarding this command */
     serverCommandProc *proc;        /* Command implementation */
-    int arity;                      /* Number of arguments, it is possible to use -N to say >= N */
     uint64_t flags;                 /* Command flags, see CMD_*. */
     uint64_t acl_categories;        /* ACl categories, see ACL_CATEGORY_*. */
     commandDbIdArgs *get_dbid_args; /* Function to get database IDs used by this command */
     keySpec *key_specs;
-    int key_specs_num;
     /* Use a function to determine keys arguments in a command line.
      * Used for Cluster redirect (may be NULL) */
     serverGetKeysProc *getkeys_proc;
+    int doc_flags;            /* Flags for documentation (see CMD_DOC_*). */
+    serverCommandGroup group; /* Command group */
+    int num_history;
+    int num_tips;
+    int arity; /* Number of arguments, it is possible to use -N to say >= N */
+    int key_specs_num;
     int num_args; /* Length of args array. */
+    int id;       /* Command ID. This is a progressive ID starting from 0 that
+                     is assigned at runtime, and is used in order to check
+                     ACLs. A connection is able to execute a given command if
+                     the user associated to the connection has this command
+                     bit set in the bitmap of allowed commands.
+                     Placed here (rather than with the other runtime data) so it
+                     fills the padding that would otherwise follow the ints above. */
     /* Array of subcommands (may be NULL) */
     struct serverCommand *subcommands;
     /* Array of arguments (may be NULL) */
@@ -2790,11 +2797,6 @@ struct serverCommand {
 
     /* Runtime populated data */
     long long microseconds, calls, rejected_calls, failed_calls;
-    int id;           /* Command ID. This is a progressive ID starting from 0 that
-                         is assigned at runtime, and is used in order to check
-                         ACLs. A connection is able to execute a given command if
-                         the user associated to the connection has this command
-                         bit set in the bitmap of allowed commands. */
     sds fullname;     /* Includes parent name if any: "parentcmd|childcmd". Unchanged if command is renamed. */
     sds current_name; /* Same as fullname, becomes a separate string if command is renamed. */
     struct hdr_histogram


### PR DESCRIPTION
Similar to #4618

Currently the serverCommand structure has an 32 byte memory hole

```
(gdb) ptype /o struct serverCommand
/* offset      |    size */  type = struct serverCommand {
......
/*     32      |       4 */    int doc_flags;
/* XXX  4-byte hole      */
......
/*     56      |       4 */    serverCommandGroup group;
/* XXX  4-byte hole      */
/*     64      |       8 */    commandHistory *history;
/*     72      |       4 */    int num_history;
/* XXX  4-byte hole      */
/*     80      |       8 */    const char **tips;
/*     88      |       4 */    int num_tips;
/* XXX  4-byte hole      */
/*     96      |       8 */    serverCommandProc *proc;
/*    104      |       4 */    int arity;
/* XXX  4-byte hole      */
......
/*    144      |       4 */    int key_specs_num;
/* XXX  4-byte hole      */
/*    152      |       8 */    serverGetKeysProc *getkeys_proc;
/*    160      |       4 */    int num_args;
/* XXX  4-byte hole      */
......
/*    216      |       4 */    int id;
/* XXX  4-byte hole      */
......
                               /* total size (bytes):  344 */
                             }
```

By moving the variables inside the structure we can close this hole saving 32 bytes per serverCommand definition.

This structure is heavily used in the commands.def so by optimizing it we can save a lot of memory

Before Change: 21238712 bytes
After Change: 21224304 bytes
Reduction: 14408 bytes => ~14KB