### PR TITLE
Track field TTLs in the volatile set when a HASH_2 load converts mid-listpack

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -124,7 +124,9 @@ bool hashTypeHasVolatileFields(robj *o) {
 
     if (objectGetEncoding(o) == OBJ_ENCODING_LISTPACK) {
         /* O(1): the aggregate header exists iff at least one field carries
-         * an expiry. */
+         * an expiry. The one exception is the RDB_TYPE_HASH_2 loader, which
+         * appends field expiries inside its loop and installs the header only
+         * after it, so do not reach this from inside that loop. */
         return lpIsMetadata(lpStart(objectGetVal(o)));
     }
 
@@ -995,7 +997,11 @@ void hashTypeConvertListpack(robj *o, int enc) {
 
     } else if (enc == OBJ_ENCODING_HASHTABLE) {
         hashTypeIterator hi;
-        bool has_volatile = hashTypeHasVolatileFields(o);
+        /* Whether any entry we actually carried over has an expiry. Derived
+         * from the entries themselves rather than from the aggregate header,
+         * which a half-built listpack does not have yet: the RDB loader
+         * installs it only after its listpack loop. */
+        bool has_volatile = false;
 
         hashtable *ht = hashtableCreate(&hashHashtableType);
 
@@ -1008,6 +1014,7 @@ void hashTypeConvertListpack(robj *o, int enc) {
             sds value = hashTypeCurrentObjectNewSds(&hi, OBJ_HASH_VALUE);
             /* Get expiry for this field from the metadata value */
             long long expiry = hashTypeCurrentExpiry(o, &hi);
+            if (expiry != EXPIRY_NONE) has_volatile = true;
             entry *entry = entryCreate(field, value, expiry);
             sdsfree(field);
             if (!hashtableAdd(ht, entry)) {

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -5009,6 +5009,7 @@ start_server {tags {"hashexpire"}} {
 
 start_server {tags {"hash expire listpack"}} {
     r config set hash-max-listpack-entries 128
+    set original_max_value [lindex [r config get hash-max-listpack-value] 1]
 
     test "Volatile-count header tracks listpack expiry transitions" {
         r del myhash
@@ -5069,6 +5070,42 @@ start_server {tags {"hash expire listpack"}} {
             fail "volatile tracking not cleared after reap"
         }
     }
+
+    # A HASH_2 payload that makes the loader convert to a hashtable only after
+    # a volatile field has landed in the listpack: 'a' and 'b' are one byte and
+    # stay under the lowered value threshold, field 'cc' does not. The loader
+    # installs the aggregate volatile-count header after its listpack loop, so
+    # at conversion time the listpack does not have one yet.
+    r config set hash-max-listpack-value $original_max_value
+    r del myhash
+    r hset myhash a b cc dd
+    r hexpire myhash 1000 FIELDS 1 a
+    assert_encoding listpack myhash
+    set mid_load_payload [r dump myhash]
+    r config set hash-max-listpack-value 1
+
+    test "RESTORE tracks field TTLs when the load converts mid-listpack" {
+        r del myhash
+        r restore myhash 0 $mid_load_payload
+        assert_encoding hashtable myhash
+
+        assert_equal 1 [get_keys_with_volatile_items r]
+        assert_range [lindex [r httl myhash FIELDS 1 a] 0] 1 1000
+        assert_equal 1 [r hdel myhash a]
+        assert_equal 0 [get_keys_with_volatile_items r]
+        assert_equal {dd} [r hget myhash cc]
+    }
+
+    test "Field TTLs survive a save after a mid-listpack conversion" {
+        # An untracked expiry also makes the save pick RDB_TYPE_HASH over
+        # RDB_TYPE_HASH_2, dropping the TTL instead of crashing.
+        r del myhash
+        r restore myhash 0 $mid_load_payload
+        r debug reload
+        assert_range [lindex [r httl myhash FIELDS 1 a] 0] 1 1000
+    } {} {needs:debug}
+
+    r config set hash-max-listpack-value $original_max_value
 }
 
 start_server {tags {"hashexpire"}} {


### PR DESCRIPTION
Loading a `HASH_2` payload can build a hash whose field-expiry metadata is inconsistent with its volatile set. The loader appends each field's expiry to the listpack as it goes but installs the aggregate volatile-count header only after the loop, and `hashTypeConvertListpack()` decides whether to register the converted entries in the volatile set by peeking at exactly that header. A payload whose later field crosses `hash-max-listpack-value` therefore converts a header-less listpack, and the resulting hashtable entries carry an expiry while belonging to no volatile set: the fields never expire, their TTLs are dropped by the next RDB save, and `HDEL` of one of them dereferences a NULL set. This derives the decision from the expiries of the entries the conversion actually carried over, so it no longer depends on the header being installed.

<details>
<summary>Details</summary>

## Problem

`rdbLoadObject()` builds a `RDB_TYPE_HASH_2` hash incrementally. Each field's expiry goes in as a trailing tagged metadata entry inside the loop (`src/rdb.c:2428-2436`), but the leading aggregate volatile-count header is installed once, after the loop (`src/rdb.c:2449-2454`), to avoid rewriting it per field.

Inside the loop, a field or value over `hash-max-listpack-value` converts the partially built object (`src/rdb.c:2404-2409`). That call site assumes conversion carries the already-loaded TTLs across on its own:

```c
/* hashTypeConvert carries the TTLs of the pairs already in the
 * listpack into the volatile set; no header is needed for that. */
hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
```

It did not. `hashTypeConvertListpack()` gated its volatile-set registration loop on `hashTypeHasVolatileFields(o)` (`src/t_hash.c:998`), which for a listpack is an O(1) peek at the leading header (`src/t_hash.c:128`). Mid-load, the header does not exist yet, so the gate was false. The conversion loop still copied each field's expiry into the new entry (`src/t_hash.c:1010-1011`), so the hashtable ended up holding entries with an expiry that no `vset` knew about.

Three consequences, all confirmed on a build of unstable at `da91ccd12`:

`keys_with_volatile_items` stays 0 and the fields are never reaped or lazily hidden. `dbTrackKeyWithVolatileItems()` asks the same `hashTypeHasVolatileFields()` (`src/db.c:549`), which for a hashtable is `set && !vsetIsEmpty(set)`, so the key is not tracked; and because `hashTypeTrackEntry()` never ran, `hashTypeIgnoreTTL(o, false)` never swapped in `hashWithVolatileItemsHashtableType`, so reads have no validate callback either.

The field TTLs are silently dropped by the next RDB save. `rdbObjectType()` selects `RDB_TYPE_HASH_2` only when `hashTypeHasVolatileFields(o)` (`src/rdb.c:775-783`), so a desynced hash is written as plain `RDB_TYPE_HASH`:

```
httl before reload: 1000
OK
httl after reload:  -1
```

`HDEL` of a volatile field crashes. `hashTypeUntrackEntry()` takes `hashTypeGetVolatileSet()`, which returns NULL for uninitialized metadata (`src/t_hash.c:67-71`); the `debugServerAssert(set)` at `src/t_hash.c:201` is compiled out of a release build and `vsetRemoveEntryWithExpiry()` dereferences it one line before its own `assert(bucket)` (`src/vset.c:1839`):

```
EIP:
0   valkey-server                       0x0000000104c7f5f4 vsetRemoveEntryWithExpiry + 40

Backtrace:
0   libsystem_platform.dylib            0x0000000181c81744 _sigtramp + 56
1   valkey-server                       0x0000000104c29a1c hashTypeUntrackEntry + 188
2   valkey-server                       0x0000000104c296d8 hashTypeDelete + 168
3   valkey-server                       0x0000000104c2bf28 hdelCommand + 376
4   valkey-server                       0x0000000104c10230 call + 1048
```

Reproduction, with no crafted payload; the source hash is one the server itself produced, and the threshold change stands in for any load whose `hash-max-listpack-value` is smaller than the one in effect when the payload was written:

```
config set hash-max-listpack-value 64
hset myhash a b cc dd
hexpire myhash 1000 FIELDS 1 a          # listpack, 'a' first and volatile
dump myhash
config set hash-max-listpack-value 1    # 'a'/'b' still fit, field 'cc' does not
restore myhash 0 <payload>              # converts after 'a' landed in the listpack
hdel myhash a                           # SIGSEGV
```

Both halves of the mismatch, the deferred header install and the header-based gate, came from #3212. No tag contains that commit.

## Fix

Set `has_volatile` from the expiry of each entry the conversion carries over, in the same statement that hands that expiry to `entryCreate()`. The flag can no longer disagree with what landed in the hashtable, and it no longer reads the header at all, so the loader's deferred install stops being load-bearing. `hashTypeCurrentExpiry()` was already called on that line, so this adds no pass over the entries, and the registration pass is still skipped entirely when nothing carries an expiry.

`hashTypeHasVolatileFields()` documented its listpack fast path as "the aggregate header exists iff at least one field carries an expiry", which is false for the duration of the loader's loop. That comment now names the exception, so the next header consumer added on a path reachable from the loop does not reintroduce this.

Behavior of `RDB_TYPE_HASH_2` loads, per input:

| payload | before | after |
| --- | --- | --- |
| `len > hash-max-listpack-entries` | correct: converts an empty listpack, every field tracked by the hashtable loop at `rdb.c:2526-2528` | unchanged |
| fits the listpack, no field over `hash-max-listpack-value` | correct: header installed after the loop | unchanged |
| first field over the value threshold | correct: converts before any expiry is appended, nothing to register | unchanged |
| a volatile field appended, then a field over the value threshold | entry keeps its expiry, `vset` empty | entry registered in the `vset` |

## Alternative considered

Install the aggregate header in `rdb.c` before the mid-load `hashTypeConvert()` call. It is the same line count and it fixes this caller, but it keeps `hashTypeConvertListpack()` depending on a header that every caller has to remember to maintain, which is the thing that broke. It also spends a `lpInsertMetadata()` realloc writing a header into a listpack the very next call frees. The conversion is already reading every field's expiry; asking it to consult a summary of data it holds in its hand buys nothing.

Making `hashTypeUntrackEntry()` return an error on a NULL set is the other tempting fix. Not doing that here: with the invariant repaired, a NULL set at that point means a fresh desync, and converting it into a returned error would hide it. Promoting `debugServerAssert(set)` to `serverAssert(set)` so release builds fail the same way the test suite does is defensible, but it is a separate change and it belongs at `vset.c:1839`, where the dereference precedes the existing assert and defeats it.

## Testing

Two tests, because the missing registration has two independent observable consequences and the second one is not a crash. Both fail with the `t_hash.c` hunk reverted:

```
[err]: RESTORE tracks field TTLs when the load converts mid-listpack
Expected '1' to be equal to '0' (context: type eval line 6 cmd {assert_equal 1 [get_keys_with_volatile_items r]} proc ::test)
[err]: Field TTLs survive a save after a mid-listpack conversion
Expected '-1' to be between to '1' and '1000' (context: type eval line 7 cmd {assert_range [lindex [r httl myhash FIELDS 1 a] 0] 1 1000} proc ::test)
Test Summary: 449 passed, 2 failed
```

The discriminating assertion in the first test is `keys_with_volatile_items`, not the `HTTL` line above it: `HTTL` reads the entry's own expiry and is independent of the vset, so it reports 1000 either way. The second test is tagged `needs:debug` for `debug reload` and is separate rather than folded into the first so the crash and vset assertions still run when that tag is denied.

`hashexpire.tcl` already covered DUMP/RESTORE of a listpack hash with field TTLs (`tests/unit/hashexpire.tcl:5044`) and loads that go straight to a hashtable on the entry count. Neither reaches a mid-load conversion: the first keeps the listpack encoding end to end, and the second converts an empty listpack before reading a single field. Nothing exercised a load that converts after a volatile field had already landed in the listpack.

</details>

This was generated by AI but verified, with love, by a human.
