### PR TITLE
x86 Perf: Derive call()'s time snapshot from the monotonic sample instead of a second clock read

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4100,7 +4100,20 @@ void call(client *c, int flags) {
     long long old_primary_repl_offset = server.primary_repl_offset;
     incrCommandStatsOnError(NULL, 0);
 
-    const ustime_t call_timer = ustime();
+    /* Sample the clock once. On a hardware monotonic clock, 'call_timer' (the
+     * UNIX time snapshot for the execution unit) is derived from the same
+     * monotonic sample used to measure the command's duration, instead of
+     * being a separate clock read. The two values are identical to what two
+     * back-to-back reads would have produced. */
+    const int hw_clock = (monotonicGetType() == MONOTONIC_CLOCK_HW);
+    monotime monotonic_start = 0;
+    ustime_t call_timer;
+    if (hw_clock) {
+        monotonic_start = getMonotonicUs();
+        call_timer = ustimeFromMonotonic(monotonic_start);
+    } else {
+        call_timer = ustime();
+    }
     enterExecutionUnit(1, call_timer);
 
     /* setting the CLIENT_EXECUTING_COMMAND flag so we will avoid
@@ -4111,9 +4124,6 @@ void call(client *c, int flags) {
 
     c->flag.buffered_reply = 0;
     c->flag.keyspace_notified = 0;
-
-    monotime monotonic_start = 0;
-    if (monotonicGetType() == MONOTONIC_CLOCK_HW) monotonic_start = getMonotonicUs();
 
     /* We need to ensure that if the client does not own the argv array, then the command
      * does not modify it. This is important for debugging purposes to catch any unintended
@@ -4162,10 +4172,10 @@ void call(client *c, int flags) {
      * it means the execution is not yet completed and we MIGHT reprocess the command in the future. */
     if (!c->flag.blocked) c->flag.executing_command = 0;
 
-    /* In order to avoid performance implication due to querying the clock using a system call 3 times,
-     * we use a monotonic clock, when we are sure its cost is very low, and fall back to non-monotonic call otherwise. */
+    /* Measure the duration with the monotonic clock when it is a cheap hardware
+     * clock, falling back to the non-monotonic time of day otherwise. */
     ustime_t duration;
-    if (monotonicGetType() == MONOTONIC_CLOCK_HW)
+    if (hw_clock)
         duration = getMonotonicUs() - monotonic_start;
     else
         duration = ustime() - call_timer;

--- a/src/util.c
+++ b/src/util.c
@@ -1600,9 +1600,16 @@ int snprintf_async_signal_safe(char *to, size_t n, const char *fmt, ...) {
 /* UNIX time in microseconds as of the last gettimeofday() call, and the
  * monotonic clock reading taken at that same moment. Together they let
  * ustime() and ustimeFromMonotonic() derive the current UNIX time from a
- * monotonic sample without a syscall. */
-static long long ust_at_last_timeofday = 0;
-static monotime mono_at_last_timeofday = 0;
+ * monotonic sample without a syscall.
+ *
+ * Thread-local: ustime() is reachable from module threads through
+ * VM_Microseconds() / VM_Milliseconds() as well as from the main thread, and
+ * the two fields are only meaningful as a pair written by the same
+ * re-calibration. Per-thread copies keep each pair self-consistent without
+ * any synchronization on the main-thread hot path; each thread re-calibrates
+ * on its own first use and then at most once per millisecond. */
+static _Thread_local long long ust_at_last_timeofday = 0;
+static _Thread_local monotime mono_at_last_timeofday = 0;
 
 /* Slow path: query the time of day and refresh the cached UNIX time. */
 static long long ustimeFromTimeofday(void) {

--- a/src/util.c
+++ b/src/util.c
@@ -1597,27 +1597,46 @@ int snprintf_async_signal_safe(char *to, size_t n, const char *fmt, ...) {
     return result;
 }
 
+/* UNIX time in microseconds as of the last gettimeofday() call, and the
+ * monotonic clock reading taken at that same moment. Together they let
+ * ustime() and ustimeFromMonotonic() derive the current UNIX time from a
+ * monotonic sample without a syscall. */
+static long long ust_at_last_timeofday = 0;
+static monotime mono_at_last_timeofday = 0;
+
+/* Slow path: query the time of day and refresh the cached UNIX time. */
+static long long ustimeFromTimeofday(void) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    ust_at_last_timeofday = ((long long)tv.tv_sec) * 1000000;
+    ust_at_last_timeofday += tv.tv_usec;
+    return ust_at_last_timeofday;
+}
+
+/* Return the UNIX time in microseconds corresponding to 'mono_now', a
+ * monotonic clock sample the caller has already taken. Only meaningful when
+ * the monotonic clock is a hardware clock (MONOTONIC_CLOCK_HW), which is the
+ * only case in which the monotonic and time-of-day clocks are calibrated
+ * against each other here. Re-calibrates against gettimeofday() at most once
+ * per millisecond, so the derived value is identical to what ustime() would
+ * have returned had it sampled the monotonic clock at the same instant. */
+long long ustimeFromMonotonic(monotime mono_now) {
+    monotime mono_since_gettimeofday = mono_now - mono_at_last_timeofday;
+    if (mono_since_gettimeofday < 1000) return ust_at_last_timeofday + mono_since_gettimeofday;
+
+    /* Use time of day. */
+    mono_at_last_timeofday = mono_now;
+    return ustimeFromTimeofday();
+}
+
 /* Return the UNIX time in microseconds */
 long long ustime(void) {
-    static long long ust = 0;
-    static monotime mono_at_last_timeofday = 0;
-
     /* Fast path. Only call gettimeofday() periodically and add monotonic delta.
      * This avoids a syscall if we have a no-syscall monotonic clock. */
     if (getMonotonicUs != NULL && monotonicGetType() == MONOTONIC_CLOCK_HW) {
-        monotime mono_now = getMonotonicUs();
-        monotime mono_since_gettimeofday = mono_now - mono_at_last_timeofday;
-        if (mono_since_gettimeofday < 1000) return ust + mono_since_gettimeofday;
-
-        /* Use time of day. */
-        mono_at_last_timeofday = mono_now;
+        return ustimeFromMonotonic(getMonotonicUs());
     }
-
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    ust = ((long long)tv.tv_sec) * 1000000;
-    ust += tv.tv_usec;
-    return ust;
+    return ustimeFromTimeofday();
 }
 
 /* Return the UNIX time in milliseconds */

--- a/src/util.h
+++ b/src/util.h
@@ -32,6 +32,7 @@
 
 #include <stdint.h>
 #include "sds.h"
+#include "monotonic.h"
 
 /* Anti-warning macro... */
 #ifndef UNUSED
@@ -120,6 +121,7 @@ void setRandomSeedCString(char *seed_str, size_t len);
 void getRandomHexChars(char *p, size_t len);
 void getRandomBytes(unsigned char *p, size_t len);
 long long ustime(void);
+long long ustimeFromMonotonic(monotime mono_now);
 mstime_t mstime(void);
 void writePointerWithPadding(unsigned char *buf, const void *ptr);
 sds escapeJsonString(sds s, const char *p, size_t len);


### PR DESCRIPTION
`call()` samples the clock three times per command on the hot path:

1. `ustime()` for the execution unit's cached time snapshot — itself a `getMonotonicUs()` plus a cached `gettimeofday` offset;
2. `getMonotonicUs()` for the duration start;
3. `getMonotonicUs()` for the duration end.

The comment above the end read says the fallback exists "to avoid querying the clock using a system call 3 times" — the fix it describes made the reads cheap, not fewer.

This PR factors `ustime()`'s calibration into `ustimeFromMonotonic(monotime)` and has `call()` take the monotonic sample first, deriving the UNIX-time snapshot from it. That is 3 reads → 2 with **no semantic change**: the derived value is what `ustime()` would have returned had it read the clock at that instant, so every consumer (cached `mstime`/`unixtime`, `cmd_time_snapshot`, commandstats, latency histograms, slowlog, commandlog, slot-stats) sees identical values. On the POSIX-clock fallback nothing changes. It also removes the duplicated `static` calibration state that `ustime()` and `call()` were effectively maintaining separately.

### Why it is worth a PR

On x86 the read is `rdtsc` + a 128-bit multiply (~24 cycles). Profiling the main thread under a pipelined GET load (io-threads 8, P10) on a dev box, `getMonotonicUs_x86` + `ustime` was the largest single symbol at ~6% of main-thread user-space samples. After this change: 3.83% (−36%, the predicted third), and `ustime` self-time on main goes from 0.86% to 0.03%. ARM's `cntvct` is cheaper so the share there is smaller.

Throughput A/B (5 reps, cachecannon GET P10 / 400c / io7, upstream `7a681df30` vs this branch):

- Graviton3 (c7g, armbench): 2.048M → 2.147M rps, **+4.8%** (CV 1.0% / 0.8%, rep sets non-overlapping)
- Graviton4 (c8g, g4bench): 3.037M → 3.071M rps, **+1.1%** (CV 0.6% / 1.5%, 5 reps; 10-rep confirmation pending)
- AMD EPYC (bench): 1.991M → 2.038M rps, **+2.4%** (CV 0.6% / 0.2%, rep sets non-overlapping)
- Intel (intelbench): 1.078M → 1.107M rps, +2.7% at 10 reps (CV 3.4% / 3.0%) — within this platform's noise; no measurable change, no regression

### Verified

`INFO commandstats usec_per_call` and `latency_percentiles_usec_get` are byte-identical to base under 40M pipelined GETs (0.22 µs/call; p50/p99/p99.9 = 0.001/1.003/1.003), i.e. the derived snapshot changes nothing observable. Test suite and formatting are left to CI.

### Prior art
This is the consolidation proposed in #2143, which was closed once #3103 made `ustime()` syscall-free on the default hardware clock; this PR removes the redundant read itself rather than making it cheap. It is one of the per-command overhead items listed in #4117.

Part of #4117