### PR TITLE
Validate cluster bus extension minimum sizes

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3591,6 +3591,25 @@ static uint32_t getReplicaPriorityExtSize(void) {
     return getAlignedPingExtSize(sizeof(clusterMsgPingExtReplicaPriority));
 }
 
+/* Return the minimum encoded size for an extension type. Unknown extensions
+ * only require the common header to preserve forward compatibility. */
+static uint32_t getMinimumPingExtSize(uint16_t type) {
+    switch (type) {
+    case CLUSTERMSG_EXT_TYPE_HOSTNAME: return getAlignedPingExtSize(sizeof(clusterMsgPingExtHostname));
+    case CLUSTERMSG_EXT_TYPE_HUMAN_NODENAME: return getAlignedPingExtSize(sizeof(clusterMsgPingExtHumanNodename));
+    case CLUSTERMSG_EXT_TYPE_FORGOTTEN_NODE: return getForgottenNodeExtSize();
+    case CLUSTERMSG_EXT_TYPE_SHARDID: return getShardIdPingExtSize();
+    case CLUSTERMSG_EXT_TYPE_CLIENT_IPV4: return getAlignedPingExtSize(sizeof(clusterMsgPingExtClientIpV4));
+    case CLUSTERMSG_EXT_TYPE_CLIENT_IPV6: return getAlignedPingExtSize(sizeof(clusterMsgPingExtClientIpV6));
+    case CLUSTERMSG_EXT_TYPE_CLIENT_PORT: return getAlignedPingExtSize(sizeof(clusterMsgPingExtClientPort));
+    case CLUSTERMSG_EXT_TYPE_CLIENT_TLS_PORT: return getAlignedPingExtSize(sizeof(clusterMsgPingExtClientTlsPort));
+    case CLUSTERMSG_EXT_TYPE_AVAILABILITY_ZONE:
+        return getAlignedPingExtSize(sizeof(clusterMsgPingExtAvailabilityZone));
+    case CLUSTERMSG_EXT_TYPE_REPLICA_PRIORITY: return getReplicaPriorityExtSize();
+    default: return sizeof(clusterMsgPingExt);
+    }
+}
+
 static void *preparePingExt(clusterMsgPingExt *ext, uint16_t type, uint32_t length) {
     ext->type = htons(type);
     ext->length = htonl(length);
@@ -3997,6 +4016,14 @@ int clusterIsValidPacket(clusterLink *link) {
                 if (extlen % 8 != 0) {
                     serverLog(LL_WARNING, "Received a %s packet without proper padding (%d bytes)",
                               clusterGetMessageTypeString(type), (int)extlen);
+                    return 0;
+                }
+                uint16_t ext_type = ntohs(ext->type);
+                uint32_t min_extlen = getMinimumPingExtSize(ext_type);
+                if (extlen < min_extlen) {
+                    serverLog(LL_WARNING,
+                              "Received invalid %s packet with extension type %d that is %d bytes but requires at least %d",
+                              clusterGetMessageTypeString(type), (int)ext_type, (int)extlen, (int)min_extlen);
                     return 0;
                 }
                 /* Similar check to earlier, but we want to make sure the extension length is valid

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3998,6 +3998,13 @@ int clusterIsValidPacket(clusterLink *link) {
             return 0;
         }
 
+        if (!(msg->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) && extensions != 0) {
+            serverLog(LL_WARNING,
+                      "Received invalid %s packet with %d extensions but no extension data flag",
+                      clusterGetMessageTypeString(type), extensions);
+            return 0;
+        }
+
         /* If there is extension data, which doesn't have a fixed length,
          * loop through them and validate the length of it now. */
         if (msg->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -214,6 +214,38 @@ start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
 }
 
 start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
+    test "Reject cluster bus extensions shorter than their type requires" {
+        set base_port [srv 0 port]
+        set cluster_port [expr {$base_port + 10000}]
+        set sender_node_id [R 0 cluster myid]
+
+        foreach extension_type {0 1 2 3 4 5 6 7 8 9} {
+            set packet [create_cluster_meet_packet \
+                $sender_node_id $base_port $cluster_port 0 1 4]
+
+            # Append only the common eight-byte extension header. Every known
+            # extension type requires an additional data payload.
+            append packet [binary format I 8]
+            append packet [binary format S $extension_type]
+            append packet [binary format S 0]
+            set packet [string replace $packet 4 7 [binary format I [string length $packet]]]
+
+            set loglines [count_log_lines 0]
+            set sock [socket 127.0.0.1 $cluster_port]
+            fconfigure $sock -translation binary -buffering none -blocking 1
+            puts -nonewline $sock $packet
+            flush $sock
+            close $sock
+
+            wait_for_log_messages 0 \
+                [list "*Received invalid meet packet with extension type $extension_type that is 8 bytes*"] \
+                $loglines 1000 10
+            assert_equal "PONG" [R 0 ping]
+        }
+    }
+}
+
+start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
     test "Packet with missing gossip messages don't cause invalid read" {
         set base_port [srv 0 port]
         set cluster_port [expr {$base_port + 10000}]

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -214,6 +214,27 @@ start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
 }
 
 start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
+    test "Reject extension count without extension data flag" {
+        set base_port [srv 0 port]
+        set cluster_port [expr {$base_port + 10000}]
+        set sender_node_id [R 0 cluster myid]
+
+        set packet [create_cluster_meet_packet \
+            $sender_node_id $base_port $cluster_port 0 1 0]
+
+        set loglines [count_log_lines 0]
+        set sock [socket 127.0.0.1 $cluster_port]
+        fconfigure $sock -translation binary -buffering none -blocking 1
+        puts -nonewline $sock $packet
+        flush $sock
+        close $sock
+
+        wait_for_log_messages 0 \
+            [list "*Received invalid meet packet with 1 extensions but no extension data flag*"] \
+            $loglines 1000 10
+        assert_equal "PONG" [R 0 ping]
+    }
+
     test "Reject cluster bus extensions shorter than their type requires" {
         set base_port [srv 0 port]
         set cluster_port [expr {$base_port + 10000}]

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -264,6 +264,29 @@ start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
             assert_equal "PONG" [R 0 ping]
         }
     }
+
+    test "Accept header-only unknown cluster bus extensions" {
+        set base_port [srv 0 port]
+        set cluster_port [expr {$base_port + 10000}]
+        set sender_node_id [R 0 cluster myid]
+
+        set packet [create_cluster_meet_packet \
+            $sender_node_id $base_port $cluster_port 0 1 4]
+        append packet [binary format I 8]
+        append packet [binary format S 10]
+        append packet [binary format S 0]
+        set packet [string replace $packet 4 7 [binary format I [string length $packet]]]
+
+        set loglines [count_log_lines 0]
+        set sock [socket 127.0.0.1 $cluster_port]
+        fconfigure $sock -translation binary -buffering none -blocking 1
+        puts -nonewline $sock $packet
+        flush $sock
+        close $sock
+
+        wait_for_log_messages 0 [list "*Received unknown extension type 10*"] $loglines 1000 10
+        assert_equal "PONG" [R 0 ping]
+    }
 }
 
 start_cluster 1 0 {tags {external:skip cluster tls:skip}} {


### PR DESCRIPTION
## Problem

Cluster packet validation checked that extensions were aligned and fit within the packet, but it did not verify that recognized extension types contained their required payload.

A known extension could declare only the common eight-byte header. The packet would pass validation, after which extension processing could read fields beyond the declared extension boundary.

NUL-termination validation for string extension types is handled separately in #4661.

## Fix

Define the minimum encoded size of every recognized extension type and reject extensions shorter than that size.

Unknown extension types continue to require only the common header so that newer extensions remain compatible with older nodes.

Also reject packets that declare extensions without setting the extension-data flag, so extension processing cannot bypass validation.

## Testing

Added a regression test that sends a header-only extension for every currently recognized type and verifies that:

- Each packet is rejected.
- The server remains responsive.

Added coverage for a nonzero extension count without the extension-data flag.

Added a compatibility test confirming that a header-only unknown extension is accepted.

Validated with:

- `./runtest --single unit/cluster/packet`
- An AddressSanitizer build with warnings treated as errors
