### PR TITLE
Fix NULL pointer dereference in MODULE LOADEX unload cleanup

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -13547,7 +13547,8 @@ static int moduleInitPostOnLoadResolved(ModuleLoadFunc onload,
     }
 
     if (post_load_err) {
-        moduleUnload(ctx.module->name, NULL);
+        const char *unload_err = NULL;
+        moduleUnload(ctx.module->name, &unload_err);
         moduleFreeContext(&ctx);
         return C_ERR;
     }


### PR DESCRIPTION
Fixes #4630

## The bug

When `MODULE LOADEX ... CONFIG k v` was used and the module's `OnLoad` callback never consumed the config arguments, the post-load check set `post_load_err = 1` and called `moduleUnload(ctx.module->name, NULL)`. If the unload was then refused (module registered a data type, had blocked clients, held a timer, etc.), `moduleUnloadInternal` unconditionally wrote the error string through the `NULL errmsg` pointer — causing a **SIGSEGV that killed the server**, instead of returning a normal command error.

The non-LOADEX path (`moduleUnload`) already passes a valid pointer; only the LOADEX cleanup path introduced the NULL.

## Fix

Pass the address of a local `const char *` and let the error message propagate naturally (the variable is intentionally unused since the command is already in an error path).

## Note

The same NULL guard pattern (`if (errmsg)`) exists at lines 13539/13546 in the same function, confirming this was the one call site that missed the check.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>