### PR TITLE
Add per command histograms to track the end to end latency

### DIFF
--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -116,6 +116,7 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/trace/trace_cluster.c
     ${CMAKE_SOURCE_DIR}/src/trace/trace_server.c
     ${CMAKE_SOURCE_DIR}/src/commands.c
+    ${CMAKE_SOURCE_DIR}/src/latency_e2e.c
     ${CMAKE_SOURCE_DIR}/src/strl.c
     ${CMAKE_SOURCE_DIR}/src/connection.c
     ${CMAKE_SOURCE_DIR}/src/unix.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -489,6 +489,7 @@ ENGINE_SERVER_OBJ = \
     cluster_slot_stats.o \
     commandlog.o \
     commands.o \
+    latency_e2e.o \
     compression.o \
     compression_lz4.o \
     compression_stream.o \

--- a/src/ae.c
+++ b/src/ae.c
@@ -464,6 +464,8 @@ int aeProcessEvents(aeEventLoop *eventLoop, int flags) {
             numevents = 0;
         }
 
+        if (!(flags & AE_DONT_WAIT)) eventLoop->wakeup_time = getMonotonicUs();
+
         /* After sleep callback. */
         if (eventLoop->aftersleep != NULL && flags & AE_CALL_AFTER_SLEEP) eventLoop->aftersleep(eventLoop, numevents);
 

--- a/src/ae.h
+++ b/src/ae.h
@@ -113,16 +113,17 @@ typedef struct aeEventLoop {
     int maxfd;   /* highest file descriptor currently registered */
     int setsize; /* max number of file descriptors tracked */
     long long timeEventNextId;
+    int stop;
+    int flags;
+    monotime wakeup_time;
     aeFileEvent *events; /* Registered events */
     aeFiredEvent *fired; /* Fired events */
     aeTimeEvent *timeEventHead;
-    int stop;
     aeApiState *apidata; /* Polling API specific state (owned by the backend) */
     aeBeforeSleepProc *beforesleep;
     aeAfterSleepProc *aftersleep;
     aeCustomPollProc *custompoll;
     pthread_mutex_t poll_mutex;
-    int flags;
 } aeEventLoop;
 
 /* Prototypes */

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -143,8 +143,13 @@ void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int failed_
         else
             debugServerAssertWithInfo(c, NULL, 0);
     }
-    if (server.latency_tracking_enabled)
+    if (server.latency_tracking_enable_cmd) {
         updateCommandLatencyHistogram(&(c->lastcmd->latency_histogram), c->duration * 1000);
+    }
+    if (server.latency_tracking_enable_e2e && c->latency_e2e.cur_cmd_time != 0) {
+        /* Only record the EXEC command for MULTI/EXEC, & Skip commands with no responses. */
+        if (!c->flag.multi && !c->flag.reply_off && !c->flag.reply_skip) latencyE2eRecordCommand(c, c->lastcmd);
+    }
     /* Log the command into the commandlog if needed. */
     commandlogPushCurrentCommand(c, c->lastcmd);
     c->duration = 0;

--- a/src/commands.def
+++ b/src/commands.def
@@ -8056,8 +8056,15 @@ const char *LATENCY_HISTOGRAM_Tips[] = {
 #define LATENCY_HISTOGRAM_Keyspecs NULL
 #endif
 
+/* LATENCY HISTOGRAM metric argument table */
+struct COMMAND_ARG LATENCY_HISTOGRAM_metric_Subargs[] = {
+{MAKE_ARG("cmd",ARG_TYPE_PURE_TOKEN,-1,"CMD",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("e2e",ARG_TYPE_PURE_TOKEN,-1,"E2E",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
 /* LATENCY HISTOGRAM argument table */
 struct COMMAND_ARG LATENCY_HISTOGRAM_Args[] = {
+{MAKE_ARG("metric",ARG_TYPE_ONEOF,-1,NULL,NULL,"9.2.0",CMD_ARG_OPTIONAL,2,NULL),.subargs=LATENCY_HISTOGRAM_metric_Subargs},
 {MAKE_ARG("command",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,0,NULL)},
 };
 
@@ -8138,7 +8145,7 @@ struct COMMAND_STRUCT LATENCY_Subcommands[] = {
 {MAKE_CMD("doctor","Returns a human-readable latency analysis report.","O(1)","2.8.13",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,LATENCY_DOCTOR_History,0,LATENCY_DOCTOR_Tips,3,latencyCommand,2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,LATENCY_DOCTOR_Keyspecs,0,NULL,0)},
 {MAKE_CMD("graph","Returns a latency graph for an event.","O(1)","2.8.13",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,LATENCY_GRAPH_History,0,LATENCY_GRAPH_Tips,3,latencyCommand,3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,LATENCY_GRAPH_Keyspecs,0,NULL,1),.args=LATENCY_GRAPH_Args},
 {MAKE_CMD("help","Returns helpful text about the different subcommands.","O(1)","2.8.13",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,LATENCY_HELP_History,0,LATENCY_HELP_Tips,0,latencyCommand,2,CMD_LOADING|CMD_STALE,ACL_CATEGORY_SLOW,NULL,LATENCY_HELP_Keyspecs,0,NULL,0)},
-{MAKE_CMD("histogram","Returns the cumulative distribution of latencies of a subset or all commands.","O(N) where N is the number of commands with latency information being retrieved.","7.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,LATENCY_HISTOGRAM_History,0,LATENCY_HISTOGRAM_Tips,3,latencyCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,LATENCY_HISTOGRAM_Keyspecs,0,NULL,1),.args=LATENCY_HISTOGRAM_Args},
+{MAKE_CMD("histogram","Returns the cumulative distribution of latencies of a subset or all commands. With CMD (default) returns processing-time histograms; with E2E returns the per-command end-to-end latency histograms.","O(N) where N is the number of commands with latency information being retrieved.","7.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,LATENCY_HISTOGRAM_History,0,LATENCY_HISTOGRAM_Tips,3,latencyCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,LATENCY_HISTOGRAM_Keyspecs,0,NULL,2),.args=LATENCY_HISTOGRAM_Args},
 {MAKE_CMD("history","Returns timestamp-latency samples for an event.","O(1)","2.8.13",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,LATENCY_HISTORY_History,0,LATENCY_HISTORY_Tips,3,latencyCommand,3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,LATENCY_HISTORY_Keyspecs,0,NULL,1),.args=LATENCY_HISTORY_Args},
 {MAKE_CMD("latest","Returns the latest latency samples for all events.","O(1)","2.8.13",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,LATENCY_LATEST_History,0,LATENCY_LATEST_Tips,3,latencyCommand,2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,LATENCY_LATEST_Keyspecs,0,NULL,0)},
 {MAKE_CMD("reset","Resets the latency data for one or more events.","O(1)","2.8.13",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,LATENCY_RESET_History,0,LATENCY_RESET_Tips,2,latencyCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,LATENCY_RESET_Keyspecs,0,NULL,1),.args=LATENCY_RESET_Args},

--- a/src/commands/latency-histogram.json
+++ b/src/commands/latency-histogram.json
@@ -1,6 +1,6 @@
 {
     "HISTOGRAM": {
-        "summary": "Returns the cumulative distribution of latencies of a subset or all commands.",
+        "summary": "Returns the cumulative distribution of latencies of a subset or all commands. With CMD (default) returns processing-time histograms; with E2E returns the per-command end-to-end latency histograms.",
         "complexity": "O(N) where N is the number of commands with latency information being retrieved.",
         "group": "server",
         "since": "7.0.0",
@@ -43,6 +43,24 @@
             }
         },
         "arguments": [
+            {
+                "name": "metric",
+                "type": "oneof",
+                "optional": true,
+                "since": "9.2.0",
+                "arguments": [
+                    {
+                        "name": "cmd",
+                        "type": "pure-token",
+                        "token": "CMD"
+                    },
+                    {
+                        "name": "e2e",
+                        "type": "pure-token",
+                        "token": "E2E"
+                    }
+                ]
+            },
             {
                 "name": "COMMAND",
                 "type": "string",

--- a/src/config.c
+++ b/src/config.c
@@ -113,6 +113,11 @@ configEnum shutdown_on_sig_enum[] = {
     {"failover", SHUTDOWN_FAILOVER},
     {NULL, 0}};
 
+configEnum latency_tracking_features_enum[] = {
+    {"cmd", LATENCY_TRACK_CMD}, /* per-command processing-time histogram */
+    {"e2e", LATENCY_TRACK_E2E}, /* per-command end-to-end time histogram */
+    {NULL, 0}};
+
 configEnum repl_diskless_load_enum[] = {
     {"disabled", REPL_DISKLESS_LOAD_DISABLED},
     {"on-empty-db", REPL_DISKLESS_LOAD_WHEN_DB_EMPTY},
@@ -2628,6 +2633,14 @@ static int isValidProcTitleTemplate(char *val, const char **err) {
     return 1;
 }
 
+/* precompute the effective latency-tracking flags. */
+int updateLatencyTrackingFlags(const char **err) {
+    UNUSED(err);
+    server.latency_tracking_enable_cmd = server.latency_tracking_enabled && (server.latency_tracking_features & LATENCY_TRACK_CMD);
+    server.latency_tracking_enable_e2e = server.latency_tracking_enabled && (server.latency_tracking_features & LATENCY_TRACK_E2E);
+    return 1;
+}
+
 static int updateLocaleCollate(const char **err) {
     const char *s = setlocale(LC_COLLATE, server.locale_collate);
     if (s == NULL) {
@@ -3419,7 +3432,7 @@ standardConfig static_configs[] = {
     createBoolConfig("disable-thp", NULL, IMMUTABLE_CONFIG, server.disable_thp, 1, NULL, NULL),
     createBoolConfig("cluster-allow-replica-migration", NULL, MODIFIABLE_CONFIG, server.cluster_allow_replica_migration, 1, NULL, NULL),
     createBoolConfig("replica-announced", NULL, MODIFIABLE_CONFIG, server.replica_announced, 1, NULL, NULL),
-    createBoolConfig("latency-tracking", NULL, MODIFIABLE_CONFIG, server.latency_tracking_enabled, 1, NULL, NULL),
+    createBoolConfig("latency-tracking", NULL, MODIFIABLE_CONFIG, server.latency_tracking_enabled, 1, NULL, updateLatencyTrackingFlags),
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
     createBoolConfig("extended-redis-compatibility", NULL, MODIFIABLE_CONFIG, server.extended_redis_compat, 0, NULL, updateExtendedRedisCompat),
@@ -3484,6 +3497,7 @@ standardConfig static_configs[] = {
     createEnumConfig("propagation-error-behavior", NULL, MODIFIABLE_CONFIG, propagation_error_behavior_enum, server.propagation_error_behavior, PROPAGATION_ERR_BEHAVIOR_IGNORE, NULL, NULL),
     createEnumConfig("shutdown-on-sigint", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, shutdown_on_sig_enum, server.shutdown_on_sigint, 0, isValidShutdownOnSigFlags, NULL),
     createEnumConfig("shutdown-on-sigterm", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, shutdown_on_sig_enum, server.shutdown_on_sigterm, 0, isValidShutdownOnSigFlags, NULL),
+    createEnumConfig("latency-tracking-features", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, latency_tracking_features_enum, server.latency_tracking_features, LATENCY_TRACK_CMD, NULL, updateLatencyTrackingFlags),
     createEnumConfig("log-format", NULL, MODIFIABLE_CONFIG, log_format_enum, server.log_format, LOG_FORMAT_LEGACY, NULL, NULL),
     createEnumConfig("log-timestamp-format", NULL, MODIFIABLE_CONFIG, log_timestamp_format_enum, server.log_timestamp_format, LOG_TIMESTAMP_LEGACY, NULL, NULL),
     createEnumConfig("rdb-version-check", NULL, MODIFIABLE_CONFIG, rdb_version_check_enum, server.rdb_version_check, RDB_VERSION_CHECK_STRICT, NULL, NULL),

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -532,6 +532,7 @@ int trySendReadToIOThreads(client *c) {
     c->read_flags |= isReplicatedClient(c) ? READ_FLAGS_REPLICATED : 0;
 
     c->io_read_state = CLIENT_PENDING_IO;
+    c->io_event_loop_wakeup_time = server.el->wakeup_time;
     connSetPostponeUpdateState(c->conn, clientConnPostponeMaskFromIOState(c));
 
     if (unlikely(spmcEnqueue(&io_shared_inbox, tagJob(c, JOB_REQ_READ_CLIENT)) == false)) {
@@ -579,6 +580,7 @@ int trySendWriteToIOThreads(client *c) {
          * position to io_last_bufpos. The I/O thread will write only up to
          * io_last_bufpos, regardless of the c->bufpos value. This is to prevent I/O
          * threads from reading data that might be invalid in their local CPU cache. */
+        c->io_reply_len = listLength(c->reply);
         c->io_last_reply_block = listLast(c->reply);
         if (c->io_last_reply_block) {
             block = (clientReplyBlock *)listNodeValue(c->io_last_reply_block);
@@ -601,6 +603,7 @@ int trySendWriteToIOThreads(client *c) {
         c->write_flags = 0;
         c->io_last_reply_block = NULL;
         c->io_last_bufpos = 0;
+        c->io_reply_len = 0;
         return C_ERR;
     }
     /* Force new header after successful enqueue so the main thread doesn't

--- a/src/latency.c
+++ b/src/latency.c
@@ -529,20 +529,21 @@ void fillCommandCDF(client *c, struct hdr_histogram *histogram) {
 
 /* latencyCommand() helper to produce for all commands,
  * a per command cumulative distribution of latencies. */
-void latencyAllCommandsFillCDF(client *c, hashtable *commands, int *command_with_data) {
+void latencyAllCommandsFillCDF(client *c, hashtable *commands, int *command_with_data, int latency_e2e) {
     hashtableIterator iter;
     hashtableInitIterator(&iter, commands, HASHTABLE_ITER_SAFE);
     void *next;
     while (hashtableNext(&iter, &next)) {
         struct serverCommand *cmd = next;
-        if (cmd->latency_histogram) {
+        struct hdr_histogram *hist = latency_e2e ? cmd->latency_e2e_histogram : cmd->latency_histogram;
+        if (hist) {
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
-            fillCommandCDF(c, cmd->latency_histogram);
+            fillCommandCDF(c, hist);
             (*command_with_data)++;
         }
 
         if (cmd->subcommands) {
-            latencyAllCommandsFillCDF(c, cmd->subcommands_ht, command_with_data);
+            latencyAllCommandsFillCDF(c, cmd->subcommands_ht, command_with_data, latency_e2e);
         }
     }
     hashtableCleanupIterator(&iter);
@@ -550,19 +551,20 @@ void latencyAllCommandsFillCDF(client *c, hashtable *commands, int *command_with
 
 /* latencyCommand() helper to produce for a specific command set,
  * a per command cumulative distribution of latencies. */
-void latencySpecificCommandsFillCDF(client *c) {
+void latencySpecificCommandsFillCDF(client *c, int argstart, int latency_e2e) {
     void *replylen = addReplyDeferredLen(c);
     int command_with_data = 0;
-    for (int j = 2; j < c->argc; j++) {
+    for (int j = argstart; j < c->argc; j++) {
         struct serverCommand *cmd = lookupCommandBySds(objectGetVal(c->argv[j]));
         /* If the command does not exist we skip the reply */
         if (cmd == NULL) {
             continue;
         }
 
-        if (cmd->latency_histogram) {
+        struct hdr_histogram *hist = latency_e2e ? cmd->latency_e2e_histogram : cmd->latency_histogram;
+        if (hist) {
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
-            fillCommandCDF(c, cmd->latency_histogram);
+            fillCommandCDF(c, hist);
             command_with_data++;
         }
 
@@ -572,9 +574,10 @@ void latencySpecificCommandsFillCDF(client *c) {
             void *next;
             while (hashtableNext(&iter, &next)) {
                 struct serverCommand *sub = next;
-                if (sub->latency_histogram) {
+                struct hdr_histogram *subhist = latency_e2e ? sub->latency_e2e_histogram : sub->latency_histogram;
+                if (subhist) {
                     addReplyBulkCBuffer(c, sub->fullname, sdslen(sub->fullname));
-                    fillCommandCDF(c, sub->latency_histogram);
+                    fillCommandCDF(c, subhist);
                     command_with_data++;
                 }
             }
@@ -724,14 +727,28 @@ void latencyCommand(client *c) {
             addReplyLongLong(c, resets);
         }
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "histogram") && c->argc >= 2) {
-        /* LATENCY HISTOGRAM*/
-        if (c->argc == 2) {
+        /* LATENCY HISTOGRAM [CMD|E2E] [command ...]
+         * An optional metric selector chooses which per-command histograms to report:
+         *   CMD (default) - processing-time histograms.
+         *   E2E           - end-to-end histograms, incl. queue + block time.
+         * Any first token that isn't a selector is treated as a command-name filter. */
+        int latency_e2e = 0;
+        int argstart = 2;
+        if (c->argc >= 3) {
+            if (!strcasecmp(objectGetVal(c->argv[2]), "e2e")) {
+                latency_e2e = 1;
+                argstart = 3;
+            } else if (!strcasecmp(objectGetVal(c->argv[2]), "cmd")) {
+                argstart = 3;
+            }
+        }
+        if (c->argc == argstart) {
             int command_with_data = 0;
             void *replylen = addReplyDeferredLen(c);
-            latencyAllCommandsFillCDF(c, server.commands, &command_with_data);
+            latencyAllCommandsFillCDF(c, server.commands, &command_with_data, latency_e2e);
             setDeferredMapLen(c, replylen, command_with_data);
         } else {
-            latencySpecificCommandsFillCDF(c);
+            latencySpecificCommandsFillCDF(c, argstart, latency_e2e);
         }
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "help") && c->argc == 2) {
         const char *help[] = {
@@ -746,9 +763,11 @@ void latencyCommand(client *c) {
             "RESET [<event> ...]",
             "    Reset latency data of one or more <event> classes.",
             "    (default: reset all data for all event classes)",
-            "HISTOGRAM [COMMAND ...]",
+            "HISTOGRAM [CMD|E2E] [COMMAND ...]",
             "    Return a cumulative distribution of latencies in the format of a histogram for the specified command names.",
             "    If no commands are specified then all histograms are replied.",
+            "    With CMD (default), report processing-time histograms. "
+            "    With E2E, report the end-to-end latency histograms.",
             NULL,
         };
         addReplyHelp(c, help);

--- a/src/latency_e2e.c
+++ b/src/latency_e2e.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "server.h"
+
+/* Flush the content of the aggregation table to the command histograms. */
+static void latencyE2eFlushTable(latencyE2eTable *t, monotime write_time) {
+    int64_t duration_ns = (int64_t)(write_time - t->cmd_read_time) * 1000;
+    for (int i = 0; i < t->nslots; i++) {
+        updateCommandLatencyE2eHistogram(&t->cmds[i]->latency_e2e_histogram, duration_ns, t->counts[i]);
+    }
+}
+
+/* Flush the aggregation table, clear it & reset it. */
+static void latencyE2eFlushTableAndReset(client *c, latencyE2eTable *table) {
+    if (table->nslots > 0) {
+        latencyE2eFlushTable(table, c->latency_e2e.cur_write_time);
+        /* reset table for next cycle of commands. */
+        memset(table->cmds, 0, sizeof(table->cmds));
+        table->nslots = 0;
+    }
+    table->boundary = -1ULL;
+}
+
+/* Obtain a fresh table for end-to-end latency recording. If already at capacity, flush the oldest table early. */
+static latencyE2eTable *latencyE2eOpenTable(client *c) {
+    if (c->latency_e2e.tables == NULL) {
+        c->latency_e2e.tables = listCreate();
+        listSetFreeMethod(c->latency_e2e.tables, zfree);
+    }
+
+    /* Flush & reuse the oldest. */
+    if (listLength(c->latency_e2e.tables) >= LATENCY_E2E_MAX_TABLES) {
+        listNode *ln = listLast(c->latency_e2e.tables);
+        latencyE2eTable *oldest = listNodeValue(ln);
+
+        listUnlinkNode(c->latency_e2e.tables, ln);
+        listLinkNodeHead(c->latency_e2e.tables, ln);
+        latencyE2eFlushTableAndReset(c, oldest);
+        oldest->cmd_read_time = c->latency_e2e.cur_cmd_time;
+        c->latency_e2e.open = oldest;
+        return oldest;
+    }
+
+    /* check if the top table went through latencyE2eFlushTableAndReset. */
+    if (listLength(c->latency_e2e.tables) != 0) {
+        latencyE2eTable *table = listNodeValue(listFirst(c->latency_e2e.tables));
+        if (table->boundary == -1ULL) {
+            table->cmd_read_time = c->latency_e2e.cur_cmd_time;
+            c->latency_e2e.open = table;
+            return table;
+        }
+    }
+
+    latencyE2eTable *table = zcalloc(sizeof(*table));
+    table->boundary = -1ULL;
+    table->cmd_read_time = c->latency_e2e.cur_cmd_time;
+    c->latency_e2e.open = table;
+    listAddNodeHead(c->latency_e2e.tables, table);
+    return table;
+}
+
+/* Add a sample of the command to the current table. */
+void latencyE2eRecordCommand(client *c, struct serverCommand *cmd) {
+    latencyE2eTable *table = c->latency_e2e.open;
+    if (table == NULL || table->boundary != -1ULL) table = latencyE2eOpenTable(c);
+
+    /* Aggregate into an existing slot for this command if present. */
+    for (int i = 0; i < LATENCY_E2E_MAX_SLOTS; i++) {
+        if (table->cmds[i] == cmd) {
+            table->counts[i]++;
+            return;
+        }
+        if (table->cmds[i] == NULL) {
+            table->cmds[i] = cmd;
+            table->counts[i] = 1;
+            table->nslots++;
+            return;
+        }
+    }
+
+    /* If more than 9 unique command types per batch, the 9th+ command will be dropped silently from the tracking table. */
+}
+
+/* Flush and remove every table whose replies are fully written. */
+void latencyE2eFlushCompleted(client *c) {
+    if (listLength(c->latency_e2e.tables) == 1) {
+        /* Fast path: single table, flushed in place & reuse. */
+        latencyE2eTable *table = listNodeValue(listFirst(c->latency_e2e.tables));
+        if (table->boundary != -1ULL && table->boundary <= c->latency_e2e.reply_blocks_removed) {
+            latencyE2eFlushTableAndReset(c, table);
+        }
+    } else {
+        listIter li;
+        listRewindTail(c->latency_e2e.tables, &li);
+
+        listNode *ln;
+        while ((ln = listNext(&li))) {
+            latencyE2eTable *table = listNodeValue(ln);
+            if (table->boundary > c->latency_e2e.reply_blocks_removed) break;
+            if (ln->next == NULL) {
+                /* reuse last aggregation table to avoid future allocations. */
+                latencyE2eFlushTableAndReset(c, table);
+            } else if (table->boundary != -1ULL) {
+                latencyE2eFlushTable(table, c->latency_e2e.cur_write_time);
+                listDelNode(c->latency_e2e.tables, ln);
+            }
+        }
+    }
+}
+
+/* Release all data related to end-to-end latency tracking.
+ * Any samples still buffered (e.g. a client disconnected) are dropped. */
+void latencyE2eRelease(client *c) {
+    if (c->latency_e2e.tables == NULL) return;
+    listRelease(c->latency_e2e.tables);
+    /* For simplicity clear the entire structure. */
+    memset(&c->latency_e2e, 0, sizeof(latencyE2e));
+}
+
+void latencyE2ePostClientWrite(client *c) {
+    if (c->latency_e2e.tables == NULL || c->nwritten <= 0) return;
+
+    if (!server.latency_tracking_enable_e2e) {
+        latencyE2eRelease(c);
+        return;
+    }
+
+    if (c->latency_e2e.open != NULL && c->latency_e2e.open->nslots > 0) {
+        latencyE2eTable *table = c->latency_e2e.open;
+        table->boundary = c->latency_e2e.reply_block_watermark;
+        /* Let the next command execution handle the creations of a new aggregation table. */
+        c->latency_e2e.open = NULL;
+    }
+
+    latencyE2eFlushCompleted(c);
+}
+
+void latencyE2ePostReplicaWrite(client *c) {
+    if (c->latency_e2e.tables == NULL) return;
+
+    /* Feature is not needed for replica clients, free memory. */
+    latencyE2eRelease(c);
+}

--- a/src/latency_e2e.c
+++ b/src/latency_e2e.c
@@ -117,10 +117,11 @@ void latencyE2eFlushCompleted(client *c) {
 void latencyE2eRelease(client *c) {
     if (c->latency_e2e.tables == NULL) return;
     listRelease(c->latency_e2e.tables);
-    /* For simplicity clear the entire structure. */
-    memset(&c->latency_e2e, 0, sizeof(latencyE2e));
+    c->latency_e2e.tables = NULL;
+    c->latency_e2e.open = NULL;
 }
 
+/* After a client write: close the current aggregation table to edits and flush any table whose replies are fully written. */
 void latencyE2ePostClientWrite(client *c) {
     if (c->latency_e2e.tables == NULL || c->nwritten <= 0) return;
 
@@ -139,9 +140,23 @@ void latencyE2ePostClientWrite(client *c) {
     latencyE2eFlushCompleted(c);
 }
 
+/* After a replica write: replicas are never tracked, so free any tables allocated before the role was known. */
 void latencyE2ePostReplicaWrite(client *c) {
     if (c->latency_e2e.tables == NULL) return;
 
     /* Feature is not needed for replica clients, free memory. */
     latencyE2eRelease(c);
+    /* Avoid future tracking allocations. */
+    c->latency_e2e.cur_read_time = 0;
+}
+
+/* Called when a module is unloaded, before its registered commands are freed.
+ * Aggregation tables hold raw serverCommand* values which might are freed during the module unloading. */
+void latencyE2eModuleUnload(void) {
+    listIter li;
+    listNode *ln;
+    listRewind(server.clients, &li);
+    while ((ln = listNext(&li))) {
+        latencyE2eRelease(listNodeValue(ln));
+    }
 }

--- a/src/module.c
+++ b/src/module.c
@@ -13333,6 +13333,10 @@ int moduleFreeCommand(struct ValkeyModule *module, struct serverCommand *cmd) {
         hdr_close(cmd->latency_histogram);
         cmd->latency_histogram = NULL;
     }
+    if (cmd->latency_e2e_histogram) {
+        hdr_close(cmd->latency_e2e_histogram);
+        cmd->latency_e2e_histogram = NULL;
+    }
     for (int i = 0; i < RESP_CACHE_INDEX_MAX; i++) {
         if (cmd->info_cache[i]) {
             sdsfree(cmd->info_cache[i]);

--- a/src/module.c
+++ b/src/module.c
@@ -13369,6 +13369,8 @@ int moduleFreeCommand(struct ValkeyModule *module, struct serverCommand *cmd) {
 void moduleUnregisterCommands(struct ValkeyModule *module) {
     /* Drain IO queue before modifying commands dictionary to prevent concurrent access while modifying it. */
     drainIOThreadsQueue();
+    /* Purge any in-flight end-to-end latency samples (may contain commands that are freed below). */
+    latencyE2eModuleUnload();
     /* Unregister all the commands registered by this module. */
     hashtableIterator iter;
     void *next;

--- a/src/networking.c
+++ b/src/networking.c
@@ -319,6 +319,14 @@ static int isCopyAvoidPreferred(client *c, robj *obj) {
     return server.min_string_size_copy_avoid_threaded && sdslen(objectGetVal(obj)) >= (size_t)server.min_string_size_copy_avoid_threaded;
 }
 
+/* record write for end-to-end latency. */
+static inline void latencyE2eClientWrite(client *c) {
+    if (server.latency_tracking_enable_e2e && c->nwritten > 0) {
+        c->latency_e2e.cur_write_time = getMonotonicUs();
+        c->latency_e2e.reply_block_watermark = c->latency_e2e.reply_blocks_removed + (inMainThread() ? listLength(c->reply) : c->io_reply_len);
+    }
+}
+
 client *createClient(connection *conn) {
     client *c = zmalloc(sizeof(client));
 
@@ -416,9 +424,11 @@ client *createClient(connection *conn) {
     c->commands_processed = 0;
     c->io_last_reply_block = NULL;
     c->io_last_bufpos = 0;
+    c->io_reply_len = 0;
     c->io_last_written.buf = NULL;
     c->io_last_written.bufpos = 0;
     c->io_last_written.data_len = 0;
+    memset(&c->latency_e2e, 0, sizeof(c->latency_e2e));
     return c;
 }
 
@@ -2282,6 +2292,7 @@ int freeClient(client *c) {
     if (c->lib_ver) decrRefCount(c->lib_ver);
     freeClientMultiState(c);
     if (c->cob_trend) trendCalculator_free(c->cob_trend);
+    latencyE2eRelease(c);
     sdsfree(c->peerid);
     sdsfree(c->sockname);
     zfree(c);
@@ -3066,6 +3077,7 @@ static void _postWriteToClient(client *c) {
         if (last_written) return;
     }
 
+    unsigned long length = listLength(c->reply);
     listIter iter;
     listNode *next;
     listRewind(c->reply, &iter);
@@ -3092,8 +3104,11 @@ static void _postWriteToClient(client *c) {
             /* If completely written buffer is last written then reset last written state */
             if (last_written) resetLastWrittenBuf(c);
         }
-        if (last_written) return;
+        if (last_written) break;
     }
+
+    /* Count drained reply blocks. */
+    c->latency_e2e.reply_blocks_removed += (length - listLength(c->reply));
 }
 
 /* Updates the client's memory usage and bucket and server stats after writing.
@@ -3102,12 +3117,15 @@ static void _postWriteToClient(client *c) {
 int postWriteToClient(client *c) {
     c->io_last_reply_block = NULL;
     c->io_last_bufpos = 0;
+    c->io_reply_len = 0;
     /* Update total number of writes on server */
     server.stat_total_writes_processed++;
     if (getClientType(c) != CLIENT_TYPE_REPLICA) {
         _postWriteToClient(c);
+        latencyE2ePostClientWrite(c);
     } else {
         postWriteToReplica(c);
+        latencyE2ePostReplicaWrite(c);
     }
 
     if (c->write_flags & WRITE_FLAGS_WRITE_ERROR) {
@@ -3157,6 +3175,7 @@ int writeToClient(client *c) {
         writeToReplica(c);
     } else {
         _writeToClient(c);
+        latencyE2eClientWrite(c);
     }
 
     return postWriteToClient(c);
@@ -3479,6 +3498,7 @@ void resetClientIOState(client *c) {
     c->flag.pending_command = 0;
     c->io_last_bufpos = 0;
     c->io_last_reply_block = NULL;
+    c->io_reply_len = 0;
 }
 
 /* Initializes the shared query buffer to a new sds with the default capacity.
@@ -4333,6 +4353,11 @@ int processInputBuffer(client *c) {
     return C_OK;
 }
 
+static inline int latencyE2eTracks(client *c) {
+    if (c->flag.monitor) return 0;
+    return getClientType(c) == CLIENT_TYPE_NORMAL;
+}
+
 /* This function can be called from the main-thread or from the IO-thread.
  * The function allocates query-buf for the client if required and reads to it from the network.
  * It will set c->nread to the bytes read from the network.
@@ -4404,6 +4429,13 @@ static bool readToQueryBuf(client *c) {
     if (c->nread <= 0) {
         return false;
     }
+
+    /* 0 Is used to avoid future allocations on non-tracked clients. */
+    monotime wakeup_time = 0;
+    if (server.latency_tracking_enable_e2e && latencyE2eTracks(c)) {
+        wakeup_time = inMainThread() ? server.el->wakeup_time : c->io_event_loop_wakeup_time;
+    }
+    c->latency_e2e.cur_read_time = wakeup_time;
 
     sdsIncrLen(c->querybuf, c->nread);
     qblen = sdslen(c->querybuf);
@@ -6792,6 +6824,7 @@ void ioThreadWriteToClient(client *c) {
         writeToReplica(c);
     } else {
         _writeToClient(c);
+        latencyE2eClientWrite(c);
     }
 
     c->io_write_state = CLIENT_COMPLETED_IO;

--- a/src/server.c
+++ b/src/server.c
@@ -3220,6 +3220,8 @@ void initServer(void) {
     commandlogInit();
     latencyMonitorInit();
     throttle_init();
+    /* Initialize latency flags from the default configurations. */
+    updateLatencyTrackingFlags(NULL);
     initSharedQueryBuf();
     bgIteration_init();
 
@@ -3486,6 +3488,7 @@ int populateCommandStructure(struct serverCommand *c) {
     /* We start with an unallocated histogram and only allocate memory when a command
      * has been issued for the first time */
     c->latency_histogram = NULL;
+    c->latency_e2e_histogram = NULL;
 
     /* Initialize command info cache */
     for (int i = 0; i < RESP_CACHE_INDEX_MAX; i++) {
@@ -3554,6 +3557,10 @@ void resetCommandTableStats(hashtable *commands) {
         if (c->latency_histogram) {
             hdr_close(c->latency_histogram);
             c->latency_histogram = NULL;
+        }
+        if (c->latency_e2e_histogram) {
+            hdr_close(c->latency_e2e_histogram);
+            c->latency_e2e_histogram = NULL;
         }
         if (c->subcommands_ht) resetCommandTableStats(c->subcommands_ht);
     }
@@ -3914,6 +3921,19 @@ void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int
     hdr_record_value(*latency_histogram, duration_hist);
 }
 
+/* Like updateCommandLatencyHistogram,
+ * but for the per-command service-time (end-to-end read->write)
+ * histogram: records the same duration `count` times in one call. */
+void updateCommandLatencyE2eHistogram(struct hdr_histogram **latency_e2e_histogram, int64_t duration_hist, long long count) {
+    if (count <= 0) return;
+    if (duration_hist < LATENCY_E2E_HISTOGRAM_MIN_VALUE) duration_hist = LATENCY_E2E_HISTOGRAM_MIN_VALUE;
+    if (duration_hist > LATENCY_E2E_HISTOGRAM_MAX_VALUE) duration_hist = LATENCY_E2E_HISTOGRAM_MAX_VALUE;
+    if (*latency_e2e_histogram == NULL)
+        hdr_init(LATENCY_E2E_HISTOGRAM_MIN_VALUE, LATENCY_E2E_HISTOGRAM_MAX_VALUE, LATENCY_E2E_HISTOGRAM_PRECISION,
+                 latency_e2e_histogram);
+    hdr_record_values(*latency_e2e_histogram, duration_hist, count);
+}
+
 /* Handle the alsoPropagate() API to handle commands that want to propagate
  * multiple separated commands. Note that alsoPropagate() is not affected
  * by CLIENT_PREVENT_PROP flag. */
@@ -4234,8 +4254,13 @@ void call(client *c, int flags) {
     if (update_command_stats && !c->flag.blocked) {
         real_cmd->calls++;
         real_cmd->microseconds += c->duration;
-        if (server.latency_tracking_enabled && !c->flag.blocked)
+        if (server.latency_tracking_enable_cmd) {
             updateCommandLatencyHistogram(&(real_cmd->latency_histogram), c->duration * 1000);
+        }
+        if (server.latency_tracking_enable_e2e && c->latency_e2e.cur_cmd_time != 0) {
+            /* Only record the EXEC command for MULTI/EXEC, & Skip commands with no responses. */
+            if (!c->flag.multi && !c->flag.reply_off && !c->flag.reply_skip) latencyE2eRecordCommand(c, real_cmd);
+        }
         clusterSlotStatsAddCpuDuration(c, c->duration);
     }
 
@@ -4472,6 +4497,7 @@ static void prepareCommandGeneric(robj **argv, int argc, int *read_flags, struct
 
 /* Prepare the client's current command. See prepareCommandGeneric(). */
 void prepareCommand(client *c) {
+    c->latency_e2e.cur_cmd_time = c->latency_e2e.cur_read_time;
     prepareCommandGeneric(c->argv, c->argc, &c->read_flags, &c->parsed_cmd, &c->slot);
 }
 
@@ -6089,8 +6115,8 @@ void bytesToHuman(char *s, size_t size, unsigned long long n) {
 }
 
 /* Fill percentile distribution of latencies. */
-sds fillPercentileDistributionLatencies(sds info, const char *histogram_name, struct hdr_histogram *histogram) {
-    info = sdscatfmt(info, "latency_percentiles_usec_%s:", histogram_name);
+sds fillPercentileDistributionLatencies(sds info, const char *metric, const char *histogram_name, struct hdr_histogram *histogram) {
+    info = sdscatfmt(info, "%s_percentiles_usec_%s:", metric, histogram_name);
     for (int j = 0; j < server.latency_tracking_info_percentiles_len; j++) {
         char fbuf[128];
         size_t len = snprintf(fbuf, sizeof(fbuf), "%f", server.latency_tracking_info_percentiles[j]);
@@ -6182,7 +6208,13 @@ sds genValkeyInfoStringLatencyStats(sds info, hashtable *commands) {
         char *tmpsafe;
         if (c->latency_histogram) {
             info = fillPercentileDistributionLatencies(
-                info, getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->latency_histogram);
+                info, "latency", getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->latency_histogram);
+            if (tmpsafe != NULL) zfree(tmpsafe);
+        }
+        if (c->latency_e2e_histogram) {
+            info = fillPercentileDistributionLatencies(
+                info, "e2e", getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe),
+                c->latency_e2e_histogram);
             if (tmpsafe != NULL) zfree(tmpsafe);
         }
         if (c->subcommands_ht) {

--- a/src/server.h
+++ b/src/server.h
@@ -727,6 +727,15 @@ typedef enum {
                                                  * LATENCY_HISTOGRAM_MAX_VALUE range. Value quantization within the range will thus be no larger than 1/100th \
                                                  * (or 1%) of any value. The total size per histogram should sit around 40 KiB Bytes. */
 
+/* End-to-end latency histogram per command init settings. */
+#define LATENCY_E2E_HISTOGRAM_MIN_VALUE 1L           /* >= 1 nanosec */
+#define LATENCY_E2E_HISTOGRAM_MAX_VALUE 10000000000L /* <= 10 secs */
+#define LATENCY_E2E_HISTOGRAM_PRECISION 2            /* 2 significant digits, as with the latency histogram. */
+
+/* Latency-tracking feature flags (server.latency_tracking_features). Select which latency metrics. */
+#define LATENCY_TRACK_CMD (1 << 0) /* command processing-time histogram */
+#define LATENCY_TRACK_E2E (1 << 1) /* per-command end-to-end (service) time histogram */
+
 /* Busy module flags, see busy_module_yield_flags */
 #define BUSY_MODULE_YIELD_NONE (0)
 #define BUSY_MODULE_YIELD_EVENTS (1 << 0)
@@ -1339,6 +1348,37 @@ typedef struct LastWrittenBuf {
 /* Forward declaration of slotMigrationJob */
 typedef struct slotMigrationJob slotMigrationJob;
 
+/* end to end latency structure & definitions. */
+#ifndef LATENCY_E2E_MAX_SLOTS
+/* Maximum number of unique commands tracked in a single batch. */
+/* Note: This is kept low to enable GCC optimization of unrolling the loop defined in latencyE2eRecordCommand. */
+#define LATENCY_E2E_MAX_SLOTS 8
+#endif
+
+/* Max number of aggregation tables per client.
+ * Each table is retired once its replies are fully written. */
+#define LATENCY_E2E_MAX_TABLES 4
+
+/* service time aggregation table. */
+typedef struct latencyE2eTable {
+    struct serverCommand *cmds[LATENCY_E2E_MAX_SLOTS];
+    int counts[LATENCY_E2E_MAX_SLOTS]; /* Number of samples per occupied slot. */
+    int nslots;                        /* Number of occupied slots. */
+    monotime cmd_read_time;            /* Arrival time of this table's commands. */
+    uint64_t boundary;                 /* reply_blocks_removed value at which this table's replies
+                                        * are fully written; -1ULL while the table is still accepting new samples. */
+} latencyE2eTable;
+
+typedef struct latencyE2e {
+    monotime cur_read_time;         /* Arrival time of the most recent socket read. */
+    monotime cur_cmd_time;          /* Current command batch read time. */
+    monotime cur_write_time;        /* The latest write time associated with the client. */
+    uint64_t reply_block_watermark; /* reply_blocks_removed value at which current responses are flushed out. */
+    uint64_t reply_blocks_removed;  /* Monotonic count of reply blocks drained from c->reply. */
+    list *tables;                   /* Lazily allocated aggregation tables. */
+    latencyE2eTable *open;          /* Current aggregation table. */
+} latencyE2e;
+
 typedef struct client {
     /* Basic client information and connection. */
     uint64_t id; /* Client incremental unique ID. */
@@ -1378,7 +1418,9 @@ typedef struct client {
     size_t buf_usable_size;              /* Usable size of buffer. */
     list *reply;                         /* List of reply objects to send to the client. */
     listNode *io_last_reply_block;       /* Last client reply block when sent to IO thread */
-    size_t io_last_bufpos;               /* The client's bufpos at the time it was sent to the IO thread */
+    size_t io_last_bufpos;               /* The client's bufpos at the time it was sent to the IO thread. */
+    size_t io_reply_len;                 /* Client reply block count when sent to IO thread.  */
+    monotime io_event_loop_wakeup_time;  /* Snapshot of the event loop wakeup_time. */
     LastWrittenBuf io_last_written;      /* Track state for last written buffer */
     unsigned long long reply_bytes;      /* Tot bytes of objects in reply list. */
     listNode clients_pending_write_node; /* list node in clients_pending_write or in clients_pending_io_write list */
@@ -1423,6 +1465,7 @@ typedef struct client {
     int slot;                                     /* The slot the client is executing against. Set to -1 if no slot is being used */
     listNode *mem_usage_bucket_node;
     clientMemUsageBucket *mem_usage_bucket;
+    latencyE2e latency_e2e;
     /* In updateClientMemoryUsage() we track the memory usage of
      * each client and add it to the sum of all the clients of a given type,
      * however we need to remember what was the old contribution of each
@@ -2046,6 +2089,9 @@ struct valkeyServer {
     int pause_cron;                            /* Don't run cron tasks (debug) */
     int dict_resizing;                         /* Whether to allow main dict and expired dict to be resized (debug) */
     int latency_tracking_enabled;              /* 1 if extended latency tracking is enabled, 0 otherwise. */
+    int latency_tracking_features;             /* Bitmask of LATENCY_TRACK_* metrics to record when tracking is enabled. */
+    int latency_tracking_enable_cmd;           /* Tracking of processing time is enabled. */
+    int latency_tracking_enable_e2e;           /* Tracking of end to end time is enabled. */
     double *latency_tracking_info_percentiles; /* Extended latency tracking info output percentile list configuration. */
     int latency_tracking_info_percentiles_len;
     unsigned int max_new_tls_conns_per_cycle; /* The maximum number of tls connections that will be accepted during each
@@ -2798,7 +2844,9 @@ struct serverCommand {
     sds fullname;     /* Includes parent name if any: "parentcmd|childcmd". Unchanged if command is renamed. */
     sds current_name; /* Same as fullname, becomes a separate string if command is renamed. */
     struct hdr_histogram
-        *latency_histogram;        /* Points to the command latency command histogram (unit of time nanosecond). */
+        *latency_histogram; /* Points to the command latency command histogram (unit of time nanosecond). */
+    struct hdr_histogram
+        *latency_e2e_histogram;    /* Points to the command end to end latency command histogram (unit of time nanosecond). */
     keySpec legacy_range_key_spec; /* The legacy (first,last,step) key spec is
                                     * still maintained (if applicable) so that
                                     * we can still support the reply format of
@@ -3583,8 +3631,13 @@ void forceCommandPropagation(client *c, int flags);
 void preventCommandPropagation(client *c);
 void preventCommandAOF(client *c);
 void preventCommandReplication(client *c);
+void latencyE2eRecordCommand(client *c, struct serverCommand *cmd);
+void latencyE2eRelease(client *c);
+void latencyE2ePostClientWrite(client *c);
+void latencyE2ePostReplicaWrite(client *c);
 void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd);
 void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int64_t duration_hist);
+void updateCommandLatencyE2eHistogram(struct hdr_histogram **latency_e2e_histogram, int64_t duration_hist, long long count);
 int prepareForShutdown(client *c, int flags);
 void replyToClientsBlockedOnShutdown(void);
 int abortShutdown(void);
@@ -3771,6 +3824,7 @@ typedef enum {
 } configType;
 
 void loadServerConfig(char *filename, char config_from_stdin, char *options);
+int updateLatencyTrackingFlags(const char **err);
 void appendServerSaveParams(time_t seconds, int changes);
 void resetServerSaveParams(void);
 struct rewriteConfigState; /* Forward declaration to export API. */

--- a/src/server.h
+++ b/src/server.h
@@ -3635,6 +3635,7 @@ void latencyE2eRecordCommand(client *c, struct serverCommand *cmd);
 void latencyE2eRelease(client *c);
 void latencyE2ePostClientWrite(client *c);
 void latencyE2ePostReplicaWrite(client *c);
+void latencyE2eModuleUnload(void);
 void commandlogPushCurrentCommand(client *c, struct serverCommand *cmd);
 void updateCommandLatencyHistogram(struct hdr_histogram **latency_histogram, int64_t duration_hist);
 void updateCommandLatencyE2eHistogram(struct hdr_histogram **latency_e2e_histogram, int64_t duration_hist, long long count);

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -71,6 +71,203 @@ start_server {tags {"latency-monitor needs:latency"}} {
         assert {[string length [r latency histogram blabla set get]] > 0}
     }
 
+    # Largest latency bucket (usec) recorded for a LATENCY HISTOGRAM command entry.
+    proc max_histogram_usec {cmd_entry} {
+        set maxk 0
+        foreach {k v} [dict get $cmd_entry histogram_usec] {
+            if {$k > $maxk} {set maxk $k}
+        }
+        return $maxk
+    }
+
+    test {LATENCY HISTOGRAM E2E is disabled by default} {
+        # Default feature set is "cmd" only (processing time); e2e is off.
+        assert_equal {cmd} [lindex [r config get latency-tracking-features] 1]
+        r config resetstat
+        r set stk v
+        r get stk
+        # Processing histogram still records; the e2e one stays empty.
+        assert {[llength [r latency histogram]] > 0}
+        assert {[llength [r latency histogram e2e]] == 0}
+    }
+
+    test {LATENCY HISTOGRAM default reporting - processing time} {
+        r config resetstat
+        r set stk v
+        r get stk
+        set cmd [dict create {*}[r latency histogram cmd]]
+        set only [dict create {*}[r latency histogram cmd set]]
+        assert_equal [dict keys $only] {set}
+    }
+
+    test {LATENCY HISTOGRAM E2E recording} {
+        r config set latency-tracking-features "cmd e2e"
+        r config resetstat
+        set rd [valkey_deferring_client]
+        $rd set stk v
+        $rd get stk
+        $rd get stk
+        $rd flush
+        # Drain the replies so the writes complete (and samples seal) before close.
+        assert_equal {OK} [$rd read]
+        assert_equal {v} [$rd read]
+        assert_equal {v} [$rd read]
+        $rd close
+        set histo [dict create {*}[r latency histogram e2e]]
+        assert_match {calls 1 histogram_usec *} [dict get $histo set]
+        assert_match {calls 2 histogram_usec *} [dict get $histo get]
+        r config set latency-tracking-features cmd
+    }
+
+    test {LATENCY HISTOGRAM E2E measures end-to-end time including queue and block wait} {
+        r config set latency-tracking-features "cmd e2e"
+        r config resetstat
+        r del stlist
+        # One batch: a fast SET, a command that blocks ~3s, then a GET that is queued behind the blocking command
+        set rd [valkey_deferring_client]
+        $rd set stk v
+        $rd blpop stlist 3
+        $rd get stk
+        $rd flush
+        # Wait for all replies
+        assert_equal {OK} [$rd read]
+        assert_equal {} [$rd read]
+        assert_equal {v} [$rd read]
+        $rd close
+
+        set histo [dict create {*}[r latency histogram e2e]]
+        assert_match {calls 1 histogram_usec *} [dict get $histo set]
+        assert_match {calls 1 histogram_usec *} [dict get $histo blpop]
+        assert_match {calls 1 histogram_usec *} [dict get $histo get]
+
+        # SET is fast (< 0.5s); BLPOP and GET span the ~3s wait (>= 2.5s).
+        assert {[max_histogram_usec [dict get $histo set]] < 500000}
+        assert {[max_histogram_usec [dict get $histo blpop]] >= 2500000}
+        assert {[max_histogram_usec [dict get $histo get]] >= 2500000}
+        r config set latency-tracking-features cmd
+    }
+
+    test {LATENCY HISTOGRAM E2E I/O threads} {
+        r config set io-threads 2
+        r config set io-threads-always-active yes
+        r config set latency-tracking-features "cmd e2e"
+        r config resetstat
+        # Batch several commands so replies are drained on the I/O-thread write path.
+        set rd [valkey_deferring_client]
+        $rd set itk v
+        $rd get itk
+        $rd get itk
+        $rd flush
+        assert_equal {OK} [$rd read]
+        assert_equal {v} [$rd read]
+        assert_equal {v} [$rd read]
+        $rd close
+        set histo [dict create {*}[r latency histogram e2e]]
+        assert_match {calls 1 histogram_usec *} [dict get $histo set]
+        assert_match {calls 2 histogram_usec *} [dict get $histo get]
+        r config set latency-tracking-features cmd
+        r config set io-threads-always-active no
+        r config set io-threads 1
+    }
+
+    test {LATENCY HISTOGRAM E2E MULTI/EXEC} {
+        r config set latency-tracking-features "cmd e2e"
+        r config resetstat
+        set rd [valkey_deferring_client]
+        $rd multi
+        $rd set mtk v
+        $rd get mtk
+        $rd incr mtn
+        $rd exec
+        $rd flush
+        assert_equal {OK} [$rd read]
+        assert_equal {QUEUED} [$rd read]
+        assert_equal {QUEUED} [$rd read]
+        assert_equal {QUEUED} [$rd read]
+        assert_equal {OK v 1} [$rd read]
+        $rd close
+        set histo [dict create {*}[r latency histogram e2e]]
+        # Only EXEC is recorded.
+        assert_match {calls 1 histogram_usec *} [dict get $histo exec]
+        assert {![dict exists $histo set]}
+        assert {![dict exists $histo get]}
+        assert {![dict exists $histo incr]}
+        assert {![dict exists $histo multi]}
+        r config set latency-tracking-features cmd
+    }
+
+    test {LATENCY HISTOGRAM E2E skips CLIENT REPLY OFF and SKIP} {
+        r config set latency-tracking-features "cmd e2e"
+        r config resetstat
+        set rd [valkey_deferring_client]
+        # skip reply on the SET command
+        $rd client reply skip
+        $rd set skipk v
+        $rd get skipk
+        $rd flush
+        assert_equal {v} [$rd read]
+        # disable reply on client
+        $rd client reply off
+        $rd set offk v
+        $rd incr offn
+        $rd client reply on
+        $rd flush
+        assert_equal {OK} [$rd read]
+        $rd close
+        # Only the GET is recorded, SET/INCR are not.
+        set histo [dict create {*}[r latency histogram e2e]]
+        assert_match {calls 1 histogram_usec *} [dict get $histo get]
+        assert {![dict exists $histo set]}
+        assert {![dict exists $histo incr]}
+        r config set latency-tracking-features cmd
+    }
+
+    test {LATENCY HISTOGRAM E2E on large multi-block reply} {
+        r config set latency-tracking-features "cmd e2e"
+        # A value large enough to spill the reply into several output blocks.
+        set big [string repeat A 200000]
+        r set bigk $big
+        r config resetstat
+        set rd [valkey_deferring_client]
+        $rd get bigk
+        $rd flush
+        assert_equal $big [$rd read]
+        $rd close
+        set histo [dict create {*}[r latency histogram e2e]]
+        assert_match {calls 1 histogram_usec *} [dict get $histo get]
+        r config set latency-tracking-features cmd
+    }
+
+    test {LATENCY HISTOGRAM E2E records nothing for replicated writes on a replica} {
+        start_server {} {
+            set replica [srv 0 client]
+            set primary [srv -1 client]
+            set primary_host [srv -1 host]
+            set primary_port [srv -1 port]
+
+            $replica config set latency-tracking-features "cmd e2e"
+            $replica replicaof $primary_host $primary_port
+            wait_for_sync $replica
+            $replica config resetstat
+
+            $primary set rpk v
+            $primary set rpk v2
+            $primary incr rpn
+            wait_for_condition 50 100 {
+                [$replica get rpk] eq {v2}
+            } else {
+                fail "replica did not apply replicated writes"
+            }
+
+            set histo [dict create {*}[$replica latency histogram e2e]]
+            assert {![dict exists $histo set]}
+            assert {![dict exists $histo incr]}
+
+            $replica replicaof no one
+            $replica config set latency-tracking-features cmd
+        }
+    }
+
 tags {"needs:debug"} {
     set old_threshold_value [lindex [r config get latency-monitor-threshold] 1]
 

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -141,33 +141,40 @@ start_server {tags {"latency-monitor needs:latency"}} {
         assert_match {calls 1 histogram_usec *} [dict get $histo get]
 
         # SET is fast (< 0.5s); BLPOP and GET span the ~3s wait (>= 2.5s).
-        assert {[max_histogram_usec [dict get $histo set]] < 500000}
-        assert {[max_histogram_usec [dict get $histo blpop]] >= 2500000}
-        assert {[max_histogram_usec [dict get $histo get]] >= 2500000}
+        # Timing-sensitive: skip under environments that can't measure latency reliably.
+        if {!$::no_latency} {
+            assert {[max_histogram_usec [dict get $histo set]] < 500000}
+            assert {[max_histogram_usec [dict get $histo blpop]] >= 2500000}
+            assert {[max_histogram_usec [dict get $histo get]] >= 2500000}
+        }
         r config set latency-tracking-features cmd
     }
 
     test {LATENCY HISTOGRAM E2E I/O threads} {
-        r config set io-threads 2
-        r config set io-threads-always-active yes
-        r config set latency-tracking-features "cmd e2e"
-        r config resetstat
-        # Batch several commands so replies are drained on the I/O-thread write path.
-        set rd [valkey_deferring_client]
-        $rd set itk v
-        $rd get itk
-        $rd get itk
-        $rd flush
-        assert_equal {OK} [$rd read]
-        assert_equal {v} [$rd read]
-        assert_equal {v} [$rd read]
-        $rd close
-        set histo [dict create {*}[r latency histogram e2e]]
-        assert_match {calls 1 histogram_usec *} [dict get $histo set]
-        assert_match {calls 2 histogram_usec *} [dict get $histo get]
-        r config set latency-tracking-features cmd
-        r config set io-threads-always-active no
-        r config set io-threads 1
+        try {
+            r config set io-threads 2
+            r config set io-threads-always-active yes
+            r config set latency-tracking-features "cmd e2e"
+            r config resetstat
+            # Batch several commands so replies are drained on the I/O-thread write path.
+            set rd [valkey_deferring_client]
+            $rd set itk v
+            $rd get itk
+            $rd get itk
+            $rd flush
+            assert_equal {OK} [$rd read]
+            assert_equal {v} [$rd read]
+            assert_equal {v} [$rd read]
+            $rd close
+            set histo [dict create {*}[r latency histogram e2e]]
+            assert_match {calls 1 histogram_usec *} [dict get $histo set]
+            assert_match {calls 2 histogram_usec *} [dict get $histo get]
+        } finally {
+            # Always restore the I/O-thread config so a failure here doesn't leak into later tests.
+            r config set latency-tracking-features cmd
+            r config set io-threads-always-active no
+            r config set io-threads 1
+        }
     }
 
     test {LATENCY HISTOGRAM E2E MULTI/EXEC} {
@@ -266,7 +273,7 @@ start_server {tags {"latency-monitor needs:latency"}} {
             $replica replicaof no one
             $replica config set latency-tracking-features cmd
         }
-    }
+    } {} {external:skip}
 
 tags {"needs:debug"} {
     set old_threshold_value [lindex [r config get latency-monitor-threshold] 1]

--- a/valkey.conf
+++ b/valkey.conf
@@ -2307,6 +2307,17 @@ latency-monitor-threshold 0
 # are the p50, p99, and p999.
 # latency-tracking-info-percentiles 50 99 99.9
 
+# When latency tracking is enabled (above), latency-tracking-features selects
+# which command latency metrics are recorded:
+#   cmd  - processing time: the time spent executing the command.
+#   e2e  - end-to-end time: from when the event loop wakes to read a
+#          command until its reply is fully written back, including time queued
+#          behind other commands and time blocked.
+#
+# Multiple values may be combined. The default is "cmd" (processing time only).
+# For example, to record both: latency-tracking-features cmd e2e
+# latency-tracking-features cmd
+
 ############################# EVENT NOTIFICATION ##############################
 
 # The server can notify Pub/Sub clients about events happening in the key space.


### PR DESCRIPTION
# Summary 

This change implements #3718.

This change adds a new per-command histogram that tracks the total WALL time of a command inside the engine,
this spans from the moment the engine read the command until the engine flushed out the responses generated by the request.

# Motivation 

Currently the valkey engine provides the `LATENCY HISTOGRAM` & `COMMANDLOG/SLOWLOG` commands to identify slow commands, however these tracking stores only track the command processing time discarding the QUEUING time
- Queuing behind slow commands 
- Queuing behind blocking commands
- Queuing behind other clients

# Design

For simplicity let's assume the simplified flow chart of a command inside the valkey engine

```mermaid
flowchart LR
    subgraph R["COMMAND PROCESSING PIPELINE"]
        direction LR

        WAKE_UP["Event Loop (epoll)"]
        READ["Reading of socket"]
        PARSE["Parsing"]
        PROC["Processing"]
        WRITE["Writing on Socket"]

        WAKE_UP -->READ --> PARSE --> PROC --> WRITE
    end
```

## Starting point

The timer is started from the moment engine becomes first aware of data exiting on the socket, which happens when the epoll returns back with results.

On large requests where the engine will take multiple events to construct a request, two options can be taken:
- Use the time of the first read operation was performed
- Use the time for the last read operation was performed

In this design, the second is done for simplicity & consistency of behavior across different workloads. 

For example during a blocking command the engine will keep reading data into the query buffer, 
when the unblock happens it will be impossible to associated a command with a proper "start timer" without extensive read tracking. (Quite expensive in terms of performance impact)

In short the start timer is collapsed towards the last read that happened before a new batch of commands is parsed & processed

## Endpoint 

The timer is stopped when the engine is confident that the response was flushed out.

This is done via tracking response blocks (`c->reply`), once a sufficient number of response blocks if flushed out, the engine can be sure that the response was fully sent to the user

Multiple aggregation tables are used account for the possibility of a new patch of commands arriving into the processing path while an old batch is yet to flush out it responses

## Aggregation

In this design all requests within a non-blocked batch are aggregated into a single span in terms of time, 
I.E. These commands share the same start & end time measurements.

The commands are aggregated into a simple counting table, which tracks how many times a command was executed within a non-blocked batch.

| CMD  | COUNT |
|:-----|:-----:|
| SET  |   5   |
| GET  |   7   |
| INCR |   2   |

# Memory Overhead (Clients)

72 Bytes inlined per client are paid regardless if the feature is turned ON or OFF.

If feature is turned on, an addition 116 is paid per aggregation table on each tracked client.

The number of aggregation tables is currently capped at 4, so the overall cost of the feature when ON will be between 116 & 464 bytes per client.

In the worst case the overall cost per a tracked connection will be 536 bytes.

# Testing

- New latency histogram is off by default
- New latency histogram accounts for blocked time
- New latency histogram skips replicas & requests with no responses
- No replica tracking
- Basic IO thread tests

# Benchmarks

Testing done on standard `valkey-benchmark` tooling using:
- `m7g.16xlarge` instance
- 4 IO threads / 8 Benchmark threads
- Pipeline limit of 10
- 128 clients
- 512 request/response sizes

| CMD/Binary | Baseline  | Candidate, Feature OFF | Candidate, Feature ON |
|:-----------|:---------:|:-----------------------|:---------------------:|
| SET        | 1.63M RPS | 1.62M RPS              |       1.60M RPS       |
| GET        | 1.7M RPS  | 1.7 RPS                |       1.68M RPS       |

Overall, when the feature a small overhead is detected that is usually <1%,
When feature is ON the overhead hovers around 2~3%.

# Commands

The new histograms can be accessed using existing latency commands

`LATENCY HISTOGRAM [CMD|E2E] [COMMAND_1] [COMMAND_2] ....`

By default, the histograms will provide the legacy execution time, which can also be accessed by specifying `LATENCY HISTOGRAM CMD`

THe new histograms are accessed via `LATENCY HISTOGRAM E2E`.

Resetting/clearing stats can be done via the standard `CONFIG RESETSTATS`.

# What's missing

This design does not attempt to do a granular per-command `start->end` spans, as that would be too expensive in terms of overhead & memory.

To keep the overhead reasonable, spans are collapsed in 2 directions:
* Start: All commands in a batch will share a starting time
  * The server will not account for the in kernel buffer queuing time.
  * The server will not account for queuing time within the client buffer.
* End: All commands in an aggregation table will share an ending time.
  * The server will not account for the fact that some responses are pushed before others

# Future Improvements

SO_TIMESTAMPING could be used on Linux systems to attempt the acquiring of a more accurate start time by accounting for kernel buffer queuing time.


