### PR TITLE
Fixes to dual certs

### DIFF
--- a/.config/typos.toml
+++ b/.config/typos.toml
@@ -12,6 +12,7 @@ ignore-hidden = false
 [default.extend-words]
 exat = "exat"
 optin = "optin"
+passin = "passin"
 smove = "smove"
 Parth = "Parth" # seems like the spellchecker does not like it is similar to "Path"
 Collet = "Collet" # LZ4 author Yann Collet
@@ -43,11 +44,6 @@ extend-ignore-re = [
 [type.tcl]
 extend-ignore-re = [
     "DUMPed",
-]
-
-[type.sh]
-extend-ignore-re = [
-    "passin", # gen-test-certs.sh
 ]
 
 [type.c.extend-identifiers]

--- a/src/server.h
+++ b/src/server.h
@@ -1711,7 +1711,7 @@ typedef struct serverTLSContextConfig {
     char *client_cert_file;     /* Certificate to use as a client; if none, use cert_file */
     char *client_key_file;      /* Private key filename for client_cert_file */
     char *client_key_file_pass; /* Optional password for client_key_file */
-    char *alt_cert_file;        /* Secondary server side cert file name */
+    char *alt_cert_file;        /* Alternate server side cert file name */
     char *alt_key_file;         /* Private key filename for alt_cert_file */
     char *alt_key_file_pass;    /* Optional password for alt_key_file */
     int client_auth_user;       /* Field to be used for automatic TLS authentication based on client TLS certificate */

--- a/src/tls.c
+++ b/src/tls.c
@@ -57,6 +57,7 @@
 #include <arpa/inet.h>
 #include <dirent.h>
 #include <ctype.h>
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -867,6 +868,8 @@ typedef struct {
     time_t ca_cert_dir_mtime;
     ino_t key_file_inode;
     time_t key_file_mtime;
+    ino_t alt_key_file_inode;
+    time_t alt_key_file_mtime;
     ino_t client_key_file_inode;
     time_t client_key_file_mtime;
 } tlsMaterialsMetadata;
@@ -930,6 +933,10 @@ static void captureMetadata(serverTLSContextConfig *ctx_config, tlsMaterialsMeta
         metadata->key_file_inode = st.st_ino;
         metadata->key_file_mtime = st.st_mtime;
     }
+    if (ctx_config->alt_key_file && stat(ctx_config->alt_key_file, &st) == 0) {
+        metadata->alt_key_file_inode = st.st_ino;
+        metadata->alt_key_file_mtime = st.st_mtime;
+    }
     if (ctx_config->client_key_file && stat(ctx_config->client_key_file, &st) == 0) {
         metadata->client_key_file_inode = st.st_ino;
         metadata->client_key_file_mtime = st.st_mtime;
@@ -964,6 +971,9 @@ static int metadataChanged(const tlsMaterialsMetadata *old, const tlsMaterialsMe
         return 1;
     }
     if (old->key_file_inode != new->key_file_inode || old->key_file_mtime != new->key_file_mtime) {
+        return 1;
+    }
+    if (old->alt_key_file_inode != new->alt_key_file_inode || old->alt_key_file_mtime != new->alt_key_file_mtime) {
         return 1;
     }
     if (old->client_key_file_inode != new->client_key_file_inode || old->client_key_file_mtime != new->client_key_file_mtime) {

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -215,6 +215,8 @@ start_server {tags {"tls"}} {
                 assert_match {*Unable to update TLS configuration*} $e
                 catch {r CONFIG SET tls-cert-file $valkey_pw_crt tls-key-file $valkey_pw_key tls-key-file-pass 1234} e
                 assert_match {*Unable to update TLS configuration*} $e
+                set logs [exec tail -n 100 < [srv 0 stdout]]
+                assert_match {*Primary and alternate certificates must use different key algorithms*Primary and alternate certificates must use different key algorithms*} $logs
             } finally {
                 #cleanup
                 r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key tls-alt-cert-file $orig_server_alt_crt tls-alt-key-file $orig_server_alt_key tls-key-file-pass ""
@@ -462,10 +464,10 @@ start_server {tags {"tls"}} {
                 assert {$serial2 ne "none"}
                 assert {$serial1 ne $serial2}
 
-                set valkey_alt_crt [format "%s/tests/tls/valkey-ec-pw.crt" [pwd]]
-                set valkey_alt_key [format "%s/tests/tls/valkey-ec-pw.key" [pwd]]
-                file copy -force $valkey_alt_crt $temp_alt_crt
-                file copy -force $valkey_alt_key $temp_alt_key
+                set valkey_alt_pw_crt [format "%s/tests/tls/valkey-ec-pw.crt" [pwd]]
+                set valkey_alt_pw_key [format "%s/tests/tls/valkey-ec-pw.key" [pwd]]
+                file copy -force $valkey_alt_pw_crt $temp_alt_crt
+                file copy -force $valkey_alt_pw_key $temp_alt_key
 
                 # Wait for another auto-reload cycle to complete
                 after 2100

--- a/utils/gen-test-certs.sh
+++ b/utils/gen-test-certs.sh
@@ -10,7 +10,7 @@
 #   tests/tls/ca-multi.crt                       CA bundle with multiple certs.
 #   tests/tls/ca-dir/                            CA directory with hashed links.
 #   tests/tls/valkey{,-pw}.{crt,key}             A certificate with no key usage/policy restrictions. With and without a passphrase.
-#   tests/tls/valkey-mldsa{,-pw}.{crt,key}       A PQC certificate with no key usage/policy restrictions. With and without a passphrase.
+#   tests/tls/valkey-ec{,-pw}.{crt,key}          An ECDSA certificate with no key usage/policy restrictions. With and without a passphrase.
 #   tests/tls/client.{crt,key}                   A certificate restricted for SSL client usage.
 #   tests/tls/client-{expired,notyet}.crt        Invalid certificates restricted for SSL client usage.
 #   tests/tls/server.{crt,key}                   A certificate restricted for SSL server usage.

--- a/valkey.conf
+++ b/valkey.conf
@@ -223,9 +223,9 @@ tcp-keepalive 300
 # You may also set up a secondary certificate and private key that use a
 # different encryption algorithm in case a client, primary or cluster peer doesn't
 # support the algorithm the above defined certificate uses (e.g. a PQC one).
-# The ordering of the primary and secondary certificate does not matter as
-# the most secure one will be chosen automatically if supported on both the
-# client and server.
+# Both certificates are offered to the peer. Which one is used is negotiated
+# from the signature algorithms both sides support, with tls-prefer-server-ciphers
+# deciding whose preference order wins. Configuration order has no effect.
 #
 # tls-alt-cert-file valkey_rsa.crt
 # tls-alt-key-file valkey_rsa.key


### PR DESCRIPTION
Addresses feedback from #3717 that isn't addressed in madolson/valkey-agents#11 :

- update various outdated comments
- fingerprint alt_key_file in tls info metadata
- make test assertions more specific to new log messages