### PR TITLE
Add ValkeyModule_AlignedAlloc and ValkeyModule_TryAlignedAlloc to the module API

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -609,6 +609,31 @@ char *VM_Strdup(const char *str) {
     return zstrdup(str);
 }
 
+/* Use like aligned_alloc(). Memory allocated with this function is reported in
+ * INFO memory, used for keys eviction according to maxmemory settings
+ * and in general is taken into account as memory allocated by the server.
+ * You should avoid using aligned_alloc() directly.
+ *
+ * 'alignment' must be a non-zero power of two, and the returned pointer is a
+ * multiple of it. Unlike the C11 aligned_alloc(), 'bytes' is not required to be
+ * a multiple of 'alignment', which matches how the common libc implementations
+ * behave.
+ *
+ * The returned pointer must be released with ValkeyModule_Free().
+ *
+ * This function returns NULL if 'alignment' is not a valid alignment, and
+ * panics if unable to allocate enough memory. */
+void *VM_AlignedAlloc(size_t alignment, size_t bytes) {
+    /* See the comment in 'VM_Alloc()' for why the '_usable' variant is used. */
+    return zaligned_alloc_usable(alignment, bytes, NULL);
+}
+
+/* Similar to VM_AlignedAlloc, but returns NULL in case of allocation failure,
+ * instead of panicking. An invalid alignment is still reported as NULL. */
+void *VM_TryAlignedAlloc(size_t alignment, size_t bytes) {
+    return ztryaligned_alloc_usable(alignment, bytes, NULL);
+}
+
 /* --------------------------------------------------------------------------
  * Pool allocator
  * -------------------------------------------------------------------------- */
@@ -15282,6 +15307,8 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(TryRealloc);
     REGISTER_API(Free);
     REGISTER_API(Strdup);
+    REGISTER_API(AlignedAlloc);
+    REGISTER_API(TryAlignedAlloc);
     REGISTER_API(CreateCommand);
     REGISTER_API(GetCommand);
     REGISTER_API(CreateSubcommand);

--- a/src/unit/test_zmalloc.cpp
+++ b/src/unit/test_zmalloc.cpp
@@ -6,8 +6,10 @@
 
 #include "generated_wrappers.hpp"
 
+#include <cerrno>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 
 extern "C" {
 #include "zmalloc.h"
@@ -64,5 +66,138 @@ TEST_F(ZmallocTest, TestZmallocCacheAlignedAllocAndFree) {
 
     ASSERT_EQ(alignment, 0u);
     ASSERT_GE(usable_size, 123u);
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
+
+/* Sweep a range of alignments and sizes through one of the aligned allocators.
+ * 'name' only makes a failure say which entry point was being exercised. */
+static void testAlignedAllocSweep(void *(*alloc)(size_t, size_t), const char *name) {
+    static const size_t alignments[] = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 4096};
+    static const size_t sizes[] = {1, 7, 123, 1024, 8193};
+    size_t used_memory_before = zmalloc_used_memory();
+    size_t i, j;
+
+    for (i = 0; i < sizeof(alignments) / sizeof(alignments[0]); i++) {
+        for (j = 0; j < sizeof(sizes) / sizeof(sizes[0]); j++) {
+            size_t alignment = alignments[i];
+            size_t size = sizes[j];
+            void *ptr = alloc(alignment, size);
+
+            ASSERT_NE(ptr, nullptr) << name << " alignment " << alignment << " size " << size;
+            ASSERT_EQ((uintptr_t)ptr % alignment, 0u) << name << " alignment " << alignment << " size " << size;
+            ASSERT_GE(zmalloc_usable_size(ptr), size) << name << " alignment " << alignment << " size " << size;
+
+            /* The whole requested range must be writable. */
+            memset(ptr, 0xa5, size);
+
+            zfree(ptr);
+        }
+    }
+
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before) << name;
+}
+
+/* Check that an allocator rejects alignments that are zero or not a power of
+ * two, without disturbing the memory accounting. */
+static void testAlignedAllocRejectsBadAlignment(void *(*alloc)(size_t, size_t), const char *name) {
+    static const size_t alignments[] = {0, 3, 6, 24, 100, 1000};
+    size_t used_memory_before = zmalloc_used_memory();
+    size_t i;
+
+    for (i = 0; i < sizeof(alignments) / sizeof(alignments[0]); i++) {
+        errno = 0;
+        ASSERT_EQ(alloc(alignments[i], 128), nullptr) << name << " alignment " << alignments[i];
+        ASSERT_EQ(errno, EINVAL) << name << " alignment " << alignments[i];
+    }
+
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before) << name;
+}
+
+TEST_F(ZmallocTest, TestZalignedAllocAndFree) {
+    testAlignedAllocSweep(zaligned_alloc, "zaligned_alloc");
+}
+
+TEST_F(ZmallocTest, TestZtryalignedAllocAndFree) {
+    testAlignedAllocSweep(ztryaligned_alloc, "ztryaligned_alloc");
+}
+
+TEST_F(ZmallocTest, TestZalignedAllocIsAccounted) {
+    size_t used_memory_before = zmalloc_used_memory();
+    void *ptr = zaligned_alloc(4096, 1024 * 1024);
+
+    ASSERT_NE(ptr, nullptr);
+    ASSERT_GE(zmalloc_used_memory() - used_memory_before, 1024u * 1024u);
+
+    zfree(ptr);
+
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
+
+TEST_F(ZmallocTest, TestZalignedAllocUsable) {
+    size_t used_memory_before = zmalloc_used_memory();
+    size_t usable = 0;
+    void *ptr = zaligned_alloc_usable(64, 123, &usable);
+
+    ASSERT_NE(ptr, nullptr);
+    ASSERT_EQ((uintptr_t)ptr % 64, 0u);
+    ASSERT_GE(usable, 123u);
+
+    /* The reported usable size must really be usable. */
+    memset(ptr, 0x5a, usable);
+
+    zfree(ptr);
+
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
+
+TEST_F(ZmallocTest, TestZalignedAllocZeroByte) {
+    size_t used_memory_before = zmalloc_used_memory();
+    void *ptr = zaligned_alloc(64, 0);
+
+    ASSERT_NE(ptr, nullptr);
+    ASSERT_EQ((uintptr_t)ptr % 64, 0u);
+
+    zfree(ptr);
+
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
+
+TEST_F(ZmallocTest, TestZalignedAllocInvalidAlignment) {
+    testAlignedAllocRejectsBadAlignment(zaligned_alloc, "zaligned_alloc");
+}
+
+TEST_F(ZmallocTest, TestZtryalignedAllocInvalidAlignment) {
+    testAlignedAllocRejectsBadAlignment(ztryaligned_alloc, "ztryaligned_alloc");
+}
+
+TEST_F(ZmallocTest, TestZtryalignedAllocUsable) {
+    size_t used_memory_before = zmalloc_used_memory();
+    size_t usable = 0;
+    void *ptr = ztryaligned_alloc_usable(128, 4096, &usable);
+
+    ASSERT_NE(ptr, nullptr);
+    ASSERT_EQ((uintptr_t)ptr % 128, 0u);
+    ASSERT_GE(usable, 4096u);
+
+    /* The reported usable size must really be usable. */
+    memset(ptr, 0x5a, usable);
+
+    zfree(ptr);
+
+    ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
+}
+
+/* An allocation too large to ever succeed must come back as NULL rather than
+ * reach the OOM handler, which is the whole point of the 'try' variant. */
+TEST_F(ZmallocTest, TestZtryalignedAllocHugeSizeReturnsNull) {
+    size_t used_memory_before = zmalloc_used_memory();
+    /* Route the size through a volatile so that the compiler doesn't warn about
+     * an allocation larger than the maximum object size. */
+    volatile size_t huge = SIZE_MAX / 2;
+
+    ASSERT_EQ(ztryaligned_alloc(64, huge), nullptr);
+    huge = SIZE_MAX;
+    ASSERT_EQ(ztryaligned_alloc(64, huge), nullptr);
+
     ASSERT_EQ(zmalloc_used_memory(), used_memory_before);
 }

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1580,6 +1580,8 @@ VALKEYMODULE_API void (*ValkeyModule_Free)(void *ptr) VALKEYMODULE_ATTR;
 VALKEYMODULE_API void *(*ValkeyModule_Calloc)(size_t nmemb, size_t size)VALKEYMODULE_ATTR;
 VALKEYMODULE_API void *(*ValkeyModule_TryCalloc)(size_t nmemb, size_t size)VALKEYMODULE_ATTR;
 VALKEYMODULE_API char *(*ValkeyModule_Strdup)(const char *str)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_AlignedAlloc)(size_t alignment, size_t bytes)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_TryAlignedAlloc)(size_t alignment, size_t bytes)VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_GetApi)(const char *, void *) VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_CreateCommand)(ValkeyModuleCtx *ctx,
                                                    const char *name,
@@ -2350,6 +2352,8 @@ static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, in
     VALKEYMODULE_GET_API(Realloc);
     VALKEYMODULE_GET_API(TryRealloc);
     VALKEYMODULE_GET_API(Strdup);
+    VALKEYMODULE_GET_API(AlignedAlloc);
+    VALKEYMODULE_GET_API(TryAlignedAlloc);
     VALKEYMODULE_GET_API(CreateCommand);
     VALKEYMODULE_GET_API(GetCommand);
     VALKEYMODULE_GET_API(CreateSubcommand);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -33,6 +33,7 @@
 #include "solarisfixes.h"
 #include "serverassert.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -253,6 +254,126 @@ void *zmalloc_cache_aligned(size_t size) {
     update_zmalloc_stat_alloc(zmalloc_size(ptr));
     return ptr;
 #endif
+}
+
+/* Return non-zero if 'alignment' is a valid alignment, that is a non-zero power
+ * of two. */
+static inline int zmallocIsValidAlignment(size_t alignment) {
+    return alignment != 0 && (alignment & (alignment - 1)) == 0;
+}
+
+/* Try allocating 'alignment'-aligned memory, and return NULL if failed.
+ * 'alignment' must be a valid alignment, the caller is expected to have checked
+ * it with zmallocIsValidAlignment(). '*usable' is set to the usable size if non
+ * NULL. */
+static inline void *ztryaligned_alloc_usable_internal(size_t alignment, size_t size, size_t *usable) {
+    size_t alloc_size = MALLOC_MIN_SIZE(size);
+
+    /* Possible overflow, return NULL, so that the caller can panic or handle a failed allocation. */
+    if (alloc_size >= SIZE_MAX / 2) return NULL;
+
+#ifdef HAVE_MALLOC_SIZE
+    void *ptr = NULL;
+
+    /* posix_memalign() only accepts an alignment that is also a multiple of
+     * sizeof(void *). Raising a smaller power of two to it still satisfies the
+     * alignment that was asked for. */
+    if (alignment < sizeof(void *)) alignment = sizeof(void *);
+
+#ifdef USE_JEMALLOC
+    int ret = je_posix_memalign(&ptr, alignment, alloc_size);
+#else
+    int ret = posix_memalign(&ptr, alignment, alloc_size);
+#endif
+    if (ret != 0 || !ptr) return NULL;
+
+    alloc_size = zmalloc_size(ptr);
+    update_zmalloc_stat_alloc(alloc_size);
+    if (usable) *usable = alloc_size;
+    return ptr;
+#else
+    /* Without a usable size reported by the allocator we keep a size header
+     * right below the returned pointer, and that header can't be made room for
+     * by simply offsetting the malloc() result without losing the alignment.
+     * Over-allocate instead, pick an aligned address leaving room for both the
+     * header and a slot holding the original malloc() pointer, and mark the
+     * stored size with ZMALLOC_CACHE_ALIGNED_FLAG so that zfree() knows to
+     * recover the allocation from that slot. */
+    if (alloc_size & ZMALLOC_CACHE_ALIGNED_FLAG) return NULL;
+
+    size_t extra = alignment - 1;
+    if (extra > SIZE_MAX - PREFIX_SIZE - sizeof(void *)) return NULL;
+    extra += PREFIX_SIZE + sizeof(void *);
+    if (alloc_size > SIZE_MAX - extra) return NULL;
+
+    unsigned char *raw = malloc(alloc_size + extra);
+    if (!raw) return NULL;
+
+    uintptr_t aligned = ((uintptr_t)(raw + sizeof(void *) + PREFIX_SIZE + alignment - 1)) & ~((uintptr_t)alignment - 1);
+    void *ptr = (void *)aligned;
+
+    *((void **)((unsigned char *)ptr - PREFIX_SIZE - sizeof(void *))) = raw;
+    *((size_t *)((unsigned char *)ptr - PREFIX_SIZE)) = alloc_size | ZMALLOC_CACHE_ALIGNED_FLAG;
+
+    update_zmalloc_stat_alloc(alloc_size + PREFIX_SIZE);
+    if (usable) *usable = alloc_size;
+    return ptr;
+#endif
+}
+
+/* Allocate 'alignment'-aligned memory or panic. Behaves like aligned_alloc(),
+ * except that 'size' isn't required to be a multiple of 'alignment'. The
+ * returned pointer can be freed with zfree().
+ *
+ * Returns NULL with errno set to EINVAL if 'alignment' is not a non-zero power
+ * of two. An invalid alignment is a caller error rather than an out of memory
+ * condition, so it doesn't reach the OOM handler.
+ *
+ * '*usable' is set to the usable size if non NULL. */
+void *zaligned_alloc_usable(size_t alignment, size_t size, size_t *usable) {
+    if (!zmallocIsValidAlignment(alignment)) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    size_t usable_size = 0;
+    void *ptr = ztryaligned_alloc_usable_internal(alignment, size, &usable_size);
+    if (!ptr) zmalloc_oom_handler(size);
+#ifdef HAVE_MALLOC_SIZE
+    ptr = extend_to_usable(ptr, usable_size);
+#endif
+    if (usable) *usable = usable_size;
+    return ptr;
+}
+
+/* Like zaligned_alloc_usable(), but without reporting the usable size. */
+void *zaligned_alloc(size_t alignment, size_t size) {
+    return zaligned_alloc_usable(alignment, size, NULL);
+}
+
+/* Similar to zaligned_alloc_usable(), but returns NULL in case of allocation
+ * failure, instead of panicking. An invalid alignment is still reported as NULL
+ * with errno set to EINVAL.
+ *
+ * '*usable' is set to the usable size if non NULL. */
+void *ztryaligned_alloc_usable(size_t alignment, size_t size, size_t *usable) {
+    if (!zmallocIsValidAlignment(alignment)) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    size_t usable_size = 0;
+    void *ptr = ztryaligned_alloc_usable_internal(alignment, size, &usable_size);
+#ifdef HAVE_MALLOC_SIZE
+    ptr = extend_to_usable(ptr, usable_size);
+#endif
+    if (usable) *usable = usable_size;
+    return ptr;
+}
+
+/* Like ztryaligned_alloc_usable(), but without reporting the usable size. */
+void *ztryaligned_alloc(size_t alignment, size_t size) {
+    return ztryaligned_alloc_usable(alignment, size, NULL);
 }
 
 /* Try allocating memory, and return NULL if failed. */

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -115,12 +115,14 @@
  * bug[https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96503] is fixed. */
 __attribute__((malloc, alloc_size(1), noinline)) void *zmalloc(size_t size);
 __attribute__((malloc, alloc_size(1), noinline)) void *zmalloc_cache_aligned(size_t size);
+__attribute__((malloc, alloc_size(2), noinline)) void *zaligned_alloc(size_t alignment, size_t size);
 __attribute__((malloc, alloc_size(1), noinline)) void *zcalloc(size_t size);
 __attribute__((malloc, alloc_size(1, 2), noinline)) void *zcalloc_num(size_t num, size_t size);
 __attribute__((alloc_size(2), noinline)) void *zrealloc(void *ptr, size_t size);
 __attribute__((malloc, alloc_size(1), noinline)) void *ztrymalloc(size_t size);
 __attribute__((malloc, alloc_size(1), noinline)) void *ztrycalloc(size_t size);
 __attribute__((alloc_size(2), noinline)) void *ztryrealloc(void *ptr, size_t size);
+__attribute__((malloc, alloc_size(2), noinline)) void *ztryaligned_alloc(size_t alignment, size_t size);
 void zfree(void *ptr);
 void zfree_with_size(void *ptr, size_t size);
 void *zmalloc_usable(size_t size, size_t *usable);
@@ -129,6 +131,8 @@ void *zrealloc_usable(void *ptr, size_t size, size_t *usable);
 void *ztrymalloc_usable(size_t size, size_t *usable);
 void *ztrycalloc_usable(size_t size, size_t *usable);
 void *ztryrealloc_usable(void *ptr, size_t size, size_t *usable);
+void *zaligned_alloc_usable(size_t alignment, size_t size, size_t *usable);
+void *ztryaligned_alloc_usable(size_t alignment, size_t size, size_t *usable);
 __attribute__((malloc)) char *zstrdup(const char *s);
 size_t zmalloc_used_memory(void);
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t));

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdint.h>
 
 #define UNUSED(x) (void)(x)
 
@@ -659,6 +660,103 @@ int test_malloc_api(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     return VALKEYMODULE_OK;
 }
 
+/* Exercises one of the aligned allocators over a range of alignments, checking
+ * that the returned pointer is aligned, that the whole requested range is
+ * usable, and that an invalid alignment is rejected instead of panicking.
+ * Returns NULL on success, or an error message naming the failing case. */
+static const char *check_aligned_alloc(void *(*alloc)(size_t, size_t)) {
+    static const size_t alignments[] = {1, 8, 16, 64, 128, 512, 4096};
+    static const size_t sizes[] = {1, 123, 1024, 8193};
+    size_t i, j;
+
+    for (i = 0; i < sizeof(alignments) / sizeof(alignments[0]); i++) {
+        for (j = 0; j < sizeof(sizes) / sizeof(sizes[0]); j++) {
+            size_t alignment = alignments[i];
+            size_t size = sizes[j];
+            void *p = alloc(alignment, size);
+
+            if (p == NULL) return "ERR aligned alloc returned NULL";
+            if ((uintptr_t)p % alignment != 0) {
+                ValkeyModule_Free(p);
+                return "ERR aligned alloc returned a misaligned pointer";
+            }
+            if (ValkeyModule_MallocUsableSize(p) < size) {
+                ValkeyModule_Free(p);
+                return "ERR aligned alloc usable size is too small";
+            }
+
+            memset(p, 0xa5, size);
+            ValkeyModule_Free(p);
+        }
+    }
+
+    /* An alignment that is zero or not a power of two must return NULL rather
+     * than panic. */
+    if (alloc(0, 128) != NULL) return "ERR aligned alloc accepted a zero alignment";
+    if (alloc(24, 128) != NULL) return "ERR aligned alloc accepted a non power of two alignment";
+
+    return NULL;
+}
+
+int test_aligned_alloc(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+
+    const char *err = check_aligned_alloc(ValkeyModule_AlignedAlloc);
+    if (err != NULL) return ValkeyModule_ReplyWithError(ctx, err);
+
+    err = check_aligned_alloc(ValkeyModule_TryAlignedAlloc);
+    if (err != NULL) return ValkeyModule_ReplyWithError(ctx, err);
+
+    ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+    return VALKEYMODULE_OK;
+}
+
+/* Holds a single aligned allocation across commands, so that the test suite can
+ * observe it in the server memory diagnostics. */
+static void *aligned_alloc_held = NULL;
+
+int test_aligned_alloc_hold(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    long long alignment, size;
+
+    if (argc != 3)
+        return ValkeyModule_WrongArity(ctx);
+    if (ValkeyModule_StringToLongLong(argv[1], &alignment) != VALKEYMODULE_OK ||
+        ValkeyModule_StringToLongLong(argv[2], &size) != VALKEYMODULE_OK)
+        return ValkeyModule_ReplyWithError(ctx, "ERR invalid alignment or size");
+    if (aligned_alloc_held != NULL)
+        return ValkeyModule_ReplyWithError(ctx, "ERR an allocation is already held");
+
+    aligned_alloc_held = ValkeyModule_AlignedAlloc((size_t)alignment, (size_t)size);
+    if (aligned_alloc_held == NULL)
+        return ValkeyModule_ReplyWithError(ctx, "ERR aligned alloc returned NULL");
+    if ((uintptr_t)aligned_alloc_held % (size_t)alignment != 0) {
+        ValkeyModule_Free(aligned_alloc_held);
+        aligned_alloc_held = NULL;
+        return ValkeyModule_ReplyWithError(ctx, "ERR aligned alloc returned a misaligned pointer");
+    }
+
+    /* Touch the memory so that it is really resident. */
+    memset(aligned_alloc_held, 0xa5, (size_t)size);
+
+    ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+    return VALKEYMODULE_OK;
+}
+
+int test_aligned_alloc_release(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+
+    if (aligned_alloc_held == NULL)
+        return ValkeyModule_ReplyWithError(ctx, "ERR no allocation is held");
+
+    ValkeyModule_Free(aligned_alloc_held);
+    aligned_alloc_held = NULL;
+
+    ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+    return VALKEYMODULE_OK;
+}
+
 int test_keyslot(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     /* Static check of the ClusterKeySlot + ClusterCanonicalKeyNameInSlot
      * round-trip for all slots. */
@@ -754,6 +852,12 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     if (ValkeyModule_CreateCommand(ctx, "test.clear_n_events", test_clear_n_events,"", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
     if (ValkeyModule_CreateCommand(ctx, "test.malloc_api", test_malloc_api,"", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+    if (ValkeyModule_CreateCommand(ctx, "test.aligned_alloc", test_aligned_alloc,"", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+    if (ValkeyModule_CreateCommand(ctx, "test.aligned_alloc_hold", test_aligned_alloc_hold,"", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+    if (ValkeyModule_CreateCommand(ctx, "test.aligned_alloc_release", test_aligned_alloc_release,"", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
     if (ValkeyModule_CreateCommand(ctx, "test.keyslot", test_keyslot, "", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -591,6 +591,22 @@ start_server {overrides {save {900 1}} tags {"modules"}} {
         assert_equal {OK} [r test.malloc_api 0]
     }
 
+    test "aligned alloc API" {
+        assert_equal {OK} [r test.aligned_alloc]
+    }
+
+    test "aligned alloc is reported in used_memory" {
+        set before [s used_memory]
+        assert_equal {OK} [r test.aligned_alloc_hold 4096 10485760]
+        set held [s used_memory]
+        assert_equal {OK} [r test.aligned_alloc_release]
+        set after [s used_memory]
+
+        # The 10mb block is far above the background allocation noise.
+        assert {$held - $before > 8388608}
+        assert {$held - $after > 8388608}
+    }
+
     test "Cluster keyslot" {
         assert_equal 12182 [r test.keyslot foo]
     }


### PR DESCRIPTION
## Problem

The module heap API offers `Alloc`, `TryAlloc`, `Calloc`, `TryCalloc`, `Realloc`, `TryRealloc`, `Free` and `Strdup`, all routed through zmalloc so that every byte a module takes lands in the server's accounting. There is no aligned equivalent.

A module that needs cache-line- or page-aligned storage therefore has to call `aligned_alloc()` or `posix_memalign()` directly, and that memory becomes invisible to the server. It is missing from `INFO memory` and from the `used_memory` figure that drives `maxmemory` eviction.

## What this adds

`ValkeyModule_AlignedAlloc(alignment, bytes)`, semantically the library `aligned_alloc()`, accounted exactly like `ValkeyModule_Alloc()`, plus `ValkeyModule_TryAlignedAlloc()`, which returns NULL on allocation failure instead of panicking. That keeps the pairing the API already has for `Alloc`, `Calloc` and `Realloc`. Both are released with `ValkeyModule_Free()` like every other module allocation.

Semantics:

- `alignment` must be a non-zero power of two, and the returned pointer is a multiple of it.
- `bytes` need not be a multiple of `alignment`. This follows the common libc implementations rather than strict C11.
- An invalid alignment returns NULL with `errno` set to `EINVAL` from both functions. That is a caller error, not an out of memory condition, so it does not reach the OOM handler.
- On allocation failure `AlignedAlloc` panics and `TryAlignedAlloc` returns NULL, matching `Alloc` and `TryAlloc`.

## Implementation

zmalloc gains `zaligned_alloc()`, `zaligned_alloc_usable()`, `ztryaligned_alloc()` and `ztryaligned_alloc_usable()`, mirroring the existing `zmalloc` and `ztrymalloc` families.

Where the allocator can report sizes the new path is a thin wrapper over `posix_memalign()`, or `je_posix_memalign()` under jemalloc. An alignment below `sizeof(void *)` is raised to it, since `posix_memalign()` requires that and raising a power of two still satisfies the caller.

Where the allocator cannot report sizes, zmalloc keeps a size header immediately below the returned pointer, and room for that header cannot be made by offsetting the `malloc()` result without losing the alignment. So this path over-allocates, picks an aligned address that leaves room for the header plus a slot holding the original `malloc()` pointer, and marks the stored size with the existing flag bit. That marker scheme is already alignment-agnostic, so `zfree()`, `zfree_with_size()` and `zmalloc_size()` handle these pointers with no change.

`zmalloc_cache_aligned()` is deliberately left untouched.

## Tests

Unit tests in `src/unit/test_zmalloc.cpp` sweep both entry points over alignments from 1 to 4096 across several sizes, checking the returned alignment, that the usable size covers the request, that the whole range is writable, and that used memory returns to its baseline after `zfree()`. Further cases cover a 1MB block showing up in the accounting, the reported usable size being genuinely usable, a zero-byte request, rejection of alignments 0, 3, 6, 24, 100 and 1000 by both functions, and `TryAlignedAlloc` returning NULL for a size that can never be satisfied.

Module API tests add `test.aligned_alloc` to `tests/modules/misc.c`, which walks the same ground through both public entry points and checks that an invalid alignment returns NULL instead of panicking. A hold/release command pair lets `tests/unit/moduleapi/misc.tcl` confirm that a 10MB aligned block appears in `used_memory` and disappears when freed.

Verification run:

- Full module API suite passes.
- `ZmallocTest` gtest cases pass, 12 of 12.
- `unit/info` and `unit/other` integration tests pass.
- Both allocator branches were exercised under `_FORTIFY_SOURCE` with a standalone harness, including the manual-alignment path built with `-DNO_MALLOC_USABLE_SIZE`, covering alignment, usable size, accounting, `zfree()`, `zfree_with_size()`, invalid alignments and unsatisfiable sizes.

One pre-existing failure is unrelated to this change and reproduces on a clean `unstable`: the full gtest binary segfaults in `CmdFlagsTest.TestWriteFirstkeyOnly` when the whole suite runs in one process, though that test passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XX4N9KfNbJ5aTpXgyCE5ca
