### PR TITLE
Deflake slow slot migration snapshot test

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -1961,15 +1961,17 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster network} overrides
     test "Migration not cancelled when snapshot takes more time than repl-timeout" {
         assert_does_not_resync {
             # The target must not kill the import link while the source's
-            # snapshot is quiet for longer than repl-timeout (the source
-            # cannot send ACKs while its child is snapshotting).
+            # snapshot takes longer than repl-timeout (the source cannot send
+            # ACKs while its child is snapshotting).
             R 2 CONFIG SET repl-timeout 2
 
             # Load keys before the snapshot to target a snapshot time > 2sec.
-            # 50 * 100ms = 5 sec. The delay must be on node 0: it is the
-            # source of this migration and runs the snapshot.
+            # 50 * 100ms = 5 sec. Values larger than PROTO_IOBUF_LEN are
+            # written directly instead of accumulating in rio's buffer, so
+            # the target continues receiving data during the slow snapshot.
+            # The delay must be on node 0: it is the source of this migration.
             R 0 CONFIG SET rdb-key-save-delay 100000
-            populate 50 "$0_slot_tag:1:" 1000 -0
+            populate 50 "$0_slot_tag:1:" 32768 -0
 
             set errcode [catch {
                 assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node2_id]


### PR DESCRIPTION
The `Migration not cancelled when snapshot takes more time than repl-timeout` test intentionally makes the slot snapshot take about five seconds while setting `repl-timeout` to two seconds.

The test currently uses 1 KiB values. These writes accumulate in rio's 16 KiB file-descriptor buffer before being sent. On slower macOS runners, the interval between flushes can exceed `repl-timeout`, causing the target to close the import connection. The later 120-second wait for the slot to move is only the secondary symptom.

Use 32 KiB values so each value is written directly instead of being buffered. This keeps data flowing during the snapshot, while the 100 ms delay across 50 keys still ensures that the overall snapshot takes longer than `repl-timeout`.

This failure started after #4409 moved the save delay to the actual source node, making the test exercise the intended slow-snapshot path.

Closes #4552.