### PR TITLE
bgiteration hardening

### DIFF
--- a/src/bgiteration.c
+++ b/src/bgiteration.c
@@ -1897,6 +1897,7 @@ static bool anIteratorWillReplicateForThisCommand(void) {
 
 static bool expediteKeysForMultiExec(client *c, hashtable *waitingOnKeys) {
     serverAssert(c->cmd->proc == execCommand);
+    if (c->mstate == NULL) return false; // EXEC without MULTI
 
     /* For MULTI/EXEC, Valkey buffers all of the commands until hitting the EXEC.
      * At this point, the client holds all of the commands to be executed.  This function searches

--- a/src/bgiteration.c
+++ b/src/bgiteration.c
@@ -22,10 +22,22 @@ static bool isScriptCallWriteCmd(struct serverCommand *cmd) {
     return ((cmd->proc == fcallCommand) || (cmd->proc == evalCommand) || (cmd->proc == evalShaCommand));
 }
 
+/* Some read commands also change the internal format (not great).  We need to treat these like
+ * write commands, blocking them from modifying the format while the background thread might be
+ * operating on the item.
+ *  - PFCOUNT - modifies the underlying string (and is replicated!)
+ *  - LINDEX/LRANGE/LPOS - may modify quicklist by LZF compress/uncompress */
+static bool isFormatChangingCommand(struct serverCommand *cmd) {
+    return ((cmd->proc == pfcountCommand) ||
+            (cmd->proc == lindexCommand) ||
+            (cmd->proc == lrangeCommand) ||
+            (cmd->proc == lposCommand));
+}
+
 /* The PFCOUNT command (which does NOT have the CMD_WRITE flag) modifies the underlying string and
  * is replicated as a write.  So it needs to be detected and handled specially. */
 static bool isWriteCmd(struct serverCommand *cmd) {
-    return ((cmd->flags & CMD_WRITE) || (cmd->proc == pfcountCommand) || (cmd->proc == execCommand) || (isScriptCallWriteCmd(cmd)));
+    return ((cmd->flags & CMD_WRITE) || isFormatChangingCommand(cmd) || (cmd->proc == execCommand) || (isScriptCallWriteCmd(cmd)));
 }
 
 // Returns true if the command is a deletion based command (DEL or UNLINK)


### PR DESCRIPTION
Two items found during AI testing.

1. The list datatype modifies the data during read commands to support compression,  specifically LINDEX, LRANGE, and LPOS need to be treated as write commands (like PFCOUNT).
2. Prevents a crash if a client issues an EXEC without a preceding MULTI (an error).