### PR TITLE
Fix XPENDING reply schema for empty pending lists

### DIFF
--- a/src/commands/xpending.json
+++ b/src/commands/xpending.json
@@ -113,6 +113,30 @@
                             }
                         }
                     ]
+                },
+                {
+                    "description": "Summary form when there are no pending messages.",
+                    "type": "array",
+                    "minItems": 4,
+                    "maxItems": 4,
+                    "items": [
+                        {
+                            "description": "Total number of pending messages",
+                            "const": 0
+                        },
+                        {
+                            "description": "Minimal pending entry ID",
+                            "type": "null"
+                        },
+                        {
+                            "description": "Maximal pending entry ID",
+                            "type": "null"
+                        },
+                        {
+                            "description": "Consumers with pending messages",
+                            "type": "null"
+                        }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
When a consumer group has no pending messages, `XPENDING <key> <group>` returns:

```text
[0, null, null, null]
```

The reply schema only described non-empty summaries and extended replies, so the reply-schema validator rejected this valid response.

This adds a dedicated schema variant for the empty summary while preserving strict validation for non-empty responses. There is no change to command behavior.

This started surfacing consistently after #4629 added stream tests that call `XPENDING` after clearing the pending entries list.