### PR TITLE
Reject unterminated cluster bus string extensions

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4008,6 +4008,21 @@ int clusterIsValidPacket(clusterLink *link) {
                               clusterGetMessageTypeString(type), (unsigned long long)totlen);
                     return 0;
                 }
+                uint16_t ext_type = ntohs(ext->type);
+                bool is_string_ext = ext_type == CLUSTERMSG_EXT_TYPE_HOSTNAME ||
+                                     ext_type == CLUSTERMSG_EXT_TYPE_HUMAN_NODENAME ||
+                                     ext_type == CLUSTERMSG_EXT_TYPE_CLIENT_IPV4 ||
+                                     ext_type == CLUSTERMSG_EXT_TYPE_CLIENT_IPV6 ||
+                                     ext_type == CLUSTERMSG_EXT_TYPE_AVAILABILITY_ZONE;
+                /* String extensions are consumed as C strings. Make sure those reads
+                 * cannot continue past the declared extension. */
+                if (is_string_ext &&
+                    (extlen <= sizeof(clusterMsgPingExt) ||
+                     memchr((char *)ext + sizeof(clusterMsgPingExt), '\0', extlen - sizeof(clusterMsgPingExt)) == NULL)) {
+                    serverLog(LL_WARNING, "Received invalid %s packet with unterminated string extension type %d",
+                              clusterGetMessageTypeString(type), (int)ext_type);
+                    return 0;
+                }
                 explen += extlen;
                 ext = getNextPingExt(ext);
             }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3979,6 +3979,13 @@ int clusterIsValidPacket(clusterLink *link) {
             return 0;
         }
 
+        if (!(msg->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) && extensions != 0) {
+            serverLog(LL_WARNING,
+                      "Received invalid %s packet with %d extensions but no extension data flag",
+                      clusterGetMessageTypeString(type), extensions);
+            return 0;
+        }
+
         /* If there is extension data, which doesn't have a fixed length,
          * loop through them and validate the length of it now. */
         if (msg->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -214,6 +214,39 @@ start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
 }
 
 start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
+    test "Reject unterminated string extensions in cluster bus packets" {
+        set base_port [srv 0 port]
+        set cluster_port [expr {$base_port + 10000}]
+        set sender_node_id [R 0 cluster myid]
+
+        foreach extension_type {0 1 4 5 8} {
+            set packet [create_cluster_meet_packet \
+                $sender_node_id $base_port $cluster_port 0 1 4]
+
+            # Append an aligned 16-byte string extension whose eight data bytes
+            # contain no NUL terminator.
+            append packet [binary format I 16]
+            append packet [binary format S $extension_type]
+            append packet [binary format S 0]
+            append packet "abcdefgh"
+            set packet [string replace $packet 4 7 [binary format I [string length $packet]]]
+
+            set loglines [count_log_lines 0]
+            set sock [socket 127.0.0.1 $cluster_port]
+            fconfigure $sock -translation binary -buffering none -blocking 1
+            puts -nonewline $sock $packet
+            flush $sock
+            close $sock
+
+            wait_for_log_messages 0 \
+                [list "*Received invalid meet packet with unterminated string extension type $extension_type*"] \
+                $loglines 1000 10
+            assert_equal "PONG" [R 0 ping]
+        }
+    }
+}
+
+start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
     test "Packet with missing gossip messages don't cause invalid read" {
         set base_port [srv 0 port]
         set cluster_port [expr {$base_port + 10000}]

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -214,6 +214,27 @@ start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
 }
 
 start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
+    test "Reject extension count without extension data flag" {
+        set base_port [srv 0 port]
+        set cluster_port [expr {$base_port + 10000}]
+        set sender_node_id [R 0 cluster myid]
+
+        set packet [create_cluster_meet_packet \
+            $sender_node_id $base_port $cluster_port 0 1 0]
+
+        set loglines [count_log_lines 0]
+        set sock [socket 127.0.0.1 $cluster_port]
+        fconfigure $sock -translation binary -buffering none -blocking 1
+        puts -nonewline $sock $packet
+        flush $sock
+        close $sock
+
+        wait_for_log_messages 0 \
+            [list "*Received invalid meet packet with 1 extensions but no extension data flag*"] \
+            $loglines 1000 10
+        assert_equal "PONG" [R 0 ping]
+    }
+
     test "Reject unterminated string extensions in cluster bus packets" {
         set base_port [srv 0 port]
         set cluster_port [expr {$base_port + 10000}]


### PR DESCRIPTION
## Problem

Several cluster bus extensions contain strings, including hostnames, node names, client IP addresses, and availability zones.

These values are consumed as C strings, but packet validation only checked that the extension fit within the packet. A malformed extension without a NUL terminator could therefore cause reads beyond the extension boundary.

Minimum-size validation for fixed-layout extension types is handled separately in #4662.

## Fix

For every recognized string extension, require a NUL terminator within its declared payload. Reject the packet when no terminator is present.

Also reject packets that declare extensions without setting the extension-data flag, so extension processing cannot bypass validation.

## Testing

Added a regression test that sends unterminated values for all five string extension types and verifies that:

- The packet is rejected.
- The server remains responsive.

Added coverage for a nonzero extension count without the extension-data flag.

Validated with:

- `./runtest --single unit/cluster/packet`
- An AddressSanitizer build with warnings treated as errors
