### PR TITLE
docs: drop duplicated words in two comments

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4177,7 +4177,7 @@ void discardCommandQueue(client *c) {
     queue->off = queue->len = queue->cap = 0;
 }
 
-/* Returns the number of keys in the the incr_states array after adding keys. */
+/* Returns the number of keys in the incr_states array after adding keys. */
 static int addKeysToIncrFindBatch(client *c,
                                   struct serverCommand *cmd,
                                   robj **argv,

--- a/src/server.c
+++ b/src/server.c
@@ -3877,7 +3877,7 @@ void alsoPropagate(int dbid, robj **argv, int argc, int target, int slot) {
 }
 
 /* It is possible to call the function forceCommandPropagation() inside a
- * command implementation in order to to force the propagation of a
+ * command implementation in order to force the propagation of a
  * specific command execution into AOF / Replication. */
 void forceCommandPropagation(client *c, int flags) {
     serverAssert(c->cmd->flags & (CMD_WRITE | CMD_MAY_REPLICATE));


### PR DESCRIPTION
Two doubled-word typos in comments:

- `src/networking.c`: "keys in **the the** incr_states array"
- `src/server.c`: "in order **to to** force the propagation"

Comments only. Signed-off-by per the DCO requirement.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>