### PR TITLE
Fix linux build with clang

### DIFF
--- a/src/siphash.c
+++ b/src/siphash.c
@@ -85,7 +85,7 @@ int siptlw(int c) {
     U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
 
 #ifdef UNALIGNED_LE_CPU
-static inline uint64_t load64(const void *p) {
+static inline uint64_t load64(const uint8_t *p) {
     uint64_t value;
     memcpy(&value, p, sizeof(value));
     return value;

--- a/src/siphash.c
+++ b/src/siphash.c
@@ -85,7 +85,12 @@ int siptlw(int c) {
     U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
 
 #ifdef UNALIGNED_LE_CPU
-#define U8TO64_LE(p) (*((uint64_t*)(p)))
+static inline uint64_t load64(const void *p) {
+    uint64_t value;
+    memcpy(&value, p, sizeof(value));
+    return value;
+}
+#define U8TO64_LE(p) load64(p)
 #else
 #define U8TO64_LE(p)                                                           \
     (((uint64_t)((p)[0])) | ((uint64_t)((p)[1]) << 8) |                        \

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -220,7 +220,7 @@ TEST_F(HashtableTest, add_find_delete_avoid_resize) {
 }
 
 TEST_F(HashtableTest, instant_rehashing) {
-    long count = 200;
+    long count = 16384;
 
     /* A set of longs, i.e. pointer-sized values. */
     hashtableType type = {};
@@ -232,6 +232,13 @@ TEST_F(HashtableTest, instant_rehashing) {
     for (j = 0; j < count; j++) {
         ASSERT_TRUE(hashtableAdd(ht, (void *)j));
         ASSERT_FALSE(hashtableIsRehashing(ht));
+    }
+
+    /* The default hash must remain consistent when rehashing integer entries. */
+    for (j = 0; j < count; j++) {
+        void *found = nullptr;
+        ASSERT_TRUE(hashtableFind(ht, (void *)j, &found));
+        ASSERT_EQ(found, (void *)j);
     }
 
     /* Delete and check that rehashing is never ongoing. */


### PR DESCRIPTION
A new shiny clang 23 is out. I've tried to build valkey with it on linux. And got a crash on `make test` in `Export all slots from node` with `invalidFunctionWasCalled+0x0`.

It seems that we are getting an unconditional call through hashtableType.hashFunction for the importing-slot set.

This was caused by SipHash's U8TO64_LE macro dereference of a uint64_t pointer into arbitrary input. The default hashtable hash passes the object representation of a pointer variable, so this violates strict aliasing. Clang 23 LTO exposes the undefined behavior. Compiling only siphash.c with -fno-strict-aliasing fixes the `make test`. Replacing the typed load with memcpy also fixes it.

I'm not sure if we need to backport this anywhere. Do we even support clang?