### PR TITLE
Fix fbtree range delete skipping non-empty middle leaves

### DIFF
--- a/src/fbtree.c
+++ b/src/fbtree.c
@@ -1802,12 +1802,22 @@ static unsigned long deleteRangeSameLeaf(fbtreeIndex *fbt,
 static unsigned long deleteRangeCore(fbtreeIndex *fbt, BoundaryPaths *bp, fbtreeItemCallback callback, void *callback_ctx) {
     /* Empty range check: score/value path builders can produce boundary
      * indices that fall outside the leaf (no matching elements in that leaf).
-     * Rank paths never hit this since ranks are pre-validated. */
-    if (bp->start_idx >= bp->start_leaf->header.num_items && bp->end_idx < 0) return 0;
+     * Rank paths never hit this since ranks are pre-validated.
+     *
+     * Both boundary leaves being untouched is necessary but NOT sufficient for
+     * the range to be empty: the split node's children strictly between the
+     * left and right boundary child indices (shared_left_idx+1 .. shared_right_idx-1)
+     * are middle subtrees wholly inside [min_key, max_key], and every live node
+     * in this tree holds at least one item, so a middle child's existence alone
+     * means the range is non-empty even when both boundary leaves are untouched.
+     * Only when the boundary children are adjacent (no middle child) does
+     * leaf-untouched-on-both-sides imply a truly empty range. */
+    int split_depth = bp->shared_depth - 1;
+    bool no_middle_child = bp->shared_right_idx[split_depth] <= bp->shared_left_idx[split_depth] + 1;
+    if (bp->start_idx >= bp->start_leaf->header.num_items && bp->end_idx < 0 && no_middle_child) return 0;
     if (bp->end_idx < 0 && bp->start_leaf == bp->end_leaf) return 0;
 
     /* --- Phase 1: Boundaries diverged. Process the split. --- */
-    int split_depth = bp->shared_depth - 1;
     innerNode *split_node = (innerNode *)bp->shared_path[split_depth];
     int li = bp->shared_left_idx[split_depth];
     int ri = bp->shared_right_idx[split_depth];

--- a/src/unit/test_fbtree.cpp
+++ b/src/unit/test_fbtree.cpp
@@ -3340,6 +3340,55 @@ TEST_F(FbtreeTest, DeleteRangeByValueNoMatch) {
     expectValid();
 }
 
+/* Regression test for a false-empty short-circuit in deleteRangeCore.
+ *
+ * The tree spans multiple leaves (NODE_SIZE=61 forces this with 300+
+ * elements). After trimming the first leaf down to a single low member, a
+ * later range delete has BOTH boundaries land in leaves with no locally
+ * matching elements ("leaf-untouched") while the split node still has one
+ * or more middle children strictly between the boundary subtrees, wholly
+ * inside the deleted range and non-empty. The buggy guard only checked
+ * leaf-local untouched-ness and returned 0 (deleted nothing) even though
+ * those middle leaves' elements were still in range. */
+TEST_F(FbtreeTest, DeleteRangeByValueSkipsNoMiddleLeafFalseEmpty) {
+    /* Seed enough elements to force several leaves/levels: an empty-string
+     * low sentinel plus 300 zero-padded members "m0001".."m0300". */
+    insert("");
+    char buf[16];
+    for (int i = 1; i <= 300; i++) {
+        snprintf(buf, sizeof(buf), "m%04d", i);
+        insert(buf);
+    }
+    EXPECT_EQ(fbtreeLength(fbt), 301u);
+
+    /* Trim the first leaf down to just the empty-string member: removes
+     * [m0001, m0060] inclusive, leaving the low leaf with a single element
+     * and no members in the immediately following range. */
+    sds trim_min = createString("m0001");
+    sds trim_max = createString("m0060");
+    EXPECT_EQ(fbtreeDeleteRangeByValue(fbt, trim_min, trim_max, 0, 0, NULL, NULL), 60u);
+    sdsfree(trim_min);
+    sdsfree(trim_max);
+    expectValid();
+    EXPECT_EQ(fbtreeLength(fbt), 241u);
+
+    /* Exclusive lower bound just past the trimmed leaf's remaining element,
+     * and an upper bound landing in the gap just after "m0121" (no stored
+     * element equals "m0121x"). Both boundary leaves are leaf-locally
+     * untouched, but middle leaves fully inside the range still exist. */
+    sds range_min = createString("");
+    sds range_max = createString("m0121x");
+    unsigned long expected = fbtreeCountRangeByValue(fbt, range_min, range_max, 1, 0);
+    ASSERT_GT(expected, 0u) << "range must be non-empty for this regression to be meaningful";
+
+    unsigned long removed = fbtreeDeleteRangeByValue(fbt, range_min, range_max, 1, 0, NULL, NULL);
+    sdsfree(range_min);
+    sdsfree(range_max);
+    expectValid();
+
+    EXPECT_EQ(removed, expected) << "deleteRangeCore must not short-circuit to 0 when non-empty middle leaves lie between untouched boundary leaves";
+}
+
 TEST_F(FbtreeTest, DeleteRangeByValueExactMatch) {
     insert("aaa");
     insert("bbb");

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2465,6 +2465,39 @@ start_server {tags {"zset"}} {
         }
     }
 
+    test {ZSET btree lex range delete does not skip non-empty middle leaves} {
+        with_config zset-max-ziplist-entries 0 {
+            r del zk
+            # Build a multi-leaf btree with enough members that a lex range
+            # spans several leaves under the boundary leaves.
+            r zadd zk 0 {}
+            for {set i 1} {$i <= 300} {incr i} {
+                r zadd zk 0 [format "m%04d" $i]
+            }
+            assert_encoding btree zk
+
+            # Trim the first leaf down to just the empty-string member: the
+            # start boundary of a later range will land in this now-mostly-
+            # empty leaf with no matching elements of its own (leaf-local
+            # "untouched"), while non-empty middle leaves still lie further
+            # to the right, inside the range about to be deleted.
+            r zremrangebylex zk \[m0001 \[m0060
+
+            # The exclusive lower bound "(" and the upper bound landing in a
+            # gap just past "m0121" (a value between two stored members)
+            # together make BOTH boundary leaves leaf-locally untouched, but
+            # the range still fully contains several middle leaves. The
+            # delete short-circuit must not treat this as an empty range.
+            set expected [r zlexcount zk \( \[m0121x]
+            assert {$expected > 0}
+            set removed [r zremrangebylex zk \( \[m0121x]
+            assert_equal $expected $removed
+
+            # Nothing in the deleted range should remain.
+            assert_equal 0 [r zlexcount zk \( \[m0121x]
+        }
+    }
+
     test {ZSET btree MEMORY USAGE reflects member sizes} {
         with_config zset-max-ziplist-entries 0 {
             r del zmem


### PR DESCRIPTION
Fixes #4558

deleteRangeCore's empty-range short-circuit treated "both boundary leaves are leaf-locally untouched" (the min bound consumes the entire start leaf and the max bound lands before the end leaf's first item) as sufficient proof that a score- or value-bounded range contains nothing to delete. That check is necessary but not sufficient: when the split node has children strictly between the left and right boundary child indices, those children are subtrees wholly contained in the range, and every live node in the tree holds at least one item. A middle child's existence therefore guarantees the range is non-empty even when neither boundary leaf itself has a matching element, so the delete returned 0 and left the middle leaves untouched, while ZLEXCOUNT and ZRANGEBYLEX (rank arithmetic, no such guard) reported the members correctly. Present since the original btree implementation in https://github.com/valkey-io/valkey/pull/4359.

The fix adds the missing condition to the short-circuit: the range is empty only when both boundary leaves are untouched AND the boundary children at the split depth are adjacent (no middle child between them). deleteRangeCore is only entered on the diverged-paths case, so the split depth is always valid and same-leaf ranges never reach this guard.

Tests:

- New gtest (FbtreeTest.DeleteRangeByValueSkipsNoMiddleLeafFalseEmpty) builds the failing tree shape through real inserts and drives fbtreeDeleteRangeByValue; it removes 0 of 61 expected items without the fix and passes with it (180/180 fbtree suite).
- New TCL regression builds a multi-leaf btree-encoded zset, trims the first leaf so both bounds land in leaf-locally-untouched boundary leaves while non-empty middle leaves remain inside the range, and asserts the removed count equals the ZLEXCOUNT and the range is empty afterward. Full zset suite passes on both encodings.