### PR TITLE
bgiteration: fix unit-test feed deadlock under slow execution

### DIFF
--- a/src/bgiteration.c
+++ b/src/bgiteration.c
@@ -1653,6 +1653,13 @@ static long long bgIteration_feedIterators_task(struct aeEventLoop *eventLoop,
     }
     monotime endTime = startTime + dutyTimeUs;
 
+    /* Unit tests drive feeding manually (eventLoop == NULL) on the same thread that later performs
+     * a blocking read.  A single pass must feed every iterator regardless of the wall-clock budget,
+     * otherwise a slow environment (valgrind, 32-bit emulation) can spend the whole budget on one
+     * iterator, starve a later one, and deadlock its blocking read.  Production feeds run from the
+     * timer (eventLoop != NULL) where the budget applies and the next cycle picks up the rest. */
+    if (eventLoop == NULL) endTime = UINT64_MAX;
+
     // Run this part regardless of time limit...
     receiveItemsBackFromIterators(false);
 

--- a/src/bgiteration.c
+++ b/src/bgiteration.c
@@ -1653,11 +1653,7 @@ static long long bgIteration_feedIterators_task(struct aeEventLoop *eventLoop,
     }
     monotime endTime = startTime + dutyTimeUs;
 
-    /* Unit tests drive feeding manually (eventLoop == NULL) on the same thread that later performs
-     * a blocking read.  A single pass must feed every iterator regardless of the wall-clock budget,
-     * otherwise a slow environment (valgrind, 32-bit emulation) can spend the whole budget on one
-     * iterator, starve a later one, and deadlock its blocking read.  Production feeds run from the
-     * timer (eventLoop != NULL) where the budget applies and the next cycle picks up the rest. */
+    // Test path (manual feed, no timer thread): ignore the budget so a slow env can't starve the blocking read.
     if (eventLoop == NULL) endTime = UINT64_MAX;
 
     // Run this part regardless of time limit...

--- a/src/unit/CMakeLists.txt
+++ b/src/unit/CMakeLists.txt
@@ -168,7 +168,7 @@ add_custom_target(test-unit
         [ -n \"$large_memory\" ] && TEST_ARGS=\"$TEST_ARGS --large-memory\"; \
         [ -n \"$valgrind\" ] && TEST_ARGS=\"$TEST_ARGS --valgrind\"; \
         [ -n \"$seed\" ] && TEST_ARGS=\"$TEST_ARGS --seed $seed\"; \
-        python3 ${CMAKE_SOURCE_DIR}/deps/gtest-parallel/gtest_parallel.py $<TARGET_FILE:valkey-unit-gtests> --gtest_filter=\"$UNIT_TEST_PATTERN\"* -- $TEST_ARGS"
+        python3 ${CMAKE_SOURCE_DIR}/deps/gtest-parallel/gtest_parallel.py $<TARGET_FILE:valkey-unit-gtests> --timeout_per_test 300 --gtest_filter=\"$UNIT_TEST_PATTERN\"* -- $TEST_ARGS"
     DEPENDS valkey-unit-gtests
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Running tests with gtest-parallel"

--- a/src/unit/Makefile
+++ b/src/unit/Makefile
@@ -246,7 +246,7 @@ all: valkey-unit-gtests
 .PHONY: test-unit
 TEST_ARGS = $(if $(accurate),--accurate) $(if $(large_memory),--large-memory) $(if $(valgrind),--valgrind) $(if $(seed),--seed $(seed))
 test-unit: valkey-unit-gtests
-	python3 ../../deps/gtest-parallel/gtest_parallel.py ./valkey-unit-gtests --gtest_filter=$(UNIT_TEST_PATTERN)* -- $(TEST_ARGS)
+	python3 ../../deps/gtest-parallel/gtest_parallel.py ./valkey-unit-gtests --timeout_per_test 300 --gtest_filter=$(UNIT_TEST_PATTERN)* -- $(TEST_ARGS)
 	@printf '\033[32mAll UNIT TESTS PASSED!\033[0m\n'
 
 .PHONY: valgrind


### PR DESCRIPTION
## Problem

Unit-test CI jobs (e.g. `build-32bit`, `test-ubuntu-latest`) intermittently hang for ~6 hours until cancelled. A single `BgIterationTest` never returns; the run is later killed with `Terminate orphan process … (valkey-unit-gtests)`.

Confirmed from the actual hung logs of run `34370245690`:
- `build-32bit` (attempt 2): stuck on `BgIterationTest.modPastFutureItemBarrier_eventual`
- `test-ubuntu-latest`: stuck on `BgIterationTest.modFutureItem_eventual`

The exact test varies run to run, but it is always a `BgIterationTest` blocking read.

## Root cause

Unit tests drive feeding manually on the **same thread** that then performs a **blocking** `bgIteratorRead()` (`mutexQueuePop(…, true)`). The manual feed path (`bgIteration_feedIterators_task` invoked with `eventLoop == NULL`) is still bounded by the `BGITER_CYCLE_BUDGET_MS` (1 ms) wall-clock budget. On a slow environment (32-bit emulation, valgrind, a loaded CI box), that 1 ms can elapse before the feed queues the next needed key — at the outer guard (`getMonotonicUs() < endTime`) or inside `feedIterator` (`have_time`). The feed then queues nothing, and because there is no separate producer thread in a unit test, the blocking pop waits forever.

This is timing-dependent: on a fast machine the same test passes in tens of ms. Production is unaffected — there the feed runs from a timer (`eventLoop == server.el`) on the main thread while reads happen on a background thread, so a budget-limited pass is simply resumed on the next cycle.

The defect was introduced with the forkless-save background iterator and is independent of any particular feature PR; it can hang slow CI configs on unrelated changes.

## Fix

On the manual/test feed path only (`eventLoop == NULL`), ignore the wall-clock budget so a single pass feeds fully:

```c
if (eventLoop == NULL) endTime = UINT64_MAX;
```

`eventLoop == NULL` is reached **only** from the test path: the production timer callback always receives `server.el`, and the in-`bgIteratorRead` manual feed is guarded by `onServerMainThread()`, which is false for real (background-thread) consumers. So the branch is inert in a real server.

## Defense in depth

Also pass `--timeout_per_test 300` to `gtest_parallel.py` so any future starved/hung unit test is killed and reported failed in minutes rather than stalling CI for hours.
