### PR TITLE
Report each server certificate against the config that loaded it

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -186,10 +186,25 @@ static void tlsInit(void) {
     pending_list = listCreate();
 }
 
+/* Serial and expiry of the two server certificates, captured while the context is built
+ * because a finished context cannot tell you which slot came from tls-cert-file: OpenSSL
+ * orders slots by key algorithm and records nothing about configuration order. The key
+ * algorithm cannot stand in for the slot either, since EVP_PKEY_base_id() is NID_undef
+ * for a provider-only algorithm such as ML-DSA. */
+typedef struct {
+    long long cert_expiry;
+    sds cert_serial;
+    long long alt_cert_expiry;
+    sds alt_cert_serial;
+} tlsServerCertInfo;
+
+static tlsServerCertInfo active_cert_info = {0};
+
 static void tlsClearCertInfo(long long *expiry, sds *serial);
 static void tlsClearCACertInfo(void);
 static void tlsClearAllCertInfo(void);
 static void tlsRefreshAllCertInfo(void);
+static void tlsClearServerCertInfo(tlsServerCertInfo *info);
 
 static void tlsCleanup(void) {
     if (valkey_tls_ctx) {
@@ -201,6 +216,7 @@ static void tlsCleanup(void) {
         valkey_tls_client_ctx = NULL;
     }
     tlsClearAllCertInfo();
+    tlsClearServerCertInfo(&active_cert_info);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
     // unavailable on LibreSSL
@@ -397,20 +413,6 @@ static int tlsUpdateCertInfoFromDir(const char *path, long long *expiry, sds *se
     closedir(dir);
     return tlsStoreCertInfo(earliest_expiry, earliest_serial, cert_count, expiry, serial, count);
 }
-
-/* Serial and expiry of the two server certificates, captured while the context is built
- * because a finished context cannot tell you which slot came from tls-cert-file: OpenSSL
- * orders slots by key algorithm and records nothing about configuration order. The key
- * algorithm cannot stand in for the slot either, since EVP_PKEY_base_id() is NID_undef
- * for a provider-only algorithm such as ML-DSA. */
-typedef struct {
-    long long cert_expiry;
-    sds cert_serial;
-    long long alt_cert_expiry;
-    sds alt_cert_serial;
-} tlsServerCertInfo;
-
-static tlsServerCertInfo active_cert_info = {0};
 
 static void tlsClearServerCertInfo(tlsServerCertInfo *info) {
     tlsClearCertSerial(&info->cert_serial);

--- a/src/tls.c
+++ b/src/tls.c
@@ -398,22 +398,44 @@ static int tlsUpdateCertInfoFromDir(const char *path, long long *expiry, sds *se
     return tlsStoreCertInfo(earliest_expiry, earliest_serial, cert_count, expiry, serial, count);
 }
 
+/* Serial and expiry of the two server certificates, captured while the context is built
+ * because a finished context cannot tell you which slot came from tls-cert-file: OpenSSL
+ * orders slots by key algorithm and records nothing about configuration order. The key
+ * algorithm cannot stand in for the slot either, since EVP_PKEY_base_id() is NID_undef
+ * for a provider-only algorithm such as ML-DSA. */
+typedef struct {
+    long long cert_expiry;
+    sds cert_serial;
+    long long alt_cert_expiry;
+    sds alt_cert_serial;
+} tlsServerCertInfo;
+
+static tlsServerCertInfo active_cert_info = {0};
+
+static void tlsClearServerCertInfo(tlsServerCertInfo *info) {
+    tlsClearCertSerial(&info->cert_serial);
+    tlsClearCertSerial(&info->alt_cert_serial);
+    info->cert_expiry = 0;
+    info->alt_cert_expiry = 0;
+}
+
+static void tlsPublishCertInfo(long long src_expiry, sds src_serial, long long *expiry, sds *serial) {
+    tlsClearCertInfo(expiry, serial);
+    if (!src_serial) return;
+    *expiry = src_expiry;
+    *serial = sdsdup(src_serial);
+}
+
 static void tlsRefreshServerCertInfo(void) {
-    /* Cycle through both certificates to get the correct info for each */
-    if (!(server.tls_port || server.tls_replication || server.tls_cluster) || !valkey_tls_ctx ||
-        SSL_CTX_set_current_cert(valkey_tls_ctx, SSL_CERT_SET_FIRST) != 1 ||
-        tlsUpdateCertInfoFromCtx(valkey_tls_ctx, &server.tls_server_cert_expire_time, &server.tls_server_cert_serial) == C_ERR) {
-        tlsClearCertInfo(&server.tls_server_cert_expire_time, &server.tls_server_cert_serial);
-    }
-    if (SSL_CTX_set_current_cert(valkey_tls_ctx, SSL_CERT_SET_NEXT) != 1 ||
-        tlsUpdateCertInfoFromCtx(valkey_tls_ctx, &server.tls_server_alt_cert_expire_time, &server.tls_server_alt_cert_serial) == C_ERR) {
-        tlsClearCertInfo(&server.tls_server_alt_cert_expire_time, &server.tls_server_alt_cert_serial);
-    }
-    if (SSL_CTX_set_current_cert(valkey_tls_ctx, SSL_CERT_SET_FIRST) != 1) {
-        serverLog(LL_WARNING, "Certificate unset during refresh, clearing all server certificate info");
+    if (!(server.tls_port || server.tls_replication || server.tls_cluster) || !valkey_tls_ctx) {
         tlsClearCertInfo(&server.tls_server_cert_expire_time, &server.tls_server_cert_serial);
         tlsClearCertInfo(&server.tls_server_alt_cert_expire_time, &server.tls_server_alt_cert_serial);
+        return;
     }
+    tlsPublishCertInfo(active_cert_info.cert_expiry, active_cert_info.cert_serial,
+                       &server.tls_server_cert_expire_time, &server.tls_server_cert_serial);
+    tlsPublishCertInfo(active_cert_info.alt_cert_expiry, active_cert_info.alt_cert_serial,
+                       &server.tls_server_alt_cert_expire_time, &server.tls_server_alt_cert_serial);
 }
 
 static void tlsRefreshClientCertInfo(void) {
@@ -579,7 +601,7 @@ static bool areAllCaCertsValid(SSL_CTX *ctx) {
 /* Create a *base* SSL_CTX using the SSL configuration provided. The base context
  * includes everything that's common for both client-side and server-side connections.
  */
-static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protocols, int client) {
+static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protocols, int client, tlsServerCertInfo *out_info) {
     const char *cert_file = client ? ctx_config->client_cert_file : ctx_config->cert_file;
     const char *key_file = client ? ctx_config->client_key_file : ctx_config->key_file;
     const char *key_file_pass = client ? ctx_config->client_key_file_pass : ctx_config->key_file_pass;
@@ -630,6 +652,10 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
         goto error;
     }
 
+    /* INFO reporting only. A failure leaves the field as none rather than refusing the
+     * configuration. */
+    if (out_info) tlsUpdateCertInfoFromCtx(ctx, &out_info->cert_expiry, &out_info->cert_serial);
+
     if (alt_cert_file) {
         primary_pkey = X509_get_pubkey(SSL_CTX_get0_certificate(ctx));
         if (!primary_pkey) {
@@ -658,6 +684,7 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
             serverLog(LL_WARNING, "Primary and alternate certificates must use different key algorithms");
             goto error;
         }
+        if (out_info) tlsUpdateCertInfoFromCtx(ctx, &out_info->alt_cert_expiry, &out_info->alt_cert_serial);
     }
 
     if (SSL_CTX_use_PrivateKey_file(ctx, key_file, SSL_FILETYPE_PEM) <= 0) {
@@ -704,6 +731,10 @@ static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protoco
     }
 #endif
 
+    /* Loading the alternate certificate moved the current certificate to its slot,
+     * and outgoing TLS 1.2 connections pick their client certificate from there.
+     * Leave it on the lowest slot, which is where it sat before dual certificates. */
+    SSL_CTX_set_current_cert(ctx, SSL_CERT_SET_FIRST);
     EVP_PKEY_free(primary_pkey);
     EVP_PKEY_free(alt_pkey);
     return ctx;
@@ -720,7 +751,10 @@ error:
  * Returns C_OK on success, C_ERR on failure.
  * On success, *ctx and *client_ctx are set (client_ctx may be NULL).
  * On failure, both are set to NULL. */
-static int tlsCreateContexts(serverTLSContextConfig *ctx_config, SSL_CTX **out_ctx, SSL_CTX **out_client_ctx) {
+static int tlsCreateContexts(serverTLSContextConfig *ctx_config,
+                             SSL_CTX **out_ctx,
+                             SSL_CTX **out_client_ctx,
+                             tlsServerCertInfo *out_info) {
     char errbuf[256];
     SSL_CTX *ctx = NULL;
     SSL_CTX *client_ctx = NULL;
@@ -756,7 +790,7 @@ static int tlsCreateContexts(serverTLSContextConfig *ctx_config, SSL_CTX **out_c
     if (protocols == -1) goto error;
 
     /* Create server side/general context */
-    ctx = createSSLContext(ctx_config, protocols, 0);
+    ctx = createSSLContext(ctx_config, protocols, 0, out_info);
     if (!ctx) goto error;
 
     if (ctx_config->session_caching) {
@@ -837,7 +871,7 @@ static int tlsCreateContexts(serverTLSContextConfig *ctx_config, SSL_CTX **out_c
 
     /* If a client-side certificate is configured, create an explicit client context */
     if (ctx_config->client_cert_file && ctx_config->client_key_file) {
-        client_ctx = createSSLContext(ctx_config, protocols, 1);
+        client_ctx = createSSLContext(ctx_config, protocols, 1, NULL);
         if (!client_ctx) goto error;
     }
 
@@ -846,6 +880,7 @@ static int tlsCreateContexts(serverTLSContextConfig *ctx_config, SSL_CTX **out_c
     return C_OK;
 
 error:
+    if (out_info) tlsClearServerCertInfo(out_info);
     if (ctx) SSL_CTX_free(ctx);
     if (client_ctx) SSL_CTX_free(client_ctx);
     *out_ctx = NULL;
@@ -877,6 +912,7 @@ typedef struct {
     SSL_CTX *ctx;
     SSL_CTX *client_ctx;
     tlsMaterialsMetadata metadata;
+    tlsServerCertInfo cert_info;
 } tlsPendingReload;
 
 /* Last known (active) TLS materials metadata */
@@ -1014,7 +1050,8 @@ static int tlsConfigure(void *priv, int reconfigure, bool background) {
         }
         serverLog(LL_NOTICE, "TLS materials changed, reloading in background");
 
-        if (tlsCreateContexts(ctx_config, &ctx, &client_ctx) == C_ERR) {
+        tlsServerCertInfo cert_info = {0};
+        if (tlsCreateContexts(ctx_config, &ctx, &client_ctx, &cert_info) == C_ERR) {
             serverLog(LL_WARNING, "Background TLS reload failed");
             return C_ERR;
         }
@@ -1023,16 +1060,19 @@ static int tlsConfigure(void *priv, int reconfigure, bool background) {
         if (pending_reload.ctx) {
             SSL_CTX_free(pending_reload.ctx);
             SSL_CTX_free(pending_reload.client_ctx);
+            tlsClearServerCertInfo(&pending_reload.cert_info);
             serverLog(LL_DEBUG, "Replacing previous pending TLS reload");
         }
         pending_reload.ctx = ctx;
         pending_reload.client_ctx = client_ctx;
         pending_reload.metadata = new_metadata;
+        pending_reload.cert_info = cert_info;
         pthread_mutex_unlock(&pending_reload_mutex);
 
         serverLog(LL_DEBUG, "Background TLS reload parsed TLS materials successfully");
     } else {
-        if (tlsCreateContexts(ctx_config, &ctx, &client_ctx) == C_ERR) {
+        tlsServerCertInfo cert_info = {0};
+        if (tlsCreateContexts(ctx_config, &ctx, &client_ctx, &cert_info) == C_ERR) {
             return C_ERR;
         }
 
@@ -1040,6 +1080,8 @@ static int tlsConfigure(void *priv, int reconfigure, bool background) {
         SSL_CTX_free(valkey_tls_client_ctx);
         valkey_tls_ctx = ctx;
         valkey_tls_client_ctx = client_ctx;
+        tlsClearServerCertInfo(&active_cert_info);
+        active_cert_info = cert_info;
         captureMetadata(ctx_config, &active_metadata);
         tlsRefreshAllCertInfo();
     }
@@ -1075,6 +1117,7 @@ void tlsApplyPendingReload(void) {
     if (!metadataChanged(&active_metadata, &pending_reload.metadata)) {
         SSL_CTX_free(pending_reload.ctx);
         SSL_CTX_free(pending_reload.client_ctx);
+        tlsClearServerCertInfo(&pending_reload.cert_info);
         memset(&pending_reload, 0, sizeof(pending_reload));
         pthread_mutex_unlock(&pending_reload_mutex);
         serverLog(LL_DEBUG, "Discarding pending TLS reload with unchanged materials");
@@ -1092,6 +1135,8 @@ void tlsApplyPendingReload(void) {
     valkey_tls_client_ctx = local_pending.client_ctx;
 
     active_metadata = local_pending.metadata;
+    tlsClearServerCertInfo(&active_cert_info);
+    active_cert_info = local_pending.cert_info;
 
     SSL_CTX_free(old_ctx);
     SSL_CTX_free(old_client_ctx);

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -154,6 +154,87 @@ start_server {tags {"tls"}} {
             }
         }
 
+        test {TLS: INFO reports each certificate against the config that loaded it} {
+            set rsa_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+            set rsa_key [format "%s/tests/tls/valkey.key" [pwd]]
+            set ec_crt [format "%s/tests/tls/valkey-ec.crt" [pwd]]
+            set ec_key [format "%s/tests/tls/valkey-ec.key" [pwd]]
+
+            # With one certificate there is nothing to attribute, so this pins which
+            # serial belongs to which file.
+            start_server [list overrides [list tls-cert-file $ec_crt tls-key-file $ec_key]] {
+                set info [r info tls]
+                set ec_serial [getInfoProperty $info tls_server_cert_serial]
+                assert {$ec_serial ni {"" "none"}}
+                assert_equal "none" [getInfoProperty $info tls_server_alt_cert_serial]
+            }
+
+            # OpenSSL orders its certificate slots by key algorithm, not by the order
+            # the certificates were configured, so the EC certificate has to follow the
+            # config it was given to rather than staying on one side.
+            start_server [list overrides [list tls-cert-file $ec_crt tls-key-file $ec_key \
+                                              tls-alt-cert-file $rsa_crt tls-alt-key-file $rsa_key]] {
+                set info [r info tls]
+                assert_equal $ec_serial [getInfoProperty $info tls_server_cert_serial]
+                set rsa_serial [getInfoProperty $info tls_server_alt_cert_serial]
+                assert {$rsa_serial ne $ec_serial}
+            }
+
+            start_server [list overrides [list tls-cert-file $rsa_crt tls-key-file $rsa_key \
+                                              tls-alt-cert-file $ec_crt tls-alt-key-file $ec_key]] {
+                set info [r info tls]
+                assert_equal $rsa_serial [getInfoProperty $info tls_server_cert_serial]
+                assert_equal $ec_serial [getInfoProperty $info tls_server_alt_cert_serial]
+            }
+        }
+
+        test {TLS: INFO follows the config across a background reload} {
+            if {$::tls_module} {
+                # The auto-reload cron is only installed when TLS is built in
+                skip "Not supported with TLS built as a module"
+            }
+
+            set rsa_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+            set rsa_key [format "%s/tests/tls/valkey.key" [pwd]]
+            set ec_crt [format "%s/tests/tls/valkey-ec.crt" [pwd]]
+            set ec_key [format "%s/tests/tls/valkey-ec.key" [pwd]]
+            set tmp_crt [format "%s/tests/tls/reload-primary.crt" [pwd]]
+            set tmp_key [format "%s/tests/tls/reload-primary.key" [pwd]]
+            set tmp_alt_crt [format "%s/tests/tls/reload-alt.crt" [pwd]]
+            set tmp_alt_key [format "%s/tests/tls/reload-alt.key" [pwd]]
+            file copy -force $ec_crt $tmp_crt
+            file copy -force $ec_key $tmp_key
+            file copy -force $rsa_crt $tmp_alt_crt
+            file copy -force $rsa_key $tmp_alt_key
+
+            try {
+                start_server [list overrides [list tls-cert-file $tmp_crt tls-key-file $tmp_key \
+                                                  tls-alt-cert-file $tmp_alt_crt tls-alt-key-file $tmp_alt_key \
+                                                  tls-auto-reload-interval 1]] {
+                    set info [r info tls]
+                    set before_primary [getInfoProperty $info tls_server_cert_serial]
+                    set before_alt [getInfoProperty $info tls_server_alt_cert_serial]
+                    assert {$before_primary ni {"" "none"}}
+                    assert {$before_primary ne $before_alt}
+
+                    # The reload builds its context off the main thread, so it has to
+                    # carry its own mapping. Trade the two files, and the two reported
+                    # serials have to trade with them.
+                    file copy -force $rsa_crt $tmp_crt
+                    file copy -force $rsa_key $tmp_key
+                    file copy -force $ec_crt $tmp_alt_crt
+                    file copy -force $ec_key $tmp_alt_key
+                    wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 150 100
+
+                    set info [r info tls]
+                    assert_equal $before_alt [getInfoProperty $info tls_server_cert_serial]
+                    assert_equal $before_primary [getInfoProperty $info tls_server_alt_cert_serial]
+                }
+            } finally {
+                file delete -force $tmp_crt $tmp_key $tmp_alt_crt $tmp_alt_key
+            }
+        }
+
         test {TLS: alt cert and key files must be provided together} {
             # backup current certificates
             set orig_server_crt [lindex [r config get tls-cert-file] 1]


### PR DESCRIPTION
`tls_server_cert_serial` reports whichever certificate OpenSSL gave the lower slot index, not the one in `tls-cert-file`. Slot order is by key algorithm, so with an RSA and an ECDSA certificate configured, swapping the two config values produces identical INFO output. Anyone alerting on `tls_server_cert_expires_in_seconds` silently starts watching a different file the moment they add an alt certificate. This captures each certificate's serial and expiry while the context is being built, which is the last point where the file it came from is known, and carries those with the context.

<details>
<summary>Details</summary>

## Problem

`tlsRefreshServerCertInfo` walks the cursor with `SSL_CERT_SET_FIRST` then `SSL_CERT_SET_NEXT` and assigns the results to the primary and alt fields in that order (src/tls.c:401-417). OpenSSL orders slots by algorithm, not configuration order:

```c
/* openssl-3.5 ssl/ssl_cert.c:390 */
int ssl_cert_set_current(CERT *c, long op)
{
    if (op == SSL_CERT_SET_FIRST)
        idx = 0;
    ...
    for (i = idx; i < c->ssl_pkey_num; i++) {
        CERT_PKEY *cpk = c->pkeys + i;
        if (cpk->x509 && cpk->privatekey) {
            c->key = cpk;
            return 1;
```

`SSL_PKEY_RSA` is `0` (`ssl/ssl_local.h:319`).

| config | before | after |
|---|---|---|
| cert=EC, alt=RSA | RSA / EC | EC / RSA |
| cert=RSA, alt=EC | RSA / EC | RSA / EC |
| cert=ML-DSA, alt=RSA | RSA / ML-DSA | ML-DSA / RSA |
| cert=EC, no alt | EC / none | EC / none |

Two configs, byte-identical output:

```
### tls-cert-file=valkey-ec.crt   tls-alt-cert-file=valkey.crt
    tls_server_cert_serial:5D4D62F058073EEFF4EE8CBB2298B81525011451
    tls_server_alt_cert_serial:5D4D62F058073EEFF4EE8CBB2298B81525011453
### tls-cert-file=valkey.crt      tls-alt-cert-file=valkey-ec.crt
    tls_server_cert_serial:5D4D62F058073EEFF4EE8CBB2298B81525011451
    tls_server_alt_cert_serial:5D4D62F058073EEFF4EE8CBB2298B81525011453
```

Not RSA-specific. Ed25519 (slot 7) with ECDSA (slot 3) and no RSA anywhere still reports the EC certificate as primary in both orders. Single-certificate configs report correctly, which is why this is quiet.

## Fix

`createSSLContext` records each certificate's serial and expiry right after it loads it, into a `tlsServerCertInfo` that travels with the context through both the synchronous and background reload paths. The refresh publishes those. Nothing has to identify a slot afterwards.

## Alternatives considered

**Read the configured PEM at refresh time to recover its key algorithm, then find the matching slot.** Much less plumbing. It loses because it makes INFO follow the file on disk rather than the loaded certificate, and `tls-auto-reload-interval` defaults to 0 while `applyTLSPort` (src/config.c:2939) calls `tlsResetCertInfo()` without rebuilding the context, so the two diverge indefinitely. Deleting `tls-cert-file` and then setting `tls-port` reported `tls_server_cert_serial:none` for a certificate still being served.

**Record the key algorithm at load time and use that as the slot key.** Two ints instead of two `sds`, so no ownership to thread through the reload paths. It is wrong for the case the feature exists for. `EVP_PKEY_base_id` goes through the legacy `pkey->type`, which is -1 for a provider-only key, so it returns `NID_undef` for ML-DSA. `ssl_cert_lookup_by_pkey` matches by name via `EVP_PKEY_is_a` and has a second loop over provider-registered sigalgs (`ssl/ssl_cert.c:1325`), so the certificate resolves to a slot and loads fine. Result on OpenSSL 3.6.2 with the stock default provider:

```
$ valkey-server --tls-cert-file mldsa.crt --tls-key-file mldsa.key
tls_server_cert_serial:none
$ echo | openssl s_client -connect 127.0.0.1:33560
subject=O=Valkey Test, CN=MLDSA-cert
Peer signature type: mldsa44
```

**Read the two files outright with `tlsUpdateCertInfoFromFile()`**, the way `tlsRefreshCACertInfo()` does for CA certificates. Loses for the same reason as the first alternative.

## Certificate cursor

`tlsRefreshServerCertInfo` used to reset the current certificate to the lowest slot at the end of every refresh. It no longer walks the cursor, so `createSSLContext` resets it instead and outgoing TLS 1.2 connections pick the same client certificate they picked before. No behaviour change, so no test.

Worth its own change: with `tls-cert-file` on a higher slot than `tls-alt-cert-file`, a replica with no `tls-client-cert-file` presents the alternate. That is true before and after this.

## Not fixed here

A certificate whose private key does not match it still loads, because OpenSSL routes a key to the slot for its own algorithm and only checks it against whatever certificate is already there. `tls_server_cert_serial` then names a certificate the server cannot present. #3717 got that case wrong too, naming the alternate's certificate instead, and a single mismatched pair with no alternate configured already starts a server that completes no handshake at all. Separate bug, separate change.

Two provider-only certificates, ML-DSA-44 with ML-DSA-65, are rejected as "the same key algorithm" because `EVP_PKEY_base_id` is `NID_undef` for both. Pre-existing in #3717 and untouched here.

## Testing

The mapping test pins each serial to the file that configured it, using the single-certificate case to establish which serial is which. Asserting only that the two serials differ, or that they swap, passes while the mapping is inverted.

Both tests fail with only `src/tls.c` reverted:

```
[err]: TLS: INFO reports each certificate against the config that loaded it in tests/unit/tls.tcl
Expected '5D4D62F058073EEFF4EE8CBB2298B81525011453' to be equal to '5D4D62F058073EEFF4EE8CBB2298B81525011451'
```

The reload test covers the background path, which the mapping test does not reach. Deleting the swap in `tlsApplyPendingReload` leaves the mapping test green and fails only this one.

ML-DSA is verified by hand, not in the suite: `utils/gen-test-certs.sh` no longer generates a PQC certificate as of #3717.

</details>

This was generated by AI but verified, with love, by a human.
