### PR TITLE
Optimize hash TTL queries, GEOPOS and GEOHASH with batched hashtable lookup

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -34,6 +34,10 @@
 #include "debugmacro.h"
 #include "pqsort.h"
 
+#define GEO_FIND_BATCH_SIZE 16
+static_assert(GEO_FIND_BATCH_SIZE <= HASHTABLE_FIND_BATCH_MAX_SIZE,
+              "GEO batch size exceeds hashtable batch lookup limit");
+
 /* Things exported from t_zset.c only for geo.c, since it is the only other
  * part of the server that requires close zset introspection. */
 unsigned char *zzlFirstInRange(unsigned char *zl, zrangespec *range);
@@ -890,12 +894,89 @@ void geosearchstoreCommand(client *c) {
     georadiusGeneric(c, 2, GEOSEARCH | GEOSEARCHSTORE);
 }
 
+/* Reply with the standard geohash, or null if the score cannot be decoded. */
+static void addGeohashToReply(client *c, double score) {
+    char *geoalphabet = "0123456789bcdefghjkmnpqrstuvwxyz";
+
+    /* The internal format we use for geocoding is a bit different
+     * than the standard, since we use as initial latitude range
+     * -85,85, while the normal geohashing algorithm uses -90,90.
+     * So we have to decode our position and re-encode using the
+     * standard ranges in order to output a valid geohash string. */
+
+    /* Decode... */
+    double xy[2];
+    if (!decodeGeohash(score, xy)) {
+        addReplyNull(c);
+        return;
+    }
+
+    /* Re-encode */
+    GeoHashRange r[2];
+    GeoHashBits hash;
+    r[0].min = -180;
+    r[0].max = 180;
+    r[1].min = -90;
+    r[1].max = 90;
+    geohashEncode(&r[0], &r[1], xy[0], xy[1], 26, &hash);
+
+    char buf[12];
+    int i;
+    for (i = 0; i < 11; i++) {
+        int idx;
+        if (i == 10) {
+            /* We have just 52 bits, but the API used to output
+             * an 11 bytes geohash. For compatibility we assume
+             * zero. */
+            idx = 0;
+        } else {
+            idx = (hash.bits >> (52 - ((i + 1) * 5))) & 0x1f;
+        }
+        buf[i] = geoalphabet[idx];
+    }
+    buf[11] = '\0';
+    addReplyBulkCBuffer(c, buf, 11);
+}
+
+static void geohashReplyWithHashtable(client *c, hashtable *ht, robj **members, size_t count) {
+    const void *keys[GEO_FIND_BATCH_SIZE];
+    void *found_entries[GEO_FIND_BATCH_SIZE];
+    while (count) {
+        size_t batch = count > GEO_FIND_BATCH_SIZE ? GEO_FIND_BATCH_SIZE : count;
+
+        /* Arguments may share an SDS; mark and unmark each string only once. */
+        for (size_t i = 0; i < batch; i++) {
+            sds member = objectGetVal(members[i]);
+            if (!zsetIsLookupKey(member)) zsetMarkLookupKey(member);
+            keys[i] = member;
+        }
+
+        uint32_t result = hashtableFindBatch(ht, (int)batch, keys, found_entries);
+
+        for (size_t i = 0; i < batch; i++) {
+            sds member = objectGetVal(members[i]);
+            if (zsetIsLookupKey(member)) zsetUnmarkLookupKey(member);
+        }
+
+        for (size_t i = 0; i < batch; i++) {
+            if ((result >> i) & 1) {
+                OrderedIndexItem *node = found_entries[i];
+                addGeohashToReply(c, orderedIndexItemGetScore(node));
+            } else {
+                addReplyNull(c);
+            }
+        }
+
+        members += batch;
+        count -= batch;
+    }
+}
+
 /* GEOHASH key ele1 ele2 ... eleN
  *
  * Returns an array with an 11 characters geohash representation of the
  * position of the specified elements. */
 void geohashCommand(client *c) {
-    char *geoalphabet = "0123456789bcdefghjkmnpqrstuvwxyz";
     int j;
 
     /* Look up the requested zset */
@@ -904,51 +985,67 @@ void geohashCommand(client *c) {
 
     /* Geohash elements one after the other, using a null bulk reply for
      * missing elements. */
-    addReplyArrayLen(c, c->argc - 2);
+    size_t count = c->argc - 2;
+    addReplyArrayLen(c, count);
+    if (zobj && zobj->encoding == OBJ_ENCODING_BTREE && count > 1) {
+        zset *zs = objectGetVal(zobj);
+        geohashReplyWithHashtable(c, zs->ht, c->argv + 2, count);
+        return;
+    }
+
     for (j = 2; j < c->argc; j++) {
         double score;
         if (!zobj || zsetScore(zobj, objectGetVal(c->argv[j]), &score) == C_ERR) {
             addReplyNull(c);
         } else {
-            /* The internal format we use for geocoding is a bit different
-             * than the standard, since we use as initial latitude range
-             * -85,85, while the normal geohashing algorithm uses -90,90.
-             * So we have to decode our position and re-encode using the
-             * standard ranges in order to output a valid geohash string. */
-
-            /* Decode... */
-            double xy[2];
-            if (!decodeGeohash(score, xy)) {
-                addReplyNull(c);
-                continue;
-            }
-
-            /* Re-encode */
-            GeoHashRange r[2];
-            GeoHashBits hash;
-            r[0].min = -180;
-            r[0].max = 180;
-            r[1].min = -90;
-            r[1].max = 90;
-            geohashEncode(&r[0], &r[1], xy[0], xy[1], 26, &hash);
-
-            char buf[12];
-            int i;
-            for (i = 0; i < 11; i++) {
-                int idx;
-                if (i == 10) {
-                    /* We have just 52 bits, but the API used to output
-                     * an 11 bytes geohash. For compatibility we assume
-                     * zero. */
-                    idx = 0;
-                } else {
-                    idx = (hash.bits >> (52 - ((i + 1) * 5))) & 0x1f;
-                }
-                buf[i] = geoalphabet[idx];
-            }
-            buf[11] = '\0';
-            addReplyBulkCBuffer(c, buf, 11);
+            addGeohashToReply(c, score);
         }
+    }
+}
+
+/* Reply with decoded coordinates, or null if the score cannot be decoded. */
+static void addGeoPositionToReply(client *c, double score) {
+    double xy[2];
+    if (!decodeGeohash(score, xy)) {
+        addReplyNullArray(c);
+        return;
+    }
+    addReplyArrayLen(c, 2);
+    addReplyHumanLongDouble(c, xy[0]);
+    addReplyHumanLongDouble(c, xy[1]);
+}
+
+static void geoposReplyWithHashtable(client *c, hashtable *ht, robj **members, size_t count) {
+    const void *keys[GEO_FIND_BATCH_SIZE];
+    void *found_entries[GEO_FIND_BATCH_SIZE];
+    while (count) {
+        size_t batch = count > GEO_FIND_BATCH_SIZE ? GEO_FIND_BATCH_SIZE : count;
+
+        /* Arguments may share an SDS; mark and unmark each string only once. */
+        for (size_t i = 0; i < batch; i++) {
+            sds member = objectGetVal(members[i]);
+            if (!zsetIsLookupKey(member)) zsetMarkLookupKey(member);
+            keys[i] = member;
+        }
+
+        uint32_t result = hashtableFindBatch(ht, (int)batch, keys, found_entries);
+
+        for (size_t i = 0; i < batch; i++) {
+            sds member = objectGetVal(members[i]);
+            if (zsetIsLookupKey(member)) zsetUnmarkLookupKey(member);
+        }
+
+        for (size_t i = 0; i < batch; i++) {
+            if ((result >> i) & 1) {
+                OrderedIndexItem *node = found_entries[i];
+                addGeoPositionToReply(c, orderedIndexItemGetScore(node));
+            } else {
+                addReplyNullArray(c);
+            }
+        }
+
+        members += batch;
+        count -= batch;
     }
 }
 
@@ -963,23 +1060,21 @@ void geoposCommand(client *c) {
     robj *zobj = lookupKeyRead(c->db, c->argv[1]);
     if (checkType(c, zobj, OBJ_ZSET)) return;
 
-    /* Report elements one after the other, using a null bulk reply for
-     * missing elements. */
-    addReplyArrayLen(c, c->argc - 2);
+    /* Reply in request order, using null arrays for missing elements. */
+    size_t count = c->argc - 2;
+    addReplyArrayLen(c, count);
+    if (zobj && zobj->encoding == OBJ_ENCODING_BTREE && count > 1) {
+        zset *zs = objectGetVal(zobj);
+        geoposReplyWithHashtable(c, zs->ht, c->argv + 2, count);
+        return;
+    }
+
     for (j = 2; j < c->argc; j++) {
         double score;
         if (!zobj || zsetScore(zobj, objectGetVal(c->argv[j]), &score) == C_ERR) {
             addReplyNullArray(c);
         } else {
-            /* Decode... */
-            double xy[2];
-            if (!decodeGeohash(score, xy)) {
-                addReplyNullArray(c);
-                continue;
-            }
-            addReplyArrayLen(c, 2);
-            addReplyHumanLongDouble(c, xy[0]);
-            addReplyHumanLongDouble(c, xy[1]);
+            addGeoPositionToReply(c, score);
         }
     }
 }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -42,6 +42,10 @@
 #include <string.h>
 #include "entry.h"
 
+#define HASH_FIND_BATCH_SIZE 16
+static_assert(HASH_FIND_BATCH_SIZE <= HASHTABLE_FIND_BATCH_MAX_SIZE,
+              "Hash batch size exceeds hashtable batch lookup limit");
+
 /* enumeration of all the possible return values of commands manipulating fields expiration. */
 typedef enum {
     /* SDS aux flag. If set, it indicates that the entry has TTL metadata set. */
@@ -1096,10 +1100,6 @@ static void addHashFieldToReply(client *c, robj *o, sds field) {
     }
 }
 
-#define HMGET_FIND_BATCH_SIZE 16
-static_assert(HMGET_FIND_BATCH_SIZE <= HASHTABLE_FIND_BATCH_MAX_SIZE,
-              "HMGET batch size exceeds hashtable batch lookup limit");
-
 static void addHashEntryToReply(client *c, const entry *hash_entry) {
     if (hash_entry == NULL) {
         addReplyNull(c);
@@ -1113,10 +1113,10 @@ static void addHashEntryToReply(client *c, const entry *hash_entry) {
 }
 
 static void hmgetReplyWithHashtable(client *c, hashtable *ht, robj **fields, size_t count) {
-    const void *keys[HMGET_FIND_BATCH_SIZE];
-    void *found_entries[HMGET_FIND_BATCH_SIZE];
+    const void *keys[HASH_FIND_BATCH_SIZE];
+    void *found_entries[HASH_FIND_BATCH_SIZE];
     while (count) {
-        size_t batch = count > HMGET_FIND_BATCH_SIZE ? HMGET_FIND_BATCH_SIZE : count;
+        size_t batch = count > HASH_FIND_BATCH_SIZE ? HASH_FIND_BATCH_SIZE : count;
 
         for (size_t i = 0; i < batch; i++) {
             keys[i] = objectGetVal(fields[i]);
@@ -2116,6 +2116,41 @@ void hpersistCommand(client *c) {
     commitDeferredReplyBuffer(c, 1);
 }
 
+static void addHashExpiryToReply(client *c, mstime_t expiry, mstime_t basetime, int unit) {
+    if (expiry == EXPIRY_NONE) {
+        addReplyLongLong(c, -1);
+    } else {
+        mstime_t ttl = expiry - basetime;
+        if (ttl < 0) ttl = 0;
+        addReplyLongLong(c, unit == UNIT_MILLISECONDS ? ttl : ((ttl + 500) / 1000));
+    }
+}
+
+static void httlReplyWithHashtable(client *c, hashtable *ht, robj **fields, size_t count, mstime_t basetime, int unit) {
+    const void *keys[HASH_FIND_BATCH_SIZE];
+    void *found_entries[HASH_FIND_BATCH_SIZE];
+    while (count) {
+        size_t batch = count > HASH_FIND_BATCH_SIZE ? HASH_FIND_BATCH_SIZE : count;
+
+        for (size_t i = 0; i < batch; i++) {
+            keys[i] = objectGetVal(fields[i]);
+        }
+
+        uint32_t found = hashtableFindBatch(ht, (int)batch, keys, found_entries);
+
+        for (size_t i = 0; i < batch; i++) {
+            if ((found >> i) & 1) {
+                addHashExpiryToReply(c, entryGetExpiry(found_entries[i]), basetime, unit);
+            } else {
+                addReplyLongLong(c, -2);
+            }
+        }
+
+        fields += batch;
+        count -= batch;
+    }
+}
+
 /* High-Level Algorithm of HTTL / HPTTL / HEXPIRETIME / HPEXPIRETIME Commands:
  *
  * - These commands return the remaining time to live (TTL) or absolute expiry time
@@ -2168,15 +2203,16 @@ void httlGenericCommand(client *c, mstime_t basetime, int unit) {
     /* From this point we would return array reply */
     addReplyArrayLen(c, num_fields);
 
+    if (hash && hash->encoding == OBJ_ENCODING_HASHTABLE && num_fields > 1) {
+        httlReplyWithHashtable(c, objectGetVal(hash), c->argv + fields_index, num_fields, basetime, unit);
+        return;
+    }
+
     for (int i = 0; i < num_fields; i++) {
         if (!hash || hashTypeGetExpiry(hash, objectGetVal(c->argv[fields_index + i]), &result) == C_ERR) {
             addReplyLongLong(c, -2);
-        } else if (result == EXPIRY_NONE) {
-            addReplyLongLong(c, -1);
         } else {
-            result = result - basetime;
-            if (result < 0) result = 0;
-            addReplyLongLong(c, unit == UNIT_MILLISECONDS ? result : ((result + 500) / 1000));
+            addHashExpiryToReply(c, result, basetime, unit);
         }
     }
 }

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -411,6 +411,28 @@ start_server {tags {"geo"}} {
         assert {$result eq {}}
     } 
 
+    set original_max [lindex [r config get zset-max-listpack-entries] 1]
+    r config set zset-max-listpack-entries 0
+    test {GEOHASH batch lookup handles existing, missing and repeated members} {
+        r del geohashbatchtest
+        set query_members {}
+        set expected {}
+        set i 1
+        # Geohashes for coordinates (1, 11) through (6, 16).
+        foreach geohash {s1bwwf2pts0 s41km883560 s461uq8d3p0 s46zeh8eyu0 s4et3f8vk60 s4u7089nf00} {
+            r geoadd geohashbatchtest $i [expr {$i + 10}] m$i
+            lappend query_members m$i missing$i m$i
+            lappend expected $geohash {} $geohash
+            incr i
+        }
+        lappend query_members missing
+        lappend expected {}
+        assert_encoding btree geohashbatchtest
+
+        assert_equal $expected [r geohash geohashbatchtest {*}$query_members]
+    }
+    r config set zset-max-listpack-entries $original_max
+
     test {GEOPOS simple} {
         r del points
         r geoadd points 10 20 a 30 40 b
@@ -434,6 +456,35 @@ start_server {tags {"geo"}} {
         set result [r geopos points]
         assert {$result eq {}}
     }
+
+    set original_max [lindex [r config get zset-max-listpack-entries] 1]
+    r config set zset-max-listpack-entries 0
+    test {GEOPOS batch lookup handles existing, missing and repeated members} {
+        r del geoposbatchtest
+        set query_members {}
+        for {set i 1} {$i <= 6} {incr i} {
+            r geoadd geoposbatchtest $i [expr {$i + 10}] m$i
+            lappend query_members m$i missing$i m$i
+        }
+        lappend query_members missing
+        assert_encoding btree geoposbatchtest
+
+        set result [r geopos geoposbatchtest {*}$query_members]
+        assert_equal 19 [llength $result]
+        set i 1
+        foreach {position missing duplicate} [lrange $result 0 end-1] {
+            assert_equal 2 [llength $position]
+            lassign $position longitude latitude
+            # Geohash encoding quantizes coordinates.
+            assert {abs($longitude - $i) < 0.001}
+            assert {abs($latitude - ($i + 10)) < 0.001}
+            assert_equal {} $missing
+            assert_equal $position $duplicate
+            incr i
+        }
+        assert_equal {} [lindex $result end]
+    }
+    r config set zset-max-listpack-entries $original_max
 
     test {GEODIST simple & unit} {
         r del points

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1069,6 +1069,47 @@ start_server {tags {"hashexpire"}} {
         }
     }
 
+    test {Hash TTL batch lookup handles live, expired, persistent and missing fields} {
+        # Keep expired entries to test lookup filtering.
+        r DEBUG SET-ACTIVE-EXPIRE 0
+        r del ttlbatchtest
+        set live_fields {}
+        set expired_fields {}
+        set query_fields {}
+
+        for {set i 1} {$i <= 6} {incr i} {
+            r hset ttlbatchtest live$i value expired$i stale persistent$i value
+            lappend live_fields live$i
+            lappend expired_fields expired$i
+            lappend query_fields live$i expired$i persistent$i
+        }
+        lappend query_fields missing
+        set expire_at_sec [expr {[clock seconds] + 60}]
+        set expire_at_ms [expr {$expire_at_sec * 1000}]
+        r hpexpireat ttlbatchtest $expire_at_ms FIELDS 6 {*}$live_fields
+        r hpexpire ttlbatchtest 1 FIELDS 6 {*}$expired_fields
+        assert_encoding hashtable ttlbatchtest
+        after 2
+
+        foreach {cmd min max} [list \
+            HTTL 50 60 \
+            HPTTL 50000 60000 \
+            HEXPIRETIME $expire_at_sec $expire_at_sec \
+            HPEXPIRETIME $expire_at_ms $expire_at_ms] {
+            set result [r $cmd ttlbatchtest FIELDS 19 {*}$query_fields]
+            assert_equal 19 [llength $result]
+
+            # Groups: live, expired, persistent; missing is last.
+            foreach {ttl expired persistent} [lrange $result 0 end-1] {
+                assert_range $ttl $min $max
+                assert_equal -2 $expired
+                assert_equal -1 $persistent
+            }
+            assert_equal -2 [lindex $result end]
+        }
+        r DEBUG SET-ACTIVE-EXPIRE 1
+    } {OK} {needs:debug}
+
     ##### EXPIRETIME ######
 
     # Basic Expiry Functionality

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1089,7 +1089,11 @@ start_server {tags {"hashexpire"}} {
         r hpexpireat ttlbatchtest $expire_at_ms FIELDS 6 {*}$live_fields
         r hpexpire ttlbatchtest 1 FIELDS 6 {*}$expired_fields
         assert_encoding hashtable ttlbatchtest
-        after 2
+        wait_for_condition 100 10 {
+            [r hpttl ttlbatchtest FIELDS 6 {*}$expired_fields] eq {-2 -2 -2 -2 -2 -2}
+        } else {
+            fail "Hash fields did not expire"
+        }
 
         foreach {cmd min max} [list \
             HTTL 50 60 \


### PR DESCRIPTION
## Description

This PR extends `hashtableFindBatch()` to more read commands, following the [discussion](https://github.com/valkey-io/valkey/pull/4017#issuecomment-5507432086) in #4017.

The following commands are left out of this PR:

- `HGETEX`, `HEXPIRE` and `HPEXPIRE`: Updating TTLs can invalidate entry pointers, so `hashtableFindBatch()` isn't suitable here. A batched version of `hashtableFindRef()` might be a good approach, but I don't have a definitive answer yet.
- `GEODIST`: The current implementation looks up members sequentially, querying the second only if the first exists. Batched lookup queries both members. Our benchmark showed a 4.30% drop in QPS for random reads on a large dataset when the first member was missing and the second existed.

This PR adds batched lookups for:

- Hash TTL queries: `HTTL`, `HPTTL`, `HEXPIRETIME` and `HPEXPIRETIME`.
- GEO queries: `GEOPOS` and `GEOHASH`.

The batched path is used only for requests with two or more fields or members on hashtable-backed encodings. The returned entries are used directly to produce replies. Single-field or single-member requests and compact encodings keep their existing lookup paths.

## Benchmark

The benchmark checks for regressions with small-dataset hot reads and measures gains with large-dataset random reads.

Example: HTTL with 8 fields on a large dataset (`BENCH_HOST` is the server IP).

1. Start a single-threaded server with persistence and compact encoding disabled:

   ```sh
   taskset -c 0 valkey-server \
     --bind 127.0.0.1 "$BENCH_HOST" --port 16379 \
     --protected-mode no --io-threads 1 \
     --save "" --appendonly no \
     --hash-max-listpack-entries 0 --enable-debug-command yes
   ```

2. Load a hash with expiring fields:

   ```sh
   valkey-benchmark -h "$BENCH_HOST" -p 16379 --threads 2 -c 50 \
     --sequential -r 10000000 -n 10000000 -P 16 \
     HSETEX bench:ttl:10000000 EX 604800 FIELDS 1 field:__rand_int__ 12345678
   ```

3. Verify `hashtable` encoding with `OBJECT ENCODING` and confirm `rehashing index = -1` with `DEBUG HTSTATS-KEY` before measurement.

4. Query 8 random fields per request:

   ```sh
   valkey-benchmark -h "$BENCH_HOST" -p 16379 --threads 2 -c 50 \
     -r 10000000 -n 10000000 -P 1 --warmup 10 --csv \
     HTTL bench:ttl:10000000 FIELDS 8 \
     field:__rand_int__ field:__rand_int__ field:__rand_int__ field:__rand_int__ \
     field:__rand_int__ field:__rand_int__ field:__rand_int__ field:__rand_int__
   ```

Other commands, dataset sizes and field/member counts follow the same procedure.

Each benchmark case is run 3 times, and the median QPS is used for comparison.

| Workload | Dataset size | Command | Fields/Members | Baseline QPS | Optimized QPS | Change |
| --- | ---: | --- | ---: | ---: | ---: | ---: |
| Small dataset, hot reads | 128 | HTTL | 1 | 208493.86 | 209020.97 | +0.25% |
| Small dataset, hot reads | 128 | HTTL | 2 | 202374.84 | 203256.75 | +0.44% |
| Small dataset, hot reads | 128 | HTTL | 8 | 176231.57 | 172889.41 | -1.90% |
| Large dataset, random reads | 10000000 | HTTL | 1 | 195037.05 | 187128.52 | -4.05% |
| Large dataset, random reads | 10000000 | HTTL | 2 | 171152.50 | 184865.21 | +8.01% |
| Large dataset, random reads | 10000000 | HTTL | 8 | 103587.77 | 156631.93 | +51.21% |
| Small dataset, hot reads | 128 | HPTTL | 1 | 203068.63 | 212470.85 | +4.63% |
| Small dataset, hot reads | 128 | HPTTL | 2 | 207421.32 | 200933.98 | -3.13% |
| Small dataset, hot reads | 128 | HPTTL | 8 | 178406.86 | 174423.20 | -2.23% |
| Large dataset, random reads | 10000000 | HPTTL | 1 | 187557.33 | 185006.17 | -1.36% |
| Large dataset, random reads | 10000000 | HPTTL | 2 | 168271.65 | 183736.51 | +9.19% |
| Large dataset, random reads | 10000000 | HPTTL | 8 | 103857.94 | 157121.24 | +51.28% |
| Small dataset, hot reads | 128 | HEXPIRETIME | 1 | 200305.86 | 201672.25 | +0.68% |
| Small dataset, hot reads | 128 | HEXPIRETIME | 2 | 200220.96 | 201598.83 | +0.69% |
| Small dataset, hot reads | 128 | HEXPIRETIME | 8 | 172521.01 | 170759.36 | -1.02% |
| Large dataset, random reads | 10000000 | HEXPIRETIME | 1 | 184542.42 | 181409.19 | -1.70% |
| Large dataset, random reads | 10000000 | HEXPIRETIME | 2 | 165366.82 | 179510.54 | +8.55% |
| Large dataset, random reads | 10000000 | HEXPIRETIME | 8 | 100527.90 | 153683.59 | +52.88% |
| Small dataset, hot reads | 128 | HPEXPIRETIME | 1 | 198412.46 | 200353.08 | +0.98% |
| Small dataset, hot reads | 128 | HPEXPIRETIME | 2 | 195752.60 | 194009.23 | -0.89% |
| Small dataset, hot reads | 128 | HPEXPIRETIME | 8 | 175010.02 | 172908.64 | -1.20% |
| Large dataset, random reads | 10000000 | HPEXPIRETIME | 1 | 182584.60 | 182029.80 | -0.30% |
| Large dataset, random reads | 10000000 | HPEXPIRETIME | 2 | 166567.42 | 177505.38 | +6.57% |
| Large dataset, random reads | 10000000 | HPEXPIRETIME | 8 | 100293.79 | 154655.01 | +54.20% |
| Small dataset, hot reads | 128 | GEOPOS | 1 | 187486.39 | 188499.03 | +0.54% |
| Small dataset, hot reads | 128 | GEOPOS | 2 | 166891.00 | 164459.28 | -1.46% |
| Small dataset, hot reads | 128 | GEOPOS | 8 | 94138.01 | 96511.34 | +2.52% |
| Large dataset, random reads | 10000000 | GEOPOS | 1 | 167072.79 | 167910.58 | +0.50% |
| Large dataset, random reads | 10000000 | GEOPOS | 2 | 140166.73 | 148033.96 | +5.61% |
| Large dataset, random reads | 10000000 | GEOPOS | 8 | 67253.29 | 88773.80 | +32.00% |
| Small dataset, hot reads | 128 | GEOHASH | 1 | 212965.29 | 209394.41 | -1.68% |
| Small dataset, hot reads | 128 | GEOHASH | 2 | 198627.55 | 202986.36 | +2.19% |
| Small dataset, hot reads | 128 | GEOHASH | 8 | 170834.90 | 173761.88 | +1.71% |
| Large dataset, random reads | 10000000 | GEOHASH | 1 | 186507.30 | 191715.94 | +2.79% |
| Large dataset, random reads | 10000000 | GEOHASH | 2 | 170682.52 | 184901.23 | +8.33% |
| Large dataset, random reads | 10000000 | GEOHASH | 8 | 98337.40 | 152262.43 | +54.84% |

Benchmark environment (per VM):

- VM: Tencent Cloud | SA9.LARGE16
- CPU: AMD EPYC 9K65 192-Core Processor, 4 vCPUs.
- Memory: approximately 16 GB.
- OS: Ubuntu 24.04.4 LTS, x86-64.
- Two VMs: one server and one benchmark client
