### PR TITLE
Reject a negative LIMIT offset in zset range commands

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2616,8 +2616,14 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
                                  long limit,
                                  int reverse) {
     unsigned long rangelen = 0;
-
     handler->beginResultEmission(handler, -1);
+
+    /* Nothing to emit past the end; a negative offset fails at parse time. */
+    serverAssert(offset >= 0);
+    if (offset >= (long)zsetLength(zobj)) {
+        handler->finalizeResultEmission(handler, 0);
+        return;
+    }
 
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
@@ -2844,8 +2850,14 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
                                long limit,
                                int reverse) {
     unsigned long rangelen = 0;
-
     handler->beginResultEmission(handler, -1);
+
+    /* Nothing to emit past the end; a negative offset fails at parse time. */
+    serverAssert(offset >= 0);
+    if (offset >= (long)zsetLength(zobj)) {
+        handler->finalizeResultEmission(handler, 0);
+        return;
+    }
 
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
@@ -2989,7 +3001,7 @@ void zrangeGenericCommand(zrange_result_handler *handler,
         } else if (!store && !strcasecmp(objectGetVal(c->argv[j]), "xx")) {
             opt_keyexist = 1;
         } else if (!strcasecmp(objectGetVal(c->argv[j]), "limit") && leftargs >= 2) {
-            if ((getLongFromObjectOrReply(c, c->argv[j + 1], &opt_offset, NULL) != C_OK) ||
+            if ((getPositiveLongFromObjectOrReply(c, c->argv[j + 1], &opt_offset, NULL) != C_OK) ||
                 (getLongFromObjectOrReply(c, c->argv[j + 2], &opt_limit, NULL) != C_OK)) {
                 return;
             }
@@ -3074,16 +3086,6 @@ void zrangeGenericCommand(zrange_result_handler *handler,
     }
 
     if (checkType(c, zobj, OBJ_ZSET)) goto cleanup;
-
-    /* A LIMIT offset that is negative or past the end matches nothing. The
-     * ordered index seek reads a negative offset as the reverse direction, so
-     * it must not get one. Rank ranges do not take LIMIT. */
-    if ((rangetype == ZRANGE_SCORE || rangetype == ZRANGE_LEX) &&
-        (opt_offset < 0 || opt_offset >= (long)zsetLength(zobj))) {
-        handler->beginResultEmission(handler, -1);
-        handler->finalizeResultEmission(handler, 0);
-        goto cleanup;
-    }
 
     /* Step 4: Pass this to the command-specific handler. */
     switch (rangetype) {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2619,12 +2619,6 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
 
     handler->beginResultEmission(handler, -1);
 
-    /* For invalid offset, return directly. */
-    if (offset > 0 && offset >= (long)zsetLength(zobj)) {
-        handler->finalizeResultEmission(handler, 0);
-        return;
-    }
-
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
@@ -3080,6 +3074,16 @@ void zrangeGenericCommand(zrange_result_handler *handler,
     }
 
     if (checkType(c, zobj, OBJ_ZSET)) goto cleanup;
+
+    /* A LIMIT offset that is negative or past the end matches nothing. The
+     * ordered index seek reads a negative offset as the reverse direction, so
+     * it must not get one. Rank ranges do not take LIMIT. */
+    if ((rangetype == ZRANGE_SCORE || rangetype == ZRANGE_LEX) &&
+        (opt_offset < 0 || opt_offset >= (long)zsetLength(zobj))) {
+        handler->beginResultEmission(handler, -1);
+        handler->finalizeResultEmission(handler, 0);
+        goto cleanup;
+    }
 
     /* Step 4: Pass this to the command-specific handler. */
     switch (rangetype) {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -771,20 +771,26 @@ start_server {tags {"zset"}} {
             assert_equal {} [r zrevrangebylex zset (hill (omega]
         }
 
-        test "ZRANGEBYSCORE/ZRANGEBYLEX with a negative LIMIT offset - $encoding" {
+        test "ZRANGEBYSCORE/ZRANGEBYLEX with a negative or past-the-end LIMIT offset - $encoding" {
             create_default_zset
-            assert_equal {} [r zrangebyscore zset -inf +inf LIMIT -1 10]
-            assert_equal {} [r zrevrangebyscore zset +inf -inf LIMIT -1 10]
-            assert_equal {} [r zrange zset -inf +inf BYSCORE LIMIT -2 10]
-            assert_equal {} [r zrange zset +inf -inf BYSCORE REV LIMIT -2 10]
+            assert_error "ERR value is out of range*" {r zrangebyscore zset -inf +inf LIMIT -1 10}
+            assert_error "ERR value is out of range*" {r zrevrangebyscore zset +inf -inf LIMIT -1 10}
+            assert_error "ERR value is out of range*" {r zrange zset -inf +inf BYSCORE LIMIT -2 10}
+            assert_error "ERR value is out of range*" {r zrange zset +inf -inf BYSCORE REV LIMIT -2 10}
+            assert_equal {g} [r zrangebyscore zset -inf +inf LIMIT 6 10]
+            assert_equal {} [r zrangebyscore zset -inf +inf LIMIT 7 10]
+            assert_equal {} [r zrevrangebyscore zset +inf -inf LIMIT 100 10]
             create_default_lex_zset
-            assert_equal {} [r zrangebylex zset - + LIMIT -1 10]
-            assert_equal {} [r zrevrangebylex zset + - LIMIT -1 10]
-            assert_equal {} [r zrange zset - + BYLEX LIMIT -2 10]
-            assert_equal {} [r zrange zset + - BYLEX REV LIMIT -2 10]
-            assert_equal {} [r zrangebylex zset - + LIMIT 100 10]
-            assert_equal 0 [r zrangestore dst zset - + BYLEX LIMIT -1 10]
-            assert_equal 0 [r exists dst]
+            assert_error "ERR value is out of range*" {r zrangebylex zset - + LIMIT -1 10}
+            assert_error "ERR value is out of range*" {r zrevrangebylex zset + - LIMIT -1 10}
+            assert_error "ERR value is out of range*" {r zrange zset - + BYLEX LIMIT -2 10}
+            assert_error "ERR value is out of range*" {r zrange zset + - BYLEX REV LIMIT -2 10}
+            assert_equal {omega} [r zrangebylex zset - + LIMIT 8 10]
+            assert_equal {} [r zrangebylex zset - + LIMIT 9 10]
+            assert_equal {} [r zrevrangebylex zset + - LIMIT 100 10]
+            assert_error "ERR value is out of range*" {r zrangestore dst{zset} zset - + BYLEX LIMIT -1 10}
+            assert_equal 0 [r zrangestore dst{zset} zset - + BYLEX LIMIT 100 10]
+            assert_equal 0 [r exists dst{zset}]
         }
 
         test "ZLEXCOUNT advanced - $encoding" {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -771,6 +771,22 @@ start_server {tags {"zset"}} {
             assert_equal {} [r zrevrangebylex zset (hill (omega]
         }
 
+        test "ZRANGEBYSCORE/ZRANGEBYLEX with a negative LIMIT offset - $encoding" {
+            create_default_zset
+            assert_equal {} [r zrangebyscore zset -inf +inf LIMIT -1 10]
+            assert_equal {} [r zrevrangebyscore zset +inf -inf LIMIT -1 10]
+            assert_equal {} [r zrange zset -inf +inf BYSCORE LIMIT -2 10]
+            assert_equal {} [r zrange zset +inf -inf BYSCORE REV LIMIT -2 10]
+            create_default_lex_zset
+            assert_equal {} [r zrangebylex zset - + LIMIT -1 10]
+            assert_equal {} [r zrevrangebylex zset + - LIMIT -1 10]
+            assert_equal {} [r zrange zset - + BYLEX LIMIT -2 10]
+            assert_equal {} [r zrange zset + - BYLEX REV LIMIT -2 10]
+            assert_equal {} [r zrangebylex zset - + LIMIT 100 10]
+            assert_equal 0 [r zrangestore dst zset - + BYLEX LIMIT -1 10]
+            assert_equal 0 [r exists dst]
+        }
+
         test "ZLEXCOUNT advanced - $encoding" {
             create_default_lex_zset
 


### PR DESCRIPTION
Part of #4619 (item 4).

**Problem**

`zrangeGenericCommand` accepted any `long` as the LIMIT offset. On btree-encoded keys the offset flows into `orderedIndexSeekToScoreRange` / `orderedIndexSeekToLexRange` as `reverse ? -offset - 1 : offset`, where a negative value *is* the reverse-direction encoding. The cursor ended up positioned for `prev()` while the caller stepped with `next()` (or vice versa), so exactly one element outside the window was returned; listpack returned an empty array.

```
ZADD z 1 a 2 b 3 c 4 d 5 e
ZRANGEBYSCORE z 1 5 LIMIT -2 10      -> btree: e     listpack: (empty array)
ZREVRANGEBYSCORE z 5 1 LIMIT -2 10   -> btree: a     listpack: (empty array)
ZADD l 0 a 0 b 0 c 0 d 0 e
ZRANGEBYLEX l - + LIMIT -2 10        -> btree: e     listpack: (empty array)
```

**Fix**

The LIMIT offset is parsed with `getPositiveLongFromObjectOrReply()`, so a negative offset is rejected at parse time with `ERR value is out of range, must be positive`, before the key lookup, in every command that takes LIMIT (ZRANGE, ZRANGESTORE, ZRANGEBYSCORE, ZREVRANGEBYSCORE, ZRANGEBYLEX, ZREVRANGEBYLEX). The LIMIT count keeps `getLongFromObjectOrReply()`: a negative count means all elements from the offset.

With negative offsets ruled out, the offset-vs-`zsetLength()` check in `genericZrangebyscoreCommand()` is only a quick path for "nothing left to emit". It stays there, `genericZrangebylexCommand()` gains the same one, and both assert `offset >= 0`.

**Behaviour change**

A negative LIMIT offset now returns an error where it previously returned a result: an empty array on listpack, and on the btree an element outside the window, as shown above. The LIMIT documentation never defined negative offsets, the reply already depended on the key's encoding, and parse-time rejection follows the SINTERCARD LIMIT and LPOS COUNT convention..

**Tests**

`ZRANGEBYSCORE/ZRANGEBYLEX with a negative or past-the-end LIMIT offset` in `tests/unit/type/zset.tcl`, both encodings: the error for ZRANGEBYSCORE, ZREVRANGEBYSCORE, ZRANGEBYLEX, ZREVRANGEBYLEX, the ZRANGE BYSCORE/BYLEX/REV forms and ZRANGESTORE; the last element, the first past-the-end offset and a far past-the-end offset for both range types; ZRANGESTORE past the end returning 0 without creating the destination, with hash-tagged keys so the suite runs in cluster mode. `unit/type/zset` passes locally in standalone and cluster mode.