### PR TITLE
Fix double-promotion compilation error in test_util.cpp

### DIFF
--- a/src/unit/test_util.cpp
+++ b/src/unit/test_util.cpp
@@ -195,7 +195,7 @@ TEST_F(UtilTest, TestLd2string) {
     long double v;
     int sz;
 
-    v = 0.0 / 0.0;
+    v = 0.0L / 0.0L;
     sz = ld2string(buf, sizeof(buf), v, LD_STR_AUTO);
     ASSERT_EQ(sz, 3);
     ASSERT_TRUE(!strcmp(buf, "nan"));


### PR DESCRIPTION
When trying to compile unit tests using clang-23 the following compilation error was hit 

```
test_util.cpp:198:13: error: implicit conversion increases floating-point precision: 'double' to 'long double' [-Werror,-Wdouble-promotion]
  198 |     v = 0.0 / 0.0;
      |       ~ ~~~~^~~~~
1 error generated.  
```

