### PR TITLE
Reject bulk lengths that would overflow the bulk-size arithmetic

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3843,6 +3843,9 @@ static int parseMultibulk(client *c,
             } else if (ll > 16384 && auth_required) {
                 return READ_FLAGS_ERROR_UNAUTHENTICATED_BULK_LEN;
             }
+            if (ll > LONG_MAX - 2) {
+                return READ_FLAGS_ERROR_MBULK_INVALID_BULK_LEN;
+            }
 
             c->qb_pos = newline - c->querybuf + 2;
             if (!(is_replicated) && ll >= PROTO_MBULK_BIG_ARG) {

--- a/tests/unit/querybuf.tcl
+++ b/tests/unit/querybuf.tcl
@@ -126,5 +126,22 @@ start_server {tags {"querybuf slow"}} {
      
         $rd close
     }
+}
 
+start_server {tags {"querybuf slow"}} {
+    test "huge bulk length is rejected without crashing the server" {
+        set announcement 2147483647
+        if {[s arch_bits] == 64} {
+            set announcement 9223372036854775807
+        }
+        r config set proto-max-bulk-len $announcement
+        foreach len [list $announcement [expr {$announcement - 1}]] {
+            set rd [valkey_deferring_client]
+            $rd write "*1\r\n\$$len\r\n"
+            $rd flush
+            assert_error "*invalid bulk length*" {$rd read}
+            $rd close
+        }
+        assert_equal "PONG" [r ping]
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a signed integer overflow (undefined behavior) in the bulk-length arithmetic.

`string2ll()` accepts a `$<len>` announcement up to `LLONG_MAX`, and the replicated-client path skips the `proto-max-bulk-len` check. For announcements of `$9223372036854775806` or `$9223372036854775807`, `c->bulklen + 2` — computed in `parseMultibulk()` and `readToQueryBuf()` — overflows signed `long` (`c->bulklen`'s type; C11 6.5/5, caught by the sanitizer build). The wrapped value drives a ~9.2 EB allocation attempt that aborts the server.

## Fix

Reject those two announcements at the bulk-length check with the existing invalid-bulk-length error. The bound is `LONG_MAX - 2` because `c->bulklen` is `long`: the assignment is lossless and `bulklen + 2` cannot overflow, on 32- and 64-bit alike. Behavior for every other value is unchanged.

## Test

`tests/unit/querybuf.tcl` (64-bit): with `proto-max-bulk-len` raised to `LLONG_MAX`, announcing `$LLONG_MAX` is rejected with `invalid bulk length` and the server stays healthy. Without the fix the sanitizer build reports the overflow.
